### PR TITLE
PSY-796: pilot server-side hydration on artist detail page

### DIFF
--- a/frontend/app/artists/[slug]/page.tsx
+++ b/frontend/app/artists/[slug]/page.tsx
@@ -21,10 +21,10 @@ interface ArtistPageProps {
 }
 
 /**
- * PSY-796: wrap with `React.cache()` so `generateMetadata` and the page
- * body share ONE fetch per request instead of two. The result also seeds
- * the TanStack Query cache via `prefetchQuery` below, eliminating the
- * client-side refetch on first paint.
+ * Wrapped with `React.cache()` so `generateMetadata` and the page body
+ * share ONE backend fetch per request instead of two. The result also
+ * seeds the TanStack Query cache via `prefetchQuery` below, eliminating
+ * the client-side refetch on first paint.
  */
 const getArtist = cache(async (slug: string): Promise<Artist | null> => {
   try {
@@ -98,11 +98,11 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
     notFound()
   }
 
-  // PSY-796: pilot SSR hydration. Seed a request-scoped QueryClient with the
-  // artist payload the server already fetched, then dehydrate so the client
-  // `useArtist` hook resolves from the cache instead of refetching. The
-  // queryFn just returns the cached value — `cache()` above ensures the
-  // network call already happened, so this is a synchronous cache write.
+  // Seed a request-scoped QueryClient with the artist payload the server
+  // already fetched, then dehydrate so the client `useArtist` hook resolves
+  // from the cache instead of refetching. The queryFn returns the cached
+  // value synchronously — `cache()` above guarantees the network call has
+  // already happened, so this is a no-op cache write rather than a refetch.
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
     queryKey: queryKeys.artists.detail(slug),

--- a/frontend/app/artists/[slug]/page.tsx
+++ b/frontend/app/artists/[slug]/page.tsx
@@ -1,11 +1,14 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { ArtistDetail } from '@/features/artists'
+import type { Artist } from '@/features/artists/types'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateMusicGroupSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
+import { getQueryClient, queryKeys } from '@/lib/queryClient'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -17,15 +20,13 @@ interface ArtistPageProps {
   params: Promise<{ slug: string }>
 }
 
-interface ArtistData {
-  name: string
-  slug?: string
-  city?: string | null
-  state?: string | null
-  social?: Record<string, string | null>
-}
-
-async function getArtist(slug: string): Promise<ArtistData | null> {
+/**
+ * PSY-796: wrap with `React.cache()` so `generateMetadata` and the page
+ * body share ONE fetch per request instead of two. The result also seeds
+ * the TanStack Query cache via `prefetchQuery` below, eliminating the
+ * client-side refetch on first paint.
+ */
+const getArtist = cache(async (slug: string): Promise<Artist | null> => {
   try {
     const res = await fetch(`${API_BASE_URL}/artists/${slug}`, {
       next: { revalidate: 3600 },
@@ -48,7 +49,7 @@ async function getArtist(slug: string): Promise<ArtistData | null> {
     })
   }
   return null
-}
+})
 
 export async function generateMetadata({ params }: ArtistPageProps): Promise<Metadata> {
   const { slug } = await params
@@ -97,6 +98,17 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
     notFound()
   }
 
+  // PSY-796: pilot SSR hydration. Seed a request-scoped QueryClient with the
+  // artist payload the server already fetched, then dehydrate so the client
+  // `useArtist` hook resolves from the cache instead of refetching. The
+  // queryFn just returns the cached value — `cache()` above ensures the
+  // network call already happened, so this is a synchronous cache write.
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.artists.detail(slug),
+    queryFn: () => artistData,
+  })
+
   return (
     <>
       <JsonLd data={generateMusicGroupSchema({
@@ -104,16 +116,21 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
         slug: artistData.slug || slug,
         city: artistData.city,
         state: artistData.state,
-        social: artistData.social,
+        // `ArtistSocial` is a struct of named optional fields; spread into a
+        // plain object so it satisfies the schema helper's index-signature
+        // parameter type without changing the cross-feature type.
+        social: { ...artistData.social },
       })} />
       <JsonLd data={generateBreadcrumbSchema([
         { name: 'Home', url: 'https://psychichomily.com' },
         { name: 'Artists', url: 'https://psychichomily.com/artists' },
         { name: artistData.name, url: `https://psychichomily.com/artists/${artistData.slug || slug}` },
       ])} />
-      <Suspense fallback={<ArtistLoadingFallback />}>
-        <ArtistDetail artistId={slug} />
-      </Suspense>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Suspense fallback={<ArtistLoadingFallback />}>
+          <ArtistDetail artistId={slug} />
+        </Suspense>
+      </HydrationBoundary>
     </>
   )
 }

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -1,10 +1,15 @@
-'use client'
-
 /**
  * TanStack Query Configuration
  *
  * This module configures TanStack Query with environment-aware settings
  * and provides query client utilities for the application.
+ *
+ * No `'use client'` directive: the module body is isomorphic so server
+ * components (e.g. `app/artists/[slug]/page.tsx`) can import
+ * `getQueryClient` for SSR prefetch + hydration. `getQueryClient` gates
+ * on `typeof window` to mint a fresh client per request on the server
+ * and reuse a singleton in the browser. The cache `onError` handlers
+ * read `browserQueryClient?.…` which safely short-circuits on the server.
  */
 
 import { QueryClient, DefaultOptions, QueryCache, MutationCache } from '@tanstack/react-query'


