### PR TITLE
PSY-806: derive NTS radio air_date from episode alias

### DIFF
--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -492,6 +492,14 @@ func (s *RadioService) importEpisode(showID uint, ep RadioEpisodeImport, provide
 		return nil, fmt.Errorf("checking existing episode: %w", err)
 	}
 
+	// air_date is NOT NULL; an episode with no recoverable date (no broadcast
+	// and no parseable alias date) can't be stored. Skip it rather than fail the
+	// whole import batch on a date NOT NULL violation — same posture as the
+	// dedup skip above.
+	if ep.AirDate == "" {
+		return &contracts.EpisodeImportResult{}, nil
+	}
+
 	// Create episode
 	episode := &catalogm.RadioEpisode{
 		ShowID:          showID,

--- a/backend/internal/services/catalog/radio_provider_nts.go
+++ b/backend/internal/services/catalog/radio_provider_nts.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -320,6 +322,13 @@ func parseNTSEpisode(ntsEp ntsEpisode, showExternalID string) RadioEpisodeImport
 		}
 	}
 
+	// Older NTS episodes return no `broadcast`; the air date still lives in the
+	// episode alias (e.g. "anu-11th-july-2017"). Fall back to it so the episode
+	// imports instead of failing the air_date NOT NULL insert.
+	if ep.AirDate == "" {
+		ep.AirDate = dateFromNTSAlias(ntsEp.EpisodeAlias)
+	}
+
 	if ntsEp.Name != "" {
 		name := ntsEp.Name
 		ep.Title = &name
@@ -338,6 +347,33 @@ func parseNTSEpisode(ntsEp ntsEpisode, showExternalID string) RadioEpisodeImport
 	}
 
 	return ep
+}
+
+// ntsAliasDateRegex captures a trailing "{day}{ordinal}-{month}-{year}" date in
+// an NTS episode alias slug, e.g. "anu-11th-july-2017" -> 11, july, 2017.
+var ntsAliasDateRegex = regexp.MustCompile(`(\d{1,2})(?:st|nd|rd|th)-([a-z]+)-(\d{4})$`)
+
+// dateFromNTSAlias derives a YYYY-MM-DD air date from an episode alias slug like
+// "anu-11th-july-2017". Returns "" when the alias has no trailing date or the
+// date is invalid. Used as a fallback when the NTS API omits `broadcast`.
+func dateFromNTSAlias(alias string) string {
+	m := ntsAliasDateRegex.FindStringSubmatch(strings.ToLower(alias))
+	if m == nil {
+		return ""
+	}
+	day, _ := strconv.Atoi(m[1])
+	month, ok := monthMap[m[2]]
+	if !ok {
+		return ""
+	}
+	year, _ := strconv.Atoi(m[3])
+	t := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	// time.Date normalizes overflow (Feb 31 -> Mar 3), so a round-trip mismatch
+	// means the alias held an impossible date — reject it.
+	if t.Day() != day || t.Month() != month || t.Year() != year {
+		return ""
+	}
+	return t.Format("2006-01-02")
 }
 
 // encodeTagsJSON converts a slice of strings to a JSON-encoded *json.RawMessage.

--- a/backend/internal/services/catalog/radio_provider_nts_test.go
+++ b/backend/internal/services/catalog/radio_provider_nts_test.go
@@ -812,3 +812,53 @@ func TestNTS_ParseNTSEpisode_DateOnlyBroadcast(t *testing.T) {
 	require.NotNil(t, ep.AirTime)
 	assert.Equal(t, "00:00:00", *ep.AirTime)
 }
