### PR TITLE
PSY-797: roll out server hydration to 5 entity detail pages

### DIFF
--- a/frontend/app/artists/[slug]/page.tsx
+++ b/frontend/app/artists/[slug]/page.tsx
@@ -3,18 +3,14 @@ import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
-import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import { HydrationBoundary } from '@tanstack/react-query'
 import { ArtistDetail } from '@/features/artists'
 import type { Artist } from '@/features/artists/types'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateMusicGroupSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
-import { getQueryClient, queryKeys } from '@/lib/queryClient'
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : 'https://api.psychichomily.com')
+import { API_BASE_URL } from '@/lib/api-base'
+import { queryKeys } from '@/lib/queryClient'
+import { prefetchEntity } from '@/lib/query-hydration'
 
 interface ArtistPageProps {
   params: Promise<{ slug: string }>
@@ -23,7 +19,7 @@ interface ArtistPageProps {
 /**
  * Wrapped with `React.cache()` so `generateMetadata` and the page body
  * share ONE backend fetch per request instead of two. The result also
- * seeds the TanStack Query cache via `prefetchQuery` below, eliminating
+ * seeds the TanStack Query cache via `prefetchEntity` below, eliminating
  * the client-side refetch on first paint.
  */
 const getArtist = cache(async (slug: string): Promise<Artist | null> => {
@@ -98,16 +94,10 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
     notFound()
   }
 
-  // Seed a request-scoped QueryClient with the artist payload the server
-  // already fetched, then dehydrate so the client `useArtist` hook resolves
-  // from the cache instead of refetching. The queryFn returns the cached
-  // value synchronously — `cache()` above guarantees the network call has
-  // already happened, so this is a no-op cache write rather than a refetch.
-  const queryClient = getQueryClient()
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.artists.detail(slug),
-    queryFn: () => artistData,
-  })
+  const dehydratedState = await prefetchEntity(
+    queryKeys.artists.detail(slug),
+    artistData,
+  )
 
   return (
     <>
@@ -126,7 +116,7 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
         { name: 'Artists', url: 'https://psychichomily.com/artists' },
         { name: artistData.name, url: `https://psychichomily.com/artists/${artistData.slug || slug}` },
       ])} />
-      <HydrationBoundary state={dehydrate(queryClient)}>
+      <HydrationBoundary state={dehydratedState}>
         <Suspense fallback={<ArtistLoadingFallback />}>
           <ArtistDetail artistId={slug} />
         </Suspense>

--- a/frontend/app/festivals/[slug]/page.tsx
+++ b/frontend/app/festivals/[slug]/page.tsx
@@ -1,31 +1,26 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
+import { HydrationBoundary } from '@tanstack/react-query'
 import { FestivalDetail } from '@/features/festivals/components'
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : 'https://api.psychichomily.com')
+import type { FestivalDetail as FestivalDetailData } from '@/features/festivals/types'
+import { API_BASE_URL } from '@/lib/api-base'
+import { queryKeys } from '@/lib/queryClient'
+import { prefetchEntity } from '@/lib/query-hydration'
 
 interface FestivalPageProps {
   params: Promise<{ slug: string }>
 }
 
