### PR TITLE
PSY-819: GORM TranslateError + shared IsDuplicateKey helper

### DIFF
--- a/backend/db/connection.go
+++ b/backend/db/connection.go
@@ -32,9 +32,17 @@ func Connect(cfg *config.Config) error {
 		gormLogger = gormLogger.LogMode(logger.Info)
 	}
 
-	// Connect to database
+	// Connect to database.
+	//
+	// TranslateError maps driver errors to GORM sentinel errors (e.g. Postgres
+	// 23505 unique violations → gorm.ErrDuplicatedKey, 23503 FK violations →
+	// gorm.ErrForeignKeyViolated). This lets the service layer discriminate on
+	// errors.Is(err, gorm.ErrDuplicatedKey) instead of fragile substring
+	// matching on the raw driver message. See services/shared/db_errors.go for
+	// the canonical helper.
 	DB, err = gorm.Open(postgres.Open(cfg.Database.URL), &gorm.Config{
-		Logger: gormLogger,
+		Logger:         gormLogger,
+		TranslateError: true,
 		NowFunc: func() time.Time {
 			return time.Now().UTC()
 		},

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -78,19 +78,6 @@ func (s *PendingEditService) renderRejectionReason(reason *string) string {
 	return s.renderMarkdown(*reason)
 }
 
-// isDuplicateKeyErr reports whether err is a Postgres unique-constraint
-// violation. The GORM connection does not enable TranslateError, so the
-// underlying pq error surfaces as a raw string; we match on the stable
-// substrings the driver emits. This is the single place that interprets that
-// string — callers receive a typed conflict instead.
-func isDuplicateKeyErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "duplicate key") || strings.Contains(msg, "unique constraint")
-}
-
 // CreatePendingEdit submits a new pending edit for an entity.
 func (s *PendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
 	if s.db == nil {
@@ -142,7 +129,7 @@ func (s *PendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditR
 	if err := s.db.Create(edit).Error; err != nil {
 		// A unique-constraint violation means the submitter already has a
 		// pending edit for this entity — a conflict, not an internal fault.
-		if isDuplicateKeyErr(err) {
+		if shared.IsDuplicateKey(err) {
 			return nil, apperrors.ErrPendingEditDuplicate(err)
 		}
 		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to create pending edit: %w", err))

--- a/backend/internal/services/pipeline/enrichment_test.go
+++ b/backend/internal/services/pipeline/enrichment_test.go
@@ -166,7 +166,9 @@ func (s *EnrichmentIntegrationTestSuite) SetupSuite() {
 	port, _ := container.MappedPort(s.ctx, "5432")
 
 	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable", host, port.Port())
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	// Match production: TranslateError so duplicate-key checks behave the same
+	// in tests as in production.
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{TranslateError: true})
 	s.Require().NoError(err)
 	s.db = db
 

--- a/backend/internal/services/shared/db_errors.go
+++ b/backend/internal/services/shared/db_errors.go
@@ -1,0 +1,27 @@
+// Package shared provides cross-service helpers usable from any service
+// or handler. db_errors.go centralizes detection of GORM/driver errors
+// so callers do not duplicate fragile substring matches on the raw
+// Postgres message.
+package shared
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+// IsDuplicateKey reports whether err is a GORM duplicate-key (unique
+// constraint) violation.
+//
+// Requires gorm.Config.TranslateError = true so the underlying
+// pgconn.PgError (SQLSTATE 23505) is translated to gorm.ErrDuplicatedKey
+// before it reaches callers. db.Connect and the testcontainer setup both
+// enable that option.
+//
+// Use this instead of strings.Contains(err.Error(), "duplicate key"). The
+// driver message ("duplicate key value violates unique constraint ...") is
+// not part of any public contract and can change between postgres/pgx
+// versions.
+func IsDuplicateKey(err error) bool {
+	return errors.Is(err, gorm.ErrDuplicatedKey)
+}

--- a/backend/internal/services/shared/db_errors_test.go
+++ b/backend/internal/services/shared/db_errors_test.go
@@ -1,0 +1,35 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestIsDuplicateKey(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("connection refused"), false},
+		// Pre-TranslateError driver message must NOT be treated as a hit —
+		// the helper is intentionally typed-only so callers that forget to
+		// enable TranslateError get a loud false-negative rather than a
+		// silent substring match.
+		{"raw driver string", errors.New("duplicate key value violates unique constraint \"users_username_key\""), false},
+		{"gorm sentinel direct", gorm.ErrDuplicatedKey, true},
+		{"gorm sentinel wrapped", fmt.Errorf("create failed: %w", gorm.ErrDuplicatedKey), true},
+		{"unrelated gorm error", gorm.ErrRecordNotFound, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsDuplicateKey(tc.err); got != tc.want {
+				t.Errorf("IsDuplicateKey(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -3,7 +3,6 @@ package user
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/markbates/goth"
@@ -609,28 +608,16 @@ func (s *UserService) UpdateUser(userID uint, updates map[string]any) (*authm.Us
 
 	if result.Error != nil {
 		// A unique-constraint violation on profile update means the chosen
-		// username is taken. Translate the driver error into a typed error
-		// here so handlers discriminate on a code rather than string-matching
-		// the Postgres message (the only volatile site for this check).
-		if isUniqueViolation(result.Error) {
+		// username is taken. Translate the typed DB error into the user-facing
+		// CodeUsernameTaken so handlers discriminate on a code instead of the
+		// raw driver message.
+		if shared.IsDuplicateKey(result.Error) {
 			return nil, apperrors.ErrUsernameTaken(result.Error)
 		}
 		return nil, fmt.Errorf("failed to update user: %w", result.Error)
 	}
 
 	return s.GetUserByID(userID)
-}
-
-// isUniqueViolation reports whether err is a Postgres unique-constraint
-// violation by matching the driver message text. This mirrors the boundary
-// detection used elsewhere in the codebase (e.g. admin/pending_edit.go) and
-// is isolated here so the volatile driver-string match has a single home.
-func isUniqueViolation(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "duplicate key") || strings.Contains(msg, "unique")
 }
 
 func (s *UserService) HashPassword(password string) (string, error) {

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -1700,28 +1700,6 @@ func TestUserService_SetDefaultReplyPermission_InvalidValue(t *testing.T) {
 	}
 }
 
-// isUniqueViolation backs UpdateUser's translation of a Postgres
-// unique-constraint violation into a typed CodeUsernameTaken error. PSY-792.
-func TestIsUniqueViolation(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"nil", nil, false},
-		{"duplicate key", fmt.Errorf("ERROR: duplicate key value violates unique constraint \"users_username_key\""), true},
-		{"unique substring", fmt.Errorf("violates unique constraint"), true},
-		{"unrelated", fmt.Errorf("connection refused"), false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isUniqueViolation(tc.err); got != tc.want {
-				t.Errorf("isUniqueViolation(%v) = %v, want %v", tc.err, got, tc.want)
-			}
-		})
-	}
-}
-
 func (suite *UserServiceIntegrationTestSuite) TestSetDefaultReplyPermission_CreatesRowWhenMissing() {
 	user, err := suite.userService.CreateUserWithPassword(
 		"rp-prefs-create@example.com", "Pass123!", "RP", "Prefs",

--- a/backend/internal/testutil/postgres.go
+++ b/backend/internal/testutil/postgres.go
@@ -66,7 +66,9 @@ func SetupTestPostgres(t *testing.T) *TestDatabase {
 	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
 		host, port.Port())
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	// Match production db.Connect: TranslateError so integration tests see the
+	// same wrapped sentinels (gorm.ErrDuplicatedKey, etc.).
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{TranslateError: true})
 	if err != nil {
 		t.Fatalf("failed to connect to test database: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Enable `gorm.Config.TranslateError` so Postgres SQLSTATE 23505 surfaces as `gorm.ErrDuplicatedKey` instead of a driver-string message.
- Add `services/shared.IsDuplicateKey` (single `errors.Is(err, gorm.ErrDuplicatedKey)` check) and replace the two scattered substring-matching helpers (`user.go isUniqueViolation`, `services/admin/pending_edit.go isDuplicateKeyErr`).
- Mirror `TranslateError: true` in the testcontainer setup so DB-integration tests exercise the same wrapped sentinels as production.

The auth handler dup-key check the audit referenced had already been moved to the user service (the typed `CodeUsernameTaken` flow); no third inline site to fix. Re-grepping for `duplicate key` / `record not found` / `foreign key` turned up no further service-layer string checks, so no TranslateError ripples to fix.

## Test plan
- [x] `cd backend && go build ./...` - passed
- [x] `cd backend && go test ./...` - passed (full suite, incl. DB-integration via testcontainers)

## Manual repro
DB-integration tests that exercise the duplicate-key path through real Postgres + GORM with TranslateError enabled:
- `TestPendingEditServiceIntegrationSuite/TestCreatePendingEdit_DuplicatePending` - PASS (real INSERT into pending_entity_edits hits unique index, helper converts to `ErrPendingEditDuplicate`)
- `TestShowServiceIntegrationTestSuite/TestCreateShow_DirectInsertHitsPartialUniqueIndex` - PASS (direct GORM Create against the `shows_artist_venue_eventdate_uniq` partial index returns translated error)
- `TestShowServiceIntegrationTestSuite/TestCreateShow_DuplicateDedupKey_SurfacesAsCleanError` - PASS (advisory-lock pre-check still produces a user-facing "already performing" message, no raw "duplicate key" leak)

Plus the new unit test for the helper itself:
- `TestIsDuplicateKey` - 6 cases (nil, plain error, raw driver string returns false, sentinel direct, sentinel wrapped, unrelated gorm error). Asserts the helper is typed-only: a pre-TranslateError raw driver message returns `false` so callers that forget to enable TranslateError get a loud false-negative rather than a silent substring fallback.

## Scope deviation
- Helper placed at `backend/internal/services/shared/db_errors.go` instead of the ticket's `api/handlers/shared/db_errors.go`. Both existing dup-key call sites are at the service layer (`services/user/user.go`, `services/admin/pending_edit.go`); `api/handlers/shared` cannot be imported from `services/*` without a layering inversion. Putting the helper in `services/shared/` lets all callers share ONE helper (the ticket's load-bearing goal) without forcing a duplicate or a layering violation. `api/handlers/shared` already depends on `services/shared` (via `safego`, `ticker_loop`), so future handler callers can use the same helper.
- Also enabled `TranslateError: true` in two test gorm.Open sites (`testutil/postgres.go`, `services/pipeline/enrichment_test.go`) so integration tests behave identically to production. Without this, tests would silently pass under the old substring matching while production behaves differently.

## Simplify
Run inline (no Agent tool in this worktree). Three-axis review: reuse / quality / efficiency. Only edits: stripped `PSY-819` references from production doc comments per `feedback_strip_ticket_refs_from_doc_comments.md` (4 sites: `connection.go`, `db_errors.go`, `testutil/postgres.go`, `enrichment_test.go`). No structural changes.

## Rebase note
Branched from `7c68ff1e`; rebased onto `20c23abd` (PSY-821 landed on main during this work, also touching `db/connection.go`). Clean merge - PSY-821's logger config + PSY-819's `TranslateError` coexist in the same `gorm.Config{}` block. Full test suite re-run after rebase.

Closes PSY-819