### PR TITLE
PSY-814: surface swallowed DB errors in radio matching + affinity sync

### DIFF
--- a/backend/internal/services/catalog/radio_affinity_sync_test.go
+++ b/backend/internal/services/catalog/radio_affinity_sync_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -431,4 +432,87 @@ func (s *RadioAffinitySyncSuite) TestSync_DoesNotDeleteOtherRelationshipTypes() 
 			lowID, highID, catalogm.RelationshipTypeSharedBills).
 		Count(&count)
 	s.Equal(int64(1), count)
+}
+
+// TestSync_CreateFailureIsReported verifies that a failed relationship INSERT
+// is counted in result.Failed instead of being silently swallowed (the create
+// path previously incremented nothing on error, hiding the failure).
+func (s *RadioAffinitySyncSuite) TestSync_CreateFailureIsReported() {
+	artist1 := s.createArtist("Artist A", "artist-a-failcreate")
+	artist2 := s.createArtist("Artist B", "artist-b-failcreate")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+	s.insertAffinity(lowID, highID, 5, 3, 1)
+
+	// Inject a failure on the artist_relationships INSERT. The callback is on
+	// the shared connection, so remove it after the test for isolation.
+	const cbName = "test:fail_artist_relationships_create"
+	s.Require().NoError(s.db.Callback().Create().Before("gorm:create").Register(cbName, func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Table == "artist_relationships" {
+			_ = tx.AddError(fmt.Errorf("simulated create failure"))
+		}
+	}))
+	defer func() {
+		s.Require().NoError(s.db.Callback().Create().Remove(cbName))
+	}()
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(0, result.Created)
+	s.Equal(1, result.Failed)
+
+	// The relationship must not exist, since the create failed.
+	var count int64
+	s.db.Model(&catalogm.ArtistRelationship{}).
+		Where("relationship_type = ?", catalogm.RelationshipTypeRadioCooccurrence).
+		Count(&count)
+	s.Equal(int64(0), count)
+}
+
+// TestSync_UpdateFailureIsReported verifies that a failed relationship UPDATE
+// is counted in result.Failed instead of being swallowed (the update path
+// previously incremented result.Updated unconditionally, ignoring the error).
+func (s *RadioAffinitySyncSuite) TestSync_UpdateFailureIsReported() {
+	artist1 := s.createArtist("Artist A", "artist-a-failupdate")
+	artist2 := s.createArtist("Artist B", "artist-b-failupdate")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// Seed an existing relationship so the sync takes the update path.
+	existingRel := &catalogm.ArtistRelationship{
+		SourceArtistID:   lowID,
+		TargetArtistID:   highID,
+		RelationshipType: catalogm.RelationshipTypeRadioCooccurrence,
+		Score:            0.1,
+		AutoDerived:      true,
+	}
+	s.Require().NoError(s.db.Create(existingRel).Error)
+	s.insertAffinity(lowID, highID, 25, 10, 2)
+
+	const cbName = "test:fail_artist_relationships_update"
+	s.Require().NoError(s.db.Callback().Update().Before("gorm:update").Register(cbName, func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Table == "artist_relationships" {
+			_ = tx.AddError(fmt.Errorf("simulated update failure"))
+		}
+	}))
+	defer func() {
+		s.Require().NoError(s.db.Callback().Update().Remove(cbName))
+	}()
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(0, result.Updated)
+	s.Equal(1, result.Failed)
+
+	// The score must be unchanged, since the update failed.
+	var rel catalogm.ArtistRelationship
+	s.Require().NoError(s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, catalogm.RelationshipTypeRadioCooccurrence).First(&rel).Error)
+	s.InDelta(0.1, float64(rel.Score), 0.01)
 }

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -322,6 +322,7 @@ func (s *RadioFetchService) runAffinityCycle() {
 		"created", syncResult.Created,
 		"updated", syncResult.Updated,
 		"deleted", syncResult.Deleted,
+		"failed", syncResult.Failed,
 		"duration", time.Since(syncStart),
 	)
 }

--- a/backend/internal/services/catalog/radio_matching.go
+++ b/backend/internal/services/catalog/radio_matching.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"gorm.io/gorm"
@@ -101,7 +102,16 @@ func (m *RadioMatchingEngine) matchPlay(play *catalogm.RadioPlay) bool {
 	}
 
 	if len(updates) > 0 {
-		m.db.Model(play).Updates(updates)
+		if err := m.db.Model(play).Updates(updates).Error; err != nil {
+			// The match did not persist, so report the play as unmatched rather
+			// than over-counting it; a swallowed error here left plays silently
+			// unmatched in the DB while the caller recorded a match.
+			slog.Error("radio match: failed to persist play match",
+				"play_id", play.ID,
+				"artist_name", play.ArtistName,
+				"error", err)
+			return false
+		}
 	}
 
 	return artistMatched

--- a/backend/internal/services/catalog/radio_unmatched.go
+++ b/backend/internal/services/catalog/radio_unmatched.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -348,7 +349,8 @@ func (s *RadioService) SyncAffinityToRelationships() (*contracts.SyncAffinityRes
 			aff.ArtistAID, aff.ArtistBID, catalogm.RelationshipTypeRadioCooccurrence).
 			First(&existing).Error
 