-interface FestivalData {
-  name: string
-  slug?: string
-  city?: string | null
-  state?: string | null
-  start_date?: string
-  end_date?: string
-  status?: string
-}
-
-async function getFestival(slug: string): Promise<FestivalData | null> {
+/**
+ * Wrapped with `React.cache()` so `generateMetadata` and the page body
+ * share ONE backend fetch per request instead of two. The result also
+ * seeds the TanStack Query cache via `prefetchEntity` below, eliminating
+ * the client-side refetch on first paint.
+ */
+const getFestival = cache(async (slug: string): Promise<FestivalDetailData | null> => {
   try {
     const res = await fetch(`${API_BASE_URL}/festivals/${slug}`, {
       next: { revalidate: 3600 },
@@ -48,7 +43,7 @@ async function getFestival(slug: string): Promise<FestivalData | null> {
     })
   }
   return null
-}
+})
 
 export async function generateMetadata({
   params,
@@ -101,9 +96,16 @@ export default async function FestivalPage({ params }: FestivalPageProps) {
     notFound()
   }
 
+  const dehydratedState = await prefetchEntity(
+    queryKeys.festivals.detail(slug),
+    festivalData,
+  )
+
   return (
-    <Suspense fallback={<FestivalLoadingFallback />}>
-      <FestivalDetail idOrSlug={slug} />
-    </Suspense>
+    <HydrationBoundary state={dehydratedState}>
+      <Suspense fallback={<FestivalLoadingFallback />}>
+        <FestivalDetail idOrSlug={slug} />
+      </Suspense>
+    </HydrationBoundary>
   )
 }

--- a/frontend/app/labels/[slug]/page.tsx
+++ b/frontend/app/labels/[slug]/page.tsx
@@ -1,29 +1,26 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
+import { HydrationBoundary } from '@tanstack/react-query'
 import { LabelDetail } from '@/features/labels/components'
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : 'https://api.psychichomily.com')
+import type { LabelDetail as LabelDetailData } from '@/features/labels/types'
+import { API_BASE_URL } from '@/lib/api-base'
+import { queryKeys } from '@/lib/queryClient'
+import { prefetchEntity } from '@/lib/query-hydration'
 
 interface LabelPageProps {
   params: Promise<{ slug: string }>
 }
 
-interface LabelData {
-  name: string
-  slug?: string
-  city?: string | null
-  state?: string | null
-  status?: string
-}
-
-async function getLabel(slug: string): Promise<LabelData | null> {
+/**
+ * Wrapped with `React.cache()` so `generateMetadata` and the page body
+ * share ONE backend fetch per request instead of two. The result also
+ * seeds the TanStack Query cache via `prefetchEntity` below, eliminating
+ * the client-side refetch on first paint.
+ */
+const getLabel = cache(async (slug: string): Promise<LabelDetailData | null> => {
   try {
     const res = await fetch(`${API_BASE_URL}/labels/${slug}`, {
       next: { revalidate: 3600 },
@@ -46,7 +43,7 @@ async function getLabel(slug: string): Promise<LabelData | null> {
     })
   }
   return null
-}
+})
 
 export async function generateMetadata({
   params,
@@ -99,9 +96,16 @@ export default async function LabelPage({ params }: LabelPageProps) {
     notFound()
   }
 
+  const dehydratedState = await prefetchEntity(
+    queryKeys.labels.detail(slug),
+    labelData,
+  )
+
   return (
-    <Suspense fallback={<LabelLoadingFallback />}>
-      <LabelDetail idOrSlug={slug} />
-    </Suspense>
+    <HydrationBoundary state={dehydratedState}>
+      <Suspense fallback={<LabelLoadingFallback />}>
+        <LabelDetail idOrSlug={slug} />
+      </Suspense>
+    </HydrationBoundary>
   )
 }

--- a/frontend/app/releases/[slug]/page.tsx
+++ b/frontend/app/releases/[slug]/page.tsx
@@ -1,28 +1,26 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
+import { HydrationBoundary } from '@tanstack/react-query'
 import { ReleaseDetail } from '@/features/releases/components'
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : 'https://api.psychichomily.com')
+import type { ReleaseDetail as ReleaseDetailData } from '@/features/releases/types'
+import { API_BASE_URL } from '@/lib/api-base'
+import { queryKeys } from '@/lib/queryClient'
+import { prefetchEntity } from '@/lib/query-hydration'
 
 interface ReleasePageProps {
   params: Promise<{ slug: string }>
 }
 
-interface ReleaseData {
-  title: string
-  slug?: string
-  release_type?: string
-  release_year?: number | null
-}
-
-async function getRelease(slug: string): Promise<ReleaseData | null> {
+/**
+ * Wrapped with `React.cache()` so `generateMetadata` and the page body
+ * share ONE backend fetch per request instead of two. The result also
+ * seeds the TanStack Query cache via `prefetchEntity` below, eliminating
+ * the client-side refetch on first paint.
+ */
+const getRelease = cache(async (slug: string): Promise<ReleaseDetailData | null> => {
   try {
     const res = await fetch(`${API_BASE_URL}/releases/${slug}`, {
       next: { revalidate: 3600 },
@@ -45,7 +43,7 @@ async function getRelease(slug: string): Promise<ReleaseData | null> {
     })
   }
   return null
-}
+})
 
 export async function generateMetadata({
   params,
@@ -97,9 +95,16 @@ export default async function ReleasePage({ params }: ReleasePageProps) {
     notFound()
   }
 
+  const dehydratedState = await prefetchEntity(
+    queryKeys.releases.detail(slug),
+    releaseData,
+  )
+
   return (
-    <Suspense fallback={<ReleaseLoadingFallback />}>
-      <ReleaseDetail idOrSlug={slug} />
-    </Suspense>
+    <HydrationBoundary state={dehydratedState}>
+      <Suspense fallback={<ReleaseLoadingFallback />}>
+        <ReleaseDetail idOrSlug={slug} />
+      </Suspense>
+    </HydrationBoundary>
   )
 }

--- a/frontend/app/shows/[slug]/page.tsx
+++ b/frontend/app/shows/[slug]/page.tsx
@@ -1,55 +1,28 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import * as Sentry from '@sentry/nextjs'
+import { HydrationBoundary } from '@tanstack/react-query'
 import { ShowDetail } from '@/features/shows'
+import type { ShowResponse } from '@/features/shows/types'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateMusicEventSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : 'https://api.psychichomily.com')
+import { API_BASE_URL } from '@/lib/api-base'
+import { queryKeys } from '@/lib/queryClient'
+import { prefetchEntity } from '@/lib/query-hydration'
 
 interface ShowPageProps {
   params: Promise<{ slug: string }>
 }
 
-interface ShowData {
-  title?: string
-  event_date: string
-  slug?: string
-  description?: string | null
-  price?: number
-  is_sold_out: boolean
-  is_cancelled: boolean
-  venues: Array<{
-    name: string
-    slug: string
-    address?: string | null
-    city: string
-    state: string
-  }>
-  artists: Array<{
-    name: string
-    slug: string
-    is_headliner?: boolean | null
-    socials: {
-      instagram?: string | null
-      facebook?: string | null
-      twitter?: string | null
-      youtube?: string | null
-      spotify?: string | null
-      soundcloud?: string | null
-      bandcamp?: string | null
-      website?: string | null
-    }
-  }>
-}
-
-async function getShow(slug: string): Promise<ShowData | null> {
+/**
+ * Wrapped with `React.cache()` so `generateMetadata` and the page body
+ * share ONE backend fetch per request instead of two. The result also
+ * seeds the TanStack Query cache via `prefetchEntity` below, eliminating
+ * the client-side refetch on first paint.
+ */
+const getShow = cache(async (slug: string): Promise<ShowResponse | null> => {
   try {
     const res = await fetch(`${API_BASE_URL}/shows/${slug}`, {
       next: { revalidate: 3600 },
@@ -73,7 +46,7 @@ async function getShow(slug: string): Promise<ShowData | null> {
     })
   }
   return null
-}
+})
 
 function formatShowDate(dateString: string): string {
   const date = new Date(dateString)
@@ -141,6 +114,11 @@ export default async function ShowPage({ params }: ShowPageProps) {
     notFound()
   }
 
+  const dehydratedState = await prefetchEntity(
+    queryKeys.shows.detail(slug),
+    showData,
+  )
+
   const headliner = showData.artists?.find(a => a.is_headliner)?.name || showData.artists?.[0]?.name || 'Live Music'
   const showName = showData.title || `${headliner} at ${showData.venues?.[0]?.name || 'TBA'}`
 
@@ -163,9 +141,12 @@ export default async function ShowPage({ params }: ShowPageProps) {
           name: a.name,
           slug: a.slug,
           is_headliner: a.is_headliner ?? undefined,
-          socials: a.socials,
+          // `ShowArtistSocials` is a struct of named optional fields; spread into a
+          // plain object so it satisfies the schema helper's index-signature parameter
+          // type without changing the cross-feature type.
+          socials: { ...a.socials },
         })),
-        price: showData.price,
+        price: showData.price ?? undefined,
         slug: showData.slug,
       })} />
       <JsonLd data={generateBreadcrumbSchema([
@@ -173,9 +154,11 @@ export default async function ShowPage({ params }: ShowPageProps) {
         { name: 'Shows', url: 'https://psychichomily.com/shows' },
         { name: showName, url: `https://psychichomily.com/shows/${slug}` },
       ])} />
-      <Suspense fallback={<ShowLoadingFallback />}>
-        <ShowDetail showId={slug} />
-      </Suspense>
+      <HydrationBoundary state={dehydratedState}>
+        <Suspense fallback={<ShowLoadingFallback />}>
+          <ShowDetail showId={slug} />
+        </Suspense>
+      </HydrationBoundary>
     </>
   )
 }

