### PR TITLE
PSY-787: modernize tsconfig with bundler resolution + ES2022 target

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- Set `moduleResolution: "bundler"` (was `"node"`) and `target: "ES2022"` (was `"ES2017"`) in `frontend/tsconfig.json`
- Aligns with Next 16 / React 19.2 expectations; removes unnecessary downleveling
- Independent of the in-flight strict-mode ratchet (PSY-786/788/789/790) — `strict` and sub-flags untouched

## Test plan
- [x] `bun run typecheck` — passed
- [x] `bun run test:run` — passed (403 files / 4605 tests)
- [x] `bun run build` — passed (production Next.js build)

## Manual repro
Production `next build` succeeded across the entire frontend codebase — the most exhaustive compile-check possible for a tsconfig change. This is the mode=none pattern: the build IS the manual repro. Verbatim tail of `bun run build` output:

```
├ ƒ /shows/[slug]
├ ƒ /shows/[slug]/opengraph-image
├ ƒ /shows/saved
├ ○ /shows/submit
├ ○ /sitemap.xml                                                                1h      1y
├ ○ /submissions
├ ○ /tags
├ ƒ /tags/[slug]
├ ○ /terms
├ ○ /unsubscribe/show-reminders
├ ƒ /users/[username]
├ ○ /venues                                                                     1h      1y
├ ƒ /venues/[slug]
└ ○ /verify-email


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand
```

## Simplify
No changes — 2-line tsconfig diff with no runtime code; none of the reuse / quality / efficiency dimensions apply.

Closes PSY-787