### PR DESCRIPTION
## Summary
- Eliminate the artist-detail double-fetch: server prefetches `/artists/{slug}` into a request-scoped QueryClient, page wraps `<ArtistDetail>` in `<HydrationBoundary>`, and client `useArtist` resolves from the seeded cache (no spinner, no client refetch within the 15-min staleTime).
- Dedupe the server-side fetch via `React.cache()` so `generateMetadata` and the page body share ONE network call instead of two.
- Remove `'use client'` from `lib/queryClient.ts` so the isomorphic `getQueryClient()` can be imported from server components. Module body was already SSR-safe (gated `typeof window` check + nullable `browserQueryClient` reads).

## Test plan
- [x] `cd frontend && bun run typecheck` — passed (no errors).
- [x] `cd frontend && bun run test:run` — 4601/4601 tests passed across 403 files.

## Manual repro
- Brought up isolated dispatch stack (`scripts/dispatch/stack-up.sh --mode=shared` auto-escalated to isolated).
- Navigated to `http://localhost:56559/artists/calexico` via chrome-devtools MCP.
- Network panel filtered to `xhr,fetch`: ZERO requests to `GET /api/artists/calexico` from the browser. The remaining `/api/artists/1/...` calls are sidecar queries (shows, graph, bill composition, etc.) that are out of scope for this pilot.
- Server HTML (curl) embeds `"queryKey":["artists","detail","calexico"]` with the full `ArtistDetailResponse` payload in the dehydrated state — proving the prefetch + dehydrate path works end-to-end.
- First paint shows artist name, breadcrumb, sidebar stats, and shows table immediately — no `<Loader2>` spinner visible.
- Evidence: `dogfood-output/PSY-796/screenshots/artist-page-rendered.png` + `network-observation.txt` (gitignored; agent local).

## Simplify
Stripped `PSY-796:` ticket prefixes from in-code doc comments per the project convention (ticket IDs rot; semantic WHY remains useful). One follow-up commit. Re-ran typecheck — still green. No runtime semantics changed by the simplify pass, so the manual repro was not re-executed.

## Pattern note (for PSY-797 rollout)
Inline prefetch + `<HydrationBoundary>` in the page is ~5 lines and clean as-is. Helper extraction deferred to PSY-797 — once we've copied the shape to 5 sites we'll have better information to decide on a clean API (and whether to share the request-scoped QueryClient or mint fresh ones per page).

## Scope-adjacent (not addressed)
- `app/artists/[slug]/page.tsx` redeclares its own `API_BASE_URL` constant instead of importing from `@/lib/api-base`. Pre-existing tech debt; not introduced by this PR. Worth folding into the PSY-797 rollout when each page is touched.
- Sidecar queries (`/artists/{id}/shows`, `/artists/{id}/graph`, `/artists/{id}/bill-composition`, etc.) still fetch from the client. Out of scope for the pilot, which is intentionally scoped to the entity detail itself.

Closes PSY-796