### PR TITLE
PSY-809: parse NTS broadcast (RFC3339 offset) for air_date/time + fix date filter

### DIFF
--- a/backend/internal/services/catalog/radio_provider_nts.go
+++ b/backend/internal/services/catalog/radio_provider_nts.go
@@ -124,22 +124,15 @@ func (p *NTSProvider) FetchNewEpisodes(showExternalID string, since time.Time, u
 		for _, ntsEp := range page.Results {
 			ep := parseNTSEpisode(ntsEp, showExternalID)
 
-			// Filter by date range
-			if ntsEp.Broadcast != "" {
-				broadcastTime, err := time.Parse("2006-01-02T15:04:05Z", ntsEp.Broadcast)
-				if err != nil {
-					// Try date-only format
-					broadcastTime, err = time.Parse("2006-01-02", ntsEp.Broadcast)
+			// Filter by date range using the broadcast timestamp.
+			if broadcastTime, ok := parseNTSBroadcast(ntsEp.Broadcast); ok {
+				if broadcastTime.Before(since) {
+					reachedOldEpisodes = true
+					break
 				}
-				if err == nil {
-					if broadcastTime.Before(since) {
-						reachedOldEpisodes = true
-						break
-					}
-					// Skip episodes after until bound
-					if !until.IsZero() && broadcastTime.After(until) {
-						continue
-					}
+				// Skip episodes after the until bound
+				if !until.IsZero() && broadcastTime.After(until) {
+					continue
 				}
 			}
 
@@ -307,24 +300,15 @@ func parseNTSEpisode(ntsEp ntsEpisode, showExternalID string) RadioEpisodeImport
 		ShowExternalID: showExternalID,
 	}
 
-	// Parse broadcast date
-	if ntsEp.Broadcast != "" {
-		broadcastTime, err := time.Parse("2006-01-02T15:04:05Z", ntsEp.Broadcast)
-		if err != nil {
-			// Try date-only format
-			broadcastTime, err = time.Parse("2006-01-02", ntsEp.Broadcast)
-		}
-		if err == nil {
-			airDate := broadcastTime.Format("2006-01-02")
-			airTime := broadcastTime.Format("15:04:05")
-			ep.AirDate = airDate
-			ep.AirTime = &airTime
-		}
+	// Parse the broadcast timestamp for both air date and air time.
+	if t, ok := parseNTSBroadcast(ntsEp.Broadcast); ok {
+		ep.AirDate = t.Format("2006-01-02")
+		airTime := t.Format("15:04:05")
+		ep.AirTime = &airTime
 	}
 
-	// Older NTS episodes return no `broadcast`; the air date still lives in the
-	// episode alias (e.g. "anu-11th-july-2017"). Fall back to it so the episode
-	// imports instead of failing the air_date NOT NULL insert.
+	// Fallback for the rare episode with no `broadcast`: recover the date from
+	// the episode alias (e.g. "anu-11th-july-2017"). No air time is available.
 	if ep.AirDate == "" {
 		ep.AirDate = dateFromNTSAlias(ntsEp.EpisodeAlias)
 	}
@@ -347,6 +331,24 @@ func parseNTSEpisode(ntsEp ntsEpisode, showExternalID string) RadioEpisodeImport
 	}
 
 	return ep
+}
+
+// parseNTSBroadcast parses an NTS `broadcast` timestamp. NTS returns RFC3339
+// with a numeric offset (e.g. "2021-11-04T12:00:00+00:00"); a few records may
+// be date-only. Returns the parsed time and true on success. The literal-`Z`
+// layout the provider used before never matched the offset form, so every
+// episode's air date was silently dropped.
+func parseNTSBroadcast(broadcast string) (time.Time, bool) {
+	if broadcast == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, broadcast); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02", broadcast); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
 }
 
 // ntsAliasDateRegex captures a trailing "{day}{ordinal}-{month}-{year}" date in

--- a/backend/internal/services/catalog/radio_provider_nts_test.go
+++ b/backend/internal/services/catalog/radio_provider_nts_test.go
@@ -862,3 +862,71 @@ func TestNTS_DateFromNTSAlias(t *testing.T) {
 		})
 	}
 }
