### PR TITLE
PSY-821: suppress GORM ErrRecordNotFound log noise

### DIFF
--- a/backend/db/connection.go
+++ b/backend/db/connection.go
@@ -3,6 +3,7 @@ package db
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"gorm.io/driver/postgres"
@@ -19,10 +20,16 @@ var (
 func Connect(cfg *config.Config) error {
 	var err error
 
-	// Configure GORM logger
-	gormLogger := logger.Default
+	// ErrRecordNotFound is application-level branching (lookup-or-create, radio
+	// matching against unmatched plays), not an error worth surfacing.
+	gormLogger := logger.New(log.New(os.Stdout, "", log.LstdFlags), logger.Config{
+		SlowThreshold:             200 * time.Millisecond,
+		LogLevel:                  logger.Warn,
+		IgnoreRecordNotFoundError: true,
+		Colorful:                  cfg.Server.LogLevel == "debug",
+	})
 	if cfg.Server.LogLevel == "debug" {
-		gormLogger = logger.Default.LogMode(logger.Info)
+		gormLogger = gormLogger.LogMode(logger.Info)
 	}
 
 	// Connect to database


### PR DESCRIPTION
## Summary

- Build the GORM logger explicitly with `IgnoreRecordNotFoundError: true` so `First()` misses (radio matching against unmatched plays, lookup-or-create, lookup-or-skip patterns everywhere) stop emitting `record not found` lines at warn level. The application code already treats `err != nil` as "no match" — only the logger needed to catch up.
- Drop the `"\r\n"` log prefix and gate ANSI coloring on `LogLevel == "debug"` so production logs on Railway (non-TTY, JSON slog elsewhere) don't accumulate `\x1b[...]` escape literals.
- `IgnoreRecordNotFoundError` is verified orthogonal to `SlowThreshold` in GORM v1.30 source — slow queries still log normally.

Closes PSY-821.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./db/... ./internal/services/catalog/...` pass
- [ ] Local `bash run-dev.sh`: confirm radio-matching tick no longer spams `record not found`
- [ ] Local `bash run-dev.sh` with `SERVER_LOG_LEVEL=debug`: confirm verbose SQL still logs (Info mode preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)