### PR TITLE
PSY-798: evaluate hydration for scene/collection/tag pages

### DIFF
--- a/frontend/app/collections/[slug]/page.tsx
+++ b/frontend/app/collections/[slug]/page.tsx
@@ -1,10 +1,13 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { CollectionDetail } from '@/features/collections/components'
+import type { CollectionDetail as CollectionDetailData } from '@/features/collections/types'
+import { getQueryClient, queryKeys } from '@/lib/queryClient'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -16,54 +19,59 @@ interface CollectionPageProps {
   params: Promise<{ slug: string }>
 }
 
-interface CollectionData {
-  title: string
-  slug?: string
-  description?: string
-  creator_name?: string
-}
-
 // PSY-551: forward the viewer's auth cookie so SSR sees the same view as the
 // browser. Private collections 404 to anonymous viewers (correct), but the
 // page route runs server-side and previously bypassed the /api proxy that
 // normally attaches the cookie — so private-but-owned collections rendered
 // 404 for their own creator. Mirrors the cookie-forward pattern in
 // app/api/[...path]/route.ts.
-async function getCollection(slug: string): Promise<CollectionData | null> {
-  const cookieStore = await cookies()
-  const authToken = cookieStore.get('auth_token')
+//
+// PSY-798: wrapped with `React.cache()` so `generateMetadata` and the page
+// body share ONE backend fetch per request instead of two. The result also
+// seeds the TanStack Query cache via `prefetchQuery` below, eliminating the
+// client-side refetch on first paint. Same endpoint + same key as the client
+// `useCollection` hook, so the dehydrated entry resolves directly.
+//
+// Privacy: the backend `GetBySlug` enforces visibility (403 for unauthorized
+// access to private collections; mapped to HTTP 403). We treat any non-2xx
+// as null and fall through to `notFound()`, so the SSR payload only contains
+// data the viewer is authorized to see. Authenticated requests use
+// `cache: 'no-store'` to avoid cross-user cache pollution; anonymous
+// requests stay on ISR for public-collection performance.
+const getCollection = cache(
+  async (slug: string): Promise<CollectionDetailData | null> => {
+    const cookieStore = await cookies()
+    const authToken = cookieStore.get('auth_token')
 
-  // When auth is present the backend response is viewer-specific (private
-  // collections gate on creator_id), so we must NOT cache it across users.
-  // Anonymous requests stay on ISR for public-collection performance.
-  const fetchInit: RequestInit = authToken
-    ? {
-        headers: { Cookie: `auth_token=${authToken.value}` },
-        cache: 'no-store',
+    const fetchInit: RequestInit = authToken
+      ? {
+          headers: { Cookie: `auth_token=${authToken.value}` },
+          cache: 'no-store',
+        }
+      : { next: { revalidate: 3600 } }
+
+    try {
+      const res = await fetch(`${API_BASE_URL}/collections/${slug}`, fetchInit)
+      if (res.ok) {
+        return res.json()
       }
-    : { next: { revalidate: 3600 } }
-
-  try {
-    const res = await fetch(`${API_BASE_URL}/collections/${slug}`, fetchInit)
-    if (res.ok) {
-      return res.json()
-    }
-    if (res.status >= 500) {
-      Sentry.captureMessage(`Collection page fetch error: ${res.status}`, {
+      if (res.status >= 500) {
+        Sentry.captureMessage(`Collection page fetch error: ${res.status}`, {
+          level: 'error',
+          tags: { service: 'collection-page' },
+          extra: { slug, status: res.status },
+        })
+      }
+    } catch (error) {
+      Sentry.captureException(error, {
         level: 'error',
         tags: { service: 'collection-page' },
-        extra: { slug, status: res.status },
+        extra: { slug },
       })
     }
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
-      tags: { service: 'collection-page' },
-      extra: { slug },
-    })
+    return null
   }
-  return null
-}
+)
 
 export async function generateMetadata({
   params,
@@ -118,9 +126,23 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
     notFound()
   }
 
+  // Seed a request-scoped QueryClient with the collection payload the server
+  // already fetched, then dehydrate so the client `useCollection` hook
+  // resolves from the cache instead of refetching. The queryFn returns the
+  // cached value synchronously — `cache()` above guarantees the network call
+  // has already happened, so this is a no-op cache write rather than a
+  // refetch.
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.collections.detail(slug),
+    queryFn: () => collectionData,
+  })
+
   return (
-    <Suspense fallback={<CollectionLoadingFallback />}>
-      <CollectionDetail slug={slug} />
-    </Suspense>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<CollectionLoadingFallback />}>
+        <CollectionDetail slug={slug} />
+      </Suspense>
+    </HydrationBoundary>
   )
 }

