### PR TITLE
PSY-791: typed errors + mappers for catalog handlers

### DIFF
--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -401,8 +401,8 @@ func (h *ArtistHandler) AdminCreateArtistHandler(ctx context.Context, req *Admin
 
 	artist, err := h.artistService.CreateArtist(createReq)
 	if err != nil {
-		if strings.Contains(err.Error(), "already exists") {
-			return nil, huma.Error409Conflict(err.Error())
+		if mapped := shared.MapArtistError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("admin_create_artist_failed",
 			"error", err.Error(),
@@ -713,14 +713,8 @@ func (h *ArtistHandler) DeleteArtistHandler(ctx context.Context, req *DeleteArti
 
 	err = h.artistService.DeleteArtist(uint(artistID))
 	if err != nil {
-		var artistErr *apperrors.ArtistError
-		if errors.As(err, &artistErr) {
-			switch artistErr.Code {
-			case apperrors.CodeArtistNotFound:
-				return nil, huma.Error404NotFound("Artist not found")
-			case apperrors.CodeArtistHasShows:
-				return nil, huma.Error409Conflict(artistErr.Message)
-			}
+		if mapped := shared.MapArtistError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("delete_artist_failed",
 			"artist_id", artistID,
@@ -982,12 +976,8 @@ func (h *ArtistHandler) AddArtistAliasHandler(ctx context.Context, req *AddArtis
 
 	alias, err := h.artistService.AddArtistAlias(uint(artistID), req.Body.Alias)
 	if err != nil {
-		var artistErr *apperrors.ArtistError
-		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
-			return nil, huma.Error404NotFound("Artist not found")
-		}
-		if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "conflicts with") {
-			return nil, huma.Error409Conflict(err.Error())
+		if mapped := shared.MapArtistError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("add_artist_alias_failed",
 			"artist_id", artistID,
@@ -1028,8 +1018,8 @@ func (h *ArtistHandler) DeleteArtistAliasHandler(ctx context.Context, req *Delet
 
 	err = h.artistService.RemoveArtistAlias(uint(aliasID))
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Alias not found")
+		if mapped := shared.MapArtistError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("delete_artist_alias_failed",
 			"alias_id", aliasID,
@@ -1081,12 +1071,8 @@ func (h *ArtistHandler) MergeArtistsHandler(ctx context.Context, req *MergeArtis
 
 	result, err := h.artistService.MergeArtists(req.Body.CanonicalArtistID, req.Body.MergeFromArtistID)
 	if err != nil {
-		var artistErr *apperrors.ArtistError
-		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
-			return nil, huma.Error404NotFound("Artist not found")
-		}
-		if strings.Contains(err.Error(), "cannot merge an artist with itself") {
-			return nil, huma.Error422UnprocessableEntity("Cannot merge an artist with itself")
+		if mapped := shared.MapArtistError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("merge_artists_failed",
 			"canonical_id", req.Body.CanonicalArtistID,

--- a/backend/internal/api/handlers/catalog/artist_relationship.go
+++ b/backend/internal/api/handlers/catalog/artist_relationship.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
@@ -69,8 +70,8 @@ func (h *ArtistRelationshipHandler) GetArtistGraphHandler(ctx context.Context, r
 
 	graph, err := h.relService.GetArtistGraph(uint(id), types, userID)
 	if err != nil {
-		if err.Error() == "artist not found" || (len(err.Error()) > 16 && err.Error()[:16] == "artist not found") {
-			return nil, huma.Error404NotFound("Artist not found")
+		if mapped := shared.MapArtistError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to get artist graph")
 	}
@@ -105,8 +106,8 @@ func (h *ArtistRelationshipHandler) GetArtistBillCompositionHandler(ctx context.
 
 	bc, err := h.relService.GetArtistBillComposition(uint(id), req.Months)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "artist not found") {
-			return nil, huma.Error404NotFound("Artist not found")
+		if mapped := shared.MapArtistError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to get bill composition")
 	}

--- a/backend/internal/api/handlers/catalog/artist_relationship_test.go
+++ b/backend/internal/api/handlers/catalog/artist_relationship_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -295,8 +296,8 @@ func TestGetArtistBillComposition_NotFound(t *testing.T) {
 	h := NewArtistRelationshipHandler(
 		&testhelpers.MockArtistRelationshipService{
 			GetArtistBillCompositionFn: func(_ uint, _ int) (*contracts.ArtistBillComposition, error) {
-				// Handler maps an "artist not found"-prefixed error to 404.
-				return nil, fmt.Errorf("artist not found: 99")
+				// Handler maps the typed ArtistError (not-found) to 404.
+				return nil, apperrors.ErrArtistNotFound(99)
 			},
 		},
 		nil,

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -971,7 +971,7 @@ func TestAddArtistAlias_Success(t *testing.T) {
 func TestAddArtistAlias_Conflict(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
 		AddArtistAliasFn: func(artistID uint, alias string) (*contracts.ArtistAliasResponse, error) {
-			return nil, fmt.Errorf("alias 'Test' already exists")
+			return nil, apperrors.ErrArtistAliasExists("alias 'Test' already exists")
 		},
 	}
 	h := NewArtistHandler(mock, nil, nil, nil)
@@ -1011,7 +1011,7 @@ func TestDeleteArtistAlias_Success(t *testing.T) {
 func TestDeleteArtistAlias_NotFound(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
 		RemoveArtistAliasFn: func(aliasID uint) error {
-			return fmt.Errorf("alias not found")
+			return apperrors.ErrArtistAliasNotFound()
 		},
 	}
 	h := NewArtistHandler(mock, nil, nil, nil)
@@ -1035,7 +1035,7 @@ func TestMergeArtists_MissingIDs(t *testing.T) {
 func TestMergeArtists_SelfMerge(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
 		MergeArtistsFn: func(canonicalID, mergeFromID uint) (*contracts.MergeArtistResult, error) {
-			return nil, fmt.Errorf("cannot merge an artist with itself")
+			return nil, apperrors.ErrArtistMergeSelf()
 		},
 	}
 	h := NewArtistHandler(mock, nil, nil, nil)
@@ -1186,7 +1186,7 @@ func TestAdminCreateArtist_WithSocials(t *testing.T) {
 func TestAdminCreateArtist_Conflict(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
 		CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
-			return nil, fmt.Errorf("artist with name 'Existing' already exists")
+			return nil, apperrors.ErrArtistExists("Existing")
 		},
 	}
 	h := NewArtistHandler(mock, nil, nil, nil)

--- a/backend/internal/api/handlers/catalog/festival.go
+++ b/backend/internal/api/handlers/catalog/festival.go
@@ -529,12 +529,8 @@ func (h *FestivalHandler) AddFestivalArtistHandler(ctx context.Context, req *Add
 
 	artist, err := h.festivalService.AddFestivalArtist(uint(festivalID), serviceReq)
 	if err != nil {
-		var festivalErr *apperrors.FestivalError
-		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
-			return nil, huma.Error404NotFound("Festival not found")
-		}
-		if err.Error() == "artist not found" {
-			return nil, huma.Error404NotFound("Artist not found")
+		if mapped := shared.MapFestivalError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("add_festival_artist_failed",
 			"festival_id", festivalID,
@@ -602,8 +598,8 @@ func (h *FestivalHandler) UpdateFestivalArtistHandler(ctx context.Context, req *
 
 	artist, err := h.festivalService.UpdateFestivalArtist(uint(festivalID), uint(artistID), serviceReq)
 	if err != nil {
-		if err.Error() == "artist not found in festival lineup" {
-			return nil, huma.Error404NotFound("Artist not found in festival lineup")
+		if mapped := shared.MapFestivalError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("update_festival_artist_failed",
 			"festival_id", festivalID,
@@ -650,8 +646,8 @@ func (h *FestivalHandler) RemoveFestivalArtistHandler(ctx context.Context, req *
 
 	err = h.festivalService.RemoveFestivalArtist(uint(festivalID), uint(artistID))
 	if err != nil {
-		if err.Error() == "artist not found in festival lineup" {
-			return nil, huma.Error404NotFound("Artist not found in festival lineup")
+		if mapped := shared.MapFestivalError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("remove_festival_artist_failed",
 			"festival_id", festivalID,
@@ -750,12 +746,8 @@ func (h *FestivalHandler) AddFestivalVenueHandler(ctx context.Context, req *AddF
 
 	venue, err := h.festivalService.AddFestivalVenue(uint(festivalID), serviceReq)
 	if err != nil {
-		var festivalErr *apperrors.FestivalError
-		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
-			return nil, huma.Error404NotFound("Festival not found")
-		}
-		if err.Error() == "venue not found" {
-			return nil, huma.Error404NotFound("Venue not found")
+		if mapped := shared.MapFestivalError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("add_festival_venue_failed",
 			"festival_id", festivalID,
@@ -801,8 +793,8 @@ func (h *FestivalHandler) RemoveFestivalVenueHandler(ctx context.Context, req *R
 
 	err = h.festivalService.RemoveFestivalVenue(uint(festivalID), uint(venueID))
 	if err != nil {
-		if err.Error() == "venue not found in festival" {
-			return nil, huma.Error404NotFound("Venue not found in festival")
+		if mapped := shared.MapFestivalError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("remove_festival_venue_failed",
 			"festival_id", festivalID,

--- a/backend/internal/api/handlers/catalog/festival_intelligence.go
+++ b/backend/internal/api/handlers/catalog/festival_intelligence.go
@@ -63,8 +63,8 @@ func (h *FestivalIntelligenceHandler) GetSimilarFestivalsHandler(ctx context.Con
 
 	similar, err := h.intelligenceService.GetSimilarFestivals(festivalID, limit)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Festival not found")
+		if mapped := shared.MapFestivalIntelligenceError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to compute similar festivals", err)
 	}
@@ -96,8 +96,8 @@ func (h *FestivalIntelligenceHandler) GetFestivalOverlapHandler(ctx context.Cont
 
 	overlap, err := h.intelligenceService.GetFestivalOverlap(festivalAID, festivalBID)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Festival not found")
+		if mapped := shared.MapFestivalIntelligenceError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to compute festival overlap", err)
 	}
@@ -121,8 +121,8 @@ func (h *FestivalIntelligenceHandler) GetFestivalBreakoutsHandler(ctx context.Co
 
 	breakouts, err := h.intelligenceService.GetFestivalBreakouts(festivalID)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Festival not found")
+		if mapped := shared.MapFestivalIntelligenceError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to compute breakouts", err)
 	}
@@ -146,8 +146,8 @@ func (h *FestivalIntelligenceHandler) GetArtistFestivalTrajectoryHandler(ctx con
 
 	trajectory, err := h.intelligenceService.GetArtistFestivalTrajectory(artistID)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Artist not found")
+		if mapped := shared.MapFestivalIntelligenceError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to compute trajectory", err)
 	}
@@ -190,11 +190,8 @@ func (h *FestivalIntelligenceHandler) GetSeriesComparisonHandler(ctx context.Con
 
 	comparison, err := h.intelligenceService.GetSeriesComparison(req.SeriesSlug, years)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "no festivals found") {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		if strings.Contains(err.Error(), "at least 2 years") {
-			return nil, huma.Error422UnprocessableEntity(err.Error())
+		if mapped := shared.MapFestivalIntelligenceError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to compute series comparison", err)
 	}

--- a/backend/internal/api/handlers/catalog/scene.go
+++ b/backend/internal/api/handlers/catalog/scene.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -78,8 +79,8 @@ func (h *SceneHandler) GetSceneDetailHandler(ctx context.Context, req *GetSceneD
 
 	detail, err := h.sceneService.GetSceneDetail(city, state)
 	if err != nil {
-		if isSceneNotFoundErr(err) {
-			return nil, huma.Error404NotFound("Scene not found")
+		if mapped := shared.MapSceneError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to get scene detail", err)
 	}
@@ -125,8 +126,8 @@ func (h *SceneHandler) GetSceneActiveArtistsHandler(ctx context.Context, req *Ge
 
 	artists, total, err := h.sceneService.GetActiveArtists(city, state, period, limit, req.Offset)
 	if err != nil {
-		if isSceneNotFoundErr(err) {
-			return nil, huma.Error404NotFound("Scene not found")
+		if mapped := shared.MapSceneError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to get active artists", err)
 	}
@@ -215,8 +216,8 @@ func (h *SceneHandler) GetSceneGraphHandler(ctx context.Context, req *GetSceneGr
 
 	graph, err := h.sceneService.GetSceneGraph(city, state, parseTypesQueryParam(req.Types))
 	if err != nil {
-		if isSceneNotFoundErr(err) {
-			return nil, huma.Error404NotFound("Scene not found")
+		if mapped := shared.MapSceneError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError("Failed to get scene graph", err)
 	}
@@ -239,13 +240,4 @@ func parseTypesQueryParam(raw string) []string {
 		}
 	}
 	return out
-}
-
-// isSceneNotFoundErr checks if an error indicates a scene was not found.
-func isSceneNotFoundErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return len(msg) >= 15 && msg[:15] == "scene not found"
 }

--- a/backend/internal/api/handlers/catalog/scene_test.go
+++ b/backend/internal/api/handlers/catalog/scene_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -122,7 +123,7 @@ func TestGetSceneDetail_SceneNotFound(t *testing.T) {
 			return "Tiny", "XX", nil
 		},
 		GetSceneDetailFn: func(city, state string) (*contracts.SceneDetailResponse, error) {
-			return nil, fmt.Errorf("scene not found: %s, %s", city, state)
+			return nil, apperrors.ErrSceneNotFound(fmt.Sprintf("scene not found: %s, %s", city, state))
 		},
 	}
 	h := NewSceneHandler(mock)
@@ -196,7 +197,7 @@ func TestGetSceneActiveArtists_SceneNotFound(t *testing.T) {
 			return "Tiny", "XX", nil
 		},
 		GetActiveArtistsFn: func(city, state string, periodDays, limit, offset int) ([]*contracts.SceneArtistResponse, int64, error) {
-			return nil, 0, fmt.Errorf("scene not found: %s, %s", city, state)
+			return nil, 0, apperrors.ErrSceneNotFound(fmt.Sprintf("scene not found: %s, %s", city, state))
 		},
 	}
 	h := NewSceneHandler(mock)
@@ -313,7 +314,7 @@ func TestGetSceneGraph_SceneNotFound(t *testing.T) {
 			return "Tiny", "XX", nil
 		},
 		GetSceneGraphFn: func(city, state string, _ []string) (*contracts.SceneGraphResponse, error) {
-			return nil, fmt.Errorf("scene not found: %s, %s", city, state)
+			return nil, apperrors.ErrSceneNotFound(fmt.Sprintf("scene not found: %s, %s", city, state))
 		},
 	}
 	h := NewSceneHandler(mock)
@@ -349,25 +350,6 @@ func TestParseTypesQueryParam(t *testing.T) {
 	got := parseTypesQueryParam(" similar , shared_bills ")
 	if len(got) != 2 || got[0] != "similar" || got[1] != "shared_bills" {
 		t.Errorf("parseTypesQueryParam = %v, want [similar shared_bills]", got)
-	}
-}
-
-// ============================================================================
-// isSceneNotFoundErr Tests
-// ============================================================================
-
-func TestIsSceneNotFoundErr(t *testing.T) {
-	if !isSceneNotFoundErr(fmt.Errorf("scene not found: Phoenix, AZ")) {
-		t.Error("expected true for scene not found error")
-	}
-	if !isSceneNotFoundErr(fmt.Errorf("scene not found for slug: phoenix-az")) {
-		t.Error("expected true for scene not found for slug")
-	}
-	if isSceneNotFoundErr(fmt.Errorf("database error")) {
-		t.Error("expected false for non-scene error")
-	}
-	if isSceneNotFoundErr(nil) {
-		t.Error("expected false for nil error")
 	}
 }
 

--- a/backend/internal/api/handlers/shared/error_mappers.go
+++ b/backend/internal/api/handlers/shared/error_mappers.go
@@ -171,19 +171,17 @@ func MapNotificationFilterError(err error) error {
 // Returns nil if err is not a *apperrors.ArtistError, leaving the caller free
 // to fall through to a generic 500.
 //
-// PSY-791: replaces the strings.Contains(err.Error(), ...) discrimination in
-// the artist catalog handlers. Not-found (artist or alias) → 404; name/alias
-// collision → 409 conflict; merge-into-self → 422 (semantic validation).
-// HasShows preserves the artist handler's existing 409 (conflict on delete).
+// Not-found (artist or alias) → 404; name/alias collision and delete-blocked-
+// by-shows → 409 conflict; merge-into-self → 422 (semantic validation).
+// HasShows is 409 here — intentionally distinct from venue HasShows (422) —
+// to preserve each handler's pre-existing status contract.
 func MapArtistError(err error) error {
 	var artistErr *apperrors.ArtistError
 	if errors.As(err, &artistErr) {
 		switch artistErr.Code {
 		case apperrors.CodeArtistNotFound, apperrors.CodeArtistAliasNotFound:
 			return huma.Error404NotFound(artistErr.Message)
-		case apperrors.CodeArtistExists, apperrors.CodeArtistAliasExists:
-			return huma.Error409Conflict(artistErr.Message)
-		case apperrors.CodeArtistHasShows:
+		case apperrors.CodeArtistExists, apperrors.CodeArtistAliasExists, apperrors.CodeArtistHasShows:
 			return huma.Error409Conflict(artistErr.Message)
 		case apperrors.CodeArtistMergeSelf:
 			return huma.Error422UnprocessableEntity(artistErr.Message)
@@ -195,10 +193,8 @@ func MapArtistError(err error) error {
 // MapVenueError converts a VenueError to an appropriate Huma HTTP error.
 // Returns nil if err is not a *apperrors.VenueError.
 //
-// PSY-791: centralises the venue handler's inline errors.As discrimination.
-// Not-found → 404; HasShows → 422 (preserves the venue handler's existing
-// "cannot delete, associated with shows" status — note this intentionally
-// differs from artist HasShows, which is 409).
+// Not-found → 404; HasShows → 422 (the "cannot delete, associated with shows"
+// status — intentionally distinct from artist HasShows, which is 409).
 func MapVenueError(err error) error {
 	var venueErr *apperrors.VenueError
 	if errors.As(err, &venueErr) {
@@ -215,9 +211,8 @@ func MapVenueError(err error) error {
 // MapFestivalError converts a FestivalError to an appropriate Huma HTTP error.
 // Returns nil if err is not a *apperrors.FestivalError.
 //
-// PSY-791: replaces the err.Error() == "..." discrimination in the festival
-// catalog handlers. Festival/artist/venue not-found (and not-in-lineup /
-// not-in-festival) all map to 404; an already-exists festival → 409.
+// Festival/artist/venue not-found (and not-in-lineup / not-in-festival) all
+// map to 404; an already-exists festival → 409.
 func MapFestivalError(err error) error {
 	var festivalErr *apperrors.FestivalError
 	if errors.As(err, &festivalErr) {
@@ -239,11 +234,9 @@ func MapFestivalError(err error) error {
 // appropriate Huma HTTP error. Returns nil if err is not a
 // *apperrors.FestivalIntelligenceError.
 //
-// PSY-791: replaces the strings.Contains(err.Error(), ...) discrimination in
-// festival_intelligence.go. Referenced-entity / no-festivals-for-series →
-// 404; too-few-years → 422 (semantic validation). The not-found and
-// no-festivals messages are preserved so the series-comparison handler's
-// err.Error()-as-message behaviour is unchanged.
+// Referenced-entity / no-festivals-for-series → 404; too-few-years → 422
+// (semantic validation). Each typed error carries its own message so the
+// series-comparison handler's caller-supplied copy is surfaced verbatim.
 func MapFestivalIntelligenceError(err error) error {
 	var intelErr *apperrors.FestivalIntelligenceError
 	if errors.As(err, &intelErr) {
@@ -260,7 +253,6 @@ func MapFestivalIntelligenceError(err error) error {
 // MapSceneError converts a SceneError to an appropriate Huma HTTP error.
 // Returns nil if err is not a *apperrors.SceneError.
 //
-// PSY-791: replaces the isSceneNotFoundErr string-prefix helper in scene.go.
 // Scene-not-found → 404; database faults fall through to the generic 500.
 func MapSceneError(err error) error {
 	var sceneErr *apperrors.SceneError

--- a/backend/internal/api/handlers/shared/error_mappers.go
+++ b/backend/internal/api/handlers/shared/error_mappers.go
@@ -166,3 +166,109 @@ func MapNotificationFilterError(err error) error {
 	}
 	return nil
 }
+
+// MapArtistError converts an ArtistError to an appropriate Huma HTTP error.
+// Returns nil if err is not a *apperrors.ArtistError, leaving the caller free
+// to fall through to a generic 500.
+//
+// PSY-791: replaces the strings.Contains(err.Error(), ...) discrimination in
+// the artist catalog handlers. Not-found (artist or alias) → 404; name/alias
+// collision → 409 conflict; merge-into-self → 422 (semantic validation).
+// HasShows preserves the artist handler's existing 409 (conflict on delete).
+func MapArtistError(err error) error {
+	var artistErr *apperrors.ArtistError
+	if errors.As(err, &artistErr) {
+		switch artistErr.Code {
+		case apperrors.CodeArtistNotFound, apperrors.CodeArtistAliasNotFound:
+			return huma.Error404NotFound(artistErr.Message)
+		case apperrors.CodeArtistExists, apperrors.CodeArtistAliasExists:
+			return huma.Error409Conflict(artistErr.Message)
+		case apperrors.CodeArtistHasShows:
+			return huma.Error409Conflict(artistErr.Message)
+		case apperrors.CodeArtistMergeSelf:
+			return huma.Error422UnprocessableEntity(artistErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapVenueError converts a VenueError to an appropriate Huma HTTP error.
+// Returns nil if err is not a *apperrors.VenueError.
+//
+// PSY-791: centralises the venue handler's inline errors.As discrimination.
+// Not-found → 404; HasShows → 422 (preserves the venue handler's existing
+// "cannot delete, associated with shows" status — note this intentionally
+// differs from artist HasShows, which is 409).
+func MapVenueError(err error) error {
+	var venueErr *apperrors.VenueError
+	if errors.As(err, &venueErr) {
+		switch venueErr.Code {
+		case apperrors.CodeVenueNotFound:
+			return huma.Error404NotFound(venueErr.Message)
+		case apperrors.CodeVenueHasShows:
+			return huma.Error422UnprocessableEntity(venueErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapFestivalError converts a FestivalError to an appropriate Huma HTTP error.
+// Returns nil if err is not a *apperrors.FestivalError.
+//
+// PSY-791: replaces the err.Error() == "..." discrimination in the festival
+// catalog handlers. Festival/artist/venue not-found (and not-in-lineup /
+// not-in-festival) all map to 404; an already-exists festival → 409.
+func MapFestivalError(err error) error {
+	var festivalErr *apperrors.FestivalError
+	if errors.As(err, &festivalErr) {
+		switch festivalErr.Code {
+		case apperrors.CodeFestivalNotFound,
+			apperrors.CodeFestivalArtistNotFound,
+			apperrors.CodeFestivalArtistNotInLineup,
+			apperrors.CodeFestivalVenueNotFound,
+			apperrors.CodeFestivalVenueNotInFestival:
+			return huma.Error404NotFound(festivalErr.Message)
+		case apperrors.CodeFestivalExists:
+			return huma.Error409Conflict(festivalErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapFestivalIntelligenceError converts a FestivalIntelligenceError to an
+// appropriate Huma HTTP error. Returns nil if err is not a
+// *apperrors.FestivalIntelligenceError.
+//
+// PSY-791: replaces the strings.Contains(err.Error(), ...) discrimination in
+// festival_intelligence.go. Referenced-entity / no-festivals-for-series →
+// 404; too-few-years → 422 (semantic validation). The not-found and
+// no-festivals messages are preserved so the series-comparison handler's
+// err.Error()-as-message behaviour is unchanged.
+func MapFestivalIntelligenceError(err error) error {
+	var intelErr *apperrors.FestivalIntelligenceError
+	if errors.As(err, &intelErr) {
+		switch intelErr.Code {
+		case apperrors.CodeFestivalIntelNotFound, apperrors.CodeFestivalIntelNoFestivals:
+			return huma.Error404NotFound(intelErr.Message)
+		case apperrors.CodeFestivalIntelInsufficientYears:
+			return huma.Error422UnprocessableEntity(intelErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapSceneError converts a SceneError to an appropriate Huma HTTP error.
+// Returns nil if err is not a *apperrors.SceneError.
+//
+// PSY-791: replaces the isSceneNotFoundErr string-prefix helper in scene.go.
+// Scene-not-found → 404; database faults fall through to the generic 500.
+func MapSceneError(err error) error {
+	var sceneErr *apperrors.SceneError
+	if errors.As(err, &sceneErr) {
+		switch sceneErr.Code {
+		case apperrors.CodeSceneNotFound:
+			return huma.Error404NotFound(sceneErr.Message)
+		}
+	}
+	return nil
+}

--- a/backend/internal/api/handlers/shared/error_mappers_test.go
+++ b/backend/internal/api/handlers/shared/error_mappers_test.go
@@ -226,6 +226,35 @@ func TestMapNotificationFilterError_CodeToStatus(t *testing.T) {
 	}
 }
 
+func TestMapArtistError_CodeToStatus(t *testing.T) {
+	// Cover the whole switch so a future code added without a status mapping is
+	// caught. HasShows is 409 (preserves the artist delete handler's existing
+	// conflict status — intentionally distinct from venue HasShows, which is 422).
+	cases := []struct {
+		name   string
+		err    *apperrors.ArtistError
+		status int
+	}{
+		{"not found", apperrors.ErrArtistNotFound(7), 404},
+		{"alias not found", apperrors.ErrArtistAliasNotFound(), 404},
+		{"exists", apperrors.ErrArtistExists("Frozen Soul"), 409},
+		{"alias exists", apperrors.ErrArtistAliasExists("alias 'x' already exists"), 409},
+		{"has shows", apperrors.ErrArtistHasShows(7, 3), 409},
+		{"merge self", apperrors.ErrArtistMergeSelf(), 422},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapArtistError(tc.err)
+			if got == nil {
+				t.Fatalf("MapArtistError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapArtistError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
 func TestMapNotificationFilterError_NonFilterErrorReturnsNil(t *testing.T) {
 	if got := MapNotificationFilterError(stderrors.New("boom")); got != nil {
 		t.Errorf("MapNotificationFilterError(plain error) = %v, want nil", got)
@@ -233,5 +262,134 @@ func TestMapNotificationFilterError_NonFilterErrorReturnsNil(t *testing.T) {
 	unknown := &apperrors.NotificationFilterError{Code: "FILTER_NEW_CODE", Message: "x"}
 	if got := MapNotificationFilterError(unknown); got != nil {
 		t.Errorf("MapNotificationFilterError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapArtistError_NonArtistErrorReturnsNil(t *testing.T) {
+	if got := MapArtistError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapArtistError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.ArtistError{Code: "ARTIST_NEW_CODE", Message: "x"}
+	if got := MapArtistError(unknown); got != nil {
+		t.Errorf("MapArtistError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapVenueError_CodeToStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    *apperrors.VenueError
+		status int
+	}{
+		{"not found", apperrors.ErrVenueNotFound(7), 404},
+		{"has shows", apperrors.ErrVenueHasShows(7, 3), 422},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapVenueError(tc.err)
+			if got == nil {
+				t.Fatalf("MapVenueError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapVenueError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapVenueError_NonVenueErrorReturnsNil(t *testing.T) {
+	if got := MapVenueError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapVenueError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.VenueError{Code: "VENUE_NEW_CODE", Message: "x"}
+	if got := MapVenueError(unknown); got != nil {
+		t.Errorf("MapVenueError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapFestivalError_CodeToStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    *apperrors.FestivalError
+		status int
+	}{
+		{"not found", apperrors.ErrFestivalNotFound(7), 404},
+		{"artist not found", apperrors.ErrFestivalArtistNotFound(), 404},
+		{"artist not in lineup", apperrors.ErrFestivalArtistNotInLineup(), 404},
+		{"venue not found", apperrors.ErrFestivalVenueNotFound(), 404},
+		{"venue not in festival", apperrors.ErrFestivalVenueNotInFestival(), 404},
+		{"exists", apperrors.ErrFestivalExists("M3F 2026"), 409},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapFestivalError(tc.err)
+			if got == nil {
+				t.Fatalf("MapFestivalError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapFestivalError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapFestivalError_NonFestivalErrorReturnsNil(t *testing.T) {
+	if got := MapFestivalError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapFestivalError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.FestivalError{Code: "FESTIVAL_NEW_CODE", Message: "x"}
+	if got := MapFestivalError(unknown); got != nil {
+		t.Errorf("MapFestivalError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapFestivalIntelligenceError_CodeToStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    *apperrors.FestivalIntelligenceError
+		status int
+	}{
+		{"not found", apperrors.ErrFestivalIntelNotFound("festival A not found"), 404},
+		{"no festivals", apperrors.ErrFestivalIntelNoFestivals("m3f"), 404},
+		{"insufficient years", apperrors.ErrFestivalIntelInsufficientYears(), 422},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapFestivalIntelligenceError(tc.err)
+			if got == nil {
+				t.Fatalf("MapFestivalIntelligenceError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapFestivalIntelligenceError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapFestivalIntelligenceError_NonIntelErrorReturnsNil(t *testing.T) {
+	if got := MapFestivalIntelligenceError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapFestivalIntelligenceError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.FestivalIntelligenceError{Code: "FESTIVAL_INTEL_NEW_CODE", Message: "x"}
+	if got := MapFestivalIntelligenceError(unknown); got != nil {
+		t.Errorf("MapFestivalIntelligenceError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapSceneError_CodeToStatus(t *testing.T) {
+	if got := MapSceneError(apperrors.ErrSceneNotFound("scene not found: Phoenix, AZ")); got == nil {
+		t.Fatal("MapSceneError(scene not found) = nil, want 404")
+	} else if s := statusOf(t, got); s != 404 {
+		t.Errorf("scene-not-found status = %d, want 404", s)
+	}
+}
+
+func TestMapSceneError_NonSceneErrorReturnsNil(t *testing.T) {
+	if got := MapSceneError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapSceneError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.SceneError{Code: "SCENE_NEW_CODE", Message: "x"}
+	if got := MapSceneError(unknown); got != nil {
+		t.Errorf("MapSceneError(unknown code) = %v, want nil", got)
 	}
 }

--- a/backend/internal/errors/artist.go
+++ b/backend/internal/errors/artist.go
@@ -8,6 +8,15 @@ import (
 const (
 	CodeArtistNotFound = "ARTIST_NOT_FOUND"
 	CodeArtistHasShows = "ARTIST_HAS_SHOWS"
+	// CodeArtistExists indicates an artist with the same name already exists.
+	CodeArtistExists = "ARTIST_EXISTS"
+	// CodeArtistAliasExists indicates the alias collides with an existing alias
+	// or artist name.
+	CodeArtistAliasExists = "ARTIST_ALIAS_EXISTS"
+	// CodeArtistAliasNotFound indicates the alias to remove does not exist.
+	CodeArtistAliasNotFound = "ARTIST_ALIAS_NOT_FOUND"
+	// CodeArtistMergeSelf indicates an attempt to merge an artist into itself.
+	CodeArtistMergeSelf = "ARTIST_MERGE_SELF"
 )
 
 // ArtistError represents an artist-related error with additional context.
@@ -47,5 +56,38 @@ func ErrArtistHasShows(artistID uint, count int64) *ArtistError {
 		Code:     CodeArtistHasShows,
 		Message:  fmt.Sprintf("Cannot delete artist: associated with %d shows", count),
 		ArtistID: artistID,
+	}
+}
+
+// ErrArtistExists creates an artist-already-exists error.
+func ErrArtistExists(name string) *ArtistError {
+	return &ArtistError{
+		Code:    CodeArtistExists,
+		Message: fmt.Sprintf("artist with name '%s' already exists", name),
+	}
+}
+
+// ErrArtistAliasExists creates an alias-conflict error. The message describes
+// whether the alias collided with another alias or an existing artist name.
+func ErrArtistAliasExists(message string) *ArtistError {
+	return &ArtistError{
+		Code:    CodeArtistAliasExists,
+		Message: message,
+	}
+}
+
+// ErrArtistAliasNotFound creates an alias-not-found error.
+func ErrArtistAliasNotFound() *ArtistError {
+	return &ArtistError{
+		Code:    CodeArtistAliasNotFound,
+		Message: "alias not found",
+	}
+}
+
+// ErrArtistMergeSelf creates a merge-into-self error.
+func ErrArtistMergeSelf() *ArtistError {
+	return &ArtistError{
+		Code:    CodeArtistMergeSelf,
+		Message: "cannot merge an artist with itself",
 	}
 }

--- a/backend/internal/errors/festival.go
+++ b/backend/internal/errors/festival.go
@@ -8,6 +8,18 @@ import (
 const (
 	CodeFestivalNotFound = "FESTIVAL_NOT_FOUND"
 	CodeFestivalExists   = "FESTIVAL_EXISTS"
+	// CodeFestivalArtistNotFound indicates the artist being added to a festival
+	// lineup does not exist.
+	CodeFestivalArtistNotFound = "FESTIVAL_ARTIST_NOT_FOUND"
+	// CodeFestivalArtistNotInLineup indicates the artist is not part of the
+	// festival lineup (update/remove target missing).
+	CodeFestivalArtistNotInLineup = "FESTIVAL_ARTIST_NOT_IN_LINEUP"
+	// CodeFestivalVenueNotFound indicates the venue being added to a festival
+	// does not exist.
+	CodeFestivalVenueNotFound = "FESTIVAL_VENUE_NOT_FOUND"
+	// CodeFestivalVenueNotInFestival indicates the venue is not associated with
+	// the festival (remove target missing).
+	CodeFestivalVenueNotInFestival = "FESTIVAL_VENUE_NOT_IN_FESTIVAL"
 )
 
 // FestivalError represents a festival-related error with additional context.
@@ -46,5 +58,37 @@ func ErrFestivalExists(name string) *FestivalError {
 	return &FestivalError{
 		Code:    CodeFestivalExists,
 		Message: fmt.Sprintf("Festival with name '%s' already exists", name),
+	}
+}
+
+// ErrFestivalArtistNotFound creates a festival-artist-not-found error.
+func ErrFestivalArtistNotFound() *FestivalError {
+	return &FestivalError{
+		Code:    CodeFestivalArtistNotFound,
+		Message: "artist not found",
+	}
+}
+
+// ErrFestivalArtistNotInLineup creates an artist-not-in-lineup error.
+func ErrFestivalArtistNotInLineup() *FestivalError {
+	return &FestivalError{
+		Code:    CodeFestivalArtistNotInLineup,
+		Message: "artist not found in festival lineup",
+	}
+}
+
+// ErrFestivalVenueNotFound creates a festival-venue-not-found error.
+func ErrFestivalVenueNotFound() *FestivalError {
+	return &FestivalError{
+		Code:    CodeFestivalVenueNotFound,
+		Message: "venue not found",
+	}
+}
+
+// ErrFestivalVenueNotInFestival creates a venue-not-in-festival error.
+func ErrFestivalVenueNotInFestival() *FestivalError {
+	return &FestivalError{
+		Code:    CodeFestivalVenueNotInFestival,
+		Message: "venue not found in festival",
 	}
 }

--- a/backend/internal/errors/festival_intelligence.go
+++ b/backend/internal/errors/festival_intelligence.go
@@ -1,0 +1,71 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Festival intelligence error codes.
+//
+// The intelligence endpoints (similar festivals, overlap, breakouts, artist
+// trajectory, series comparison) read existing entities and compute analytics.
+// Their genuine failures are: a referenced festival or artist does not exist
+// (not found), a series query that matches no festivals (not found), and an
+// insufficient-input semantic violation (too few years to compare). Database
+// faults fall through to the generic 500 in the handler.
+const (
+	// CodeFestivalIntelNotFound indicates a referenced festival or artist does
+	// not exist.
+	CodeFestivalIntelNotFound = "FESTIVAL_INTEL_NOT_FOUND"
+	// CodeFestivalIntelNoFestivals indicates a series query matched no festivals.
+	CodeFestivalIntelNoFestivals = "FESTIVAL_INTEL_NO_FESTIVALS"
+	// CodeFestivalIntelInsufficientYears indicates fewer than two years were
+	// supplied for a series comparison.
+	CodeFestivalIntelInsufficientYears = "FESTIVAL_INTEL_INSUFFICIENT_YEARS"
+)
+
+// FestivalIntelligenceError represents a festival-intelligence error with
+// additional context.
+type FestivalIntelligenceError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *FestivalIntelligenceError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *FestivalIntelligenceError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrFestivalIntelNotFound creates a not-found error. The message is preserved
+// from the caller so existing client-facing copy (e.g. "festival A not found",
+// "artist not found") is unchanged.
+func ErrFestivalIntelNotFound(message string) *FestivalIntelligenceError {
+	return &FestivalIntelligenceError{
+		Code:    CodeFestivalIntelNotFound,
+		Message: message,
+	}
+}
+
+// ErrFestivalIntelNoFestivals creates a no-festivals-for-series error.
+func ErrFestivalIntelNoFestivals(seriesSlug string) *FestivalIntelligenceError {
+	return &FestivalIntelligenceError{
+		Code:    CodeFestivalIntelNoFestivals,
+		Message: fmt.Sprintf("no festivals found for series '%s' in the requested years", seriesSlug),
+	}
+}
+
+// ErrFestivalIntelInsufficientYears creates an insufficient-years error.
+func ErrFestivalIntelInsufficientYears() *FestivalIntelligenceError {
+	return &FestivalIntelligenceError{
+		Code:    CodeFestivalIntelInsufficientYears,
+		Message: "at least 2 years required for comparison",
+	}
+}

--- a/backend/internal/errors/scene.go
+++ b/backend/internal/errors/scene.go
@@ -1,0 +1,47 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Scene error codes.
+//
+// Scenes are city/state aggregations computed from shows. The only genuine
+// not-an-infra failure is a scene that does not exist (no qualifying shows for
+// the city/state or an unparseable slug). Database faults fall through to the
+// generic 500 in the handler.
+const (
+	// CodeSceneNotFound indicates the requested scene does not exist.
+	CodeSceneNotFound = "SCENE_NOT_FOUND"
+)
+
+// SceneError represents a scene-related error with additional context.
+type SceneError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *SceneError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *SceneError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrSceneNotFound creates a scene-not-found error. The message is preserved
+// from the caller so the existing "scene not found: <city>, <state>" /
+// "scene not found for slug: <slug>" copy (and the service tests asserting it)
+// are unchanged.
+func ErrSceneNotFound(message string) *SceneError {
+	return &SceneError{
+		Code:    CodeSceneNotFound,
+		Message: message,
+	}
+}

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -41,7 +41,7 @@ func (s *ArtistService) CreateArtist(req *contracts.CreateArtistRequest) (*contr
 	var existingArtist catalogm.Artist
 	err := s.db.Where("LOWER(name) = LOWER(?)", req.Name).First(&existingArtist).Error
 	if err == nil {
-		return nil, fmt.Errorf("artist with name '%s' already exists", req.Name)
+		return nil, apperrors.ErrArtistExists(req.Name)
 	} else if err != gorm.ErrRecordNotFound {
 		return nil, fmt.Errorf("failed to check existing artist: %w", err)
 	}
@@ -864,13 +864,13 @@ func (s *ArtistService) AddArtistAlias(artistID uint, alias string) (*contracts.
 	// Check for duplicate alias (case-insensitive)
 	var existing catalogm.ArtistAlias
 	if err := s.db.Where("LOWER(alias) = LOWER(?)", alias).First(&existing).Error; err == nil {
-		return nil, fmt.Errorf("alias '%s' already exists", alias)
+		return nil, apperrors.ErrArtistAliasExists(fmt.Sprintf("alias '%s' already exists", alias))
 	}
 
 	// Check if alias matches an existing artist name
 	var existingArtist catalogm.Artist
 	if err := s.db.Where("LOWER(name) = LOWER(?)", alias).First(&existingArtist).Error; err == nil {
-		return nil, fmt.Errorf("alias '%s' conflicts with existing artist name", alias)
+		return nil, apperrors.ErrArtistAliasExists(fmt.Sprintf("alias '%s' conflicts with existing artist name", alias))
 	}
 
 	artistAlias := &catalogm.ArtistAlias{
@@ -901,7 +901,7 @@ func (s *ArtistService) RemoveArtistAlias(aliasID uint) error {
 		return fmt.Errorf("failed to delete alias: %w", result.Error)
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("alias not found")
+		return apperrors.ErrArtistAliasNotFound()
 	}
 
 	return nil
@@ -954,7 +954,7 @@ func (s *ArtistService) MergeArtists(canonicalID, mergeFromID uint) (*contracts.
 	}
 
 	if canonicalID == mergeFromID {
-		return nil, fmt.Errorf("cannot merge an artist with itself")
+		return nil, apperrors.ErrArtistMergeSelf()
 	}
 
 	// Verify both artists exist

--- a/backend/internal/services/catalog/artist_relationship_service.go
+++ b/backend/internal/services/catalog/artist_relationship_service.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -343,7 +344,7 @@ func (s *ArtistRelationshipService) GetArtistGraph(artistID uint, types []string
 	// 1. Get center artist details
 	var centerArtist catalogm.Artist
 	if err := s.db.First(&centerArtist, artistID).Error; err != nil {
-		return nil, fmt.Errorf("artist not found: %w", err)
+		return nil, apperrors.ErrArtistNotFound(artistID)
 	}
 
 	centerSlug := ""
@@ -637,7 +638,7 @@ func (s *ArtistRelationshipService) GetArtistBillComposition(artistID uint, mont
 	// 1. Center artist
 	var centerArtist catalogm.Artist
 	if err := s.db.First(&centerArtist, artistID).Error; err != nil {
-		return nil, fmt.Errorf("artist not found: %w", err)
+		return nil, apperrors.ErrArtistNotFound(artistID)
 	}
 
 	centerNode := buildArtistGraphNode(centerArtist, 0)

--- a/backend/internal/services/catalog/artist_relationship_service_test.go
+++ b/backend/internal/services/catalog/artist_relationship_service_test.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/testutil"
@@ -460,7 +462,9 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_E
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_ArtistNotFound() {
 	_, err := suite.svc.GetArtistGraph(99999, nil, 0)
 	suite.Assert().Error(err)
-	suite.Assert().Contains(err.Error(), "artist not found")
+	var artistErr *apperrors.ArtistError
+	suite.Require().True(errors.As(err, &artistErr), "expected *apperrors.ArtistError, got %T", err)
+	suite.Assert().Equal(apperrors.CodeArtistNotFound, artistErr.Code)
 }
 
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_UpcomingShowCounts() {

--- a/backend/internal/services/catalog/festival.go
+++ b/backend/internal/services/catalog/festival.go
@@ -521,7 +521,7 @@ func (s *FestivalService) AddFestivalArtist(festivalID uint, req *contracts.AddF
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, req.ArtistID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("artist not found")
+			return nil, apperrors.ErrFestivalArtistNotFound()
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
 	}
@@ -576,7 +576,7 @@ func (s *FestivalService) UpdateFestivalArtist(festivalID, artistID uint, req *c
 	err := s.db.Where("festival_id = ? AND artist_id = ?", festivalID, artistID).First(&fa).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("artist not found in festival lineup")
+			return nil, apperrors.ErrFestivalArtistNotInLineup()
 		}
 		return nil, fmt.Errorf("failed to get festival artist: %w", err)
 	}
@@ -644,7 +644,7 @@ func (s *FestivalService) RemoveFestivalArtist(festivalID, artistID uint) error 
 		return fmt.Errorf("failed to remove artist from festival: %w", result.Error)
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("artist not found in festival lineup")
+		return apperrors.ErrFestivalArtistNotInLineup()
 	}
 
 	return nil
@@ -732,7 +732,7 @@ func (s *FestivalService) AddFestivalVenue(festivalID uint, req *contracts.AddFe
 	var venue catalogm.Venue
 	if err := s.db.First(&venue, req.VenueID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("venue not found")
+			return nil, apperrors.ErrFestivalVenueNotFound()
 		}
 		return nil, fmt.Errorf("failed to get venue: %w", err)
 	}
@@ -774,7 +774,7 @@ func (s *FestivalService) RemoveFestivalVenue(festivalID, venueID uint) error {
 		return fmt.Errorf("failed to remove venue from festival: %w", result.Error)
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("venue not found in festival")
+		return apperrors.ErrFestivalVenueNotInFestival()
 	}
 
 	return nil

--- a/backend/internal/services/catalog/festival_intelligence.go
+++ b/backend/internal/services/catalog/festival_intelligence.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -136,7 +137,7 @@ func (s *FestivalIntelligenceService) GetSimilarFestivals(festivalID uint, limit
 	var festival catalogm.Festival
 	if err := s.db.First(&festival, festivalID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("festival not found")
+			return nil, apperrors.ErrFestivalIntelNotFound("festival not found")
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
 	}
@@ -376,10 +377,10 @@ func (s *FestivalIntelligenceService) GetFestivalOverlap(festivalAID, festivalBI
 	// Verify both festivals exist
 	var festA, festB catalogm.Festival
 	if err := s.db.First(&festA, festivalAID).Error; err != nil {
-		return nil, fmt.Errorf("festival A not found")
+		return nil, apperrors.ErrFestivalIntelNotFound("festival A not found")
 	}
 	if err := s.db.First(&festB, festivalBID).Error; err != nil {
-		return nil, fmt.Errorf("festival B not found")
+		return nil, apperrors.ErrFestivalIntelNotFound("festival B not found")
 	}
 
 	// Get artists for both festivals
@@ -490,7 +491,7 @@ func (s *FestivalIntelligenceService) GetFestivalBreakouts(festivalID uint) (*co
 	// Verify festival exists and get its info
 	var festival catalogm.Festival
 	if err := s.db.First(&festival, festivalID).Error; err != nil {
-		return nil, fmt.Errorf("festival not found")
+		return nil, apperrors.ErrFestivalIntelNotFound("festival not found")
 	}
 
 	// Get artists at this festival
@@ -679,7 +680,7 @@ func (s *FestivalIntelligenceService) GetArtistFestivalTrajectory(artistID uint)
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		return nil, fmt.Errorf("artist not found")
+		return nil, apperrors.ErrFestivalIntelNotFound("artist not found")
 	}
 
 	artistSlug := ""
@@ -770,7 +771,7 @@ func (s *FestivalIntelligenceService) GetSeriesComparison(seriesSlug string, yea
 	}
 
 	if len(years) < 2 {
-		return nil, fmt.Errorf("at least 2 years required for comparison")
+		return nil, apperrors.ErrFestivalIntelInsufficientYears()
 	}
 
 	// Sort years ascending
@@ -785,7 +786,7 @@ func (s *FestivalIntelligenceService) GetSeriesComparison(seriesSlug string, yea
 	}
 
 	if len(festivals) == 0 {
-		return nil, fmt.Errorf("no festivals found for series '%s' in the requested years", seriesSlug)
+		return nil, apperrors.ErrFestivalIntelNoFestivals(seriesSlug)
 	}
 
 	// Get festival IDs and build editions

--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -132,7 +133,7 @@ func (s *SceneService) GetSceneDetail(city, state string) (*contracts.SceneDetai
 		return nil, fmt.Errorf("failed to count venues: %w", err)
 	}
 	if venueCount < sceneMinVenues {
-		return nil, fmt.Errorf("scene not found: %s, %s", city, state)
+		return nil, apperrors.ErrSceneNotFound(fmt.Sprintf("scene not found: %s, %s", city, state))
 	}
 
 	// Upcoming show count
@@ -295,7 +296,7 @@ func (s *SceneService) GetActiveArtists(city, state string, periodDays, limit, o
 		return nil, 0, fmt.Errorf("failed to count venues: %w", err)
 	}
 	if venueCount < sceneMinVenues {
-		return nil, 0, fmt.Errorf("scene not found: %s, %s", city, state)
+		return nil, 0, apperrors.ErrSceneNotFound(fmt.Sprintf("scene not found: %s, %s", city, state))
 	}
 
 	cutoff := time.Now().UTC().AddDate(0, 0, -periodDays)
@@ -385,7 +386,7 @@ func (s *SceneService) ParseSceneSlug(slug string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to resolve scene slug: %w", err)
 	}
 	if result.City == "" {
-		return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+		return "", "", apperrors.ErrSceneNotFound(fmt.Sprintf("scene not found for slug: %s", slug))
 	}
 
 	return result.City, result.State, nil
@@ -619,7 +620,7 @@ func (s *SceneService) GetSceneGraph(city, state string, types []string) (*contr
 		return nil, fmt.Errorf("failed to count venues: %w", err)
 	}
 	if venueCount < sceneMinVenues {
-		return nil, fmt.Errorf("scene not found: %s, %s", city, state)
+		return nil, apperrors.ErrSceneNotFound(fmt.Sprintf("scene not found: %s, %s", city, state))
 	}
 
 	// Whitelist + dedupe types. Empty input means "all allowed types"; an input


### PR DESCRIPTION
## Summary
- Replaces the fragile `strings.Contains(err.Error(), ...)` / `err.Error() == "..."` HTTP-status discrimination in the catalog handlers (artist, artist-relationship, festival, festival-intelligence, scene) with typed-error mappers, following the shipped PSY-761 engagement pattern.
- New / extended `apperrors` typed errors carry the discrimination: `ArtistError` gains `Exists` / `AliasExists` / `AliasNotFound` / `MergeSelf`; `FestivalError` gains the lineup/venue not-found codes; new `FestivalIntelligenceError` and `SceneError` types. Services emit them instead of plain `fmt.Errorf` strings.
- New `shared.MapArtistError` / `MapVenueError` / `MapFestivalError` / `MapFestivalIntelligenceError` / `MapSceneError` companions alongside the existing `MapTag/MapCollection/MapFollow/MapAttendance`. Handlers call the mapper and fall through to a generic 500.
- Status table preserved per surface: not-found → 404, name/alias conflict → 409, merge-self / too-few-years → 422, infra → 500. Artist `HasShows` stays 409 and venue `HasShows` stays 422 (each handler's pre-existing contract; intentionally divergent). The dead `isSceneNotFoundErr` helper is removed.
- 20 files changed; backend-only, no migration. Minor message-text refinement: handlers that previously returned a fixed string now surface the typed error's message (e.g. "festival A not found" instead of a generic "Festival not found") — statuses unchanged.

## Test plan
- [x] cd backend && go build ./... — passed
- [x] cd backend && go test ./... — passed

## Manual repro
mode=none (backend-only, no migration). The mapper + handler status-assertion tests ARE the repro:
- `TestMapArtistError_CodeToStatus`: NotFound/AliasNotFound→404, Exists/AliasExists/HasShows→409, MergeSelf→422; `_NonArtistErrorReturnsNil`: plain + unknown-code → nil (fall-through to 500).
- `TestMapVenueError_CodeToStatus`: NotFound→404, HasShows→422.
- `TestMapFestivalError_CodeToStatus`: NotFound/ArtistNotFound/ArtistNotInLineup/VenueNotFound/VenueNotInFestival→404, Exists→409.
- `TestMapFestivalIntelligenceError_CodeToStatus`: NotFound/NoFestivals→404, InsufficientYears→422.
- `TestMapSceneError_CodeToStatus`: NotFound→404; each `_Non*ErrorReturnsNil` asserts fall-through.
- Handler-level: `artist_test.go` (Create/Alias/Merge conflict + not-found), `artist_relationship_test.go` (`TestGetArtistBillComposition_NotFound`), `scene_test.go` (`TestGetScene{Detail,ActiveArtists,Graph}_SceneNotFound`) now mock the typed errors and assert the corrected statuses. Service test `TestGetArtistGraph_ArtistNotFound` now asserts the typed `*apperrors.ArtistError`.

## Simplify
edited 1 file (error_mappers.go): merged MapArtistError's three identical-409 case arms into one; stripped WHAT-narrating ticket-ref prefixes from the new mapper doc comments (kept the status-rationale WHY). Re-ran go build ./... + go test ./... — both passed.

Closes PSY-791