--- a/frontend/app/venues/[slug]/page.tsx
+++ b/frontend/app/venues/[slug]/page.tsx
@@ -1,32 +1,28 @@
-import { Suspense } from 'react'
+import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import * as Sentry from '@sentry/nextjs'
+import { HydrationBoundary } from '@tanstack/react-query'
 import { VenueDetail } from '@/features/venues'
+import type { Venue } from '@/features/venues/types'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateMusicVenueSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : 'https://api.psychichomily.com')
+import { API_BASE_URL } from '@/lib/api-base'
+import { queryKeys } from '@/lib/queryClient'
+import { prefetchEntity } from '@/lib/query-hydration'
 
 interface VenuePageProps {
   params: Promise<{ slug: string }>
 }
 
-interface VenueData {
-  name: string
-  slug?: string
-  address?: string
-  city?: string
-  state?: string
-  zip_code?: string
-}
-
-async function getVenue(slug: string): Promise<VenueData | null> {
+/**
+ * Wrapped with `React.cache()` so `generateMetadata` and the page body
+ * share ONE backend fetch per request instead of two. The result also
+ * seeds the TanStack Query cache via `prefetchEntity` below, eliminating
+ * the client-side refetch on first paint.
+ */
+const getVenue = cache(async (slug: string): Promise<Venue | null> => {
   try {
     const res = await fetch(`${API_BASE_URL}/venues/${slug}`, {
       next: { revalidate: 3600 },
@@ -50,7 +46,7 @@ async function getVenue(slug: string): Promise<VenueData | null> {
     })
   }
   return null
-}
+})
 
 export async function generateMetadata({ params }: VenuePageProps): Promise<Metadata> {
   const { slug } = await params
@@ -99,14 +95,18 @@ export default async function VenuePage({ params }: VenuePageProps) {
     notFound()
   }
 
+  const dehydratedState = await prefetchEntity(
+    queryKeys.venues.detail(slug),
+    venueData,
+  )
+
   return (
     <>
       <JsonLd data={generateMusicVenueSchema({
         name: venueData.name,
-        address: venueData.address,
+        address: venueData.address ?? undefined,
         city: venueData.city,
         state: venueData.state,
-        zip_code: venueData.zip_code,
         slug: venueData.slug || slug,
       })} />
       <JsonLd data={generateBreadcrumbSchema([
@@ -114,9 +114,11 @@ export default async function VenuePage({ params }: VenuePageProps) {
         { name: 'Venues', url: 'https://psychichomily.com/venues' },
         { name: venueData.name, url: `https://psychichomily.com/venues/${venueData.slug || slug}` },
       ])} />
-      <Suspense fallback={<VenueLoadingFallback />}>
-        <VenueDetail venueId={slug} />
-      </Suspense>
+      <HydrationBoundary state={dehydratedState}>
+        <Suspense fallback={<VenueLoadingFallback />}>
+          <VenueDetail venueId={slug} />
+        </Suspense>
+      </HydrationBoundary>
     </>
   )
 }

--- a/frontend/lib/query-hydration.ts
+++ b/frontend/lib/query-hydration.ts
@@ -1,0 +1,42 @@
+/**
+ * Server-side query hydration helpers.
+ *
+ * Companion to `lib/queryClient.ts` for server components (e.g.
+ * `app/<entity>/[slug]/page.tsx`) that need to seed a TanStack Query
+ * cache from data the server already fetched, so the matching client
+ * hook resolves from the hydrated cache instead of refetching.
+ *
+ * No `'use client'` directive — this module is server-importable.
+ *
+ * Usage:
+ *
+ *   const data = await getEntity(slug)              // React.cache-wrapped fetch
+ *   const state = await prefetchEntity(
+ *     queryKeys.<entity>.detail(slug),
+ *     data,
+ *   )
+ *   return (
+ *     <HydrationBoundary state={state}>
+ *       <EntityDetail entityId={slug} />
+ *     </HydrationBoundary>
+ *   )
+ *
+ * The `queryFn` returns the cached value synchronously — `cache()` on
+ * the upstream fetch guarantees the network call has already happened,
+ * so this is a no-op cache write rather than a second refetch.
+ */
+
+import { dehydrate, type DehydratedState } from '@tanstack/react-query'
+import { getQueryClient } from '@/lib/queryClient'
+
+export async function prefetchEntity<T>(
+  queryKey: readonly unknown[],
+  data: T,
+): Promise<DehydratedState> {
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey,
+    queryFn: () => data,
+  })
+  return dehydrate(queryClient)
+}


