### PR TITLE
PSY-808: remove dead code orphaned by PSY-759

### DIFF
--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -898,14 +898,6 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 	return &AdminUpdateArtistResponse{Body: artist}, nil
 }
 
-// ptrToStr safely dereferences a *string, returning "" if nil.
-func ptrToStr(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
 // ============================================================================
 // Artist Aliases
 // ============================================================================

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -1340,20 +1340,6 @@ type ExportShowRequest struct {
 	ShowID string `path:"show_id" validate:"required" doc:"Show ID to export"`
 }
 
-// ExportShowResponse represents the HTTP response for exporting a show
-// This is a raw response with custom content type
-type ExportShowResponse struct {
-	ContentType        string
-	ContentDisposition string
-	Body               []byte
-}
-
-// SetHeader sets custom headers for the response
-func (r *ExportShowResponse) SetContentType(w huma.Context) {
-	w.SetHeader("Content-Type", r.ContentType)
-	w.SetHeader("Content-Disposition", r.ContentDisposition)
-}
-
 // ExportShowHandler handles GET /shows/{show_id}/export
 // This endpoint is only available in development environment
 func (h *ShowHandler) ExportShowHandler(ctx context.Context, req *ExportShowRequest) (*huma.StreamResponse, error) {


### PR DESCRIPTION
## Summary
- Remove dead `ptrToStr` (`catalog/artist.go`) — orphaned by PSY-759 revisiondiff
- Remove dead `ExportShowResponse` type + `SetContentType` method (`catalog/show.go`) — never constructed; `ExportShowHandler` returns `*huma.StreamResponse`

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./...` — passed (all packages green)

## Manual repro
Pre-delete grep showed zero callers (only the definitions + doc-comment mentions in revisiondiff):

```
$ grep -rn "\bptrToStr\b" backend/
backend/internal/api/handlers/catalog/artist.go:901:// ptrToStr safely dereferences a *string, returning "" if nil.
backend/internal/api/handlers/catalog/artist.go:902:func ptrToStr(s *string) string {
backend/internal/services/shared/revisiondiff/revisiondiff.go:14://   - *string           → deref or "" (matches the old ptrToStr helper)
backend/internal/services/shared/revisiondiff/revisiondiff.go:139:// pointer is treated as the zero value, matching ptrToStr / shared.Deref /
backend/internal/services/shared/revisiondiff/revisiondiff_test.go:162:// change emitting "" → value, matching the old ptrToStr semantics.

$ grep -rn "\bExportShowResponse\b\|\bSetContentType\b" backend/
backend/internal/api/handlers/catalog/show.go:1343:// ExportShowResponse represents the HTTP response for exporting a show
backend/internal/api/handlers/catalog/show.go:1345:type ExportShowResponse struct {
backend/internal/api/handlers/catalog/show.go:1352:func (r *ExportShowResponse) SetContentType(w huma.Context) {
```

The three remaining `ptrToStr` matches are documentary comments inside revisiondiff (describing its prior semantics); not symbol references. All three deleted symbols had zero callers. Post-delete `go build ./...` + `go test ./...` confirmed (passing build/tests with the symbols removed is the repro for dead-code removal).

## Simplify
No changes — deletion-only work, no new code to review.

Closes PSY-808

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>