-		if err == gorm.ErrRecordNotFound {
+		switch {
+		case err == gorm.ErrRecordNotFound:
 			rel := &catalogm.ArtistRelationship{
 				SourceArtistID:   aff.ArtistAID,
 				TargetArtistID:   aff.ArtistBID,
@@ -357,29 +359,61 @@ func (s *RadioService) SyncAffinityToRelationships() (*contracts.SyncAffinityRes
 				AutoDerived:      true,
 				Detail:           &detailRaw,
 			}
-			if err := s.db.Create(rel).Error; err == nil {
+			if createErr := s.db.Create(rel).Error; createErr != nil {
+				slog.Error("radio affinity sync: failed to create relationship",
+					"source_artist_id", aff.ArtistAID,
+					"target_artist_id", aff.ArtistBID,
+					"error", createErr)
+				result.Failed++
+			} else {
 				result.Created++
 			}
-		} else if err == nil {
-			s.db.Model(&existing).Updates(map[string]interface{}{
+		case err == nil:
+			if updateErr := s.db.Model(&existing).Updates(map[string]interface{}{
 				"score":  score,
 				"detail": &detailRaw,
-			})
-			result.Updated++
+			}).Error; updateErr != nil {
+				slog.Error("radio affinity sync: failed to update relationship",
+					"source_artist_id", aff.ArtistAID,
+					"target_artist_id", aff.ArtistBID,
+					"error", updateErr)
+				result.Failed++
+			} else {
+				result.Updated++
+			}
+		default:
+			// A real lookup error (not ErrRecordNotFound) was previously
+			// swallowed, silently skipping the pair.
+			slog.Error("radio affinity sync: failed to look up existing relationship",
+				"source_artist_id", aff.ArtistAID,
+				"target_artist_id", aff.ArtistBID,
+				"error", err)
+			result.Failed++
 		}
 	}
 
 	// 2. Delete stale radio_cooccurrence relationships that no longer exist in affinity table
 	var staleRels []catalogm.ArtistRelationship
-	s.db.Where("relationship_type = ? AND auto_derived = TRUE", catalogm.RelationshipTypeRadioCooccurrence).
-		Find(&staleRels)
+	// A failed query aborts the sync (vs. the per-row failures above, which are
+	// counted in result.Failed and skipped): without the stale set, cleanup can't run.
+	if err := s.db.Where("relationship_type = ? AND auto_derived = TRUE", catalogm.RelationshipTypeRadioCooccurrence).
+		Find(&staleRels).Error; err != nil {
+		slog.Error("radio affinity sync: failed to query stale relationships", "error", err)
+		return result, fmt.Errorf("querying stale relationships: %w", err)
+	}
 
 	for _, rel := range staleRels {
 		pair := [2]uint{rel.SourceArtistID, rel.TargetArtistID}
 		if !affinityPairs[pair] {
 			if err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
 				rel.SourceArtistID, rel.TargetArtistID, catalogm.RelationshipTypeRadioCooccurrence).
-				Delete(&catalogm.ArtistRelationship{}).Error; err == nil {
+				Delete(&catalogm.ArtistRelationship{}).Error; err != nil {
+				slog.Error("radio affinity sync: failed to delete stale relationship",
+					"source_artist_id", rel.SourceArtistID,
+					"target_artist_id", rel.TargetArtistID,
+					"error", err)
+				result.Failed++
+			} else {
 				result.Deleted++
 			}
 		}

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -434,6 +434,9 @@ type SyncAffinityResult struct {
 	Created int `json:"created"`
 	Updated int `json:"updated"`
 	Deleted int `json:"deleted"`
+	// Failed counts per-row writes that were logged and skipped; the sync
+	// continues past individual failures rather than aborting the batch.
+	Failed int `json:"failed"`
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Radio match-persistence and affinity→relationship sync silently dropped DB write errors, so failures were invisible and `SyncAffinityToRelationships` reported success despite partial failures (and plays were counted as matched without actually persisting).

- `matchPlay` now checks the play `Updates` error: logs it and returns the play as **unmatched** instead of over-counting a match that never persisted.
- `SyncAffinityToRelationships` now checks create / update / delete **and** the previously-unhandled lookup error; each is logged and counted in a new `SyncAffinityResult.Failed` field. A failed stale-relationships query now aborts (consistent with the existing top-level affinity query) rather than silently skipping cleanup.
- The affinity fetch-cycle completion log now includes `failed`.

## Scope notes
- Fixed the 4 sites named in the ticket (`radio_matching.go` play update; `radio_unmatched.go` create / update / delete) **plus 2 adjacent same-class swallows** in the same function — the previously-unhandled lookup error and the stale-relationships query — since leaving them would make "failures surface" only half-true.
- Kept logging via package-level `slog` (writes to `slog.Default()`, which is what `RadioFetchService` already uses) rather than threading a logger field through `NewRadioService`/`NewRadioMatchingEngine` and all callers — out of scope for this fix.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/services/catalog/...` — clean
- [x] `go test ./internal/services/catalog/...` — green (~31s), incl. 2 new failure-injection tests (`TestSync_CreateFailureIsReported`, `TestSync_UpdateFailureIsReported`) asserting failures land in `result.Failed` and nothing is persisted
- [x] `/simplify` (3 reviewers) — addressed; added one clarifying comment, consciously skipped logger-injection + shared-test-helper as scope creep
- Backend-only change; no UI surface to verify

Closes PSY-814

🤖 Generated with [Claude Code](https://claude.com/claude-code)