### PR TITLE
PSY-793: typed errors + HTTP status for community + admin handlers

### DIFF
--- a/backend/internal/api/handlers/admin/auto_promotion.go
+++ b/backend/internal/api/handlers/admin/auto_promotion.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
@@ -93,8 +94,8 @@ func (h *AutoPromotionHandler) EvaluateUserHandler(ctx context.Context, req *Eva
 			"request_id", requestID,
 			"target_user_id", req.UserID,
 		)
-		if err.Error() == "user not found" {
-			return nil, huma.Error404NotFound("User not found")
+		if mapped := shared.MapAutoPromotionError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError(
 			fmt.Sprintf("Failed to evaluate user (request_id: %s)", requestID),

--- a/backend/internal/api/handlers/admin/auto_promotion_test.go
+++ b/backend/internal/api/handlers/admin/auto_promotion_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -97,8 +98,8 @@ func TestEvaluateUserHandler_Success(t *testing.T) {
 func TestEvaluateUserHandler_NotFound(t *testing.T) {
 	mock := &testhelpers.MockAutoPromotionService{
 		EvaluateUserFn: func(_ uint) (*contracts.UserEvaluationResult, error) {
-			// The handler matches on this exact message to return 404.
-			return nil, fmt.Errorf("user not found")
+			// The handler maps the typed user-not-found error to 404.
+			return nil, apperrors.ErrAutoPromotionUserNotFound()
 		},
 	}
 	h := NewAutoPromotionHandler(mock)

--- a/backend/internal/api/handlers/admin/data_quality.go
+++ b/backend/internal/api/handlers/admin/data_quality.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -107,9 +108,8 @@ func (h *DataQualityHandler) GetDataQualityCategoryHandler(ctx context.Context, 
 
 	items, total, err := h.dataQualityService.GetCategoryItems(req.Category, limit, req.Offset)
 	if err != nil {
-		// Check if it's an unknown category error
-		if err.Error() == "unknown category: "+req.Category {
-			return nil, huma.Error422UnprocessableEntity("Unknown data quality category: " + req.Category)
+		if mapped := shared.MapDataQualityError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("data_quality_category_failed",
 			"category", req.Category,

--- a/backend/internal/api/handlers/admin/data_quality_test.go
+++ b/backend/internal/api/handlers/admin/data_quality_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -164,7 +165,7 @@ func TestDataQualityHandler_Category_Success(t *testing.T) {
 func TestDataQualityHandler_Category_InvalidCategory(t *testing.T) {
 	h := NewDataQualityHandler(&testhelpers.MockDataQualityService{
 		GetCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
-			return nil, 0, fmt.Errorf("unknown category: %s", category)
+			return nil, 0, apperrors.ErrDataQualityUnknownCategory(category)
 		},
 	})
 

--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -160,11 +160,8 @@ func (h *PendingEditHandler) suggestEdit(ctx context.Context, entityType string,
 		Summary:    summary,
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "entity not found") {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique constraint") {
-			return nil, huma.Error409Conflict("You already have a pending edit for this entity")
+		if mapped := shared.MapPendingEditError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("pending_edit_create_failed",
 			"user_id", user.ID,
@@ -283,14 +280,8 @@ func (h *PendingEditHandler) CancelMyPendingEditHandler(ctx context.Context, req
 	}
 
 	if err := h.pendingEditService.CancelPendingEdit(uint(editID), user.ID); err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Pending edit not found")
-		}
-		if strings.Contains(err.Error(), "only the submitter") {
-			return nil, huma.Error403Forbidden("You can only cancel your own pending edits")
-		}
-		if strings.Contains(err.Error(), "not pending") {
-			return nil, huma.Error409Conflict("This edit has already been reviewed")
+		if mapped := shared.MapPendingEditError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("pending_edit_cancel_failed",
 			"user_id", user.ID,
@@ -399,7 +390,9 @@ func (h *PendingEditHandler) AdminApprovePendingEditHandler(ctx context.Context,
 		// PSY-572: pending_edit carried fields not on the per-entity allowlist.
 		// The service has already auto-marked the row 'rejected' and logged
 		// the rejected fields with the edit ID + admin user ID; surface a 400
-		// so the admin UI can show which fields blocked the approval.
+		// so the admin UI can show which fields blocked the approval. This is a
+		// distinct sentinel (not a PendingEditError), so it is checked before
+		// the typed mapper.
 		if errors.Is(err, adminm.ErrPendingEditDisallowedFields) {
 			rejected := strings.TrimPrefix(err.Error(), adminm.ErrPendingEditDisallowedFields.Error()+": ")
 			return nil, huma.Error400BadRequest(fmt.Sprintf(
@@ -407,14 +400,8 @@ func (h *PendingEditHandler) AdminApprovePendingEditHandler(ctx context.Context,
 				rejected,
 			))
 		}
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Pending edit not found")
-		}
-		if strings.Contains(err.Error(), "not pending") {
-			return nil, huma.Error409Conflict(err.Error())
-		}
-		if strings.Contains(err.Error(), "entity not found") {
-			return nil, huma.Error422UnprocessableEntity("Entity no longer exists — cannot apply edit")
+		if mapped := shared.MapPendingEditError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("pending_edit_approve_failed",
 			"edit_id", editID,
@@ -480,11 +467,8 @@ func (h *PendingEditHandler) AdminRejectPendingEditHandler(ctx context.Context, 
 
 	rejected, err := h.pendingEditService.RejectPendingEdit(uint(editID), user.ID, reason)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Pending edit not found")
-		}
-		if strings.Contains(err.Error(), "not pending") {
-			return nil, huma.Error409Conflict(err.Error())
+		if mapped := shared.MapPendingEditError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("pending_edit_reject_failed",
 			"edit_id", editID,

--- a/backend/internal/api/handlers/admin/pending_edit_test.go
+++ b/backend/internal/api/handlers/admin/pending_edit_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
@@ -294,7 +295,7 @@ func TestSuggestEdit_EntityNotFound(t *testing.T) {
 	h := NewPendingEditHandler(
 		&testhelpers.MockPendingEditService{
 			CreatePendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
-				return nil, fmt.Errorf("entity not found: artist 99999")
+				return nil, apperrors.ErrPendingEditEntityNotFound("artist", 99999)
 			},
 		},
 		nil,
@@ -312,7 +313,7 @@ func TestSuggestEdit_DuplicatePending(t *testing.T) {
 	h := NewPendingEditHandler(
 		&testhelpers.MockPendingEditService{
 			CreatePendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
-				return nil, fmt.Errorf("failed to create pending edit: duplicate key value violates unique constraint")
+				return nil, apperrors.ErrPendingEditDuplicate(fmt.Errorf("duplicate key value violates unique constraint"))
 			},
 		},
 		nil,
@@ -404,7 +405,7 @@ func TestCancelMyPendingEdit_NotFound(t *testing.T) {
 	h := NewPendingEditHandler(
 		&testhelpers.MockPendingEditService{
 			CancelPendingEditFn: func(editID, userID uint) error {
-				return fmt.Errorf("pending edit not found")
+				return apperrors.ErrPendingEditNotFound()
 			},
 		},
 		nil,
@@ -418,7 +419,7 @@ func TestCancelMyPendingEdit_WrongUser(t *testing.T) {
 	h := NewPendingEditHandler(
 		&testhelpers.MockPendingEditService{
 			CancelPendingEditFn: func(editID, userID uint) error {
-				return fmt.Errorf("only the submitter can cancel")
+				return apperrors.ErrPendingEditNotSubmitter()
 			},
 		},
 		nil,
@@ -533,7 +534,7 @@ func TestAdminApprove_NotFound(t *testing.T) {
 	h := NewPendingEditHandler(
 		&testhelpers.MockPendingEditService{
 			ApprovePendingEditFn: func(editID, rID uint) (*contracts.PendingEditResponse, error) {
-				return nil, fmt.Errorf("pending edit not found")
+				return nil, apperrors.ErrPendingEditNotFound()
 			},
 		},
 		nil,
@@ -547,7 +548,7 @@ func TestAdminApprove_AlreadyReviewed(t *testing.T) {
 	h := NewPendingEditHandler(
 		&testhelpers.MockPendingEditService{
 			ApprovePendingEditFn: func(editID, rID uint) (*contracts.PendingEditResponse, error) {
-				return nil, fmt.Errorf("edit is not pending (status: approved)")
+				return nil, apperrors.ErrPendingEditNotPending("approved")
 			},
 		},
 		nil,
@@ -606,7 +607,7 @@ func TestAdminReject_NotFound(t *testing.T) {
 	h := NewPendingEditHandler(
 		&testhelpers.MockPendingEditService{
 			RejectPendingEditFn: func(editID, rID uint, r string) (*contracts.PendingEditResponse, error) {
-				return nil, fmt.Errorf("pending edit not found")
+				return nil, apperrors.ErrPendingEditNotFound()
 			},
 		},
 		nil,

--- a/backend/internal/api/handlers/community/contribute.go
+++ b/backend/internal/api/handlers/community/contribute.go
@@ -6,6 +6,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"psychic-homily-backend/internal/api/handlers/admin"
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -89,9 +90,8 @@ func (h *ContributeHandler) GetOpportunityCategoryHandler(ctx context.Context, r
 
 	items, total, err := h.dataQualityService.GetCategoryItems(req.Category, limit, req.Offset)
 	if err != nil {
-		// Check if it's an unknown category error
-		if err.Error() == "unknown category: "+req.Category {
-			return nil, huma.Error422UnprocessableEntity("Unknown contribution category: " + req.Category)
+		if mapped := shared.MapDataQualityError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("contribute_category_failed",
 			"category", req.Category,

--- a/backend/internal/api/handlers/community/contribute_test.go
+++ b/backend/internal/api/handlers/community/contribute_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -179,7 +180,7 @@ func TestContributeHandler_Category_NoAuthRequired(t *testing.T) {
 func TestContributeHandler_Category_InvalidCategory(t *testing.T) {
 	h := NewContributeHandler(&testhelpers.MockDataQualityService{
 		GetCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
-			return nil, 0, fmt.Errorf("unknown category: %s", category)
+			return nil, 0, apperrors.ErrDataQualityUnknownCategory(category)
 		},
 	})
 

--- a/backend/internal/api/handlers/community/contributor_profile.go
+++ b/backend/internal/api/handlers/community/contributor_profile.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
@@ -541,6 +542,9 @@ func (h *ContributorProfileHandler) CreateSectionHandler(ctx context.Context, re
 			"error", err.Error(),
 			"request_id", requestID,
 		)
+		if mapped := shared.MapProfileError(err); mapped != nil {
+			return nil, mapped
+		}
 		return nil, huma.Error422UnprocessableEntity(err.Error())
 	}
 
@@ -592,8 +596,8 @@ func (h *ContributorProfileHandler) UpdateSectionHandler(ctx context.Context, re
 			"error", err.Error(),
 			"request_id", requestID,
 		)
-		if err.Error() == "profile section not found" {
-			return nil, huma.Error404NotFound("Profile section not found")
+		if mapped := shared.MapProfileError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error422UnprocessableEntity(err.Error())
 	}
@@ -684,8 +688,8 @@ func (h *ContributorProfileHandler) DeleteSectionHandler(ctx context.Context, re
 			"error", err.Error(),
 			"request_id", requestID,
 		)
-		if err.Error() == "profile section not found" {
-			return nil, huma.Error404NotFound("Profile section not found")
+		if mapped := shared.MapProfileError(err); mapped != nil {
+			return nil, mapped
 		}
 		return nil, huma.Error500InternalServerError(
 			fmt.Sprintf("Failed to delete section (request_id: %s)", requestID),

--- a/backend/internal/api/handlers/community/entity_report.go
+++ b/backend/internal/api/handlers/community/entity_report.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	communitym "psychic-homily-backend/internal/models/community"
@@ -110,11 +111,8 @@ func (h *EntityReportHandler) reportEntity(ctx context.Context, entityType strin
 		Details:    req.Body.Details,
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "entity not found") {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		if strings.Contains(err.Error(), "already have a pending report") {
-			return nil, huma.Error409Conflict(err.Error())
+		if mapped := shared.MapEntityReportError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("entity_report_create_failed",
 			"user_id", user.ID,
@@ -240,11 +238,8 @@ func (h *EntityReportHandler) AdminResolveEntityReportHandler(ctx context.Contex
 
 	resolved, err := h.entityReportService.ResolveEntityReport(uint(reportID), user.ID, notes)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Report not found")
-		}
-		if strings.Contains(err.Error(), "already been reviewed") {
-			return nil, huma.Error409Conflict(err.Error())
+		if mapped := shared.MapEntityReportError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("entity_report_resolve_failed",
 			"report_id", reportID,
@@ -305,11 +300,8 @@ func (h *EntityReportHandler) AdminDismissEntityReportHandler(ctx context.Contex
 
 	dismissed, err := h.entityReportService.DismissEntityReport(uint(reportID), user.ID, notes)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, huma.Error404NotFound("Report not found")
-		}
-		if strings.Contains(err.Error(), "already been reviewed") {
-			return nil, huma.Error409Conflict(err.Error())
+		if mapped := shared.MapEntityReportError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("entity_report_dismiss_failed",
 			"report_id", reportID,

--- a/backend/internal/api/handlers/community/entity_report_test.go
+++ b/backend/internal/api/handlers/community/entity_report_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -263,7 +264,7 @@ func TestReportEntity_EntityNotFound(t *testing.T) {
 	h := NewEntityReportHandler(
 		&testhelpers.MockEntityReportService{
 			CreateEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
-				return nil, fmt.Errorf("entity not found: artist 99999")
+				return nil, apperrors.ErrEntityReportEntityNotFound("artist", 99999)
 			},
 		},
 		nil,
@@ -280,7 +281,7 @@ func TestReportEntity_DuplicatePending(t *testing.T) {
 	h := NewEntityReportHandler(
 		&testhelpers.MockEntityReportService{
 			CreateEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
-				return nil, fmt.Errorf("you already have a pending report for this entity")
+				return nil, apperrors.ErrEntityReportDuplicatePending()
 			},
 		},
 		nil,
@@ -463,7 +464,7 @@ func TestAdminResolveEntityReport_NotFound(t *testing.T) {
 	h := NewEntityReportHandler(
 		&testhelpers.MockEntityReportService{
 			ResolveEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
-				return nil, fmt.Errorf("report not found")
+				return nil, apperrors.ErrEntityReportNotFound()
 			},
 		},
 		nil,
@@ -477,7 +478,7 @@ func TestAdminResolveEntityReport_AlreadyReviewed(t *testing.T) {
 	h := NewEntityReportHandler(
 		&testhelpers.MockEntityReportService{
 			ResolveEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
-				return nil, fmt.Errorf("report has already been reviewed (status: resolved)")
+				return nil, apperrors.ErrEntityReportAlreadyReviewed("resolved")
 			},
 		},
 		nil,
@@ -533,7 +534,7 @@ func TestAdminDismissEntityReport_NotFound(t *testing.T) {
 	h := NewEntityReportHandler(
 		&testhelpers.MockEntityReportService{
 			DismissEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
-				return nil, fmt.Errorf("report not found")
+				return nil, apperrors.ErrEntityReportNotFound()
 			},
 		},
 		nil,
@@ -547,7 +548,7 @@ func TestAdminDismissEntityReport_AlreadyReviewed(t *testing.T) {
 	h := NewEntityReportHandler(
 		&testhelpers.MockEntityReportService{
 			DismissEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
-				return nil, fmt.Errorf("report has already been reviewed (status: dismissed)")
+				return nil, apperrors.ErrEntityReportAlreadyReviewed("dismissed")
 			},
 		},
 		nil,

--- a/backend/internal/api/handlers/community/leaderboard.go
+++ b/backend/internal/api/handlers/community/leaderboard.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
@@ -72,11 +73,8 @@ func (h *LeaderboardHandler) GetLeaderboardHandler(ctx context.Context, req *Get
 
 	entries, err := h.leaderboardService.GetLeaderboard(dimension, period, limit)
 	if err != nil {
-		if err.Error() == "invalid dimension: "+dimension {
-			return nil, huma.Error422UnprocessableEntity("Invalid dimension: " + dimension)
-		}
-		if err.Error() == "invalid period: "+period {
-			return nil, huma.Error422UnprocessableEntity("Invalid period: " + period)
+		if mapped := shared.MapLeaderboardError(err); mapped != nil {
+			return nil, mapped
 		}
 		logger.FromContext(ctx).Error("leaderboard_failed", "error", err.Error())
 		return nil, huma.Error500InternalServerError("Failed to get leaderboard")

--- a/backend/internal/api/handlers/community/leaderboard_test.go
+++ b/backend/internal/api/handlers/community/leaderboard_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -107,8 +108,8 @@ func TestGetLeaderboard_UserRankErrorIsNonFatal(t *testing.T) {
 func TestGetLeaderboard_InvalidDimension(t *testing.T) {
 	mock := &testhelpers.MockLeaderboardService{
 		GetLeaderboardFn: func(dimension, _ string, _ int) ([]contracts.LeaderboardEntry, error) {
-			// Handler maps this exact message to 422.
-			return nil, fmt.Errorf("invalid dimension: %s", dimension)
+			// Handler maps the typed invalid-dimension error to 422.
+			return nil, apperrors.ErrLeaderboardInvalidDimension(dimension)
 		},
 	}
 	h := NewLeaderboardHandler(mock)

--- a/backend/internal/api/handlers/shared/error_mappers.go
+++ b/backend/internal/api/handlers/shared/error_mappers.go
@@ -264,3 +264,131 @@ func MapSceneError(err error) error {
 	}
 	return nil
 }
+
+// MapEntityReportError converts an EntityReportError to an appropriate Huma
+// HTTP error. Returns nil if err is not a *apperrors.EntityReportError.
+//
+// Reported-entity-not-found / report-not-found → 404; duplicate-pending /
+// already-reviewed → 409; invalid entity/report type → 422 (semantic
+// validation); infrastructure fault → 500.
+func MapEntityReportError(err error) error {
+	var reportErr *apperrors.EntityReportError
+	if errors.As(err, &reportErr) {
+		switch reportErr.Code {
+		case apperrors.CodeEntityReportEntityNotFound, apperrors.CodeEntityReportNotFound:
+			return huma.Error404NotFound(reportErr.Message)
+		case apperrors.CodeEntityReportDuplicatePending, apperrors.CodeEntityReportAlreadyReviewed:
+			return huma.Error409Conflict(reportErr.Message)
+		case apperrors.CodeEntityReportInvalidEntityType, apperrors.CodeEntityReportInvalidReportType:
+			return huma.Error422UnprocessableEntity(reportErr.Message)
+		case apperrors.CodeEntityReportInternal:
+			return huma.Error500InternalServerError(reportErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapLeaderboardError converts a LeaderboardError to an appropriate Huma HTTP
+// error. Returns nil if err is not a *apperrors.LeaderboardError.
+//
+// Invalid dimension / period → 422 (semantic validation); infra fault → 500.
+// There is no not-found path (an empty board is a 200).
+func MapLeaderboardError(err error) error {
+	var lbErr *apperrors.LeaderboardError
+	if errors.As(err, &lbErr) {
+		switch lbErr.Code {
+		case apperrors.CodeLeaderboardInvalidDimension, apperrors.CodeLeaderboardInvalidPeriod:
+			return huma.Error422UnprocessableEntity(lbErr.Message)
+		case apperrors.CodeLeaderboardInternal:
+			return huma.Error500InternalServerError(lbErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapDataQualityError converts a DataQualityError to an appropriate Huma HTTP
+// error. Returns nil if err is not a *apperrors.DataQualityError.
+//
+// Unknown category → 422 (semantic validation); infra fault → 500. Shared by
+// the admin data-quality dashboard and the public contribute surface, which
+// both consume DataQualityService.
+func MapDataQualityError(err error) error {
+	var dqErr *apperrors.DataQualityError
+	if errors.As(err, &dqErr) {
+		switch dqErr.Code {
+		case apperrors.CodeDataQualityUnknownCategory:
+			return huma.Error422UnprocessableEntity(dqErr.Message)
+		case apperrors.CodeDataQualityInternal:
+			return huma.Error500InternalServerError(dqErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapAutoPromotionError converts an AutoPromotionError to an appropriate Huma
+// HTTP error. Returns nil if err is not a *apperrors.AutoPromotionError.
+//
+// User-not-found → 404; infra fault → 500.
+func MapAutoPromotionError(err error) error {
+	var apErr *apperrors.AutoPromotionError
+	if errors.As(err, &apErr) {
+		switch apErr.Code {
+		case apperrors.CodeAutoPromotionUserNotFound:
+			return huma.Error404NotFound(apErr.Message)
+		case apperrors.CodeAutoPromotionInternal:
+			return huma.Error500InternalServerError(apErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapProfileError converts a ProfileError to an appropriate Huma HTTP error.
+// Returns nil if err is not a *apperrors.ProfileError.
+//
+// Section-not-found → 404; section-validation → 422 (the message is
+// user-facing and surfaced verbatim); infra fault → 500.
+func MapProfileError(err error) error {
+	var profileErr *apperrors.ProfileError
+	if errors.As(err, &profileErr) {
+		switch profileErr.Code {
+		case apperrors.CodeProfileSectionNotFound:
+			return huma.Error404NotFound(profileErr.Message)
+		case apperrors.CodeProfileSectionInvalid:
+			return huma.Error422UnprocessableEntity(profileErr.Message)
+		case apperrors.CodeProfileInternal:
+			return huma.Error500InternalServerError(profileErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapPendingEditError converts a PendingEditError to an appropriate Huma HTTP
+// error. Returns nil if err is not a *apperrors.PendingEditError.
+//
+// Entity-not-found (create) → 404; entity-gone (approve) → 422; edit-not-found
+// → 404; not-pending / duplicate → 409; not-submitter → 403 (cancel only);
+// invalid entity type / malformed request → 422; infra fault → 500.
+//
+// The disallowed-fields auto-rejection is a separate sentinel
+// (adminm.ErrPendingEditDisallowedFields → 400) handled by the approve
+// handler before this mapper runs.
+func MapPendingEditError(err error) error {
+	var editErr *apperrors.PendingEditError
+	if errors.As(err, &editErr) {
+		switch editErr.Code {
+		case apperrors.CodePendingEditEntityNotFound, apperrors.CodePendingEditNotFound:
+			return huma.Error404NotFound(editErr.Message)
+		case apperrors.CodePendingEditNotPending, apperrors.CodePendingEditDuplicate:
+			return huma.Error409Conflict(editErr.Message)
+		case apperrors.CodePendingEditNotSubmitter:
+			return huma.Error403Forbidden(editErr.Message)
+		case apperrors.CodePendingEditEntityGone,
+			apperrors.CodePendingEditInvalidEntityType,
+			apperrors.CodePendingEditInvalidRequest:
+			return huma.Error422UnprocessableEntity(editErr.Message)
+		case apperrors.CodePendingEditInternal:
+			return huma.Error500InternalServerError(editErr.Message)
+		}
+	}
+	return nil
+}

--- a/backend/internal/api/handlers/shared/error_mappers_test.go
+++ b/backend/internal/api/handlers/shared/error_mappers_test.go
@@ -393,3 +393,187 @@ func TestMapSceneError_NonSceneErrorReturnsNil(t *testing.T) {
 		t.Errorf("MapSceneError(unknown code) = %v, want nil", got)
 	}
 }
+
+func TestMapEntityReportError_CodeToStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    *apperrors.EntityReportError
+		status int
+	}{
+		{"entity not found", apperrors.ErrEntityReportEntityNotFound("artist", 9), 404},
+		{"report not found", apperrors.ErrEntityReportNotFound(), 404},
+		{"duplicate pending", apperrors.ErrEntityReportDuplicatePending(), 409},
+		{"already reviewed", apperrors.ErrEntityReportAlreadyReviewed("resolved"), 409},
+		{"invalid entity type", apperrors.ErrEntityReportInvalidEntityType("planet"), 422},
+		{"invalid report type", apperrors.ErrEntityReportInvalidReportType("nope", "artist"), 422},
+		{"internal", apperrors.ErrEntityReportInternal(stderrors.New("db down")), 500},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapEntityReportError(tc.err)
+			if got == nil {
+				t.Fatalf("MapEntityReportError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapEntityReportError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapEntityReportError_NonEntityReportErrorReturnsNil(t *testing.T) {
+	if got := MapEntityReportError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapEntityReportError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.EntityReportError{Code: "ENTITY_REPORT_NEW_CODE", Message: "x"}
+	if got := MapEntityReportError(unknown); got != nil {
+		t.Errorf("MapEntityReportError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapLeaderboardError_CodeToStatus(t *testing.T) {
+	if got := MapLeaderboardError(apperrors.ErrLeaderboardInvalidDimension("bogus")); got == nil {
+		t.Fatal("MapLeaderboardError(invalid dimension) = nil, want 422")
+	} else if s := statusOf(t, got); s != 422 {
+		t.Errorf("invalid-dimension status = %d, want 422", s)
+	}
+
+	if got := MapLeaderboardError(apperrors.ErrLeaderboardInvalidPeriod("decade")); got == nil {
+		t.Fatal("MapLeaderboardError(invalid period) = nil, want 422")
+	} else if s := statusOf(t, got); s != 422 {
+		t.Errorf("invalid-period status = %d, want 422", s)
+	}
+
+	if got := MapLeaderboardError(apperrors.ErrLeaderboardInternal(stderrors.New("db down"))); got == nil {
+		t.Fatal("MapLeaderboardError(internal) = nil, want 500")
+	} else if s := statusOf(t, got); s != 500 {
+		t.Errorf("internal status = %d, want 500", s)
+	}
+}
+
+func TestMapLeaderboardError_NonLeaderboardErrorReturnsNil(t *testing.T) {
+	if got := MapLeaderboardError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapLeaderboardError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.LeaderboardError{Code: "LEADERBOARD_NEW_CODE", Message: "x"}
+	if got := MapLeaderboardError(unknown); got != nil {
+		t.Errorf("MapLeaderboardError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapDataQualityError_CodeToStatus(t *testing.T) {
+	if got := MapDataQualityError(apperrors.ErrDataQualityUnknownCategory("nope")); got == nil {
+		t.Fatal("MapDataQualityError(unknown category) = nil, want 422")
+	} else if s := statusOf(t, got); s != 422 {
+		t.Errorf("unknown-category status = %d, want 422", s)
+	}
+
+	if got := MapDataQualityError(apperrors.ErrDataQualityInternal(stderrors.New("db down"))); got == nil {
+		t.Fatal("MapDataQualityError(internal) = nil, want 500")
+	} else if s := statusOf(t, got); s != 500 {
+		t.Errorf("internal status = %d, want 500", s)
+	}
+}
+
+func TestMapDataQualityError_NonDataQualityErrorReturnsNil(t *testing.T) {
+	if got := MapDataQualityError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapDataQualityError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.DataQualityError{Code: "DATA_QUALITY_NEW_CODE", Message: "x"}
+	if got := MapDataQualityError(unknown); got != nil {
+		t.Errorf("MapDataQualityError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapAutoPromotionError_CodeToStatus(t *testing.T) {
+	if got := MapAutoPromotionError(apperrors.ErrAutoPromotionUserNotFound()); got == nil {
+		t.Fatal("MapAutoPromotionError(user not found) = nil, want 404")
+	} else if s := statusOf(t, got); s != 404 {
+		t.Errorf("user-not-found status = %d, want 404", s)
+	}
+
+	if got := MapAutoPromotionError(apperrors.ErrAutoPromotionInternal(stderrors.New("db down"))); got == nil {
+		t.Fatal("MapAutoPromotionError(internal) = nil, want 500")
+	} else if s := statusOf(t, got); s != 500 {
+		t.Errorf("internal status = %d, want 500", s)
+	}
+}
+
+func TestMapAutoPromotionError_NonAutoPromotionErrorReturnsNil(t *testing.T) {
+	if got := MapAutoPromotionError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapAutoPromotionError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.AutoPromotionError{Code: "AUTO_PROMOTION_NEW_CODE", Message: "x"}
+	if got := MapAutoPromotionError(unknown); got != nil {
+		t.Errorf("MapAutoPromotionError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapProfileError_CodeToStatus(t *testing.T) {
+	if got := MapProfileError(apperrors.ErrProfileSectionNotFound()); got == nil {
+		t.Fatal("MapProfileError(section not found) = nil, want 404")
+	} else if s := statusOf(t, got); s != 404 {
+		t.Errorf("section-not-found status = %d, want 404", s)
+	}
+
+	if got := MapProfileError(apperrors.ErrProfileSectionInvalid("title too long")); got == nil {
+		t.Fatal("MapProfileError(section invalid) = nil, want 422")
+	} else if s := statusOf(t, got); s != 422 {
+		t.Errorf("section-invalid status = %d, want 422", s)
+	}
+
+	if got := MapProfileError(apperrors.ErrProfileInternal(stderrors.New("db down"))); got == nil {
+		t.Fatal("MapProfileError(internal) = nil, want 500")
+	} else if s := statusOf(t, got); s != 500 {
+		t.Errorf("internal status = %d, want 500", s)
+	}
+}
+
+func TestMapProfileError_NonProfileErrorReturnsNil(t *testing.T) {
+	if got := MapProfileError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapProfileError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.ProfileError{Code: "PROFILE_NEW_CODE", Message: "x"}
+	if got := MapProfileError(unknown); got != nil {
+		t.Errorf("MapProfileError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapPendingEditError_CodeToStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    *apperrors.PendingEditError
+		status int
+	}{
+		{"entity not found (create)", apperrors.ErrPendingEditEntityNotFound("artist", 9), 404},
+		{"entity gone (approve)", apperrors.ErrPendingEditEntityGone("artist", 9), 422},
+		{"edit not found", apperrors.ErrPendingEditNotFound(), 404},
+		{"not pending", apperrors.ErrPendingEditNotPending("approved"), 409},
+		{"duplicate", apperrors.ErrPendingEditDuplicate(stderrors.New("unique constraint")), 409},
+		{"not submitter", apperrors.ErrPendingEditNotSubmitter(), 403},
+		{"invalid entity type", apperrors.ErrPendingEditInvalidEntityType("show"), 422},
+		{"invalid request", apperrors.ErrPendingEditInvalidRequest("no changes provided"), 422},
+		{"internal", apperrors.ErrPendingEditInternal(stderrors.New("db down")), 500},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapPendingEditError(tc.err)
+			if got == nil {
+				t.Fatalf("MapPendingEditError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapPendingEditError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapPendingEditError_NonPendingEditErrorReturnsNil(t *testing.T) {
+	if got := MapPendingEditError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapPendingEditError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.PendingEditError{Code: "PENDING_EDIT_NEW_CODE", Message: "x"}
+	if got := MapPendingEditError(unknown); got != nil {
+		t.Errorf("MapPendingEditError(unknown code) = %v, want nil", got)
+	}
+}

--- a/backend/internal/errors/auto_promotion.go
+++ b/backend/internal/errors/auto_promotion.go
@@ -1,0 +1,54 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Auto-promotion error codes.
+//
+// Evaluating a single user for tier auto-promotion can fail because the user
+// does not exist (not found) or because of a database fault (internal). The
+// batch evaluation only fails on internal faults.
+const (
+	// CodeAutoPromotionUserNotFound indicates the target user does not exist.
+	CodeAutoPromotionUserNotFound = "AUTO_PROMOTION_USER_NOT_FOUND"
+	// CodeAutoPromotionInternal indicates a database or infrastructure failure.
+	CodeAutoPromotionInternal = "AUTO_PROMOTION_INTERNAL"
+)
+
+// AutoPromotionError represents an auto-promotion error with context.
+type AutoPromotionError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *AutoPromotionError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *AutoPromotionError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrAutoPromotionUserNotFound creates a user-not-found error.
+func ErrAutoPromotionUserNotFound() *AutoPromotionError {
+	return &AutoPromotionError{
+		Code:    CodeAutoPromotionUserNotFound,
+		Message: "user not found",
+	}
+}
+
+// ErrAutoPromotionInternal wraps a database or infrastructure failure.
+func ErrAutoPromotionInternal(internal error) *AutoPromotionError {
+	return &AutoPromotionError{
+		Code:     CodeAutoPromotionInternal,
+		Message:  "failed to evaluate user for auto-promotion",
+		Internal: internal,
+	}
+}

--- a/backend/internal/errors/contributor_profile.go
+++ b/backend/internal/errors/contributor_profile.go
@@ -1,0 +1,69 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Contributor-profile (section) error codes.
+//
+// Profile sections are user-owned. Mutating one can fail because the section
+// does not exist (or isn't owned by the caller — surfaced as not-found so we
+// don't leak existence), because a field value is rejected by the section
+// validation rules (semantic validation: title length, content length,
+// position range, max-section count), or because of a database fault.
+const (
+	// CodeProfileSectionNotFound indicates the section does not exist for the
+	// requesting user.
+	CodeProfileSectionNotFound = "PROFILE_SECTION_NOT_FOUND"
+	// CodeProfileSectionInvalid indicates a section field failed validation.
+	CodeProfileSectionInvalid = "PROFILE_SECTION_INVALID"
+	// CodeProfileInternal indicates a database or infrastructure failure.
+	CodeProfileInternal = "PROFILE_INTERNAL"
+)
+
+// ProfileError represents a contributor-profile error with context.
+type ProfileError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *ProfileError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *ProfileError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrProfileSectionNotFound creates a section-not-found error.
+func ErrProfileSectionNotFound() *ProfileError {
+	return &ProfileError{
+		Code:    CodeProfileSectionNotFound,
+		Message: "profile section not found",
+	}
+}
+
+// ErrProfileSectionInvalid creates a section-validation error. The message is
+// user-facing — it is surfaced verbatim by the handler so the contributor
+// sees which rule was violated.
+func ErrProfileSectionInvalid(message string) *ProfileError {
+	return &ProfileError{
+		Code:    CodeProfileSectionInvalid,
+		Message: message,
+	}
+}
+
+// ErrProfileInternal wraps a database or infrastructure failure.
+func ErrProfileInternal(internal error) *ProfileError {
+	return &ProfileError{
+		Code:     CodeProfileInternal,
+		Message:  "failed to update profile section",
+		Internal: internal,
+	}
+}

--- a/backend/internal/errors/data_quality.go
+++ b/backend/internal/errors/data_quality.go
@@ -1,0 +1,57 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Data-quality error codes.
+//
+// Listing the items in a data-quality / contribution category can fail
+// because the category key is not recognised (semantic validation) or
+// because of a database fault (internal). The summary endpoint only fails on
+// internal faults. This error type is shared by the admin data-quality
+// dashboard and the public contribute-opportunities surface, which both
+// consume DataQualityService.
+const (
+	// CodeDataQualityUnknownCategory indicates an unrecognised category key.
+	CodeDataQualityUnknownCategory = "DATA_QUALITY_UNKNOWN_CATEGORY"
+	// CodeDataQualityInternal indicates a database or infrastructure failure.
+	CodeDataQualityInternal = "DATA_QUALITY_INTERNAL"
+)
+
+// DataQualityError represents a data-quality error with additional context.
+type DataQualityError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *DataQualityError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *DataQualityError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrDataQualityUnknownCategory creates an unknown-category error.
+func ErrDataQualityUnknownCategory(category string) *DataQualityError {
+	return &DataQualityError{
+		Code:    CodeDataQualityUnknownCategory,
+		Message: fmt.Sprintf("unknown category: %s", category),
+	}
+}
+
+// ErrDataQualityInternal wraps a database or infrastructure failure.
+func ErrDataQualityInternal(internal error) *DataQualityError {
+	return &DataQualityError{
+		Code:     CodeDataQualityInternal,
+		Message:  "failed to query data quality",
+		Internal: internal,
+	}
+}

--- a/backend/internal/errors/entity_report.go
+++ b/backend/internal/errors/entity_report.go
@@ -1,0 +1,110 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Entity-report error codes.
+//
+// Reporting an entity can fail because the target entity does not exist
+// (not found), the reporter already has a pending report for it (conflict),
+// the entity type or report type is not valid for the taxonomy (semantic
+// validation), or a database fault. Admin resolve/dismiss can fail because
+// the report row does not exist (not found) or has already been reviewed
+// (conflict).
+const (
+	// CodeEntityReportEntityNotFound indicates the reported entity does not exist.
+	CodeEntityReportEntityNotFound = "ENTITY_REPORT_ENTITY_NOT_FOUND"
+	// CodeEntityReportNotFound indicates the report row itself does not exist.
+	CodeEntityReportNotFound = "ENTITY_REPORT_NOT_FOUND"
+	// CodeEntityReportDuplicatePending indicates the reporter already has a
+	// pending report for this entity.
+	CodeEntityReportDuplicatePending = "ENTITY_REPORT_DUPLICATE_PENDING"
+	// CodeEntityReportAlreadyReviewed indicates the report has already been
+	// resolved or dismissed.
+	CodeEntityReportAlreadyReviewed = "ENTITY_REPORT_ALREADY_REVIEWED"
+	// CodeEntityReportInvalidEntityType indicates an unsupported entity type.
+	CodeEntityReportInvalidEntityType = "ENTITY_REPORT_INVALID_ENTITY_TYPE"
+	// CodeEntityReportInvalidReportType indicates a report type not valid for
+	// the given entity type.
+	CodeEntityReportInvalidReportType = "ENTITY_REPORT_INVALID_REPORT_TYPE"
+	// CodeEntityReportInternal indicates a database or infrastructure failure.
+	CodeEntityReportInternal = "ENTITY_REPORT_INTERNAL"
+)
+
+// EntityReportError represents an entity-report error with additional context.
+type EntityReportError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *EntityReportError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *EntityReportError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrEntityReportEntityNotFound creates a reported-entity-not-found error.
+func ErrEntityReportEntityNotFound(entityType string, entityID uint) *EntityReportError {
+	return &EntityReportError{
+		Code:    CodeEntityReportEntityNotFound,
+		Message: fmt.Sprintf("entity not found: %s %d", entityType, entityID),
+	}
+}
+
+// ErrEntityReportNotFound creates a report-not-found error.
+func ErrEntityReportNotFound() *EntityReportError {
+	return &EntityReportError{
+		Code:    CodeEntityReportNotFound,
+		Message: "report not found",
+	}
+}
+
+// ErrEntityReportDuplicatePending creates an already-pending-report error.
+func ErrEntityReportDuplicatePending() *EntityReportError {
+	return &EntityReportError{
+		Code:    CodeEntityReportDuplicatePending,
+		Message: "you already have a pending report for this entity",
+	}
+}
+
+// ErrEntityReportAlreadyReviewed creates an already-reviewed error.
+func ErrEntityReportAlreadyReviewed(status string) *EntityReportError {
+	return &EntityReportError{
+		Code:    CodeEntityReportAlreadyReviewed,
+		Message: fmt.Sprintf("report has already been reviewed (status: %s)", status),
+	}
+}
+
+// ErrEntityReportInvalidEntityType creates an invalid-entity-type error.
+func ErrEntityReportInvalidEntityType(entityType string) *EntityReportError {
+	return &EntityReportError{
+		Code:    CodeEntityReportInvalidEntityType,
+		Message: fmt.Sprintf("invalid entity type: %s", entityType),
+	}
+}
+
+// ErrEntityReportInvalidReportType creates an invalid-report-type error.
+func ErrEntityReportInvalidReportType(reportType, entityType string) *EntityReportError {
+	return &EntityReportError{
+		Code:    CodeEntityReportInvalidReportType,
+		Message: fmt.Sprintf("invalid report type '%s' for entity type '%s'", reportType, entityType),
+	}
+}
+
+// ErrEntityReportInternal wraps a database or infrastructure failure.
+func ErrEntityReportInternal(internal error) *EntityReportError {
+	return &EntityReportError{
+		Code:     CodeEntityReportInternal,
+		Message:  "failed to process entity report",
+		Internal: internal,
+	}
+}

--- a/backend/internal/errors/leaderboard.go
+++ b/backend/internal/errors/leaderboard.go
@@ -1,0 +1,65 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Leaderboard error codes.
+//
+// Computing a leaderboard can fail because the requested dimension or period
+// is not one of the supported values (semantic validation), or because of a
+// database fault (internal). There is no not-found path — an empty board is a
+// valid 200 result, not an error.
+const (
+	// CodeLeaderboardInvalidDimension indicates an unsupported dimension.
+	CodeLeaderboardInvalidDimension = "LEADERBOARD_INVALID_DIMENSION"
+	// CodeLeaderboardInvalidPeriod indicates an unsupported time period.
+	CodeLeaderboardInvalidPeriod = "LEADERBOARD_INVALID_PERIOD"
+	// CodeLeaderboardInternal indicates a database or infrastructure failure.
+	CodeLeaderboardInternal = "LEADERBOARD_INTERNAL"
+)
+
+// LeaderboardError represents a leaderboard-related error with context.
+type LeaderboardError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *LeaderboardError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *LeaderboardError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrLeaderboardInvalidDimension creates an invalid-dimension error.
+func ErrLeaderboardInvalidDimension(dimension string) *LeaderboardError {
+	return &LeaderboardError{
+		Code:    CodeLeaderboardInvalidDimension,
+		Message: fmt.Sprintf("invalid dimension: %s", dimension),
+	}
+}
+
+// ErrLeaderboardInvalidPeriod creates an invalid-period error.
+func ErrLeaderboardInvalidPeriod(period string) *LeaderboardError {
+	return &LeaderboardError{
+		Code:    CodeLeaderboardInvalidPeriod,
+		Message: fmt.Sprintf("invalid period: %s", period),
+	}
+}
+
+// ErrLeaderboardInternal wraps a database or infrastructure failure.
+func ErrLeaderboardInternal(internal error) *LeaderboardError {
+	return &LeaderboardError{
+		Code:     CodeLeaderboardInternal,
+		Message:  "failed to compute leaderboard",
+		Internal: internal,
+	}
+}

--- a/backend/internal/errors/pending_edit.go
+++ b/backend/internal/errors/pending_edit.go
@@ -1,0 +1,144 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Pending-edit error codes.
+//
+// Creating a pending edit can fail because the target entity does not exist
+// (not found), the entity type is not editable, the request is malformed (no
+// changes / missing or oversize summary — semantic validation), the submitter
+// already has a pending edit for this entity (conflict, surfaced from the DB
+// unique constraint), or a database fault.
+//
+// Approve/reject/cancel can fail because the edit row does not exist (not
+// found), it has already been reviewed (conflict), the caller is not the
+// submitter (forbidden — cancel only), or the entity was deleted between
+// submission and approval (unprocessable — the edit can no longer be applied).
+//
+// Note: the disallowed-fields auto-rejection on the approve path is its own
+// sentinel (adminm.ErrPendingEditDisallowedFields, mapped to 400 by the
+// handler via errors.Is) and is intentionally NOT modelled here.
+const (
+	// CodePendingEditEntityNotFound indicates the target entity does not exist
+	// at submission time (create path → 404).
+	CodePendingEditEntityNotFound = "PENDING_EDIT_ENTITY_NOT_FOUND"
+	// CodePendingEditEntityGone indicates the entity was deleted between
+	// submission and approval (approve path → 422, the edit is unprocessable).
+	CodePendingEditEntityGone = "PENDING_EDIT_ENTITY_GONE"
+	// CodePendingEditNotFound indicates the pending-edit row does not exist.
+	CodePendingEditNotFound = "PENDING_EDIT_NOT_FOUND"
+	// CodePendingEditNotPending indicates the edit has already been reviewed.
+	CodePendingEditNotPending = "PENDING_EDIT_NOT_PENDING"
+	// CodePendingEditNotSubmitter indicates a non-submitter tried to cancel.
+	CodePendingEditNotSubmitter = "PENDING_EDIT_NOT_SUBMITTER"
+	// CodePendingEditDuplicate indicates the submitter already has a pending
+	// edit for this entity (DB unique-constraint violation).
+	CodePendingEditDuplicate = "PENDING_EDIT_DUPLICATE"
+	// CodePendingEditInvalidEntityType indicates an unsupported entity type.
+	CodePendingEditInvalidEntityType = "PENDING_EDIT_INVALID_ENTITY_TYPE"
+	// CodePendingEditInvalidRequest indicates a malformed request (no changes,
+	// missing or oversize summary/reason — semantic validation).
+	CodePendingEditInvalidRequest = "PENDING_EDIT_INVALID_REQUEST"
+	// CodePendingEditInternal indicates a database or infrastructure failure.
+	CodePendingEditInternal = "PENDING_EDIT_INTERNAL"
+)
+
+// PendingEditError represents a pending-edit error with additional context.
+type PendingEditError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *PendingEditError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *PendingEditError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrPendingEditEntityNotFound creates an entity-not-found error for the
+// create path.
+func ErrPendingEditEntityNotFound(entityType string, entityID uint) *PendingEditError {
+	return &PendingEditError{
+		Code:    CodePendingEditEntityNotFound,
+		Message: fmt.Sprintf("entity not found: %s %d", entityType, entityID),
+	}
+}
+
+// ErrPendingEditEntityGone creates an entity-deleted-before-approval error for
+// the approve path.
+func ErrPendingEditEntityGone(entityType string, entityID uint) *PendingEditError {
+	return &PendingEditError{
+		Code:    CodePendingEditEntityGone,
+		Message: fmt.Sprintf("entity not found: %s %d", entityType, entityID),
+	}
+}
+
+// ErrPendingEditNotFound creates a pending-edit-not-found error.
+func ErrPendingEditNotFound() *PendingEditError {
+	return &PendingEditError{
+		Code:    CodePendingEditNotFound,
+		Message: "pending edit not found",
+	}
+}
+
+// ErrPendingEditNotPending creates an already-reviewed error.
+func ErrPendingEditNotPending(status string) *PendingEditError {
+	return &PendingEditError{
+		Code:    CodePendingEditNotPending,
+		Message: fmt.Sprintf("edit is not pending (status: %s)", status),
+	}
+}
+
+// ErrPendingEditNotSubmitter creates a not-the-submitter error.
+func ErrPendingEditNotSubmitter() *PendingEditError {
+	return &PendingEditError{
+		Code:    CodePendingEditNotSubmitter,
+		Message: "only the submitter can cancel their own edit",
+	}
+}
+
+// ErrPendingEditDuplicate creates a duplicate-pending-edit error. internal
+// carries the underlying unique-constraint violation for logging.
+func ErrPendingEditDuplicate(internal error) *PendingEditError {
+	return &PendingEditError{
+		Code:     CodePendingEditDuplicate,
+		Message:  "you already have a pending edit for this entity",
+		Internal: internal,
+	}
+}
+
+// ErrPendingEditInvalidEntityType creates an invalid-entity-type error.
+func ErrPendingEditInvalidEntityType(entityType string) *PendingEditError {
+	return &PendingEditError{
+		Code:    CodePendingEditInvalidEntityType,
+		Message: fmt.Sprintf("invalid entity type: %s", entityType),
+	}
+}
+
+// ErrPendingEditInvalidRequest creates a malformed-request error. The message
+// is user-facing.
+func ErrPendingEditInvalidRequest(message string) *PendingEditError {
+	return &PendingEditError{
+		Code:    CodePendingEditInvalidRequest,
+		Message: message,
+	}
+}
+
+// ErrPendingEditInternal wraps a database or infrastructure failure.
+func ErrPendingEditInternal(internal error) *PendingEditError {
+	return &PendingEditError{
+		Code:     CodePendingEditInternal,
+		Message:  "failed to process pending edit",
+		Internal: internal,
+	}
+}

--- a/backend/internal/services/admin/auto_promotion.go
+++ b/backend/internal/services/admin/auto_promotion.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
@@ -338,15 +339,15 @@ func (s *AutoPromotionService) writeTierChangeAuditLog(user *authm.User, change 
 // EvaluateUser checks a single user for promotion/demotion eligibility.
 func (s *AutoPromotionService) EvaluateUser(userID uint) (*contracts.UserEvaluationResult, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrAutoPromotionInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var user authm.User
 	if err := s.db.First(&user, userID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("user not found")
+			return nil, apperrors.ErrAutoPromotionUserNotFound()
 		}
-		return nil, fmt.Errorf("failed to get user: %w", err)
+		return nil, apperrors.ErrAutoPromotionInternal(fmt.Errorf("failed to get user: %w", err))
 	}
 
 	return s.evaluateUserInternal(&user)

--- a/backend/internal/services/admin/data_quality.go
+++ b/backend/internal/services/admin/data_quality.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -110,7 +111,7 @@ func (s *DataQualityService) GetSummary() (*contracts.DataQualitySummary, error)
 // GetCategoryItems returns paginated items for a specific data quality category.
 func (s *DataQualityService) GetCategoryItems(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
 	if _, ok := categoryDefinitions[category]; !ok {
-		return nil, 0, fmt.Errorf("unknown category: %s", category)
+		return nil, 0, apperrors.ErrDataQualityUnknownCategory(category)
 	}
 
 	if limit <= 0 {
@@ -138,7 +139,7 @@ func (s *DataQualityService) GetCategoryItems(category string, limit, offset int
 	case "releases_missing_year":
 		return s.getReleasesMissingYear(limit, offset)
 	default:
-		return nil, 0, fmt.Errorf("unknown category: %s", category)
+		return nil, 0, apperrors.ErrDataQualityUnknownCategory(category)
 	}
 }
 

--- a/backend/internal/services/admin/entity_report.go
+++ b/backend/internal/services/admin/entity_report.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/services/shared"
@@ -28,14 +29,14 @@ func NewEntityReportService(database *gorm.DB) *EntityReportService {
 // CreateEntityReport submits a new report for an entity.
 func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("database not initialized"))
 	}
 
 	if !communitym.IsValidEntityReportEntityType(req.EntityType) {
-		return nil, fmt.Errorf("invalid entity type: %s", req.EntityType)
+		return nil, apperrors.ErrEntityReportInvalidEntityType(req.EntityType)
 	}
 	if !communitym.IsValidReportType(req.EntityType, req.ReportType) {
-		return nil, fmt.Errorf("invalid report type '%s' for entity type '%s'", req.ReportType, req.EntityType)
+		return nil, apperrors.ErrEntityReportInvalidReportType(req.ReportType, req.EntityType)
 	}
 
 	// Verify the entity exists
@@ -46,10 +47,10 @@ func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityRepo
 	}
 	var count int64
 	if err := s.db.Table(tableName).Where("id = ?", req.EntityID).Count(&count).Error; err != nil {
-		return nil, fmt.Errorf("failed to verify entity: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to verify entity: %w", err))
 	}
 	if count == 0 {
-		return nil, fmt.Errorf("entity not found: %s %d", req.EntityType, req.EntityID)
+		return nil, apperrors.ErrEntityReportEntityNotFound(req.EntityType, req.EntityID)
 	}
 
 	// Check for existing pending report from this user for this entity
@@ -58,10 +59,10 @@ func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityRepo
 		Where("entity_type = ? AND entity_id = ? AND reported_by = ? AND status = ?",
 			req.EntityType, req.EntityID, req.UserID, communitym.EntityReportStatusPending).
 		Count(&existingCount).Error; err != nil {
-		return nil, fmt.Errorf("failed to check existing report: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to check existing report: %w", err))
 	}
 	if existingCount > 0 {
-		return nil, fmt.Errorf("you already have a pending report for this entity")
+		return nil, apperrors.ErrEntityReportDuplicatePending()
 	}
 
 	report := &communitym.EntityReport{
@@ -74,7 +75,7 @@ func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityRepo
 	}
 
 	if err := s.db.Create(report).Error; err != nil {
-		return nil, fmt.Errorf("failed to create entity report: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to create entity report: %w", err))
 	}
 
 	// Auto-hide comments with 3+ reports
@@ -101,7 +102,7 @@ func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityRepo
 // GetEntityReport returns a single report by ID.
 func (s *EntityReportService) GetEntityReport(reportID uint) (*contracts.EntityReportResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var report communitym.EntityReport
@@ -110,7 +111,7 @@ func (s *EntityReportService) GetEntityReport(reportID uint) (*contracts.EntityR
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get entity report: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to get entity report: %w", err))
 	}
 
 	return s.toResponse(&report), nil
@@ -119,7 +120,7 @@ func (s *EntityReportService) GetEntityReport(reportID uint) (*contracts.EntityR
 // GetEntityReports returns all reports for a specific entity.
 func (s *EntityReportService) GetEntityReports(entityType string, entityID uint) ([]contracts.EntityReportResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var reports []communitym.EntityReport
@@ -129,7 +130,7 @@ func (s *EntityReportService) GetEntityReports(entityType string, entityID uint)
 		Order("created_at DESC").
 		Find(&reports).Error
 	if err != nil {
-		return nil, fmt.Errorf("failed to get entity reports: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to get entity reports: %w", err))
 	}
 
 	return s.toResponses(reports), nil
@@ -138,7 +139,7 @@ func (s *EntityReportService) GetEntityReports(entityType string, entityID uint)
 // ListEntityReports returns reports for the admin review queue.
 func (s *EntityReportService) ListEntityReports(filters *contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error) {
 	if s.db == nil {
-		return nil, 0, fmt.Errorf("database not initialized")
+		return nil, 0, apperrors.ErrEntityReportInternal(fmt.Errorf("database not initialized"))
 	}
 
 	limit := 20
@@ -175,7 +176,7 @@ func (s *EntityReportService) ListEntityReports(filters *contracts.EntityReportF
 		Offset(offset).
 		Find(&reports).Error
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to list entity reports: %w", err)
+		return nil, 0, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to list entity reports: %w", err))
 	}
 
 	return s.toResponses(reports), total, nil
@@ -184,19 +185,19 @@ func (s *EntityReportService) ListEntityReports(filters *contracts.EntityReportF
 // ResolveEntityReport marks a report as resolved (action was taken).
 func (s *EntityReportService) ResolveEntityReport(reportID uint, reviewerID uint, notes string) (*contracts.EntityReportResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var report communitym.EntityReport
 	if err := s.db.First(&report, reportID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("report not found")
+			return nil, apperrors.ErrEntityReportNotFound()
 		}
-		return nil, fmt.Errorf("failed to get report: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to get report: %w", err))
 	}
 
 	if report.Status != communitym.EntityReportStatusPending {
-		return nil, fmt.Errorf("report has already been reviewed (status: %s)", report.Status)
+		return nil, apperrors.ErrEntityReportAlreadyReviewed(string(report.Status))
 	}
 
 	now := time.Now()
@@ -210,7 +211,7 @@ func (s *EntityReportService) ResolveEntityReport(reportID uint, reviewerID uint
 	}
 
 	if err := s.db.Model(&report).Updates(updates).Error; err != nil {
-		return nil, fmt.Errorf("failed to resolve report: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to resolve report: %w", err))
 	}
 
 	return s.GetEntityReport(reportID)
@@ -219,19 +220,19 @@ func (s *EntityReportService) ResolveEntityReport(reportID uint, reviewerID uint
 // DismissEntityReport marks a report as dismissed (spam/invalid).
 func (s *EntityReportService) DismissEntityReport(reportID uint, reviewerID uint, notes string) (*contracts.EntityReportResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var report communitym.EntityReport
 	if err := s.db.First(&report, reportID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("report not found")
+			return nil, apperrors.ErrEntityReportNotFound()
 		}
-		return nil, fmt.Errorf("failed to get report: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to get report: %w", err))
 	}
 
 	if report.Status != communitym.EntityReportStatusPending {
-		return nil, fmt.Errorf("report has already been reviewed (status: %s)", report.Status)
+		return nil, apperrors.ErrEntityReportAlreadyReviewed(string(report.Status))
 	}
 
 	now := time.Now()
@@ -245,7 +246,7 @@ func (s *EntityReportService) DismissEntityReport(reportID uint, reviewerID uint
 	}
 
 	if err := s.db.Model(&report).Updates(updates).Error; err != nil {
-		return nil, fmt.Errorf("failed to dismiss report: %w", err)
+		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to dismiss report: %w", err))
 	}
 
 	return s.GetEntityReport(reportID)

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
@@ -77,42 +78,55 @@ func (s *PendingEditService) renderRejectionReason(reason *string) string {
 	return s.renderMarkdown(*reason)
 }
 
+// isDuplicateKeyErr reports whether err is a Postgres unique-constraint
+// violation. The GORM connection does not enable TranslateError, so the
+// underlying pq error surfaces as a raw string; we match on the stable
+// substrings the driver emits. This is the single place that interprets that
+// string — callers receive a typed conflict instead.
+func isDuplicateKeyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "duplicate key") || strings.Contains(msg, "unique constraint")
+}
+
 // CreatePendingEdit submits a new pending edit for an entity.
 func (s *PendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	if !adminm.IsValidPendingEditEntityType(req.EntityType) {
-		return nil, fmt.Errorf("invalid entity type: %s", req.EntityType)
+		return nil, apperrors.ErrPendingEditInvalidEntityType(req.EntityType)
 	}
 	if len(req.Changes) == 0 {
-		return nil, fmt.Errorf("no changes provided")
+		return nil, apperrors.ErrPendingEditInvalidRequest("no changes provided")
 	}
 	if req.Summary == "" {
-		return nil, fmt.Errorf("summary is required")
+		return nil, apperrors.ErrPendingEditInvalidRequest("summary is required")
 	}
 	// PSY-605: cap the markdown source at the same length comments and
 	// collection descriptions use, so the rendered output is bounded and the
 	// renderer's allocation profile stays consistent with the rest of the
 	// markdown surfaces.
 	if len(req.Summary) > contracts.MaxPendingEditSummaryLength {
-		return nil, fmt.Errorf("summary exceeds maximum length of %d characters", contracts.MaxPendingEditSummaryLength)
+		return nil, apperrors.ErrPendingEditInvalidRequest(fmt.Sprintf("summary exceeds maximum length of %d characters", contracts.MaxPendingEditSummaryLength))
 	}
 
 	// Verify the entity exists
 	tableName := req.EntityType + "s"
 	var count int64
 	if err := s.db.Table(tableName).Where("id = ?", req.EntityID).Count(&count).Error; err != nil {
-		return nil, fmt.Errorf("failed to verify entity: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to verify entity: %w", err))
 	}
 	if count == 0 {
-		return nil, fmt.Errorf("entity not found: %s %d", req.EntityType, req.EntityID)
+		return nil, apperrors.ErrPendingEditEntityNotFound(req.EntityType, req.EntityID)
 	}
 
 	changesJSON, err := json.Marshal(req.Changes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal changes: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to marshal changes: %w", err))
 	}
 	raw := json.RawMessage(changesJSON)
 
@@ -126,7 +140,12 @@ func (s *PendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditR
 	}
 
 	if err := s.db.Create(edit).Error; err != nil {
-		return nil, fmt.Errorf("failed to create pending edit: %w", err)
+		// A unique-constraint violation means the submitter already has a
+		// pending edit for this entity — a conflict, not an internal fault.
+		if isDuplicateKeyErr(err) {
+			return nil, apperrors.ErrPendingEditDuplicate(err)
+		}
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to create pending edit: %w", err))
 	}
 
 	// Reload with relationships
@@ -136,7 +155,7 @@ func (s *PendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditR
 // GetPendingEdit returns a single pending edit by ID.
 func (s *PendingEditService) GetPendingEdit(editID uint) (*contracts.PendingEditResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var edit adminm.PendingEntityEdit
@@ -145,7 +164,7 @@ func (s *PendingEditService) GetPendingEdit(editID uint) (*contracts.PendingEdit
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get pending edit: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))
 	}
 
 	return s.toResponse(&edit), nil
@@ -154,7 +173,7 @@ func (s *PendingEditService) GetPendingEdit(editID uint) (*contracts.PendingEdit
 // GetPendingEditsForEntity returns all pending edits for a specific entity.
 func (s *PendingEditService) GetPendingEditsForEntity(entityType string, entityID uint) ([]contracts.PendingEditResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var edits []adminm.PendingEntityEdit
@@ -163,7 +182,7 @@ func (s *PendingEditService) GetPendingEditsForEntity(entityType string, entityI
 		Order("created_at ASC").
 		Find(&edits).Error
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pending edits for entity: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edits for entity: %w", err))
 	}
 
 	return s.toResponses(edits), nil
@@ -172,7 +191,7 @@ func (s *PendingEditService) GetPendingEditsForEntity(entityType string, entityI
 // GetUserPendingEdits returns all pending edits submitted by a user.
 func (s *PendingEditService) GetUserPendingEdits(userID uint, limit, offset int) ([]contracts.PendingEditResponse, int64, error) {
 	if s.db == nil {
-		return nil, 0, fmt.Errorf("database not initialized")
+		return nil, 0, apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	if limit <= 0 {
@@ -194,7 +213,7 @@ func (s *PendingEditService) GetUserPendingEdits(userID uint, limit, offset int)
 		Offset(offset).
 		Find(&edits).Error
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get user pending edits: %w", err)
+		return nil, 0, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get user pending edits: %w", err))
 	}
 
 	return s.toResponses(edits), total, nil
@@ -203,7 +222,7 @@ func (s *PendingEditService) GetUserPendingEdits(userID uint, limit, offset int)
 // ListPendingEdits returns pending edits for the admin review queue.
 func (s *PendingEditService) ListPendingEdits(filters *contracts.PendingEditFilters) ([]contracts.PendingEditResponse, int64, error) {
 	if s.db == nil {
-		return nil, 0, fmt.Errorf("database not initialized")
+		return nil, 0, apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	limit := 20
@@ -240,7 +259,7 @@ func (s *PendingEditService) ListPendingEdits(filters *contracts.PendingEditFilt
 		Offset(offset).
 		Find(&edits).Error
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to list pending edits: %w", err)
+		return nil, 0, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to list pending edits: %w", err))
 	}
 
 	return s.toResponses(edits), total, nil
@@ -250,25 +269,25 @@ func (s *PendingEditService) ListPendingEdits(filters *contracts.PendingEditFilt
 // and recording a revision.
 func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*contracts.PendingEditResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var edit adminm.PendingEntityEdit
 	if err := s.db.First(&edit, editID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("pending edit not found")
+			return nil, apperrors.ErrPendingEditNotFound()
 		}
-		return nil, fmt.Errorf("failed to get pending edit: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))
 	}
 
 	if edit.Status != adminm.PendingEditStatusPending {
-		return nil, fmt.Errorf("edit is not pending (status: %s)", edit.Status)
+		return nil, apperrors.ErrPendingEditNotPending(string(edit.Status))
 	}
 
 	// Parse field changes
 	var changes []adminm.FieldChange
 	if err := json.Unmarshal(*edit.FieldChanges, &changes); err != nil {
-		return nil, fmt.Errorf("failed to parse field changes: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to parse field changes: %w", err))
 	}
 
 	// PSY-572: per-entity allowlist gate. Defence in depth — even though the
@@ -303,8 +322,10 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 			"rejection_reason": reason,
 			"updated_at":       now,
 		}).Error; err != nil {
-			return nil, fmt.Errorf("failed to auto-reject pending edit with disallowed fields: %w", err)
+			return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to auto-reject pending edit with disallowed fields: %w", err))
 		}
+		// Sentinel (NOT a PendingEditError): the approve handler maps this via
+		// errors.Is to a 400 with the rejected field list. Keep it as-is.
 		return nil, fmt.Errorf("%w: %s", adminm.ErrPendingEditDisallowedFields, joined)
 	}
 
@@ -315,15 +336,16 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 	}
 	updates["updated_at"] = time.Now()
 
-	// Apply changes to entity within a transaction
+	// The closure returns typed errors directly: a vanished entity is a 422
+	// (the edit can no longer be applied), everything else is a 500.
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		tableName := edit.EntityType + "s"
 		result := tx.Table(tableName).Where("id = ?", edit.EntityID).Updates(updates)
 		if result.Error != nil {
-			return fmt.Errorf("failed to apply changes: %w", result.Error)
+			return apperrors.ErrPendingEditInternal(fmt.Errorf("failed to apply changes: %w", result.Error))
 		}
 		if result.RowsAffected == 0 {
-			return fmt.Errorf("entity not found: %s %d", edit.EntityType, edit.EntityID)
+			return apperrors.ErrPendingEditEntityGone(edit.EntityType, edit.EntityID)
 		}
 
 		// Mark edit as approved
@@ -334,7 +356,7 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 			"reviewed_at": now,
 			"updated_at":  now,
 		}).Error; err != nil {
-			return fmt.Errorf("failed to update edit status: %w", err)
+			return apperrors.ErrPendingEditInternal(fmt.Errorf("failed to update edit status: %w", err))
 		}
 
 		return nil
@@ -357,28 +379,28 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 // RejectPendingEdit rejects a pending edit with a reason.
 func (s *PendingEditService) RejectPendingEdit(editID uint, reviewerID uint, reason string) (*contracts.PendingEditResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	if reason == "" {
-		return nil, fmt.Errorf("rejection reason is required")
+		return nil, apperrors.ErrPendingEditInvalidRequest("rejection reason is required")
 	}
 	// PSY-605: rejection_reason mirrors summary's markdown stack and limit so
 	// the contributor-side render (PSY-600 surface, when it ships) is bounded.
 	if len(reason) > contracts.MaxPendingEditSummaryLength {
-		return nil, fmt.Errorf("rejection reason exceeds maximum length of %d characters", contracts.MaxPendingEditSummaryLength)
+		return nil, apperrors.ErrPendingEditInvalidRequest(fmt.Sprintf("rejection reason exceeds maximum length of %d characters", contracts.MaxPendingEditSummaryLength))
 	}
 
 	var edit adminm.PendingEntityEdit
 	if err := s.db.First(&edit, editID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("pending edit not found")
+			return nil, apperrors.ErrPendingEditNotFound()
 		}
-		return nil, fmt.Errorf("failed to get pending edit: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))
 	}
 
 	if edit.Status != adminm.PendingEditStatusPending {
-		return nil, fmt.Errorf("edit is not pending (status: %s)", edit.Status)
+		return nil, apperrors.ErrPendingEditNotPending(string(edit.Status))
 	}
 
 	now := time.Now()
@@ -389,7 +411,7 @@ func (s *PendingEditService) RejectPendingEdit(editID uint, reviewerID uint, rea
 		"rejection_reason": reason,
 		"updated_at":       now,
 	}).Error; err != nil {
-		return nil, fmt.Errorf("failed to reject pending edit: %w", err)
+		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to reject pending edit: %w", err))
 	}
 
 	// Send rejection notification email (fire-and-forget)
@@ -401,26 +423,29 @@ func (s *PendingEditService) RejectPendingEdit(editID uint, reviewerID uint, rea
 // CancelPendingEdit allows the submitter to cancel their own pending edit.
 func (s *PendingEditService) CancelPendingEdit(editID uint, userID uint) error {
 	if s.db == nil {
-		return fmt.Errorf("database not initialized")
+		return apperrors.ErrPendingEditInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var edit adminm.PendingEntityEdit
 	if err := s.db.First(&edit, editID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return fmt.Errorf("pending edit not found")
+			return apperrors.ErrPendingEditNotFound()
 		}
-		return fmt.Errorf("failed to get pending edit: %w", err)
+		return apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))
 	}
 
 	if edit.SubmittedBy != userID {
-		return fmt.Errorf("only the submitter can cancel their own edit")
+		return apperrors.ErrPendingEditNotSubmitter()
 	}
 
 	if edit.Status != adminm.PendingEditStatusPending {
-		return fmt.Errorf("edit is not pending (status: %s)", edit.Status)
+		return apperrors.ErrPendingEditNotPending(string(edit.Status))
 	}
 
-	return s.db.Delete(&edit).Error
+	if err := s.db.Delete(&edit).Error; err != nil {
+		return apperrors.ErrPendingEditInternal(fmt.Errorf("failed to delete pending edit: %w", err))
+	}
+	return nil
 }
 
 // toResponse converts a PendingEntityEdit model to a response DTO.

--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
@@ -624,24 +625,24 @@ func (s *ContributorProfileService) GetOwnSections(userID uint) ([]*contracts.Pr
 // CreateSection creates a new profile section. Returns error if user already has max sections.
 func (s *ContributorProfileService) CreateSection(userID uint, title string, content string, position int) (*contracts.ProfileSectionResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrProfileInternal(fmt.Errorf("database not initialized"))
 	}
 
 	if len(title) == 0 || len(title) > 255 {
-		return nil, fmt.Errorf("title must be between 1 and 255 characters")
+		return nil, apperrors.ErrProfileSectionInvalid("title must be between 1 and 255 characters")
 	}
 	if len(content) > 10000 {
-		return nil, fmt.Errorf("content must be at most 10000 characters")
+		return nil, apperrors.ErrProfileSectionInvalid("content must be at most 10000 characters")
 	}
 	if position < 0 || position >= maxProfileSections {
-		return nil, fmt.Errorf("position must be between 0 and %d", maxProfileSections-1)
+		return nil, apperrors.ErrProfileSectionInvalid(fmt.Sprintf("position must be between 0 and %d", maxProfileSections-1))
 	}
 
 	// Check section count
 	var count int64
 	s.db.Model(&authm.UserProfileSection{}).Where("user_id = ?", userID).Count(&count)
 	if count >= int64(maxProfileSections) {
-		return nil, fmt.Errorf("maximum %d profile sections allowed", maxProfileSections)
+		return nil, apperrors.ErrProfileSectionInvalid(fmt.Sprintf("maximum %d profile sections allowed", maxProfileSections))
 	}
 
 	section := authm.UserProfileSection{
@@ -653,7 +654,7 @@ func (s *ContributorProfileService) CreateSection(userID uint, title string, con
 	}
 
 	if err := s.db.Create(&section).Error; err != nil {
-		return nil, fmt.Errorf("failed to create profile section: %w", err)
+		return nil, apperrors.ErrProfileInternal(fmt.Errorf("failed to create profile section: %w", err))
 	}
 
 	return buildSectionResponse(&section), nil
@@ -662,40 +663,40 @@ func (s *ContributorProfileService) CreateSection(userID uint, title string, con
 // UpdateSection updates a profile section owned by the user.
 func (s *ContributorProfileService) UpdateSection(userID uint, sectionID uint, updates map[string]interface{}) (*contracts.ProfileSectionResponse, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrProfileInternal(fmt.Errorf("database not initialized"))
 	}
 
 	var section authm.UserProfileSection
 	err := s.db.Where("id = ? AND user_id = ?", sectionID, userID).First(&section).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("profile section not found")
+			return nil, apperrors.ErrProfileSectionNotFound()
 		}
-		return nil, fmt.Errorf("failed to find profile section: %w", err)
+		return nil, apperrors.ErrProfileInternal(fmt.Errorf("failed to find profile section: %w", err))
 	}
 
 	// Validate updates
 	if title, ok := updates["title"]; ok {
 		t := title.(string)
 		if len(t) == 0 || len(t) > 255 {
-			return nil, fmt.Errorf("title must be between 1 and 255 characters")
+			return nil, apperrors.ErrProfileSectionInvalid("title must be between 1 and 255 characters")
 		}
 	}
 	if content, ok := updates["content"]; ok {
 		c := content.(string)
 		if len(c) > 10000 {
-			return nil, fmt.Errorf("content must be at most 10000 characters")
+			return nil, apperrors.ErrProfileSectionInvalid("content must be at most 10000 characters")
 		}
 	}
 	if position, ok := updates["position"]; ok {
 		p := position.(int)
 		if p < 0 || p >= maxProfileSections {
-			return nil, fmt.Errorf("position must be between 0 and %d", maxProfileSections-1)
+			return nil, apperrors.ErrProfileSectionInvalid(fmt.Sprintf("position must be between 0 and %d", maxProfileSections-1))
 		}
 	}
 
 	if err := s.db.Model(&section).Updates(updates).Error; err != nil {
-		return nil, fmt.Errorf("failed to update profile section: %w", err)
+		return nil, apperrors.ErrProfileInternal(fmt.Errorf("failed to update profile section: %w", err))
 	}
 
 	// Reload after update
@@ -707,15 +708,15 @@ func (s *ContributorProfileService) UpdateSection(userID uint, sectionID uint, u
 // DeleteSection deletes a profile section owned by the user.
 func (s *ContributorProfileService) DeleteSection(userID uint, sectionID uint) error {
 	if s.db == nil {
-		return fmt.Errorf("database not initialized")
+		return apperrors.ErrProfileInternal(fmt.Errorf("database not initialized"))
 	}
 
 	result := s.db.Where("id = ? AND user_id = ?", sectionID, userID).Delete(&authm.UserProfileSection{})
 	if result.Error != nil {
-		return fmt.Errorf("failed to delete profile section: %w", result.Error)
+		return apperrors.ErrProfileInternal(fmt.Errorf("failed to delete profile section: %w", result.Error))
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("profile section not found")
+		return apperrors.ErrProfileSectionNotFound()
 	}
 
 	return nil

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
+	apperrors "psychic-homily-backend/internal/errors"
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
@@ -19,6 +21,16 @@ import (
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
+
+// assertProfileSectionNotFound asserts err is the typed section-not-found
+// error. Wrong-owner is surfaced as not-found so we don't leak existence of
+// another user's section.
+func (suite *ContributorProfileServiceIntegrationTestSuite) assertProfileSectionNotFound(err error) {
+	suite.Require().Error(err)
+	var profileErr *apperrors.ProfileError
+	suite.Require().True(stderrors.As(err, &profileErr), "expected *apperrors.ProfileError, got %T", err)
+	suite.Equal(apperrors.CodeProfileSectionNotFound, profileErr.Code)
+}
 
 // =============================================================================
 // UNIT TESTS (No Database Required)
@@ -1358,9 +1370,8 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdateSection_No
 		"title": "Nope",
 	})
 
-	suite.Error(err)
 	suite.Nil(section)
-	suite.Equal("profile section not found", err.Error())
+	suite.assertProfileSectionNotFound(err)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdateSection_WrongOwner() {
@@ -1375,9 +1386,8 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdateSection_Wr
 		"title": "Hijacked",
 	})
 
-	suite.Error(err)
 	suite.Nil(result)
-	suite.Equal("profile section not found", err.Error())
+	suite.assertProfileSectionNotFound(err)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestDeleteSection_Success() {
@@ -1401,8 +1411,7 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestDeleteSection_No
 
 	err := suite.profileService.DeleteSection(user.ID, 99999)
 
-	suite.Error(err)
-	suite.Equal("profile section not found", err.Error())
+	suite.assertProfileSectionNotFound(err)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestDeleteSection_WrongOwner() {
@@ -1414,8 +1423,7 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestDeleteSection_Wr
 
 	err = suite.profileService.DeleteSection(user2.ID, section.ID)
 
-	suite.Error(err)
-	suite.Equal("profile section not found", err.Error())
+	suite.assertProfileSectionNotFound(err)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_IncludesSections() {

--- a/backend/internal/services/user/leaderboard.go
+++ b/backend/internal/services/user/leaderboard.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -53,14 +54,14 @@ var dimensionWeights = map[string]int{
 // GetLeaderboard returns ranked contributor entries for a given dimension and period.
 func (s *LeaderboardService) GetLeaderboard(dimension string, period string, limit int) ([]contracts.LeaderboardEntry, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrLeaderboardInternal(fmt.Errorf("database not initialized"))
 	}
 
 	if !validDimensions[dimension] {
-		return nil, fmt.Errorf("invalid dimension: %s", dimension)
+		return nil, apperrors.ErrLeaderboardInvalidDimension(dimension)
 	}
 	if !validPeriods[period] {
-		return nil, fmt.Errorf("invalid period: %s", period)
+		return nil, apperrors.ErrLeaderboardInvalidPeriod(period)
 	}
 
 	if limit <= 0 {
@@ -82,7 +83,7 @@ func (s *LeaderboardService) GetLeaderboard(dimension string, period string, lim
 
 	var rows []leaderboardRow
 	if err := s.db.Raw(query, args...).Scan(&rows).Error; err != nil {
-		return nil, fmt.Errorf("failed to get leaderboard: %w", err)
+		return nil, apperrors.ErrLeaderboardInternal(err)
 	}
 
 	entries := make([]contracts.LeaderboardEntry, len(rows))
@@ -104,14 +105,14 @@ func (s *LeaderboardService) GetLeaderboard(dimension string, period string, lim
 // Returns nil if the user has no contributions or their contributions are hidden.
 func (s *LeaderboardService) GetUserRank(userID uint, dimension string, period string) (*int, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, apperrors.ErrLeaderboardInternal(fmt.Errorf("database not initialized"))
 	}
 
 	if !validDimensions[dimension] {
-		return nil, fmt.Errorf("invalid dimension: %s", dimension)
+		return nil, apperrors.ErrLeaderboardInvalidDimension(dimension)
 	}
 	if !validPeriods[period] {
-		return nil, fmt.Errorf("invalid period: %s", period)
+		return nil, apperrors.ErrLeaderboardInvalidPeriod(period)
 	}
 
 	// Get the full leaderboard (uncapped) to find the user's position
@@ -124,7 +125,7 @@ func (s *LeaderboardService) GetUserRank(userID uint, dimension string, period s
 
 	var rows []rankRow
 	if err := s.db.Raw(query, args...).Scan(&rows).Error; err != nil {
-		return nil, fmt.Errorf("failed to compute user rank: %w", err)
+		return nil, apperrors.ErrLeaderboardInternal(err)
 	}
 
 	for i, row := range rows {


### PR DESCRIPTION
## Summary
- Community + admin handlers no longer discriminate HTTP status with `strings.Contains(err.Error(), ...)` / `err.Error() == "..."`. Six surfaces now use typed errors mapped by new `shared.Map*Error` companions, following the PSY-761 engagement template.
- New typed-error types in `internal/errors/`: `LeaderboardError`, `EntityReportError`, `DataQualityError`, `AutoPromotionError`, `ProfileError`, `PendingEditError` (each `Code`/`Message`/`Internal` + `Unwrap` + constructors).
- Services (`user/leaderboard`, `admin/entity_report`, `admin/data_quality`, `admin/auto_promotion`, `user/contributor_profile` section CRUD, `admin/pending_edit`) emit the typed errors instead of `fmt.Errorf` strings.
- Handlers map via the new companions and fall through to a generic 500 for any unrecognised error. The `pending_edit` disallowed-fields sentinel (`adminm.ErrPendingEditDisallowedFields` -> 400) is preserved and checked before the typed mapper.
- The pending-edit duplicate-key conflict is interpreted once at the persistence boundary (`isDuplicateKeyErr`) since the GORM connection does not enable `TranslateError`, and surfaced as a typed 409.

## Test plan
- [x] cd backend && go build ./... — passed
- [x] cd backend && go test ./... — passed (29 packages ok, 0 fail)

## Manual repro
mode=none: mapper + handler status-assertion tests ARE the repro. New mapper unit tests in `internal/api/handlers/shared/error_mappers_test.go` assert the full status table per surface:

| Surface | Code | Status |
| --- | --- | --- |
| EntityReport | entity-not-found / report-not-found | 404 |
| EntityReport | duplicate-pending / already-reviewed | 409 |
| EntityReport | invalid entity type / invalid report type | 422 |
| EntityReport | internal | 500 |
| Leaderboard | invalid dimension / invalid period | 422 |
| Leaderboard | internal | 500 |
| DataQuality | unknown category | 422 |
| DataQuality | internal | 500 |
| AutoPromotion | user-not-found | 404 |
| AutoPromotion | internal | 500 |
| Profile | section-not-found | 404 |
| Profile | section-invalid (validation) | 422 |
| Profile | internal | 500 |
| PendingEdit | entity-not-found (create) / edit-not-found | 404 |
| PendingEdit | entity-gone (approve) / invalid-type / invalid-request | 422 |
| PendingEdit | not-pending / duplicate | 409 |
| PendingEdit | not-submitter (cancel) | 403 |
| PendingEdit | internal | 500 |

Mapper tests: `TestMapEntityReportError_CodeToStatus`, `TestMapLeaderboardError_CodeToStatus`, `TestMapDataQualityError_CodeToStatus`, `TestMapAutoPromotionError_CodeToStatus`, `TestMapProfileError_CodeToStatus`, `TestMapPendingEditError_CodeToStatus` (+ each `_Non*ErrorReturnsNil` fall-through). Updated handler status-assertion tests drive the typed errors through: `entity_report_test`, `leaderboard_test`, `contribute_test`, `data_quality_test`, `auto_promotion_test`, `pending_edit_test`; updated service integration tests: `contributor_profile_test` (`TestUpdateSection_NotFound/_WrongOwner`, `TestDeleteSection_NotFound/_WrongOwner`).

Behaviour change: status codes are unchanged from prior intent; a few error-message bodies shifted to the typed `.Message` (e.g. resolve/dismiss not-found 404 body "Report not found" -> "report not found"; approve entity-gone 422 body "Entity no longer exists..." -> "entity not found: <type> <id>"; data-quality unknown-category 422 body "Unknown ... category: X" -> "unknown category: X"). One genuine status improvement: a DB fault during profile-section create now returns 500 instead of 422 (validation-only 422 path preserved).

## Scope deviation
The comment* engagement sites are DEFERRED to a follow-up (orchestrator to file). Folding them would roughly triple the diff and introduce 4+ additional error domains (comment / field-note / subscription / vote) into a PR already touching 7 community+admin handler/service pairs — the PSY-761 author made the same split (engagement follow/attendance only). The remaining string-compare sites are:
- `backend/internal/api/handlers/engagement/comment.go` (~30 sites: rate-limit, reply-permission, depth, field-note edit window, rating validation, thread-root, cross-entity parent, etc.)
- `backend/internal/api/handlers/engagement/comment_admin.go` (8 sites)
- `backend/internal/api/handlers/engagement/comment_subscription.go` (4 sites)
- `backend/internal/api/handlers/engagement/field_note.go` (6 sites)
- `backend/internal/api/handlers/engagement/comment_vote.go` (3 sites, `err.Error() ==` variant)

Out of scope (NOT HTTP-status discrimination): `services/catalog/radio_provider_{kexp,wfmu}.go` (`status 404` from upstream radio APIs) and `services/engagement/{saved_show,favorite_venue}.go` (`bookmark not found` internal sentinels) — left untouched.

## Simplify
Edited 2 files: stripped `PSY-793:` ticket refs from 6 mapper doc comments + 1 test-helper comment (per project convention + PSY-761 errors-file precedent, keeping semantic WHY); trimmed 2 redundant/verbose comments in `pending_edit.go`. No reuse duplication to fold; no efficiency issues. Build + scoped tests re-run green after edits.

Closes PSY-793