### PR TITLE
PSY-817: disable autonomous music discovery on new-artist creation

### DIFF
--- a/backend/internal/api/handlers/admin/admin_shows.go
+++ b/backend/internal/api/handlers/admin/admin_shows.go
@@ -597,13 +597,6 @@ func (h *AdminShowHandler) ImportShowConfirmHandler(ctx context.Context, req *Im
 	// Send Discord notification for new show
 	h.discordService.NotifyNewShow(show, "")
 
-	// Trigger music discovery for any newly created artists
-	for _, artist := range show.Artists {
-		if artist.IsNewArtist != nil && *artist.IsNewArtist {
-			h.musicDiscoveryService.DiscoverMusicForArtist(artist.ID, artist.Name)
-		}
-	}
-
 	return &ImportShowConfirmResponse{Body: *show}, nil
 }
 
@@ -957,13 +950,6 @@ func (h *AdminShowHandler) BulkImportConfirmHandler(ctx context.Context, req *Bu
 
 		// Send Discord notification for new show
 		h.discordService.NotifyNewShow(show, "")
-
-		// Trigger music discovery for any newly created artists
-		for _, artist := range show.Artists {
-			if artist.IsNewArtist != nil && *artist.IsNewArtist {
-				h.musicDiscoveryService.DiscoverMusicForArtist(artist.ID, artist.Name)
-			}
-		}
 	}
 
 	logger.FromContext(ctx).Info("admin_bulk_import_confirm_complete",

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -451,13 +451,6 @@ func (h *ShowHandler) CreateShowHandler(ctx context.Context, req *CreateShowRequ
 	}
 	h.discordService.NotifyNewShow(show, submitterEmail)
 
-	// Trigger music discovery for any newly created artists
-	for _, artist := range show.Artists {
-		if shared.Deref(artist.IsNewArtist) {
-			h.musicDiscoveryService.DiscoverMusicForArtist(artist.ID, artist.Name)
-		}
-	}
-
 	// Notify about any newly created unverified venues
 	for _, venue := range show.Venues {
 		if shared.Deref(venue.IsNewVenue) && !venue.Verified {

--- a/backend/internal/services/pipeline/music_discovery.go
+++ b/backend/internal/services/pipeline/music_discovery.go
@@ -16,7 +16,8 @@ import (
 	"psychic-homily-backend/internal/utils"
 )
 
-// MusicDiscoveryService handles automatic discovery of music platforms for new artists
+// MusicDiscoveryService discovers an artist's music-platform links (Bandcamp/Spotify)
+// via the discovery route. It is invoked explicitly, not automatically on artist creation.
 type MusicDiscoveryService struct {
 	internalSecret string
 	frontendURL    string


### PR DESCRIPTION
## Summary
Stops autonomous music-link discovery: creating a new artist during show ingest no longer auto-attaches Bandcamp/Spotify URLs. Today that match is made by artist **name alone** with no human review, which mis-attributes streaming links for same-name bands — a trust / data-integrity risk for a What.cd-style knowledge graph.

Removes the three `IsNewArtist`-gated `DiscoverMusicForArtist` triggers:
- `CreateShowHandler` (`catalog/show.go`)
- `ImportShowConfirmHandler` (`admin/admin_shows.go`)
- `BulkImportConfirmHandler` (`admin/admin_shows.go`)

Also refreshes the now-stale `MusicDiscoveryService` doc comment (it claimed "automatic discovery for new artists").

The `MusicDiscoveryService` wiring and the frontend `discover-music` route are **intentionally retained** — they're reused by the admin-triggered, verify-before-save replacement in **PSY-816**. (The handlers' `musicDiscoveryService` field is now write-only; harmless and intentional.)

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet` on catalog + admin handler packages — clean
- [x] `go test ./internal/api/handlers/catalog/... ./internal/api/handlers/admin/...` — green
- [x] grep confirms no remaining `DiscoverMusicForArtist` callers in handlers
- [x] `/simplify` (3 reviewers, orphan/stale/side-effect focus) — fixed the one finding (stale doc comment); deletion confirmed orphan-free and side-effect-clean
- Pure deletion (21 lines) + 1 comment; no UI surface

Closes PSY-817

🤖 Generated with [Claude Code](https://claude.com/claude-code)