### PR DESCRIPTION
## Summary
- Apply the PSY-796 pilot pattern (`React.cache()` server fetch + request-scoped `prefetchQuery` + `<HydrationBoundary>`) to the 5 core entity detail pages: venue / show / release / label / festival. Each now hydrates the TanStack Query cache with the payload already fetched server-side, eliminating the duplicate client-side refetch / spinner on first paint.
- Extracted the prefetch+dehydrate boilerplate into `frontend/lib/query-hydration.ts` (server-importable) and migrated the original artist pilot to use it, so all 6 entity pages now share one shape.
- Sidecar queries (related shows, followers, comments, tags, etc.) intentionally stay client-side per the locked architectural decision — this is the surgical hydration completion for core detail data only, not broader RSC migration.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run` — 4595 passed (403 files)

## Manual repro
Frontend stack on `http://localhost:59522`, backend on `:59521`. Verified in Chrome DevTools Network panel (XHR/fetch filter) on first navigation:

| Entity | URL | `GET /api/<entity>/{slug}` calls | Screenshot |
| --- | --- | --- | --- |
| Venue | `/venues/the-rebel-lounge-phoenix-az` | 0 | `dogfood-output/PSY-797/screenshots/venue-no-refetch.png` |
| Show | `/shows/e2e-collection-saved-show` | 0 | `dogfood-output/PSY-797/screenshots/show-no-refetch.png` |
| Release | `/releases/sundressed-ep` | 0 | `dogfood-output/PSY-797/screenshots/release-no-refetch.png` |
| Label | `/labels/loma-vista-recordings` | 0 | `dogfood-output/PSY-797/screenshots/label-no-refetch.png` |
| Festival | `/festivals/test-fest-2026` | 0 | `dogfood-output/PSY-797/screenshots/festival-no-refetch.png` |