+
+func TestNTS_ParseNTSBroadcast(t *testing.T) {
+	cases := []struct {
+		name             string
+		broadcast        string
+		wantOK           bool
+		wantDate, wantTm string
+	}{
+		{"rfc3339 numeric offset (real NTS format)", "2021-11-04T12:00:00+00:00", true, "2021-11-04", "12:00:00"},
+		{"rfc3339 with Z", "2026-03-15T20:00:00Z", true, "2026-03-15", "20:00:00"},
+		{"non-UTC offset", "2026-05-20T19:00:18-07:00", true, "2026-05-20", "19:00:18"},
+		{"date only", "2026-03-15", true, "2026-03-15", "00:00:00"},
+		{"empty", "", false, "", ""},
+		{"garbage", "not-a-date", false, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseNTSBroadcast(tc.broadcast)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantDate, got.Format("2006-01-02"))
+				assert.Equal(t, tc.wantTm, got.Format("15:04:05"))
+			}
+		})
+	}
+}
+
+func TestNTS_ParseNTSEpisode_OffsetBroadcast(t *testing.T) {
+	// Regression: NTS returns RFC3339 with a numeric offset, which the old
+	// literal-Z layout failed to parse — dropping every episode's air date.
+	ep := parseNTSEpisode(ntsEpisode{
+		Name:         "Anu",
+		EpisodeAlias: "anu-4th-november-2021",
+		Broadcast:    "2021-11-04T12:00:00+00:00",
+	}, "anu")
+
+	assert.Equal(t, "2021-11-04", ep.AirDate)
+	require.NotNil(t, ep.AirTime)
+	assert.Equal(t, "12:00:00", *ep.AirTime)
+}
+
+func TestNTS_FetchNewEpisodes_DateFiltering_OffsetFormat(t *testing.T) {
+	// Regression: the [since, until] filter parsed broadcast with a literal-Z
+	// layout, so the real "+00:00" offset format never parsed and the window
+	// silently never applied (every episode passed through).
+	const body = `{"results":[
+		{"name":"Nov","episode_alias":"show-4th-november-2021","broadcast":"2021-11-04T12:00:00+00:00"},
+		{"name":"Oct","episode_alias":"show-20th-october-2021","broadcast":"2021-10-20T13:00:00+00:00"},
+		{"name":"Sep","episode_alias":"show-8th-september-2021","broadcast":"2021-09-08T13:00:00+00:00"}
+	]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	defer server.Close()
+
+	provider := NewNTSProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	// Only episodes on/after Oct 1, 2021: the Sep episode is filtered out (and,
+	// since results are date-descending, the walk stops there).
+	since := time.Date(2021, 10, 1, 0, 0, 0, 0, time.UTC)
+	episodes, err := provider.FetchNewEpisodes("show", since, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, episodes, 2)
+	assert.Equal(t, "2021-11-04", episodes[0].AirDate)
+	assert.Equal(t, "2021-10-20", episodes[1].AirDate)
+}


### PR DESCRIPTION
## Summary
Follow-up to PSY-806 (#769). That PR shipped a slug-derivation **fallback** + skip-guard that stopped the `air_date=''` crash, but left the underlying parse bug in place. Verified against the live NTS API: `broadcast` is RFC3339 with a numeric offset (`2021-11-04T12:00:00+00:00`) and is present on **0/73** sampled "anu" episodes empty — the data was never missing. The provider's layouts (`"...05Z"`, `"2006-01-02"`) both fail on the offset form (Go-confirmed: `cannot parse "+00:00" as "Z"`).

Two defects from the same root cause, now fixed via a shared `parseNTSBroadcast` (`time.RFC3339`, then date-only):
1. **`parseNTSEpisode`** — now recovers `air_date` **and** `air_time` from `broadcast` (previously the date came only from the PSY-806 slug fallback, and the time was lost).
2. **`FetchNewEpisodes`** — the `[since, until]` date filter used the same broken parse, so the window silently never applied (90-day backfill pulled all history; this is the 2017-episode flood seen locally). Now fixed.

The PSY-806 slug derivation stays as a genuine fallback (rare missing-`broadcast` case); the `importEpisode` empty-`air_date` skip-guard remains.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/services/catalog/...` (pass; DB-backed suite + new unit tests)
- Added regression tests using the **real `+00:00` offset format** (the prior fixtures used `...Z`, which is exactly what hid this): `parseNTSBroadcast` table test, `parseNTSEpisode` offset case, and a `FetchNewEpisodes` offset-format date-filtering test.

## Verification (no-assumptions)
- Confirmed the real format against the live NTS API (`/v2/shows/anu/episodes`): every sampled episode 2017–2021 carries a `+00:00` `broadcast`.
- Confirmed in Go that the old layouts fail and `time.RFC3339` parses it (recovering the time too).
- Did **not** run a full live import (needs the dev stack + a seeded NTS station). The provider parse is covered by the offset-format unit tests; the import→DB path is covered by the existing catalog testcontainer suite.

## Simplify
`/simplify` was run on this exact diff (3 parallel reviewers) — clean except one applied fix (inlined a redundant `airDate` local). Reuse confirmed `parseNTSBroadcast` dedups two identical parse blocks and per-provider parsing is the idiom.

Closes PSY-809