### PR TITLE
PSY-812: fix KEXP kexpPlay field mismatches (labels + MusicBrainz IDs)

### DIFF
--- a/backend/internal/services/catalog/radio_provider_kexp.go
+++ b/backend/internal/services/catalog/radio_provider_kexp.go
@@ -463,8 +463,9 @@ func parseKEXPPlay(kPlay kexpPlay, position int) RadioPlayImport {
 	if kPlay.Album != "" {
 		play.AlbumTitle = &kPlay.Album
 	}
-	if kPlay.Label != "" {
-		play.LabelName = &kPlay.Label
+	if len(kPlay.Labels) > 0 && kPlay.Labels[0] != "" {
+		label := kPlay.Labels[0]
+		play.LabelName = &label
 	}
 	if kPlay.ReleaseDate != "" {
 		if year := parseReleaseYear(kPlay.ReleaseDate); year > 0 {
@@ -477,13 +478,10 @@ func parseKEXPPlay(kPlay kexpPlay, position int) RadioPlayImport {
 	if kPlay.Comment != "" {
 		play.DJComment = &kPlay.Comment
 	}
-	if kPlay.IsNew {
-		play.IsNew = true
-	}
-
-	// MusicBrainz IDs
-	if kPlay.MusicBrainzArtistID != "" {
-		play.MusicBrainzArtistID = &kPlay.MusicBrainzArtistID
+	// MusicBrainz IDs — `artist_ids` is an array; take the first.
+	if len(kPlay.ArtistIDs) > 0 && kPlay.ArtistIDs[0] != "" {
+		mbArtist := kPlay.ArtistIDs[0]
+		play.MusicBrainzArtistID = &mbArtist
 	}
 	if kPlay.MusicBrainzReleaseID != "" {
 		play.MusicBrainzReleaseID = &kPlay.MusicBrainzReleaseID
@@ -582,20 +580,22 @@ type kexpPlaysResponse struct {
 }
 
 type kexpPlay struct {
-	ID                     int    `json:"id"`
-	PlayType               string `json:"play_type"`
-	Airdate                string `json:"airdate"`
-	Artist                 string `json:"artist"`
-	Song                   string `json:"song"`
-	Album                  string `json:"album"`
-	Label                  string `json:"label_name"`
-	ReleaseDate            string `json:"release_date"`
-	RotationStatus         string `json:"rotation_status"`
-	IsNew                  bool   `json:"is_new"`
-	IsLive                 bool   `json:"is_live"`
-	IsRequest              bool   `json:"is_request"`
-	Comment                string `json:"comment"`
-	MusicBrainzArtistID    string `json:"musicbrainz_artist_id"`
-	MusicBrainzReleaseID   string `json:"musicbrainz_release_id"`
-	MusicBrainzRecordingID string `json:"musicbrainz_recording_id"`
+	ID             int      `json:"id"`
+	PlayType       string   `json:"play_type"`
+	Airdate        string   `json:"airdate"`
+	Artist         string   `json:"artist"`
+	Song           string   `json:"song"`
+	Album          string   `json:"album"`
+	Labels         []string `json:"labels"`
+	ReleaseDate    string   `json:"release_date"`
+	RotationStatus string   `json:"rotation_status"`
+	IsLive         bool     `json:"is_live"`
+	IsRequest      bool     `json:"is_request"`
+	Comment        string   `json:"comment"`
+	// KEXP exposes MusicBrainz artist IDs as an array (`artist_ids`); release
+	// and recording are scalars (`release_id`, `recording_id`). There is no
+	// `is_new` field on the play.
+	ArtistIDs              []string `json:"artist_ids"`
+	MusicBrainzReleaseID   string   `json:"release_id"`
+	MusicBrainzRecordingID string   `json:"recording_id"`
 }

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -57,14 +57,13 @@ func TestParseKEXPPlay_FullFields(t *testing.T) {
 		Artist:                 "Radiohead",
 		Song:                   "Everything In Its Right Place",
 		Album:                  "Kid A",
-		Label:                  "Parlophone",
+		Labels:                 []string{"Parlophone"},
 		ReleaseDate:            "2000-10-02",
 		RotationStatus:         "heavy",
-		IsNew:                  true,
 		IsLive:                 false,
 		IsRequest:              true,
 		Comment:                "Classic album opener",
-		MusicBrainzArtistID:    "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+		ArtistIDs:              []string{"a74b1b7f-71a5-4011-9441-d0b5e4122711"},
 		MusicBrainzReleaseID:   "b95ce3ff-3d05-4e87-9e01-c97b66af13d4",
 		MusicBrainzRecordingID: "c22af0e6-1e3c-4b6c-aa83-42a2de43b84c",
 	}
@@ -78,7 +77,6 @@ func TestParseKEXPPlay_FullFields(t *testing.T) {
 	assert.Equal(t, "Parlophone", *play.LabelName)
 	assert.Equal(t, 2000, *play.ReleaseYear)
 	assert.Equal(t, "heavy", *play.RotationStatus)
-	assert.True(t, play.IsNew)
 	assert.False(t, play.IsLivePerformance)
 	assert.True(t, play.IsRequest)
 	assert.Equal(t, "Classic album opener", *play.DJComment)
@@ -387,19 +385,18 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 			"count": 3,
 			"results": []map[string]interface{}{
 				{
-					"id":                    1,
-					"play_type":             "trackplay",
-					"airdate":               "2026-01-15T06:05:00-08:00",
-					"artist":                "Radiohead",
-					"song":                  "Everything In Its Right Place",
-					"album":                 "Kid A",
-					"label_name":            "Parlophone",
-					"release_date":          "2000-10-02",
-					"rotation_status":       "library",
-					"is_new":                false,
-					"is_live":               false,
-					"is_request":            false,
-					"musicbrainz_artist_id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+					"id":              1,
+					"play_type":       "trackplay",
+					"airdate":         "2026-01-15T06:05:00-08:00",
+					"artist":          "Radiohead",
+					"song":            "Everything In Its Right Place",
+					"album":           "Kid A",
+					"labels":          []string{"Parlophone"},
+					"release_date":    "2000-10-02",
+					"rotation_status": "library",
+					"is_live":         false,
+					"is_request":      false,
+					"artist_ids":      []string{"a74b1b7f-71a5-4011-9441-d0b5e4122711"},
 				},
 				{
 					"id":        2,
@@ -412,7 +409,6 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 					"airdate":    "2026-01-15T06:15:00-08:00",
 					"artist":     "Deerhunter",
 					"song":       "Desire Lines",
-					"is_new":     true,
 					"is_live":    true,
 					"is_request": false,
 				},
@@ -457,13 +453,11 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 	assert.Equal(t, "Parlophone", *plays[0].LabelName)
 	assert.Equal(t, 2000, *plays[0].ReleaseYear)
 	assert.Equal(t, "library", *plays[0].RotationStatus)
-	assert.False(t, plays[0].IsNew)
 	assert.Equal(t, "a74b1b7f-71a5-4011-9441-d0b5e4122711", *plays[0].MusicBrainzArtistID)
 
 	// Second play
 	assert.Equal(t, 1, plays[1].Position)
 	assert.Equal(t, "Deerhunter", plays[1].ArtistName)
-	assert.True(t, plays[1].IsNew)
 	assert.True(t, plays[1].IsLivePerformance)
 }
 


### PR DESCRIPTION
## Summary
Verified against the live KEXP `/v2/plays/`: each play exposes `labels` (array), `artist_ids` (array), `release_id`, and `recording_id` — **not** `label_name`/`musicbrainz_artist_id`/`musicbrainz_release_id`/`musicbrainz_recording_id` — and has **no `is_new`**. `kexpPlay`'s tags didn't match, so KEXP plays silently dropped the label and **all three MusicBrainz IDs** (the MB-ID lookup is KEXP's main matching advantage; the matcher prefers MB-ID → name).

This was masked because KEXP imported 0 episodes until PSY-810; it would surface now that episodes import.

- Retag: `Labels []string json:"labels"`, `ArtistIDs []string json:"artist_ids"` (take the first element for the single-value import fields), `release_id`/`recording_id` scalars.
- Drop `IsNew`/`is_new` (no such API field; `RadioPlayImport.IsNew` is still set by WFMU, so the DTO field stays).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/services/catalog/...` (pass)
- Realigned the KEXP plays fixtures + `TestParseKEXPPlay_FullFields` to the real field names; removed the now-sourceless `IsNew` assertions.

## Verification (no-assumptions)
- Confirmed field names against the live API (`labels`, `artist_ids`, `release_id`, `recording_id`; no `is_new`).
- **Demonstrated** the test catches it: reverting `ArtistIDs` to `json:"musicbrainz_artist_id"` makes `TestKEXPProvider_FetchPlaylist` fail (`MusicBrainzArtistID` nil); restoring `artist_ids` passes.

## Simplify
`/simplify` run (3 reviewers) — clean. First-element slice access is idiomatic; field-name-vs-tag matches the established pattern; `IsNew` confirmed still used by WFMU (not orphaned).

## Out of scope
KEXP also exposes `release_group_id` and `label_ids` (additional MB IDs not currently modeled) — a possible future enrichment.

Sibling of PSY-810 (KEXP). Closes PSY-812