For each, the only `/api/<entity>/...` browser requests are sidecars (followers, tags, comments, related lists, etc.) — the detail call itself is absent because the cache is hydrated. Content paints with no spinner.

Festival test record was created in the isolated dispatch DB because the seed fixture had no festivals; the page renders identically against the hydrated cache.

## Helper extraction
**Extracted.** All 5 sites (now 6 with the artist pilot migrated too) mapped cleanly to `prefetchEntity(queryKey, data) -> DehydratedState` with zero per-page variance. The helper lives at `frontend/lib/query-hydration.ts` (server-importable; no `'use client'`). Inlining would have meant 6 copies of the same 4-line `getQueryClient() + prefetchQuery + dehydrate` block; the helper keeps the queryClient lifecycle in one place so the next entity page added just calls `prefetchEntity(queryKeys.<entity>.detail(slug), data)`.

## Fold-in
Scope-adjacent `API_BASE_URL` cleanup PSY-796 flagged: all 6 entity pages (venue / show / release / label / festival + artist pilot) had their own local 4-line redeclaration of the env-vs-default URL block. Each is now `import { API_BASE_URL } from '@/lib/api-base'`, matching the feature-module `api.ts` convention.

## Simplify
Reviewed against reuse / quality / efficiency. No changes needed — the helper IS the reuse fix, `API_BASE_URL` import IS the quality fix, and `React.cache()` IS the efficiency win. All comments are WHY/invariant content (cache+prefetch contract, TS index-signature trick); none are narration.

Closes PSY-797