+
+func TestNTS_ParseNTSEpisode_DerivesDateFromAliasWhenNoBroadcast(t *testing.T) {
+	// Older NTS episodes return no `broadcast`; the air date must be recovered
+	// from the alias so the episode still imports (air_date is NOT NULL).
+	ep := parseNTSEpisode(ntsEpisode{
+		Name:         "Anu",
+		EpisodeAlias: "anu-11th-july-2017",
+	}, "anu")
+
+	assert.Equal(t, "anu/anu-11th-july-2017", ep.ExternalID)
+	assert.Equal(t, "2017-07-11", ep.AirDate, "should derive air date from the alias")
+	assert.Nil(t, ep.AirTime, "no broadcast means no air time")
+}
+
+func TestNTS_ParseNTSEpisode_NoRecoverableDate(t *testing.T) {
+	// No broadcast and an alias without a trailing date -> AirDate stays empty.
+	// The import layer skips such episodes rather than insert an invalid date.
+	ep := parseNTSEpisode(ntsEpisode{
+		Name:         "Pilot",
+		EpisodeAlias: "pilot-episode",
+	}, "show")
+
+	assert.Empty(t, ep.AirDate)
+	assert.Nil(t, ep.AirTime)
+}
+
+func TestNTS_DateFromNTSAlias(t *testing.T) {
+	cases := []struct {
+		name  string
+		alias string
+		want  string
+	}{
+		{"th ordinal", "anu-11th-july-2017", "2017-07-11"},
+		{"st ordinal", "anu-21st-march-2017", "2017-03-21"},
+		{"nd ordinal", "show-2nd-june-2020", "2020-06-02"},
+		{"rd ordinal", "show-3rd-may-2019", "2019-05-03"},
+		{"multi-word slug", "anu-jm-moser-lil-stoner-diva-18th-april-2017", "2017-04-18"},
+		{"single-digit day", "x-1st-january-2021", "2021-01-01"},
+		{"mixed case", "Anu-11TH-July-2017", "2017-07-11"},
+		{"no date in slug", "morning-becomes-eclectic", ""},
+		{"month-year only, no day", "huerco-s-march-2026", ""},
+		{"invalid month name", "x-10th-smarch-2020", ""},
+		{"impossible date", "x-31st-february-2020", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, dateFromNTSAlias(tc.alias))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
NTS episodes whose API record has no `broadcast` field left `RadioEpisodeImport.AirDate` as `""`. Since `RadioEpisode.AirDate` is a non-nullable `string` mapped to a `date NOT NULL` column, the insert failed with `invalid input syntax for type date: "" (SQLSTATE 22007)` — those NTS episodes never imported, and the fetch/discover background cycles spammed errors on every run.

- **Fix:** in `parseNTSEpisode`, when `broadcast` is empty, recover the air date from the episode alias slug (e.g. `anu-11th-july-2017` → `2017-07-11`), reusing the package-level `monthMap` already used by the WFMU provider. Rejects impossible dates (Feb 31) via a `time.Date` round-trip check.
- **Safety net:** guard `importEpisode` to skip any episode that still has no `air_date` (no broadcast *and* no parseable alias date) instead of failing the batch on the NOT NULL violation — same posture as the existing dedup skip. This makes the SQLSTATE crash unreachable for any provider.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/services/catalog/...` (pass, incl. new cases)
- Added: `dateFromNTSAlias` table test (ordinals, multi-word slugs, mixed case, no-date, invalid month, impossible date) + `parseNTSEpisode` alias-fallback + no-recoverable-date cases.

## Manual repro
The new unit tests assert the exact failing slugs from the production logs (`anu-11th-july-2017`, `anu-21st-march-2017`, …) now derive correct dates. I did **not** run a full local NTS import end-to-end — reproducing it needs the NTS station seeded as an active playlist source locally (the reporter's local env has this). Quickest empirical confirm: restart the backend locally and verify the `radio_import.go` SQLSTATE flood stops. Happy to set up the seeded local repro if you want it verified that way.

## Simplify
`/simplify` run (3 parallel reviewers) — all clean, no fixes. Reuse: `monthMap` is the right shared map; per-provider date parsers are the established idiom; the skip guard matches the dedup skip. Quality/efficiency: regex compiled once at package scope, `strconv.Atoi` errors safely ignored (regex constrains input), comments are non-obvious WHY.

## Context
Surfaced during the Railway healthcheck investigation (by running the backend locally). This is **not** the cause of that deploy failure — radio fetch runs in background goroutines and doesn't block boot (see PSY-805 for the healthcheck-timeout fix) — but it's a real data bug + the startup error storm.

Closes PSY-806