### PR TITLE
PSY-792: typed errors + mappers for auth + notification handlers

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -1900,10 +1900,13 @@ func (h *AuthHandler) UpdateProfileHandler(ctx context.Context, req *UpdateProfi
 			"error", err.Error(),
 			"request_id", requestID,
 		)
-		// Check for unique constraint violation (username taken)
-		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique") {
+		// Username unique-constraint violation surfaces as a typed
+		// CodeUsernameTaken from the user service (the driver-string match
+		// lives there now, isolated to the DB boundary).
+		var authErr *autherrors.AuthError
+		if errors.As(err, &authErr) && authErr.Code == autherrors.CodeUsernameTaken {
 			resp.Body.Success = false
-			resp.Body.Message = "Username is already taken"
+			resp.Body.Message = authErr.UserMessage()
 			resp.Body.ErrorCode = autherrors.CodeValidationFailed
 			return resp, nil
 		}

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -2350,7 +2350,7 @@ func TestUpdateProfileHandler_Success(t *testing.T) {
 func TestUpdateProfileHandler_DuplicateUsername(t *testing.T) {
 	mock := &testhelpers.MockUserService{
 		UpdateUserFn: func(_ uint, _ map[string]any) (*authm.User, error) {
-			return nil, fmt.Errorf("ERROR: duplicate key value violates unique constraint")
+			return nil, autherrors.ErrUsernameTaken(fmt.Errorf("duplicate key value violates unique constraint"))
 		},
 	}
 	h := NewAuthHandler(nil, nil, mock, nil, nil, nil, testConfig())

--- a/backend/internal/api/handlers/auth/oauth_handlers.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers.go
@@ -5,14 +5,15 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
 	"psychic-homily-backend/internal/config"
+	autherrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/services/contracts"
 
 	"github.com/go-chi/chi/v5"
@@ -271,8 +272,9 @@ func (h *OAuthHTTPHandler) OAuthCallbackHTTPHandler(w http.ResponseWriter, r *ht
 	if err != nil {
 		log.Printf("OAuth callback failed: %v", err)
 		errorMessage := "authentication failed"
-		if strings.Contains(err.Error(), "terms acceptance required") || strings.Contains(err.Error(), "terms version is required") {
-			errorMessage = "Please accept the Terms of Service and Privacy Policy before creating an account."
+		var authErr *autherrors.AuthError
+		if errors.As(err, &authErr) && authErr.Code == autherrors.CodeTermsAcceptanceRequired {
+			errorMessage = authErr.UserMessage()
 		}
 
 		// Handle CLI callback error

--- a/backend/internal/api/handlers/auth/oauth_handlers_integration_test.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers_integration_test.go
@@ -254,6 +254,33 @@ func (s *OAuthHandlerIntegrationSuite) TestCallback_EmptyFrontendURL_Fallback() 
 		"expected fallback to localhost:3000, got %s", location)
 }
 
+// TestCallback_TermsNotAccepted_RedirectsWithTermsMessage: a new-user OAuth
+// callback that arrives without the signup-consent cookie surfaces a typed
+// CodeTermsAcceptanceRequired from the user service. PSY-792: the handler now
+// discriminates on the typed code (not a message substring) to pick the
+// terms-acceptance redirect message instead of the generic failure.
+func (s *OAuthHandlerIntegrationSuite) TestCallback_TermsNotAccepted_RedirectsWithTermsMessage() {
+	handler := s.newHandler(&mockOAuthCompleter{
+		user: goth.User{
+			Email:    "oauth-noterms@test.com",
+			Provider: "google",
+			UserID:   "google-noterms-789",
+			Name:     "No Terms User",
+		},
+	})
+
+	// No consent cookie → validateOAuthSignupConsent(nil) → terms error.
+	w, req := oauthCallbackRequest("google")
+	handler.OAuthCallbackHTTPHandler(w, req)
+
+	s.Equal(http.StatusTemporaryRedirect, w.Code)
+	location := w.Header().Get("Location")
+	s.True(strings.HasPrefix(location, "http://localhost:3000/auth?error="),
+		"expected redirect to frontend auth with error, got %s", location)
+	s.Contains(location, "Terms+of+Service",
+		"expected terms-acceptance message in redirect, got %s", location)
+}
+
 // --- OAuthCallbackHTTPHandler: success paths ---
 
 func (s *OAuthHandlerIntegrationSuite) TestCallback_Success_SetsCookieAndRedirects() {

--- a/backend/internal/api/handlers/auth/user_preferences.go
+++ b/backend/internal/api/handlers/auth/user_preferences.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,7 @@ import (
 
 	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
+	autherrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	authm "psychic-homily-backend/internal/models/auth"
 	engagementm "psychic-homily-backend/internal/models/engagement"
@@ -229,11 +231,15 @@ func (h *UserPreferencesHandler) SetDefaultReplyPermissionHandler(ctx context.Co
 			"error", err.Error(),
 			"user_id", user.ID,
 		)
-		if strings.Contains(err.Error(), "invalid reply_permission") {
+		// Defence-in-depth: the handler already rejects unrecognized values
+		// above, but the service-layer enum check surfaces a typed
+		// CodeInvalidReplyPermission for the same 400 if it is ever reached.
+		var authErr *autherrors.AuthError
+		if errors.As(err, &authErr) && authErr.Code == autherrors.CodeInvalidReplyPermission {
 			return nil, huma.Error400BadRequest(shared.InvalidReplyPermissionMessage)
 		}
-		return nil, huma.Error422UnprocessableEntity(
-			fmt.Sprintf("Failed to update default reply permission: %s", err.Error()),
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to update default reply permission (request_id: %s)", logger.GetRequestID(ctx)),
 		)
 	}
 

--- a/backend/internal/api/handlers/auth/user_preferences_test.go
+++ b/backend/internal/api/handlers/auth/user_preferences_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	autherrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/engagement"
 )
@@ -438,6 +439,42 @@ func TestSetDefaultReplyPermission_AcceptsAllValidEnumValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSetDefaultReplyPermission_ServiceTypedInvalid: PSY-792 defence-in-depth.
+// If the service-layer enum check is somehow reached (it surfaces a typed
+// CodeInvalidReplyPermission), the handler maps it to 400 with the canonical
+// message rather than string-matching. We bypass the handler's own enum guard
+// by mocking the service to reject a value the handler considers valid.
+func TestSetDefaultReplyPermission_ServiceTypedInvalid(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		SetDefaultReplyPermissionFn: func(_ uint, permission string) error {
+			return autherrors.ErrInvalidReplyPermission(permission)
+		},
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetDefaultReplyPermissionRequest{}
+	req.Body.Permission = "anyone"
+	_, err := h.SetDefaultReplyPermissionHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(t, err, 400, "permission must be one of: anyone, followers, author_only")
+}
+
+// TestSetDefaultReplyPermission_ServiceError: a non-typed service fault (e.g.
+// DB down) maps to 500, not 422 — PSY-792 corrects the prior 422-for-everything
+// fallthrough to match the engagement (PSY-761) convention.
+func TestSetDefaultReplyPermission_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		SetDefaultReplyPermissionFn: func(_ uint, _ string) error {
+			return errors.New("db down")
+		},
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetDefaultReplyPermissionRequest{}
+	req.Body.Permission = "anyone"
+	_, err := h.SetDefaultReplyPermissionHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 500)
 }
 
 // --- SetCollectionDigestHandler ---

--- a/backend/internal/api/handlers/notification/notification_filter.go
+++ b/backend/internal/api/handlers/notification/notification_filter.go
@@ -225,7 +225,12 @@ func (h *NotificationFilterHandler) CreateFilterHandler(ctx context.Context, req
 			"error", err.Error(),
 			"request_id", requestID,
 		)
-		return nil, huma.Error422UnprocessableEntity(err.Error())
+		if mapped := shared.MapNotificationFilterError(err); mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create filter (request_id: %s)", requestID),
+		)
 	}
 
 	logger.FromContext(ctx).Info("create_filter_success",
@@ -274,10 +279,10 @@ func (h *NotificationFilterHandler) UpdateFilterHandler(ctx context.Context, req
 			"error", err.Error(),
 			"request_id", requestID,
 		)
-		if err.Error() == "filter not found" {
-			return nil, huma.Error404NotFound("Filter not found")
+		if mapped := shared.MapNotificationFilterError(err); mapped != nil {
+			return nil, mapped
 		}
-		return nil, huma.Error422UnprocessableEntity(
+		return nil, huma.Error500InternalServerError(
 			fmt.Sprintf("Failed to update filter (request_id: %s)", requestID),
 		)
 	}
@@ -312,10 +317,10 @@ func (h *NotificationFilterHandler) DeleteFilterHandler(ctx context.Context, req
 			"error", err.Error(),
 			"request_id", requestID,
 		)
-		if err.Error() == "filter not found" {
-			return nil, huma.Error404NotFound("Filter not found")
+		if mapped := shared.MapNotificationFilterError(err); mapped != nil {
+			return nil, mapped
 		}
-		return nil, huma.Error422UnprocessableEntity(
+		return nil, huma.Error500InternalServerError(
 			fmt.Sprintf("Failed to delete filter (request_id: %s)", requestID),
 		)
 	}

--- a/backend/internal/api/handlers/notification/notification_filter_test.go
+++ b/backend/internal/api/handlers/notification/notification_filter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/services/contracts"
 
 	authm "psychic-homily-backend/internal/models/auth"
@@ -109,7 +110,7 @@ func TestCreateFilterHandler_Success(t *testing.T) {
 func TestCreateFilterHandler_ValidationError(t *testing.T) {
 	mock := &testhelpers.MockNotificationFilterService{
 		CreateFilterFn: func(_ uint, _ contracts.CreateFilterInput) (*notificationm.NotificationFilter, error) {
-			return nil, fmt.Errorf("at least one filter criteria is required")
+			return nil, apperrors.ErrFilterValidation("at least one filter criteria is required")
 		},
 	}
 	h := NewNotificationFilterHandler(mock, "test-secret")
@@ -120,6 +121,23 @@ func TestCreateFilterHandler_ValidationError(t *testing.T) {
 
 	_, err := h.CreateFilterHandler(ctx, req)
 	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestCreateFilterHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockNotificationFilterService{
+		CreateFilterFn: func(_ uint, _ contracts.CreateFilterInput) (*notificationm.NotificationFilter, error) {
+			return nil, apperrors.ErrFilterInternal(fmt.Errorf("db down"))
+		},
+	}
+	h := NewNotificationFilterHandler(mock, "test-secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	req := &CreateFilterRequest{}
+	req.Body.Name = "PHX punk"
+	req.Body.ArtistIDs = []int64{1}
+
+	_, err := h.CreateFilterHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 500)
 }
 
 // --- UpdateFilterHandler ---
@@ -141,7 +159,7 @@ func TestUpdateFilterHandler_InvalidID(t *testing.T) {
 func TestUpdateFilterHandler_NotFound(t *testing.T) {
 	mock := &testhelpers.MockNotificationFilterService{
 		UpdateFilterFn: func(_ uint, _ uint, _ contracts.UpdateFilterInput) (*notificationm.NotificationFilter, error) {
-			return nil, fmt.Errorf("filter not found")
+			return nil, apperrors.ErrFilterNotFound()
 		},
 	}
 	h := NewNotificationFilterHandler(mock, "test-secret")
@@ -149,6 +167,19 @@ func TestUpdateFilterHandler_NotFound(t *testing.T) {
 
 	_, err := h.UpdateFilterHandler(ctx, &UpdateFilterRequest{ID: "99"})
 	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestUpdateFilterHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockNotificationFilterService{
+		UpdateFilterFn: func(_ uint, _ uint, _ contracts.UpdateFilterInput) (*notificationm.NotificationFilter, error) {
+			return nil, apperrors.ErrFilterInternal(fmt.Errorf("db down"))
+		},
+	}
+	h := NewNotificationFilterHandler(mock, "test-secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	_, err := h.UpdateFilterHandler(ctx, &UpdateFilterRequest{ID: "42"})
+	testhelpers.AssertHumaError(t, err, 500)
 }
 
 func TestUpdateFilterHandler_Success(t *testing.T) {
@@ -217,7 +248,7 @@ func TestDeleteFilterHandler_Success(t *testing.T) {
 func TestDeleteFilterHandler_NotFound(t *testing.T) {
 	mock := &testhelpers.MockNotificationFilterService{
 		DeleteFilterFn: func(_, _ uint) error {
-			return fmt.Errorf("filter not found")
+			return apperrors.ErrFilterNotFound()
 		},
 	}
 	h := NewNotificationFilterHandler(mock, "test-secret")
@@ -225,6 +256,19 @@ func TestDeleteFilterHandler_NotFound(t *testing.T) {
 
 	_, err := h.DeleteFilterHandler(ctx, &DeleteFilterRequest{ID: "99"})
 	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestDeleteFilterHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockNotificationFilterService{
+		DeleteFilterFn: func(_, _ uint) error {
+			return apperrors.ErrFilterInternal(fmt.Errorf("db down"))
+		},
+	}
+	h := NewNotificationFilterHandler(mock, "test-secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	_, err := h.DeleteFilterHandler(ctx, &DeleteFilterRequest{ID: "42"})
+	testhelpers.AssertHumaError(t, err, 500)
 }
 
 // --- QuickCreateFilterHandler ---

--- a/backend/internal/api/handlers/shared/error_mappers.go
+++ b/backend/internal/api/handlers/shared/error_mappers.go
@@ -143,3 +143,27 @@ func MapAttendanceError(err error) error {
 	}
 	return nil
 }
+
+// MapNotificationFilterError converts a NotificationFilterError to an
+// appropriate Huma HTTP error. Returns nil if err is not a
+// *apperrors.NotificationFilterError.
+//
+// PSY-792 (follows the PSY-761 engagement template): replaces the
+// 422-for-everything behaviour of the filter CRUD handlers. Filter-not-found
+// → 404; domain-validation (no criteria, per-user cap) → 422; infrastructure
+// fault → 500. The handler still falls through to a generic 500 for any
+// unrecognised error.
+func MapNotificationFilterError(err error) error {
+	var filterErr *apperrors.NotificationFilterError
+	if errors.As(err, &filterErr) {
+		switch filterErr.Code {
+		case apperrors.CodeFilterNotFound:
+			return huma.Error404NotFound(filterErr.Message)
+		case apperrors.CodeFilterValidation:
+			return huma.Error422UnprocessableEntity(filterErr.Message)
+		case apperrors.CodeFilterInternal:
+			return huma.Error500InternalServerError(filterErr.Message)
+		}
+	}
+	return nil
+}

--- a/backend/internal/api/handlers/shared/error_mappers.go
+++ b/backend/internal/api/handlers/shared/error_mappers.go
@@ -148,11 +148,10 @@ func MapAttendanceError(err error) error {
 // appropriate Huma HTTP error. Returns nil if err is not a
 // *apperrors.NotificationFilterError.
 //
-// PSY-792 (follows the PSY-761 engagement template): replaces the
-// 422-for-everything behaviour of the filter CRUD handlers. Filter-not-found
-// → 404; domain-validation (no criteria, per-user cap) → 422; infrastructure
-// fault → 500. The handler still falls through to a generic 500 for any
-// unrecognised error.
+// Replaces the 422-for-everything behaviour of the filter CRUD handlers.
+// Filter-not-found → 404; domain-validation (no criteria, per-user cap) →
+// 422; infrastructure fault → 500. The handler still falls through to a
+// generic 500 for any unrecognised error.
 func MapNotificationFilterError(err error) error {
 	var filterErr *apperrors.NotificationFilterError
 	if errors.As(err, &filterErr) {

--- a/backend/internal/api/handlers/shared/error_mappers_test.go
+++ b/backend/internal/api/handlers/shared/error_mappers_test.go
@@ -202,3 +202,36 @@ func TestMapAttendanceError_NonAttendanceErrorReturnsNil(t *testing.T) {
 		t.Errorf("MapAttendanceError(unknown code) = %v, want nil", got)
 	}
 }
+
+func TestMapNotificationFilterError_CodeToStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    *apperrors.NotificationFilterError
+		status int
+	}{
+		{"not found", apperrors.ErrFilterNotFound(), 404},
+		{"validation", apperrors.ErrFilterValidation("at least one filter criteria is required"), 422},
+		{"internal", apperrors.ErrFilterInternal(stderrors.New("db down")), 500},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapNotificationFilterError(tc.err)
+			if got == nil {
+				t.Fatalf("MapNotificationFilterError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapNotificationFilterError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapNotificationFilterError_NonFilterErrorReturnsNil(t *testing.T) {
+	if got := MapNotificationFilterError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapNotificationFilterError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.NotificationFilterError{Code: "FILTER_NEW_CODE", Message: "x"}
+	if got := MapNotificationFilterError(unknown); got != nil {
+		t.Errorf("MapNotificationFilterError(unknown code) = %v, want nil", got)
+	}
+}

--- a/backend/internal/errors/auth.go
+++ b/backend/internal/errors/auth.go
@@ -31,6 +31,13 @@ const (
 	CodeAccountLocked = "ACCOUNT_LOCKED"
 	// CodeNoPasswordSet indicates the user has no password (OAuth-only account)
 	CodeNoPasswordSet = "NO_PASSWORD_SET"
+	// CodeTermsAcceptanceRequired indicates an OAuth signup arrived without the
+	// required Terms of Service / Privacy Policy consent.
+	CodeTermsAcceptanceRequired = "TERMS_ACCEPTANCE_REQUIRED"
+	// CodeInvalidReplyPermission indicates an unrecognized default-reply-permission value.
+	CodeInvalidReplyPermission = "INVALID_REPLY_PERMISSION"
+	// CodeUsernameTaken indicates a username unique-constraint violation on profile update.
+	CodeUsernameTaken = "USERNAME_TAKEN"
 )
 
 // AuthError represents an authentication-related error with additional context.
@@ -140,6 +147,23 @@ func ErrAccountLockedWithMinutes(minutes int) *AuthError {
 // ErrNoPasswordSet creates an error for OAuth-only accounts that don't have a password.
 func ErrNoPasswordSet() *AuthError {
 	return NewAuthError(CodeNoPasswordSet, "Cannot change password for OAuth-only accounts", nil)
+}
+
+// ErrTermsAcceptanceRequired creates an OAuth-signup terms-not-accepted error.
+// The detail distinguishes "no consent / not accepted" from "version missing"
+// so logs keep the cause without the handler string-matching the message.
+func ErrTermsAcceptanceRequired(detail string) *AuthError {
+	return NewAuthError(CodeTermsAcceptanceRequired, "Please accept the Terms of Service and Privacy Policy before creating an account.", fmt.Errorf("%s", detail))
+}
+
+// ErrInvalidReplyPermission creates an invalid default-reply-permission error.
+func ErrInvalidReplyPermission(permission string) *AuthError {
+	return NewAuthError(CodeInvalidReplyPermission, "Invalid reply permission", fmt.Errorf("invalid reply_permission: %s", permission))
+}
+
+// ErrUsernameTaken creates a username unique-constraint-violation error.
+func ErrUsernameTaken(internal error) *AuthError {
+	return NewAuthError(CodeUsernameTaken, "Username is already taken", internal)
 }
 
 // ToExternalCode converts internal error codes to external (safe) codes.

--- a/backend/internal/errors/notification_filter.go
+++ b/backend/internal/errors/notification_filter.go
@@ -9,9 +9,8 @@ import (
 // Filter CRUD has three genuine failure shapes: the target filter does not
 // exist or is owned by another user (not found), a request that parses but
 // violates a domain rule — no criteria set, per-user filter cap reached
-// (validation), and a database/infrastructure fault (internal). Matching the
-// PSY-761 engagement convention so the handlers can return 404 / 422 / 500
-// instead of 422-for-everything.
+// (validation), and a database/infrastructure fault (internal). These let the
+// handlers return 404 / 422 / 500 instead of 422-for-everything.
 const (
 	// CodeFilterNotFound indicates the filter does not exist for this user.
 	CodeFilterNotFound = "FILTER_NOT_FOUND"

--- a/backend/internal/errors/notification_filter.go
+++ b/backend/internal/errors/notification_filter.go
@@ -1,0 +1,69 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Notification filter error codes.
+//
+// Filter CRUD has three genuine failure shapes: the target filter does not
+// exist or is owned by another user (not found), a request that parses but
+// violates a domain rule — no criteria set, per-user filter cap reached
+// (validation), and a database/infrastructure fault (internal). Matching the
+// PSY-761 engagement convention so the handlers can return 404 / 422 / 500
+// instead of 422-for-everything.
+const (
+	// CodeFilterNotFound indicates the filter does not exist for this user.
+	CodeFilterNotFound = "FILTER_NOT_FOUND"
+	// CodeFilterValidation indicates a well-formed request rejected by a
+	// domain rule (no criteria set, per-user filter limit reached).
+	CodeFilterValidation = "FILTER_VALIDATION"
+	// CodeFilterInternal indicates a database or infrastructure failure.
+	CodeFilterInternal = "FILTER_INTERNAL"
+)
+
+// NotificationFilterError represents a notification-filter error with context.
+type NotificationFilterError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *NotificationFilterError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *NotificationFilterError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrFilterNotFound creates a filter-not-found error.
+func ErrFilterNotFound() *NotificationFilterError {
+	return &NotificationFilterError{
+		Code:    CodeFilterNotFound,
+		Message: "filter not found",
+	}
+}
+
+// ErrFilterValidation creates a domain-validation error with a caller-supplied
+// message (e.g. "at least one filter criteria is required").
+func ErrFilterValidation(message string) *NotificationFilterError {
+	return &NotificationFilterError{
+		Code:    CodeFilterValidation,
+		Message: message,
+	}
+}
+
+// ErrFilterInternal wraps a database or infrastructure failure.
+func ErrFilterInternal(internal error) *NotificationFilterError {
+	return &NotificationFilterError{
+		Code:     CodeFilterInternal,
+		Message:  "failed to process notification filter",
+		Internal: internal,
+	}
+}

--- a/backend/internal/services/notification/filter_service.go
+++ b/backend/internal/services/notification/filter_service.go
@@ -15,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	notificationm "psychic-homily-backend/internal/models/notification"
 	"psychic-homily-backend/internal/services/contracts"
@@ -56,21 +57,21 @@ const maxFilterEmailsPerDay = 10
 // CreateFilter creates a new notification filter for a user.
 func (s *NotificationFilterService) CreateFilter(userID uint, input contracts.CreateFilterInput) (*notificationm.NotificationFilter, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrFilterInternal(fmt.Errorf("database not initialized"))
 	}
 
 	// Validate at least one criteria is set
 	if !hasAnyCriteria(input) {
-		return nil, fmt.Errorf("at least one filter criteria is required")
+		return nil, apperrors.ErrFilterValidation("at least one filter criteria is required")
 	}
 
 	// Check filter count limit
 	var count int64
 	if err := s.db.Model(&notificationm.NotificationFilter{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
-		return nil, fmt.Errorf("failed to count filters: %w", err)
+		return nil, apperrors.ErrFilterInternal(fmt.Errorf("failed to count filters: %w", err))
 	}
 	if count >= maxFiltersPerUser {
-		return nil, fmt.Errorf("maximum of %d filters per user", maxFiltersPerUser)
+		return nil, apperrors.ErrFilterValidation(fmt.Sprintf("maximum of %d filters per user", maxFiltersPerUser))
 	}
 
 	now := time.Now().UTC()
@@ -96,7 +97,7 @@ func (s *NotificationFilterService) CreateFilter(userID uint, input contracts.Cr
 	}
 
 	if err := s.db.Create(&filter).Error; err != nil {
-		return nil, fmt.Errorf("failed to create filter: %w", err)
+		return nil, apperrors.ErrFilterInternal(fmt.Errorf("failed to create filter: %w", err))
 	}
 
 	return &filter, nil
@@ -111,9 +112,9 @@ func (s *NotificationFilterService) UpdateFilter(userID uint, filterID uint, inp
 	var filter notificationm.NotificationFilter
 	if err := s.db.Where("id = ? AND user_id = ?", filterID, userID).First(&filter).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("filter not found")
+			return nil, apperrors.ErrFilterNotFound()
 		}
-		return nil, fmt.Errorf("failed to get filter: %w", err)
+		return nil, apperrors.ErrFilterInternal(fmt.Errorf("failed to get filter: %w", err))
 	}
 
 	updates := map[string]interface{}{
@@ -155,12 +156,12 @@ func (s *NotificationFilterService) UpdateFilter(userID uint, filterID uint, inp
 	}
 
 	if err := s.db.Model(&filter).Updates(updates).Error; err != nil {
-		return nil, fmt.Errorf("failed to update filter: %w", err)
+		return nil, apperrors.ErrFilterInternal(fmt.Errorf("failed to update filter: %w", err))
 	}
 
 	// Reload
 	if err := s.db.First(&filter, filterID).Error; err != nil {
-		return nil, fmt.Errorf("failed to reload filter: %w", err)
+		return nil, apperrors.ErrFilterInternal(fmt.Errorf("failed to reload filter: %w", err))
 	}
 
 	return &filter, nil
@@ -169,15 +170,15 @@ func (s *NotificationFilterService) UpdateFilter(userID uint, filterID uint, inp
 // DeleteFilter deletes a filter owned by the user.
 func (s *NotificationFilterService) DeleteFilter(userID uint, filterID uint) error {
 	if s.db == nil {
-		return fmt.Errorf("database not initialized")
+		return apperrors.ErrFilterInternal(fmt.Errorf("database not initialized"))
 	}
 
 	result := s.db.Where("id = ? AND user_id = ?", filterID, userID).Delete(&notificationm.NotificationFilter{})
 	if result.Error != nil {
-		return fmt.Errorf("failed to delete filter: %w", result.Error)
+		return apperrors.ErrFilterInternal(fmt.Errorf("failed to delete filter: %w", result.Error))
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("filter not found")
+		return apperrors.ErrFilterNotFound()
 	}
 	return nil
 }

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -3,6 +3,7 @@ package user
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/markbates/goth"
@@ -461,13 +462,13 @@ func (s *UserService) createNewUserOauthWithConsent(
 
 func validateOAuthSignupConsent(consent *contracts.OAuthSignupConsent) error {
 	if consent == nil {
-		return fmt.Errorf("terms acceptance required for OAuth signup")
+		return apperrors.ErrTermsAcceptanceRequired("terms acceptance required for OAuth signup")
 	}
 	if !consent.TermsAccepted {
-		return fmt.Errorf("terms acceptance required for OAuth signup")
+		return apperrors.ErrTermsAcceptanceRequired("terms acceptance required for OAuth signup")
 	}
 	if consent.TermsVersion == "" {
-		return fmt.Errorf("terms version is required for OAuth signup")
+		return apperrors.ErrTermsAcceptanceRequired("terms version is required for OAuth signup")
 	}
 	return nil
 }
@@ -607,10 +608,29 @@ func (s *UserService) UpdateUser(userID uint, updates map[string]any) (*authm.Us
 		Updates(updates)
 
 	if result.Error != nil {
+		// A unique-constraint violation on profile update means the chosen
+		// username is taken. Translate the driver error into a typed error
+		// here so handlers discriminate on a code rather than string-matching
+		// the Postgres message (the only volatile site for this check).
+		if isUniqueViolation(result.Error) {
+			return nil, apperrors.ErrUsernameTaken(result.Error)
+		}
 		return nil, fmt.Errorf("failed to update user: %w", result.Error)
 	}
 
 	return s.GetUserByID(userID)
+}
+
+// isUniqueViolation reports whether err is a Postgres unique-constraint
+// violation by matching the driver message text. This mirrors the boundary
+// detection used elsewhere in the codebase (e.g. admin/pending_edit.go) and
+// is isolated here so the volatile driver-string match has a single home.
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "duplicate key") || strings.Contains(msg, "unique")
 }
 
 func (s *UserService) HashPassword(password string) (string, error) {
@@ -1115,7 +1135,7 @@ func (s *UserService) SetDefaultReplyPermission(userID uint, permission string) 
 		return fmt.Errorf("database not initialized")
 	}
 	if !engagementm.IsValidReplyPermission(permission) {
-		return fmt.Errorf("invalid reply_permission: %s", permission)
+		return apperrors.ErrInvalidReplyPermission(permission)
 	}
 
 	result := s.db.Model(&authm.UserPreferences{}).

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -1692,6 +1692,34 @@ func TestUserService_SetDefaultReplyPermission_InvalidValue(t *testing.T) {
 	err := s.SetDefaultReplyPermission(1, "banana")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid reply_permission")
+	// PSY-792: the invalid value surfaces as a typed AuthError so the handler
+	// discriminates on the code rather than the message string.
+	var authErr *apperrors.AuthError
+	if assert.ErrorAs(t, err, &authErr) {
+		assert.Equal(t, apperrors.CodeInvalidReplyPermission, authErr.Code)
+	}
+}
+
+// isUniqueViolation backs UpdateUser's translation of a Postgres
+// unique-constraint violation into a typed CodeUsernameTaken error. PSY-792.
+func TestIsUniqueViolation(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"duplicate key", fmt.Errorf("ERROR: duplicate key value violates unique constraint \"users_username_key\""), true},
+		{"unique substring", fmt.Errorf("violates unique constraint"), true},
+		{"unrelated", fmt.Errorf("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUniqueViolation(tc.err); got != tc.want {
+				t.Errorf("isUniqueViolation(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
 }
 
 func (suite *UserServiceIntegrationTestSuite) TestSetDefaultReplyPermission_CreatesRowWhenMissing() {


### PR DESCRIPTION
## Summary
- Replaced `strings.Contains(err.Error(), ...)` / `err.Error() == "..."` status discrimination in the auth + notification handlers with typed errors, following the PSY-761 engagement template.
- **Notification filter**: new `apperrors.NotificationFilterError` (`FILTER_NOT_FOUND` / `FILTER_VALIDATION` / `FILTER_INTERNAL`) + `shared.MapNotificationFilterError`. The filter CRUD service emits them; Create/Update/Delete handlers now map not-found → 404, validation → 422, infra fault → 500 (previously 422-for-everything).
- **Auth**: new `apperrors.AuthError` codes (`TERMS_ACCEPTANCE_REQUIRED`, `INVALID_REPLY_PERMISSION`, `USERNAME_TAKEN`) + constructors. The user service emits them; the OAuth-callback, profile-update, and default-reply-permission handlers discriminate on `errors.As` + code (the auth package's existing convention — those surfaces drive a redirect message / 200-envelope ErrorCode / 400-or-500, not a single Huma status, so they don't use a Huma mapper). Username unique-constraint detection moved into the user service (`UpdateUser` → `isUniqueViolation`), isolating the volatile driver-string match to the DB boundary.

## Test plan
- [x] cd backend && go build ./... — passed
- [x] cd backend && go test ./... — passed (29 packages ok, incl. DB-backed integration tests via testcontainers; 0 FAIL)

## Manual repro
mode=none. Mapper + handler status-assertion tests are the repro:

| Surface | Test | Condition | Status |
| --- | --- | --- | --- |
| filter mapper | `TestMapNotificationFilterError_CodeToStatus` | not found / validation / internal | 404 / 422 / 500 |
| filter mapper | `TestMapNotificationFilterError_NonFilterErrorReturnsNil` | plain + unknown code | nil (fall through) |
| Create filter | `TestCreateFilterHandler_ValidationError` / `_ServiceError` | typed validation / typed internal | 422 / 500 |
| Update filter | `TestUpdateFilterHandler_NotFound` / `_ServiceError` | typed not-found / typed internal | 404 / 500 |
| Delete filter | `TestDeleteFilterHandler_NotFound` / `_ServiceError` | typed not-found / typed internal | 404 / 500 |
| reply-permission | `TestSetDefaultReplyPermission_ServiceTypedInvalid` / `_ServiceError` | typed invalid / non-typed fault | 400 / 500 |
| profile update | `TestUpdateProfileHandler_DuplicateUsername` | typed `ErrUsernameTaken` | 200 envelope, `VALIDATION_FAILED`, "Username is already taken" |
| OAuth terms | `TestCallback_TermsNotAccepted_RedirectsWithTermsMessage` (DB integration) | nil consent → typed terms error through full wrap chain | 307 redirect w/ ToS message |
| user service | `TestUserService_SetDefaultReplyPermission_InvalidValue` (typed code), `TestIsUniqueViolation` | — | — |

## Simplify
edited 2 files — stripped the ticket refs from the two new production doc comments (error mapper + notification-filter error codes), keeping the semantic WHY. No behaviour change. Committed as `PSY-792: simplify pass`.

Closes PSY-792