### PR TITLE
PSY-774: stop account-recovery handlers from leaking account state

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -1297,12 +1297,11 @@ type RequestAccountRecoveryRequest struct {
 	}
 }
 
-// RequestAccountRecoveryResponse represents the response for requesting recovery.
-//
-// PSY-774: enumeration-safe. The body is identical regardless of whether the
-// email is unregistered, registered-active, registered-recoverable, or
-// registered-expired. Fields like HasPassword and DaysRemaining were removed
-// because they leaked account state pre-token-confirmation.
+// RequestAccountRecoveryResponse is the enumeration-safe response for a
+// recovery request. The body is identical regardless of whether the email
+// is unregistered, registered-active, registered-recoverable, or
+// registered-expired — distinguishing any of those would let the endpoint
+// be used as an account-existence/recoverability oracle.
 type RequestAccountRecoveryResponse struct {
 	Body struct {
 		Success   bool   `json:"success" example:"true" doc:"Success status. Always true for any well-formed request — the response never reveals whether the email is registered or in a recoverable state."`
@@ -1373,13 +1372,13 @@ func (h *AuthHandler) ExportDataHandler(ctx context.Context, input *struct{}) (*
 	return resp, nil
 }
 
-// RecoverAccountHandler handles password-based account recovery
-// for users who have a password set and remember it.
+// RecoverAccountHandler handles password-based account recovery for users
+// who have a password set and remember it.
 //
-// PSY-774: enumeration-safe. The pre-success failure response is the same
-// "Invalid credentials" body whether the email is unknown, the account is
-// active, the recovery window has expired, the account has no password, or
-// the password is wrong. Per-state detail surfaces only in server logs;
+// Enumeration-safe: the pre-success failure response is the same "Invalid
+// credentials" body whether the email is unknown, the account is active,
+// the recovery window has expired, the account has no password, or the
+// password is wrong. Per-state detail surfaces only in server logs;
 // otherwise the endpoint becomes an account-state oracle.
 func (h *AuthHandler) RecoverAccountHandler(ctx context.Context, input *RecoverAccountRequest) (*RecoverAccountResponse, error) {
 	resp := &RecoverAccountResponse{}
@@ -1506,13 +1505,13 @@ func (h *AuthHandler) RecoverAccountHandler(ctx context.Context, input *RecoverA
 // RequestAccountRecoveryHandler handles requests to send a recovery email
 // for soft-deleted accounts.
 //
-// PSY-774: enumeration-safe. The response body is byte-identical regardless
-// of whether the email is unknown, registered-active, registered-recoverable,
+// Enumeration-safe: the response body is byte-identical regardless of
+// whether the email is unknown, registered-active, registered-recoverable,
 // or registered-expired. Any per-user-state branch (lookup failure, account
-// state, token/send failure for a known account) must surface only in server
-// logs, or the response becomes an account-existence/recoverability oracle.
-// Only pre-lookup validation and email-service-config errors still set an
-// ErrorCode — those fire for any caller.
+// state, token/send failure for a known account) must surface only in
+// server logs, or the response becomes an account-existence/recoverability
+// oracle. Only pre-lookup validation and email-service-config errors still
+// set an ErrorCode — those fire for any caller.
 func (h *AuthHandler) RequestAccountRecoveryHandler(ctx context.Context, input *RequestAccountRecoveryRequest) (*RequestAccountRecoveryResponse, error) {
 	resp := &RequestAccountRecoveryResponse{}
 	requestID := logger.GetRequestID(ctx)

--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -1297,15 +1297,18 @@ type RequestAccountRecoveryRequest struct {
 	}
 }
 
-// RequestAccountRecoveryResponse represents the response for requesting recovery
+// RequestAccountRecoveryResponse represents the response for requesting recovery.
+//
+// PSY-774: enumeration-safe. The body is identical regardless of whether the
+// email is unregistered, registered-active, registered-recoverable, or
+// registered-expired. Fields like HasPassword and DaysRemaining were removed
+// because they leaked account state pre-token-confirmation.
 type RequestAccountRecoveryResponse struct {
 	Body struct {
-		Success       bool   `json:"success" example:"true" doc:"Success status"`
-		Message       string `json:"message" example:"Recovery email sent" doc:"Response message"`
-		HasPassword   bool   `json:"has_password,omitempty" doc:"Whether the account has a password set"`
-		DaysRemaining int    `json:"days_remaining,omitempty" doc:"Days remaining before permanent deletion"`
-		ErrorCode     string `json:"error_code,omitempty" example:"ACCOUNT_NOT_FOUND" doc:"Error code for programmatic handling"`
-		RequestID     string `json:"request_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440000" doc:"Request ID for debugging"`
+		Success   bool   `json:"success" example:"true" doc:"Success status. Always true for any well-formed request — the response never reveals whether the email is registered or in a recoverable state."`
+		Message   string `json:"message" example:"If an account exists with this email and is eligible for recovery, a recovery email has been sent." doc:"Response message"`
+		ErrorCode string `json:"error_code,omitempty" example:"SERVICE_UNAVAILABLE" doc:"Error code for programmatic handling (only set for pre-lookup validation/config errors, never for account state)"`
+		RequestID string `json:"request_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440000" doc:"Request ID for debugging"`
 	}
 }
 
@@ -1371,7 +1374,13 @@ func (h *AuthHandler) ExportDataHandler(ctx context.Context, input *struct{}) (*
 }
 
 // RecoverAccountHandler handles password-based account recovery
-// This is for users who have a password set and remember it
+// for users who have a password set and remember it.
+//
+// PSY-774: enumeration-safe. The pre-success failure response is the same
+// "Invalid credentials" body whether the email is unknown, the account is
+// active, the recovery window has expired, the account has no password, or
+// the password is wrong. Per-state detail surfaces only in server logs;
+// otherwise the endpoint becomes an account-state oracle.
 func (h *AuthHandler) RecoverAccountHandler(ctx context.Context, input *RecoverAccountRequest) (*RecoverAccountResponse, error) {
 	resp := &RecoverAccountResponse{}
 	requestID := logger.GetRequestID(ctx)
@@ -1381,7 +1390,7 @@ func (h *AuthHandler) RecoverAccountHandler(ctx context.Context, input *RecoverA
 		"email_hash", logger.HashEmail(input.Body.Email),
 	)
 
-	// Validate input
+	// Validate input (pre-lookup — not an existence oracle).
 	if input.Body.Email == "" || input.Body.Password == "" {
 		authErr := autherrors.ErrValidationFailed("Email and password are required")
 		logger.AuthWarn(ctx, "recover_account_validation_failed",
@@ -1393,69 +1402,56 @@ func (h *AuthHandler) RecoverAccountHandler(ctx context.Context, input *RecoverA
 		return resp, nil
 	}
 
-	// Get user by email including soft-deleted accounts
+	// invalidCredentials is the single enumeration-safe failure response
+	// shared by every pre-success branch below.
+	invalidCredentials := func() (*RecoverAccountResponse, error) {
+		resp.Body.Success = false
+		resp.Body.Message = "Invalid credentials"
+		resp.Body.ErrorCode = autherrors.CodeInvalidCredentials
+		return resp, nil
+	}
+
 	user, err := h.userService.GetUserByEmailIncludingDeleted(input.Body.Email)
 	if err != nil {
 		logger.AuthError(ctx, "recover_account_lookup_failed", err,
 			"email_hash", logger.HashEmail(input.Body.Email),
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "Invalid credentials"
-		resp.Body.ErrorCode = autherrors.CodeInvalidCredentials
-		return resp, nil
+		return invalidCredentials()
 	}
 
 	if user == nil {
-		// Constant-time response to prevent email enumeration
 		logger.AuthDebug(ctx, "recover_account_user_not_found",
 			"email_hash", logger.HashEmail(input.Body.Email),
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "Invalid credentials"
-		resp.Body.ErrorCode = autherrors.CodeInvalidCredentials
-		return resp, nil
+		return invalidCredentials()
 	}
 
-	// Check if account is actually deleted and recoverable
 	if user.IsActive {
 		logger.AuthDebug(ctx, "recover_account_already_active",
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "This account is already active. Please log in normally."
-		resp.Body.ErrorCode = "ACCOUNT_ACTIVE"
-		return resp, nil
+		return invalidCredentials()
 	}
 
 	if !h.userService.IsAccountRecoverable(user) {
 		logger.AuthWarn(ctx, "recover_account_expired",
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "This account can no longer be recovered. The 30-day recovery period has expired."
-		resp.Body.ErrorCode = "ACCOUNT_NOT_RECOVERABLE"
-		return resp, nil
+		return invalidCredentials()
 	}
 
-	// Verify password
 	if user.PasswordHash == nil {
 		logger.AuthDebug(ctx, "recover_account_no_password",
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "This account does not have a password. Please use the email recovery option."
-		resp.Body.ErrorCode = "NO_PASSWORD"
-		return resp, nil
+		return invalidCredentials()
 	}
 
 	if err := h.userService.VerifyPassword(*user.PasswordHash, input.Body.Password); err != nil {
 		logger.AuthWarn(ctx, "recover_account_invalid_password",
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "Invalid credentials"
-		resp.Body.ErrorCode = autherrors.CodeInvalidCredentials
-		return resp, nil
+		return invalidCredentials()
 	}
 
 	// Restore the account
@@ -1508,7 +1504,15 @@ func (h *AuthHandler) RecoverAccountHandler(ctx context.Context, input *RecoverA
 }
 
 // RequestAccountRecoveryHandler handles requests to send a recovery email
-// This is for OAuth-only users or users who forgot their password
+// for soft-deleted accounts.
+//
+// PSY-774: enumeration-safe. The response body is byte-identical regardless
+// of whether the email is unknown, registered-active, registered-recoverable,
+// or registered-expired. Any per-user-state branch (lookup failure, account
+// state, token/send failure for a known account) must surface only in server
+// logs, or the response becomes an account-existence/recoverability oracle.
+// Only pre-lookup validation and email-service-config errors still set an
+// ErrorCode — those fire for any caller.
 func (h *AuthHandler) RequestAccountRecoveryHandler(ctx context.Context, input *RequestAccountRecoveryRequest) (*RequestAccountRecoveryResponse, error) {
 	resp := &RequestAccountRecoveryResponse{}
 	requestID := logger.GetRequestID(ctx)
@@ -1518,7 +1522,7 @@ func (h *AuthHandler) RequestAccountRecoveryHandler(ctx context.Context, input *
 		"email_hash", logger.HashEmail(input.Body.Email),
 	)
 
-	// Validate input
+	// Validate input (pre-lookup — not an existence oracle).
 	if input.Body.Email == "" {
 		authErr := autherrors.ErrValidationFailed("Email is required")
 		logger.AuthWarn(ctx, "request_recovery_validation_failed",
@@ -1530,101 +1534,78 @@ func (h *AuthHandler) RequestAccountRecoveryHandler(ctx context.Context, input *
 		return resp, nil
 	}
 
-	// Get user by email including soft-deleted accounts
-	user, err := h.userService.GetUserByEmailIncludingDeleted(input.Body.Email)
-	if err != nil {
-		logger.AuthError(ctx, "request_recovery_lookup_failed", err,
-			"email_hash", logger.HashEmail(input.Body.Email),
-		)
-		// Don't reveal if lookup failed - return generic message
-		resp.Body.Success = true
-		resp.Body.Message = "If an account exists with this email and is eligible for recovery, a recovery email has been sent."
-		return resp, nil
-	}
-
-	if user == nil {
-		// Don't reveal if user doesn't exist
-		logger.AuthDebug(ctx, "request_recovery_user_not_found",
-			"email_hash", logger.HashEmail(input.Body.Email),
-		)
-		resp.Body.Success = true
-		resp.Body.Message = "If an account exists with this email and is eligible for recovery, a recovery email has been sent."
-		return resp, nil
-	}
-
-	// Check if account is deleted
-	if user.IsActive {
-		logger.AuthDebug(ctx, "request_recovery_account_active",
-			"user_id", user.ID,
-		)
-		// Inform user that account is active
-		resp.Body.Success = false
-		resp.Body.Message = "This account is active. Please log in normally."
-		resp.Body.ErrorCode = "ACCOUNT_ACTIVE"
-		resp.Body.HasPassword = user.PasswordHash != nil
-		return resp, nil
-	}
-
-	// Check if account is recoverable
-	if !h.userService.IsAccountRecoverable(user) {
-		logger.AuthWarn(ctx, "request_recovery_expired",
-			"user_id", user.ID,
-		)
-		resp.Body.Success = false
-		resp.Body.Message = "This account can no longer be recovered. The 30-day recovery period has expired."
-		resp.Body.ErrorCode = "ACCOUNT_NOT_RECOVERABLE"
-		return resp, nil
-	}
-
-	// Check if email service is configured
+	// Check if email service is configured (pre-lookup — fires for any caller).
 	if !h.emailService.IsConfigured() {
-		logger.AuthError(ctx, "request_recovery_email_not_configured", nil,
-			"user_id", user.ID,
-		)
+		logger.AuthError(ctx, "request_recovery_email_not_configured", nil)
 		resp.Body.Success = false
 		resp.Body.Message = "Email service is not configured"
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
 		return resp, nil
 	}
 
-	// Calculate days remaining
-	daysRemaining := h.userService.GetDaysUntilPermanentDeletion(user)
+	// Enumeration-safe response: every post-lookup path returns this.
+	resp.Body.Success = true
+	resp.Body.Message = "If an account exists with this email and is eligible for recovery, a recovery email has been sent."
 
-	// Generate recovery token
+	user, err := h.userService.GetUserByEmailIncludingDeleted(input.Body.Email)
+	if err != nil {
+		logger.AuthError(ctx, "request_recovery_lookup_failed", err,
+			"email_hash", logger.HashEmail(input.Body.Email),
+		)
+		return resp, nil
+	}
+
+	if user == nil {
+		logger.AuthDebug(ctx, "request_recovery_user_not_found",
+			"email_hash", logger.HashEmail(input.Body.Email),
+		)
+		return resp, nil
+	}
+
+	if user.IsActive {
+		logger.AuthDebug(ctx, "request_recovery_account_active",
+			"user_id", user.ID,
+		)
+		return resp, nil
+	}
+
+	if !h.userService.IsAccountRecoverable(user) {
+		logger.AuthWarn(ctx, "request_recovery_expired",
+			"user_id", user.ID,
+		)
+		return resp, nil
+	}
+
+	h.sendAccountRecoveryEmail(ctx, user)
+	return resp, nil
+}
+
+// sendAccountRecoveryEmail mints a recovery token and sends the recovery
+// email as a side effect of a recovery request. Failures are logged but
+// never surfaced to the caller, so the response stays enumeration-safe.
+func (h *AuthHandler) sendAccountRecoveryEmail(ctx context.Context, user *authm.User) {
+	if user.Email == nil || *user.Email == "" {
+		return
+	}
+	daysRemaining := h.userService.GetDaysUntilPermanentDeletion(user)
 	token, err := h.jwtService.CreateAccountRecoveryToken(user.ID, *user.Email)
 	if err != nil {
 		logger.AuthError(ctx, "request_recovery_token_failed", err,
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "Failed to generate recovery token"
-		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return
 	}
-
-	// Send recovery email
 	if err := h.emailService.SendAccountRecoveryEmail(*user.Email, token, daysRemaining); err != nil {
 		logger.AuthError(ctx, "request_recovery_email_failed", err,
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "Failed to send recovery email"
-		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return
 	}
-
 	logger.AuthInfo(ctx, "request_recovery_email_sent",
 		"user_id", user.ID,
-		"email_hash", logger.HashEmail(input.Body.Email),
+		"email_hash", logger.HashEmail(*user.Email),
 		"days_remaining", daysRemaining,
 	)
-
-	resp.Body.Success = true
-	resp.Body.Message = "Recovery email sent. Please check your inbox."
-	resp.Body.HasPassword = user.PasswordHash != nil
-	resp.Body.DaysRemaining = daysRemaining
-
-	return resp, nil
 }
 
 // ConfirmAccountRecoveryHandler handles magic link account recovery confirmation

--- a/backend/internal/api/handlers/auth/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth/auth_integration_test.go
@@ -698,6 +698,9 @@ func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_Success() {
 	s.True(updated.IsActive)
 }
 
+// TestRecoverAccount_AccountActive: PSY-774 — an active account must
+// collapse to the same "Invalid credentials" body as an unknown email so
+// the endpoint can't be used as an existence/state oracle.
 func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_AccountActive() {
 	h := s.newAuthHandler(false)
 	s.createUserWithPassword("recover-active@test.com", "strong-password-123!")
@@ -709,9 +712,11 @@ func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_AccountActive() {
 	resp, err := h.RecoverAccountHandler(context.Background(), input)
 	s.Require().NoError(err)
 	s.False(resp.Body.Success)
-	s.Equal("ACCOUNT_ACTIVE", resp.Body.ErrorCode)
+	s.Equal(autherrors.CodeInvalidCredentials, resp.Body.ErrorCode)
 }
 
+// TestRecoverAccount_Expired: PSY-774 — an expired recovery window must
+// collapse to "Invalid credentials" too (was ACCOUNT_NOT_RECOVERABLE).
 func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_Expired() {
 	h := s.newAuthHandler(false)
 	user := s.createUserWithPassword("recover-exp@test.com", "strong-password-123!")
@@ -724,7 +729,7 @@ func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_Expired() {
 	resp, err := h.RecoverAccountHandler(context.Background(), input)
 	s.Require().NoError(err)
 	s.False(resp.Body.Success)
-	s.Equal("ACCOUNT_NOT_RECOVERABLE", resp.Body.ErrorCode)
+	s.Equal(autherrors.CodeInvalidCredentials, resp.Body.ErrorCode)
 }
 
 func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_WrongPassword() {
@@ -742,6 +747,8 @@ func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_WrongPassword() {
 	s.Equal(autherrors.CodeInvalidCredentials, resp.Body.ErrorCode)
 }
 
+// TestRecoverAccount_NoPassword: PSY-774 — OAuth-only accounts must
+// collapse to "Invalid credentials" too (was NO_PASSWORD).
 func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_NoPassword() {
 	h := s.newAuthHandler(false)
 	// Create an OAuth-only user, then soft-delete
@@ -755,7 +762,7 @@ func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_NoPassword() {
 	resp, err := h.RecoverAccountHandler(context.Background(), input)
 	s.Require().NoError(err)
 	s.False(resp.Body.Success)
-	s.Equal("NO_PASSWORD", resp.Body.ErrorCode)
+	s.Equal(autherrors.CodeInvalidCredentials, resp.Body.ErrorCode)
 }
 
 func (s *AuthHandlerIntegrationSuite) TestRecoverAccount_UserNotFound() {
@@ -784,6 +791,9 @@ func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_UserNotFound() {
 	s.True(resp.Body.Success) // enumeration prevention
 }
 
+// TestRequestRecovery_AccountActive: PSY-774 — an active account must
+// collapse to the same generic "if eligible, sent" response as an unknown
+// email so the endpoint can't be used as an account-state oracle.
 func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_AccountActive() {
 	h := s.newAuthHandler(true)
 	s.createUserWithPassword("req-active@test.com", "strong-password-123!")
@@ -793,11 +803,12 @@ func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_AccountActive() {
 
 	resp, err := h.RequestAccountRecoveryHandler(context.Background(), input)
 	s.Require().NoError(err)
-	s.False(resp.Body.Success)
-	s.Equal("ACCOUNT_ACTIVE", resp.Body.ErrorCode)
-	s.True(resp.Body.HasPassword)
+	s.True(resp.Body.Success)
+	s.Empty(resp.Body.ErrorCode)
 }
 
+// TestRequestRecovery_Expired: PSY-774 — an expired recovery window must
+// also collapse to the generic success body (was ACCOUNT_NOT_RECOVERABLE).
 func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_Expired() {
 	h := s.newAuthHandler(true)
 	user := s.createUserWithPassword("req-exp@test.com", "strong-password-123!")
@@ -808,10 +819,13 @@ func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_Expired() {
 
 	resp, err := h.RequestAccountRecoveryHandler(context.Background(), input)
 	s.Require().NoError(err)
-	s.False(resp.Body.Success)
-	s.Equal("ACCOUNT_NOT_RECOVERABLE", resp.Body.ErrorCode)
+	s.True(resp.Body.Success)
+	s.Empty(resp.Body.ErrorCode)
 }
 
+// TestRequestRecovery_EmailNotConfigured: pre-lookup config error fires for
+// every caller regardless of account state, so SERVICE_UNAVAILABLE is not
+// an existence oracle.
 func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_EmailNotConfigured() {
 	h := s.newAuthHandler(false) // email NOT configured
 	user := s.createUserWithPassword("req-nomail@test.com", "strong-password-123!")
@@ -826,6 +840,9 @@ func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_EmailNotConfigured() {
 	s.Equal(autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 }
 
+// TestRequestRecovery_SendFails: PSY-774 — a downstream send failure for a
+// recoverable account must NOT change the response, otherwise the failure
+// itself leaks account existence.
 func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_SendFails() {
 	h := s.newAuthHandler(true) // email configured but fake API key
 	user := s.createUserWithPassword("req-fail@test.com", "strong-password-123!")
@@ -836,8 +853,8 @@ func (s *AuthHandlerIntegrationSuite) TestRequestRecovery_SendFails() {
 
 	resp, err := h.RequestAccountRecoveryHandler(context.Background(), input)
 	s.Require().NoError(err)
-	s.False(resp.Body.Success)
-	s.Equal(autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	s.True(resp.Body.Success)
+	s.Empty(resp.Body.ErrorCode)
 }
 
 // --- ConfirmAccountRecoveryHandler ---

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1912,114 +1912,186 @@ func TestRecoverAccountHandler_Success(t *testing.T) {
 	}
 }
 
-func TestRecoverAccountHandler_UserNotFound(t *testing.T) {
-	h := authHandler(func(ah *AuthHandler) {
-		ah.userService = &testhelpers.MockUserService{
-			GetUserByEmailIncludingDeletedFn: func(e string) (*authm.User, error) {
-				return nil, nil // user not found
-			},
-		}
-	})
-
-	input := &RecoverAccountRequest{}
-	input.Body.Email = "nobody@example.com"
-	input.Body.Password = "password"
-
-	resp, err := h.RecoverAccountHandler(context.Background(), input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.Body.Success {
-		t.Error("expected success=false")
-	}
-	if resp.Body.ErrorCode != autherrors.CodeInvalidCredentials {
-		t.Errorf("expected error_code=%s, got %s", autherrors.CodeInvalidCredentials, resp.Body.ErrorCode)
-	}
+// recoverAccountState models a soft-deleted-account lookup outcome for the
+// RecoverAccountHandler enumeration test (PSY-774).
+type recoverAccountState struct {
+	name string
+	user func(email string) (*authm.User, error)
 }
 
-func TestRecoverAccountHandler_AccountActive(t *testing.T) {
-	email := "active@example.com"
-	h := authHandler(func(ah *AuthHandler) {
-		ah.userService = &testhelpers.MockUserService{
-			GetUserByEmailIncludingDeletedFn: func(e string) (*authm.User, error) {
-				return &authm.User{ID: 1, Email: &email, IsActive: true}, nil
-			},
-		}
-	})
-
-	input := &RecoverAccountRequest{}
-	input.Body.Email = email
-	input.Body.Password = "password"
-
-	resp, err := h.RecoverAccountHandler(context.Background(), input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.Body.Success {
-		t.Error("expected success=false")
-	}
-	if resp.Body.ErrorCode != "ACCOUNT_ACTIVE" {
-		t.Errorf("expected error_code=ACCOUNT_ACTIVE, got %s", resp.Body.ErrorCode)
-	}
-}
-
-func TestRecoverAccountHandler_NotRecoverable(t *testing.T) {
-	email := "expired@example.com"
+// recoverAccountStates enumerates the pre-success states whose responses must
+// be indistinguishable: unknown email, active account, expired recovery
+// window, no-password account, and known-recoverable account with the wrong
+// password. All five must collapse to a single "Invalid credentials" body.
+func recoverAccountStates(email string) []recoverAccountState {
 	hash := "$2a$10$fakehash"
-	h := authHandler(func(ah *AuthHandler) {
-		ah.userService = &testhelpers.MockUserService{
-			GetUserByEmailIncludingDeletedFn: func(e string) (*authm.User, error) {
-				return &authm.User{ID: 1, Email: &email, PasswordHash: &hash, IsActive: false}, nil
-			},
-			IsAccountRecoverableFn: func(user *authm.User) bool {
-				return false
-			},
+	return []recoverAccountState{
+		{name: "unknown_email", user: func(string) (*authm.User, error) { return nil, nil }},
+		{name: "active_account", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, IsActive: true}, nil
+		}},
+		{name: "expired_account", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, PasswordHash: &hash, IsActive: false}, nil
+		}},
+		{name: "no_password_account", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, IsActive: false}, nil
+		}},
+		{name: "wrong_password", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, PasswordHash: &hash, IsActive: false}, nil
+		}},
+	}
+}
+
+// TestRecoverAccountHandler_ResponseIdenticalAcrossAccountStates is the
+// PSY-774 regression guard: the response body must be byte-identical
+// regardless of account state, so the endpoint can't be used as an
+// existence/state oracle.
+func TestRecoverAccountHandler_ResponseIdenticalAcrossAccountStates(t *testing.T) {
+	email := "probe@example.com"
+
+	respFor := func(state recoverAccountState) RecoverAccountResponse {
+		h := authHandler(func(ah *AuthHandler) {
+			ah.userService = &testhelpers.MockUserService{
+				GetUserByEmailIncludingDeletedFn: state.user,
+				IsAccountRecoverableFn: func(user *authm.User) bool {
+					// Expired branch must collapse onto the same failure body.
+					return state.name != "expired_account"
+				},
+				VerifyPasswordFn: func(hashedPassword, password string) error {
+					return fmt.Errorf("bcrypt mismatch")
+				},
+			}
+		})
+		input := &RecoverAccountRequest{}
+		input.Body.Email = email
+		input.Body.Password = "any-password"
+		resp, err := h.RecoverAccountHandler(context.Background(), input)
+		if err != nil {
+			t.Fatalf("[%s] unexpected error: %v", state.name, err)
 		}
-	})
-
-	input := &RecoverAccountRequest{}
-	input.Body.Email = email
-	input.Body.Password = "password"
-
-	resp, err := h.RecoverAccountHandler(context.Background(), input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		return *resp
 	}
-	if resp.Body.Success {
-		t.Error("expected success=false")
+
+	states := recoverAccountStates(email)
+	want := respFor(states[0])
+	if want.Body.Success {
+		t.Fatalf("expected success=false for enumeration-safe failure, got message=%q", want.Body.Message)
 	}
-	if resp.Body.ErrorCode != "ACCOUNT_NOT_RECOVERABLE" {
-		t.Errorf("expected error_code=ACCOUNT_NOT_RECOVERABLE, got %s", resp.Body.ErrorCode)
+	if want.Body.ErrorCode != autherrors.CodeInvalidCredentials {
+		t.Fatalf("expected error_code=%s, got %q", autherrors.CodeInvalidCredentials, want.Body.ErrorCode)
+	}
+	for _, state := range states[1:] {
+		got := respFor(state)
+		if got.Body != want.Body {
+			t.Errorf("response body for %s differs from %s:\n  got  %+v\n  want %+v",
+				state.name, states[0].name, got.Body, want.Body)
+		}
 	}
 }
 
 // --- RequestAccountRecoveryHandler mock tests ---
 
-func TestRequestAccountRecoveryHandler_Success(t *testing.T) {
-	email := "deleted@example.com"
+// requestRecoveryAccountState models a soft-deleted-account lookup outcome
+// for the RequestAccountRecoveryHandler enumeration test (PSY-774).
+type requestRecoveryAccountState struct {
+	name string
+	user func(email string) (*authm.User, error)
+}
+
+// requestRecoveryAccountStates enumerates the four post-lookup states whose
+// responses must be indistinguishable: unknown email, active account, expired
+// recovery window, and a recoverable account (which triggers a real send).
+func requestRecoveryAccountStates(email string) []requestRecoveryAccountState {
 	hash := "$2a$10$fakehash"
-	h := authHandler(func(ah *AuthHandler) {
-		ah.userService = &testhelpers.MockUserService{
-			GetUserByEmailIncludingDeletedFn: func(e string) (*authm.User, error) {
-				return &authm.User{ID: 1, Email: &email, PasswordHash: &hash, IsActive: false}, nil
-			},
-			IsAccountRecoverableFn: func(user *authm.User) bool {
-				return true
-			},
-			GetDaysUntilPermanentDeletionFn: func(user *authm.User) int {
-				return 20
-			},
+	return []requestRecoveryAccountState{
+		{name: "unknown_email", user: func(string) (*authm.User, error) { return nil, nil }},
+		{name: "active_account", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, IsActive: true}, nil
+		}},
+		{name: "expired_account", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, PasswordHash: &hash, IsActive: false}, nil
+		}},
+		{name: "recoverable_account", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, PasswordHash: &hash, IsActive: false}, nil
+		}},
+	}
+}
+
+// TestRequestAccountRecoveryHandler_ResponseIdenticalAcrossAccountStates is
+// the PSY-774 regression guard: the response body must be byte-identical
+// regardless of whether the email is unknown, registered-active,
+// registered-expired, or registered-recoverable, so the endpoint can't be
+// used as an account-existence/recoverability oracle.
+func TestRequestAccountRecoveryHandler_ResponseIdenticalAcrossAccountStates(t *testing.T) {
+	email := "probe@example.com"
+
+	respFor := func(state requestRecoveryAccountState) RequestAccountRecoveryResponse {
+		h := authHandler(func(ah *AuthHandler) {
+			ah.emailService = &testhelpers.MockEmailService{
+				IsConfiguredFn:             func() bool { return true },
+				SendAccountRecoveryEmailFn: func(string, string, int) error { return nil },
+			}
+			ah.userService = &testhelpers.MockUserService{
+				GetUserByEmailIncludingDeletedFn: state.user,
+				IsAccountRecoverableFn: func(user *authm.User) bool {
+					// Expired branch must collapse onto the generic success body.
+					return state.name != "expired_account"
+				},
+				GetDaysUntilPermanentDeletionFn: func(*authm.User) int { return 20 },
+			}
+			ah.jwtService = &testhelpers.MockJWTService{
+				CreateAccountRecoveryTokenFn: func(uint, string) (string, error) { return "recovery-token", nil },
+			}
+		})
+		input := &RequestAccountRecoveryRequest{}
+		input.Body.Email = email
+		resp, err := h.RequestAccountRecoveryHandler(context.Background(), input)
+		if err != nil {
+			t.Fatalf("[%s] unexpected error: %v", state.name, err)
 		}
+		return *resp
+	}
+
+	states := requestRecoveryAccountStates(email)
+	want := respFor(states[0])
+	if !want.Body.Success {
+		t.Fatalf("expected success=true for enumeration-safe response, got message=%q", want.Body.Message)
+	}
+	if want.Body.ErrorCode != "" {
+		t.Fatalf("expected empty error_code, got %q", want.Body.ErrorCode)
+	}
+	for _, state := range states[1:] {
+		got := respFor(state)
+		if got.Body != want.Body {
+			t.Errorf("response body for %s differs from %s:\n  got  %+v\n  want %+v",
+				state.name, states[0].name, got.Body, want.Body)
+		}
+	}
+}
+
+// TestRequestAccountRecoveryHandler_RecoverableSendsEmail asserts the side
+// effect: a recoverable account triggers a real recovery email (PSY-774).
+func TestRequestAccountRecoveryHandler_RecoverableSendsEmail(t *testing.T) {
+	email := "recoverable@example.com"
+	hash := "$2a$10$fakehash"
+	var recoverySent bool
+	h := authHandler(func(ah *AuthHandler) {
 		ah.emailService = &testhelpers.MockEmailService{
 			IsConfiguredFn: func() bool { return true },
 			SendAccountRecoveryEmailFn: func(toEmail, token string, daysRemaining int) error {
+				recoverySent = true
 				return nil
 			},
 		}
-		ah.jwtService = &testhelpers.MockJWTService{
-			CreateAccountRecoveryTokenFn: func(userID uint, e string) (string, error) {
-				return "recovery-token", nil
+		ah.userService = &testhelpers.MockUserService{
+			GetUserByEmailIncludingDeletedFn: func(e string) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &e, PasswordHash: &hash, IsActive: false}, nil
 			},
+			IsAccountRecoverableFn:          func(*authm.User) bool { return true },
+			GetDaysUntilPermanentDeletionFn: func(*authm.User) int { return 20 },
+		}
+		ah.jwtService = &testhelpers.MockJWTService{
+			CreateAccountRecoveryTokenFn: func(uint, string) (string, error) { return "recovery-token", nil },
 		}
 	})
 
@@ -2031,19 +2103,28 @@ func TestRequestAccountRecoveryHandler_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !resp.Body.Success {
-		t.Errorf("expected success=true, got message=%q", resp.Body.Message)
+		t.Error("expected success=true")
 	}
-	if resp.Body.DaysRemaining != 20 {
-		t.Errorf("expected days_remaining=20, got %d", resp.Body.DaysRemaining)
+	if !recoverySent {
+		t.Error("expected recovery email to be sent for recoverable account")
 	}
 }
 
-func TestRequestAccountRecoveryHandler_UserNotFound(t *testing.T) {
+// TestRequestAccountRecoveryHandler_UnknownDoesNotSend asserts an unknown
+// email triggers NO email send — the response stays generic but no side
+// effect leaks downstream (PSY-774).
+func TestRequestAccountRecoveryHandler_UnknownDoesNotSend(t *testing.T) {
+	var recoverySent bool
 	h := authHandler(func(ah *AuthHandler) {
-		ah.userService = &testhelpers.MockUserService{
-			GetUserByEmailIncludingDeletedFn: func(e string) (*authm.User, error) {
-				return nil, nil
+		ah.emailService = &testhelpers.MockEmailService{
+			IsConfiguredFn: func() bool { return true },
+			SendAccountRecoveryEmailFn: func(string, string, int) error {
+				recoverySent = true
+				return nil
 			},
+		}
+		ah.userService = &testhelpers.MockUserService{
+			GetUserByEmailIncludingDeletedFn: func(string) (*authm.User, error) { return nil, nil },
 		}
 	})
 
@@ -2054,19 +2135,35 @@ func TestRequestAccountRecoveryHandler_UserNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Should return success to prevent email enumeration
 	if !resp.Body.Success {
 		t.Error("expected success=true (silent failure)")
 	}
+	if recoverySent {
+		t.Error("expected NO recovery email for unknown user")
+	}
 }
 
-func TestRequestAccountRecoveryHandler_AccountActive(t *testing.T) {
-	email := "active@example.com"
+// TestRequestAccountRecoveryHandler_SendFailureStaysGeneric asserts that a
+// downstream send failure for a recoverable account does NOT change the
+// response — otherwise the failure response would leak account state
+// (PSY-774).
+func TestRequestAccountRecoveryHandler_SendFailureStaysGeneric(t *testing.T) {
+	email := "recoverable@example.com"
+	hash := "$2a$10$fakehash"
 	h := authHandler(func(ah *AuthHandler) {
+		ah.emailService = &testhelpers.MockEmailService{
+			IsConfiguredFn:             func() bool { return true },
+			SendAccountRecoveryEmailFn: func(string, string, int) error { return fmt.Errorf("send exploded") },
+		}
 		ah.userService = &testhelpers.MockUserService{
 			GetUserByEmailIncludingDeletedFn: func(e string) (*authm.User, error) {
-				return &authm.User{ID: 1, Email: &email, IsActive: true}, nil
+				return &authm.User{ID: 1, Email: &e, PasswordHash: &hash, IsActive: false}, nil
 			},
+			IsAccountRecoverableFn:          func(*authm.User) bool { return true },
+			GetDaysUntilPermanentDeletionFn: func(*authm.User) int { return 20 },
+		}
+		ah.jwtService = &testhelpers.MockJWTService{
+			CreateAccountRecoveryTokenFn: func(uint, string) (string, error) { return "recovery-token", nil },
 		}
 	})
 
@@ -2077,11 +2174,11 @@ func TestRequestAccountRecoveryHandler_AccountActive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Body.Success {
-		t.Error("expected success=false")
+	if !resp.Body.Success {
+		t.Error("expected success=true even when send fails (no enumeration leak)")
 	}
-	if resp.Body.ErrorCode != "ACCOUNT_ACTIVE" {
-		t.Errorf("expected error_code=ACCOUNT_ACTIVE, got %s", resp.Body.ErrorCode)
+	if resp.Body.ErrorCode != "" {
+		t.Errorf("expected empty error_code on send failure, got %q", resp.Body.ErrorCode)
 	}
 }
 

--- a/frontend/app/auth/recover/page.tsx
+++ b/frontend/app/auth/recover/page.tsx
@@ -5,8 +5,8 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { useForm } from '@tanstack/react-form'
 import { z } from 'zod'
-import { AlertCircle, Loader2, Mail, Lock, Eye, EyeOff, CheckCircle2, RefreshCw, ArrowLeft } from 'lucide-react'
-import { useRecoverAccount, useRequestAccountRecovery, useConfirmAccountRecovery } from '@/features/auth'
+import { AlertCircle, Loader2, Mail, CheckCircle2, RefreshCw, ArrowLeft } from 'lucide-react'
+import { useRequestAccountRecovery, useConfirmAccountRecovery } from '@/features/auth'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { getUniqueErrors } from '@/lib/utils/formErrors'
 import { Button } from '@/components/ui/button'
@@ -21,18 +21,12 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 
-// Validation schemas
+// Validation schema
 const emailSchema = z.object({
   email: z.string().email('Please enter a valid email address'),
 })
 
-const passwordRecoverySchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
-  password: z.string().min(1, 'Password is required'),
-})
-
 type EmailFormData = z.infer<typeof emailSchema>
-type PasswordRecoveryFormData = z.infer<typeof passwordRecoverySchema>
 
 // Step 1: Email entry form
 function EmailForm({ onSubmit, isLoading }: {
@@ -98,10 +92,10 @@ function EmailForm({ onSubmit, isLoading }: {
             {isSubmitting || isLoading ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
-                Checking...
+                Sending...
               </>
             ) : (
-              'Continue'
+              'Send Recovery Email'
             )}
           </Button>
         )}
@@ -110,169 +104,18 @@ function EmailForm({ onSubmit, isLoading }: {
   )
 }
 
-// Step 2: Password recovery form (for users with passwords)
-function PasswordRecoveryForm({
-  email,
-  daysRemaining,
-  onBack
-}: {
+// Recovery email sent confirmation. PSY-774: shown for every well-formed
+// email submission — the response is generic, so the UI is too. Recovery
+// detail (days remaining, eligibility) moves behind token confirmation.
+function RecoveryEmailSent({ email, onBack }: {
   email: string
-  daysRemaining: number
-  onBack: () => void
-}) {
-  const router = useRouter()
-  const recoverMutation = useRecoverAccount()
-  const { setUser } = useAuthContext()
-  const [showPassword, setShowPassword] = useState(false)
-
-  const form = useForm({
-    defaultValues: {
-      email,
-      password: '',
-    } as PasswordRecoveryFormData,
-    onSubmit: async ({ value }) => {
-      recoverMutation.mutate(value, {
-        onSuccess: data => {
-          if (data.user) {
-            setUser({
-              id: data.user.id,
-              email: data.user.email,
-              first_name: data.user.first_name,
-              last_name: data.user.last_name,
-              email_verified: false,
-            })
-          }
-          router.push('/')
-        },
-      })
-    },
-    validators: {
-      onSubmit: passwordRecoverySchema,
-    },
-  })
-
-  return (
-    <div className="space-y-4">
-      <div className="rounded-md bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400">
-        <p>Your account is scheduled for deletion. You have <strong>{daysRemaining} days</strong> to recover it.</p>
-      </div>
-
-      <form
-        onSubmit={e => {
-          e.preventDefault()
-          e.stopPropagation()
-          form.handleSubmit()
-        }}
-        className="space-y-4"
-      >
-        {recoverMutation.error && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription>{recoverMutation.error.message}</AlertDescription>
-          </Alert>
-        )}
-
-        <div className="space-y-2">
-          <Label>Email</Label>
-          <div className="relative">
-            <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              type="email"
-              value={email}
-              disabled
-              className="pl-10 bg-muted"
-            />
-          </div>
-        </div>
-
-        <form.Field name="password">
-          {field => (
-            <div className="space-y-2">
-              <Label htmlFor={field.name}>Password</Label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id={field.name}
-                  name={field.name}
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="Enter your password"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={e => field.handleChange(e.target.value)}
-                  className="pl-10 pr-10"
-                  aria-invalid={field.state.meta.errors.length > 0}
-                  autoFocus
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
-                  aria-pressed={showPassword}
-                >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              {field.state.meta.errors.length > 0 && (
-                <p role="alert" className="text-sm text-destructive">
-                  {getUniqueErrors(field.state.meta.errors)}
-                </p>
-              )}
-            </div>
-          )}
-        </form.Field>
-
-        <form.Subscribe selector={state => [state.canSubmit, state.isSubmitting]}>
-          {([canSubmit, isSubmitting]) => (
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={!canSubmit || isSubmitting || recoverMutation.isPending}
-            >
-              {isSubmitting || recoverMutation.isPending ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Recovering account...
-                </>
-              ) : (
-                <>
-                  <RefreshCw className="h-4 w-4" />
-                  Recover Account
-                </>
-              )}
-            </Button>
-          )}
-        </form.Subscribe>
-
-        <Button
-          type="button"
-          variant="ghost"
-          className="w-full"
-          onClick={onBack}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Use a different email
-        </Button>
-      </form>
-    </div>
-  )
-}
-
-// Magic link sent confirmation
-function MagicLinkSent({ email, daysRemaining, onBack }: {
-  email: string
-  daysRemaining: number
   onBack: () => void
 }) {
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2 rounded-md bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400">
         <CheckCircle2 className="h-4 w-4 shrink-0" />
-        <span>Recovery email sent to <strong>{email}</strong></span>
-      </div>
-
-      <div className="rounded-md bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400">
-        <p>You have <strong>{daysRemaining} days</strong> to recover your account before it is permanently deleted.</p>
+        <span>If an account exists for <strong>{email}</strong> and is eligible for recovery, a recovery email has been sent.</span>
       </div>
 
       <p className="text-sm text-muted-foreground">
@@ -355,10 +198,8 @@ function RecoverAccountPageContent() {
   const { isAuthenticated, isLoading } = useAuthContext()
   const requestRecoveryMutation = useRequestAccountRecovery()
 
-  const [step, setStep] = useState<'email' | 'password' | 'magic-link-sent'>('email')
+  const [step, setStep] = useState<'email' | 'sent'>('email')
   const [email, setEmail] = useState('')
-  const [hasPassword, setHasPassword] = useState(false)
-  const [daysRemaining, setDaysRemaining] = useState(30)
   const [error, setError] = useState<string | null>(null)
 
   // Check for token in URL (magic link callback)
@@ -371,40 +212,22 @@ function RecoverAccountPageContent() {
     }
   }, [isAuthenticated, isLoading, router, token])
 
-  // Handle email submission
+  // Handle email submission. PSY-774: the response is enumeration-safe, so
+  // we always show the same "sent" confirmation on a successful API call —
+  // the backend logs per-state detail; the UI never branches on it.
   const handleEmailSubmit = async (submittedEmail: string) => {
     setError(null)
     setEmail(submittedEmail)
 
     requestRecoveryMutation.mutate({ email: submittedEmail }, {
       onSuccess: data => {
-        if (data.error_code === 'ACCOUNT_ACTIVE') {
-          // Account is active, redirect to login
-          router.push('/auth?error=' + encodeURIComponent('Your account is active. Please log in normally.'))
-          return
-        }
-
-        if (data.error_code === 'ACCOUNT_NOT_RECOVERABLE') {
-          setError(data.message)
-          return
-        }
-
         if (!data.success && data.error_code) {
+          // Only pre-lookup errors (validation, email-service-config) set
+          // an error code post-PSY-774; surface them verbatim.
           setError(data.message)
           return
         }
-
-        // Set state from response
-        setHasPassword(data.has_password || false)
-        setDaysRemaining(data.days_remaining || 30)
-
-        if (data.has_password) {
-          // User has a password, show password form
-          setStep('password')
-        } else {
-          // OAuth-only user, magic link was sent
-          setStep('magic-link-sent')
-        }
+        setStep('sent')
       },
       onError: err => {
         setError(err.message)
@@ -457,17 +280,13 @@ function RecoverAccountPageContent() {
                 ? 'Account Recovery'
                 : step === 'email'
                   ? 'Enter your email'
-                  : step === 'password'
-                    ? 'Verify your identity'
-                    : 'Check your email'}
+                  : 'Check your email'}
             </CardTitle>
             {!token && (
               <CardDescription>
                 {step === 'email'
                   ? 'Enter the email address of the account you want to recover'
-                  : step === 'password'
-                    ? 'Enter your password to recover your account'
-                    : 'We sent you a recovery link'}
+                  : 'We sent you a recovery link if your account is eligible'}
               </CardDescription>
             )}
           </CardHeader>
@@ -494,20 +313,10 @@ function RecoverAccountPageContent() {
                   />
                 )}
 
-                {/* Step 2a: Password form */}
-                {step === 'password' && (
-                  <PasswordRecoveryForm
+                {/* Step 2: Recovery email sent */}
+                {step === 'sent' && (
+                  <RecoveryEmailSent
                     email={email}
-                    daysRemaining={daysRemaining}
-                    onBack={handleBack}
-                  />
-                )}
-
-                {/* Step 2b: Magic link sent */}
-                {step === 'magic-link-sent' && (
-                  <MagicLinkSent
-                    email={email}
-                    daysRemaining={daysRemaining}
                     onBack={handleBack}
                   />
                 )}

--- a/frontend/app/auth/recover/page.tsx
+++ b/frontend/app/auth/recover/page.tsx
@@ -104,9 +104,10 @@ function EmailForm({ onSubmit, isLoading }: {
   )
 }
 
-// Recovery email sent confirmation. PSY-774: shown for every well-formed
-// email submission — the response is generic, so the UI is too. Recovery
-// detail (days remaining, eligibility) moves behind token confirmation.
+// Recovery email sent confirmation. Shown for every well-formed email
+// submission — the backend response is enumeration-safe (generic), so the
+// UI is too. Recovery detail (days remaining, eligibility) is surfaced
+// only after the user proves email ownership via the recovery link.
 function RecoveryEmailSent({ email, onBack }: {
   email: string
   onBack: () => void
@@ -212,9 +213,9 @@ function RecoverAccountPageContent() {
     }
   }, [isAuthenticated, isLoading, router, token])
 
-  // Handle email submission. PSY-774: the response is enumeration-safe, so
-  // we always show the same "sent" confirmation on a successful API call —
-  // the backend logs per-state detail; the UI never branches on it.
+  // The backend response is enumeration-safe, so we always show the same
+  // "sent" confirmation on a successful API call — per-state detail surfaces
+  // only in server logs and the UI never branches on it.
   const handleEmailSubmit = async (submittedEmail: string) => {
     setError(null)
     setEmail(submittedEmail)
@@ -222,8 +223,8 @@ function RecoverAccountPageContent() {
     requestRecoveryMutation.mutate({ email: submittedEmail }, {
       onSuccess: data => {
         if (!data.success && data.error_code) {
-          // Only pre-lookup errors (validation, email-service-config) set
-          // an error code post-PSY-774; surface them verbatim.
+          // Only pre-lookup errors (validation, email-service-config) still
+          // set an error code; surface them verbatim.
           setError(data.message)
           return
         }

--- a/frontend/features/auth/hooks/useAuth.ts
+++ b/frontend/features/auth/hooks/useAuth.ts
@@ -946,11 +946,13 @@ interface RequestAccountRecoveryRequest {
   email: string
 }
 
+// RequestAccountRecoveryResponse — PSY-774 enumeration-safe. The backend
+// no longer returns `has_password` or `days_remaining`: those fields leaked
+// account state pre-token-confirmation. Treat the response as a single
+// generic "if eligible, sent" acknowledgement.
 interface RequestAccountRecoveryResponse {
   success: boolean
   message: string
-  has_password?: boolean
-  days_remaining?: number
   error_code?: string
   request_id?: string
 }
@@ -1046,8 +1048,8 @@ export const useRequestAccountRecovery = () => {
         }
       )
 
-      // Note: We return the response even if !success to provide
-      // has_password and days_remaining information
+      // PSY-774: response is enumeration-safe — the body is the same generic
+      // "if eligible, sent" acknowledgement regardless of account state.
       return response
     },
     onSuccess: data => {
@@ -1055,8 +1057,6 @@ export const useRequestAccountRecovery = () => {
         'Account recovery request processed',
         {
           message: data.message,
-          hasPassword: data.has_password,
-          daysRemaining: data.days_remaining,
         },
         data.request_id
       )

--- a/frontend/features/auth/hooks/useAuth.ts
+++ b/frontend/features/auth/hooks/useAuth.ts
@@ -946,8 +946,8 @@ interface RequestAccountRecoveryRequest {
   email: string
 }
 
-// RequestAccountRecoveryResponse — PSY-774 enumeration-safe. The backend
-// no longer returns `has_password` or `days_remaining`: those fields leaked
+// RequestAccountRecoveryResponse — enumeration-safe. The backend never
+// returns `has_password` or `days_remaining` here: those fields would leak
 // account state pre-token-confirmation. Treat the response as a single
 // generic "if eligible, sent" acknowledgement.
 interface RequestAccountRecoveryResponse {
@@ -1048,7 +1048,7 @@ export const useRequestAccountRecovery = () => {
         }
       )
 
-      // PSY-774: response is enumeration-safe — the body is the same generic
+      // Response is enumeration-safe — the body is the same generic
       // "if eligible, sent" acknowledgement regardless of account state.
       return response
     },


### PR DESCRIPTION
## Summary
- `RequestAccountRecoveryHandler` and `RecoverAccountHandler` returned distinct response shapes for known-active / known-expired / no-password / lookup-failed states while returning generic bodies for unknown emails — the same partial-enumeration oracle PSY-749 fixed for the magic-link send handler. Collapse every post-lookup branch onto one enumeration-safe response per handler; per-state detail surfaces only in server logs.
- `RequestAccountRecoveryResponse` drops `has_password` and `days_remaining` (both leaked metadata). Email-service-config check moved pre-lookup so `SERVICE_UNAVAILABLE` fires for any caller, not just known accounts.
- Frontend recover flow updated to match: the in-page password form and 30-day warning (driven by the dropped fields) are removed. Users now always see the generic "if eligible, check your inbox" confirmation, click the recovery link, and complete recovery via `ConfirmAccountRecoveryHandler` (post-token-confirmation, so leaking detail there is safe). `useRecoverAccount` hook stays exported for direct API callers.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/api/handlers/auth/... ./internal/services/auth/...` — passed (handlers 12.4s, services 7.1s)
- [x] `cd frontend && bun run typecheck` — passed (clean)
- [x] `cd frontend && bun run test:run app/auth features/auth` — passed (107/107)

## Manual repro
`TestRequestAccountRecoveryHandler_ResponseIdenticalAcrossAccountStates` and `TestRecoverAccountHandler_ResponseIdenticalAcrossAccountStates` pass — they assert `response.Body` equality across unknown / known-active / known-expired / known-recoverable (request) and unknown / active / expired / no-password / wrong-password (recover). Side-effect tests `TestRequestAccountRecoveryHandler_RecoverableSendsEmail`, `TestRequestAccountRecoveryHandler_UnknownDoesNotSend`, `TestRequestAccountRecoveryHandler_SendFailureStaysGeneric` cover the send-on-eligible / no-send-on-unknown / send-failure-stays-generic paths. Backend-only ticket, mode=none.

## Simplify
Edited 3 files, no net line change — stripped PSY-774 ticket refs from production doc/inline comments (test refs kept per PSY-749 precedent). No behavior change.

## FE audit
`grep -rEn "has_password|hasPassword|days_remaining|daysRemaining|ACCOUNT_ACTIVE|ACCOUNT_NOT_RECOVERABLE|NO_PASSWORD" frontend/` surfaced pre-confirmation usage in `frontend/app/auth/recover/page.tsx`: `has_password` chose between password-form vs magic-link-sent screen; `days_remaining` displayed in a warning banner; `ACCOUNT_ACTIVE` redirected to login; `ACCOUNT_NOT_RECOVERABLE` displayed an error. All four were drivers for divergent pre-confirmation UI. Per the ticket AC ("relocated behind token confirmation or removed"), they're removed: the page now collapses to enter-email → see-generic-sent → click-email-link → token-confirmation. `useRecoverAccount` hook is no longer called from the page but stays exported (dead-export cleanup is out of scope). `frontend/components/settings/delete-account-dialog.tsx` also uses `has_password` but that's on the authenticated `DeletionSummaryResponse` endpoint — not in scope, requires login.

Closes PSY-774