--- a/frontend/app/collections/[slug]/page.tsx
+++ b/frontend/app/collections/[slug]/page.tsx
@@ -19,25 +19,24 @@ interface CollectionPageProps {
   params: Promise<{ slug: string }>
 }
 
-// PSY-551: forward the viewer's auth cookie so SSR sees the same view as the
-// browser. Private collections 404 to anonymous viewers (correct), but the
-// page route runs server-side and previously bypassed the /api proxy that
-// normally attaches the cookie — so private-but-owned collections rendered
-// 404 for their own creator. Mirrors the cookie-forward pattern in
-// app/api/[...path]/route.ts.
-//
-// PSY-798: wrapped with `React.cache()` so `generateMetadata` and the page
-// body share ONE backend fetch per request instead of two. The result also
-// seeds the TanStack Query cache via `prefetchQuery` below, eliminating the
-// client-side refetch on first paint. Same endpoint + same key as the client
-// `useCollection` hook, so the dehydrated entry resolves directly.
-//
-// Privacy: the backend `GetBySlug` enforces visibility (403 for unauthorized
-// access to private collections; mapped to HTTP 403). We treat any non-2xx
-// as null and fall through to `notFound()`, so the SSR payload only contains
-// data the viewer is authorized to see. Authenticated requests use
-// `cache: 'no-store'` to avoid cross-user cache pollution; anonymous
-// requests stay on ISR for public-collection performance.
+/**
+ * Forwards the viewer's auth cookie so SSR sees the same view as the
+ * browser — without this, owners of private collections would 404 on their
+ * own pages because the page route bypasses the /api proxy that normally
+ * attaches the cookie. Mirrors the cookie-forward pattern in
+ * app/api/[...path]/route.ts.
+ *
+ * Wrapped in `React.cache()` so `generateMetadata` and the page body share
+ * one round-trip per request; the same payload then hydrates the TanStack
+ * Query cache under `queryKeys.collections.detail(slug)` so the client
+ * `useCollection` hook resolves from cache instead of refetching.
+ *
+ * Privacy: backend `GetBySlug` returns 403 for unauthorized access to
+ * private collections; we treat any non-2xx as null and fall through to
+ * `notFound()`, so the SSR payload never contains data the viewer isn't
+ * authorized to see. Authenticated requests use `cache: 'no-store'` to
+ * avoid cross-user cache pollution; anonymous requests stay on ISR.
+ */
 const getCollection = cache(
   async (slug: string): Promise<CollectionDetailData | null> => {
     const cookieStore = await cookies()
@@ -126,12 +125,9 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
     notFound()
   }
 
-  // Seed a request-scoped QueryClient with the collection payload the server
-  // already fetched, then dehydrate so the client `useCollection` hook
-  // resolves from the cache instead of refetching. The queryFn returns the
-  // cached value synchronously — `cache()` above guarantees the network call
-  // has already happened, so this is a no-op cache write rather than a
-  // refetch.
+  // `cache()` above guarantees the network call already happened, so the
+  // sync `queryFn` is a no-op cache write that just seeds the dehydrated
+  // entry the client `useCollection` hook will pick up.
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
     queryKey: queryKeys.collections.detail(slug),

--- a/frontend/app/tags/[slug]/page.tsx
+++ b/frontend/app/tags/[slug]/page.tsx
@@ -1,9 +1,12 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { TagDetail } from '@/features/tags/components'
+import type { TagEnrichedDetailResponse } from '@/features/tags/types'
+import { getQueryClient, queryKeys } from '@/lib/queryClient'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -15,55 +18,51 @@ interface TagPageProps {
   params: Promise<{ slug: string }>
 }
 
-interface TagSummaryForMetadata {
-  name: string
-  slug?: string
-  category?: string
-  usage_count?: number
-}
-
 /**
- * Fetch tag metadata for the document head. We deliberately use the lightweight
- * GET /tags/{slug} endpoint (not /tags/{slug}/detail) because we only need
- * name + usage_count for the title/description; the enriched detail call has
- * extra cost for content the client component will fetch anyway. (PSY-485)
+ * Fetch the enriched tag detail (GET /tags/{slug}/detail). PSY-485 originally
+ * used the lightweight /tags/{slug} endpoint here on the theory that the
+ * client component would refetch the enriched payload anyway. PSY-798 wires
+ * `<HydrationBoundary>` for `useTagDetail`, which inverts the trade: a single
+ * enriched server fetch now covers metadata + page render + client hydration,
+ * so the lightweight call would just be wasted bytes.
  *
- * Returns null for 404s (expected for invalid slugs) — the page component
- * uses that signal to call `notFound()` and return a hard HTTP 404 instead
- * of a soft-404 (PSY-497).
+ * Wrapped in `React.cache()` so `generateMetadata` and the page body share
+ * one backend round-trip per request. Returns null for 404s (expected for
+ * invalid slugs) — the page component uses that signal to call `notFound()`
+ * for a hard HTTP 404 instead of a soft-404 (PSY-497).
  */
-async function getTagForMetadata(
-  slug: string
-): Promise<TagSummaryForMetadata | null> {
-  try {
-    const res = await fetch(`${API_BASE_URL}/tags/${slug}`, {
-      next: { revalidate: 3600 },
-    })
-    if (res.ok) {
-      return res.json()
-    }
-    if (res.status >= 500) {
-      Sentry.captureMessage(`Tag page metadata fetch error: ${res.status}`, {
+const getTagDetail = cache(
+  async (slug: string): Promise<TagEnrichedDetailResponse | null> => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/tags/${slug}/detail`, {
+        next: { revalidate: 3600 },
+      })
+      if (res.ok) {
+        return res.json()
+      }
+      if (res.status >= 500) {
+        Sentry.captureMessage(`Tag page fetch error: ${res.status}`, {
+          level: 'error',
+          tags: { service: 'tag-page' },
+          extra: { slug, status: res.status },
+        })
+      }
+    } catch (error) {
+      Sentry.captureException(error, {
         level: 'error',
         tags: { service: 'tag-page' },
-        extra: { slug, status: res.status },
+        extra: { slug },
       })
     }
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
-      tags: { service: 'tag-page' },
-      extra: { slug },
-    })
+    return null
   }
-  return null
-}
+)
 
 export async function generateMetadata({
   params,
 }: TagPageProps): Promise<Metadata> {
   const { slug } = await params
-  const tag = await getTagForMetadata(slug)
+  const tag = await getTagDetail(slug)
 
   if (tag) {
     const usageCount = tag.usage_count ?? 0
@@ -116,19 +115,28 @@ export default async function TagDetailPage({ params }: TagPageProps) {
   // `not-found.tsx`. Without this, the client component would render a
   // friendly "Tag Not Found" page but the response status stays 200 — a
   // soft-404 that poisons SEO, monitoring, and crawlers (PSY-497).
-  //
-  // We rely on `getTagForMetadata` (already called during metadata
-  // generation) — but Next.js doesn't memoize across `generateMetadata` and
-  // the page component, so this second fetch is unavoidable. It hits
-  // `revalidate: 3600` cache in practice.
-  const tag = await getTagForMetadata(slug)
+  const tag = await getTagDetail(slug)
   if (!tag) {
     notFound()
   }
 
+  // Seed a request-scoped QueryClient with the enriched tag payload the
+  // server already fetched, then dehydrate so the client `useTagDetail` hook
+  // resolves from the cache instead of refetching. The queryFn returns the
+  // cached value synchronously — `cache()` above guarantees the network call
+  // has already happened, so this is a no-op cache write rather than a
+  // refetch.
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.tags.enrichedDetail(slug),
+    queryFn: () => tag,
+  })
+
   return (
-    <Suspense fallback={<TagLoadingFallback />}>
-      <TagDetail slug={slug} />
-    </Suspense>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<TagLoadingFallback />}>
+        <TagDetail slug={slug} />
+      </Suspense>
+    </HydrationBoundary>
   )
 }

--- a/frontend/app/tags/[slug]/page.tsx
+++ b/frontend/app/tags/[slug]/page.tsx
@@ -19,17 +19,15 @@ interface TagPageProps {
 }
 
 /**
- * Fetch the enriched tag detail (GET /tags/{slug}/detail). PSY-485 originally
- * used the lightweight /tags/{slug} endpoint here on the theory that the
- * client component would refetch the enriched payload anyway. PSY-798 wires
- * `<HydrationBoundary>` for `useTagDetail`, which inverts the trade: a single
- * enriched server fetch now covers metadata + page render + client hydration,
- * so the lightweight call would just be wasted bytes.
+ * Fetch the enriched tag detail (GET /tags/{slug}/detail) — the same shape
+ * the client `useTagDetail` hook consumes. Server hydration eliminates the
+ * client refetch, so paying for the enriched shape once on the server is
+ * cheaper than the previous lightweight-metadata + client-enriched waterfall.
  *
  * Wrapped in `React.cache()` so `generateMetadata` and the page body share
- * one backend round-trip per request. Returns null for 404s (expected for
- * invalid slugs) — the page component uses that signal to call `notFound()`
- * for a hard HTTP 404 instead of a soft-404 (PSY-497).
+ * one round-trip per request. Returns null for 404s (expected for invalid
+ * slugs) so the page can call `notFound()` for a hard HTTP 404 rather than
+ * letting the client render a soft-404 that poisons SEO and monitoring.
  */
 const getTagDetail = cache(
   async (slug: string): Promise<TagEnrichedDetailResponse | null> => {
@@ -110,22 +108,18 @@ function TagLoadingFallback() {
 export default async function TagDetailPage({ params }: TagPageProps) {
   const { slug } = await params
 
-  // Server-side existence check: if the backend doesn't know this slug, call
-  // `notFound()` so Next.js returns HTTP 404 and renders the route's
-  // `not-found.tsx`. Without this, the client component would render a
-  // friendly "Tag Not Found" page but the response status stays 200 — a
-  // soft-404 that poisons SEO, monitoring, and crawlers (PSY-497).
+  // Server-side existence check: unknown slugs must return HTTP 404 so the
+  // route renders `not-found.tsx`. Without `notFound()` the client component
+  // would render a friendly "Tag Not Found" page at HTTP 200 — a soft-404
+  // that poisons SEO, monitoring, and crawlers.
   const tag = await getTagDetail(slug)
   if (!tag) {
     notFound()
   }
 
-  // Seed a request-scoped QueryClient with the enriched tag payload the
-  // server already fetched, then dehydrate so the client `useTagDetail` hook
-  // resolves from the cache instead of refetching. The queryFn returns the
-  // cached value synchronously — `cache()` above guarantees the network call
-  // has already happened, so this is a no-op cache write rather than a
-  // refetch.
+  // `cache()` above guarantees the network call already happened, so the
+  // sync `queryFn` is a no-op cache write that just seeds the dehydrated
+  // entry the client `useTagDetail` hook will pick up.
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
     queryKey: queryKeys.tags.enrichedDetail(slug),


### PR DESCRIPTION
## Summary
- Per-page evaluation of server-side hydration for the three non-core detail pages flagged by PSY-798 (scenes, collections, tags).
- Applied the PSY-796 pilot pattern (`React.cache()` + `prefetchQuery` + `<HydrationBoundary>`) to **collections** and **tags**; **scenes** is documented as N/A because it has no server fetch to dedupe.

## Per-page decision
- **Scenes**: N/A — `app/scenes/[slug]/page.tsx` has no server fetch. `generateMetadata` derives the title from slug parsing alone (`phoenix-az` → "Phoenix, AZ"); `SceneDetailView` fetches everything client-side via `useSceneDetail`. Adding a server fetch is a separate design call out of this ticket's scope.
- **Collections**: applied. Same endpoint + same key as `useCollection` (`GET /collections/{slug}` → `queryKeys.collections.detail(slug)`). The pre-existing PSY-551 cookie-forward fetch is now wrapped in `React.cache()`, so `generateMetadata` + page body share one backend round-trip (previously two). Privacy verified — see section below.
- **Tags**: applied. Server fetch switched from the lightweight `/tags/{slug}` (PSY-485, metadata-only) to the enriched `/tags/{slug}/detail` consumed by `useTagDetail`. The PSY-485 trade inverts under hydration: one enriched server fetch now covers metadata + page render + client hydration. Cache key matches `queryKeys.tags.enrichedDetail(slug)`.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run` — 4595 tests passed (no regressions; comment-only edits in simplify pass weren't re-run)
- [x] No backend changes; backend test suite not run

## Manual repro
Dispatch stack came up in isolated mode (`STACK_FRONTEND_URL=http://localhost:59319`), seeded with public collection `e2e-worker-collection-1`, a manually-inserted tag `punk`, and a manually-inserted private collection `secret-stash` (owner = user 1).

- `/collections/e2e-worker-collection-1` (anonymous): browser network log shows **zero** `GET /api/collections/e2e-worker-collection-1` requests. The page legitimately fires `entities/collection/5/tags` and `entities/collection/5/comments` after mount — those are separate queries, not the collection detail refetch. Screenshot: `/var/folders/12/.../PSY-798-screenshots/collection-no-refetch.png` (workspace-root constraint blocked writing to repo `dogfood-output/`).
- `/tags/punk` (anonymous): browser network log shows **zero** `GET /api/tags/punk` or `/api/tags/punk/detail` requests. Screenshot at `tag-no-refetch.png`.

## Privacy verification (collections)
Three-part verification on the private collection `secret-stash` (id=6, is_public=false, creator_id=1):

1. **Backend privacy gate**: `curl $STACK_BACKEND_URL/collections/secret-stash` → HTTP 403; `curl $STACK_BACKEND_URL/collections/e2e-worker-collection-1` (public) → HTTP 200. `GetBySlug` enforces `!collection.IsPublic && collection.CreatorID != viewerID → ErrCollectionForbidden → HTTP 403`.
2. **Frontend SSR response**: anonymous `curl $STACK_FRONTEND_URL/collections/secret-stash` → HTTP 404. Page treats backend 403 as null and calls `notFound()`, so unauthorized viewers get a clean 404 instead of a leaky 200.
3. **No HTML payload leak**: `grep -ci "Secret Stash"` and `grep -ci "Private collection for SSR"` against the SSR HTML → 0 matches. The only `secret-stash` match in the HTML is the URL slug in the not-found shell (the slug the user already typed), not any private field.

Authenticated-owner path was not exercised end-to-end (would require login flow) — the cookie-forward logic is unchanged from PSY-551, and the only new wrapper (`React.cache()`) is a per-request memo that doesn't alter auth semantics.

## Simplify
Ran the simplify pass. Two cleanups landed in a follow-up commit:
- Stripped `PSY-{N}` ticket refs from the new production doc comments per project convention.
- Tightened narrative comments that re-narrated the change (the diff already shows the change) down to the load-bearing WHY (`React.cache()` semantics, the soft-404 risk that justifies the existence-check, the privacy-gate guarantee).

Re-ran typecheck after the simplify pass; full test re-run skipped because the simplify edits were comment-only.

Closes PSY-798