### PR TITLE
PSY-762: errors.Is gorm codemod + gate errorlint

### DIFF
--- a/backend/.golangci-advisory.yml
+++ b/backend/.golangci-advisory.yml
@@ -25,7 +25,3 @@ linters:
     # 474 violations. Large legacy backlog (dropped resp.Body.Close, bcrypt
     # compares, etc.); needs its own ticket.
     - errcheck
-    # 205 violations. PSY-762 will codemod the err == sentinel sites; the
-    # follow-up to PSY-762 will flip this linter from advisory to gated by
-    # moving it into .golangci.yml.
-    - errorlint

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -11,12 +11,18 @@
 #   * this file (.golangci.yml)             — gated linters; non-zero exit fails CI.
 #   * .golangci-advisory.yml                — advisory linters; soft-fail in CI.
 #
-# Violation survey (2026-05-23, golangci-lint v2.12.2):
+# Violation survey (2026-05-23, golangci-lint v2.12.2; errorlint updated 2026-05-24):
 #   linter       | violations | decision  | rationale
 #   ----------- | ---------- | --------- | ------------------------------------------------
 #   govet        |          0 | GATE      | clean once the `inline` analyzer (advisory
 #                |            |           | suggestion to swap `reflect.Ptr` → `reflect.Pointer`)
 #                |            |           | is disabled — see settings below.
+#   errorlint    |          0 | GATE      | PSY-762 codemodded 193 `err == gorm.ErrRecordNotFound`
+#                |            |           | sites (189 in source-Go + 4 in cmd/scaffold templates)
+#                |            |           | to `errors.Is(...)` via `gofmt -r`, then cleaned up
+#                |            |           | the 13 stragglers (5 fmt.Errorf %v→%w in cmd/seed +
+#                |            |           | 8 test-file `err.(*T)`→`errors.As(err, &v)`). Gated
+#                |            |           | to prevent regression of err-wrap discipline.
 #   ineffassign  |          4 | advisory  | trivial fixes, but spec says do not widen
 #                |            |           | scope; flip to gate after cleanup ticket.
 #   unused       |         25 | advisory  | mix of dead test helpers + dead consts/types;
@@ -26,8 +32,6 @@
 #                |            |           | unused-assignment bugs; flip after cleanup.
 #   errcheck     |        474 | advisory  | large legacy backlog (dropped resp.Body.Close,
 #                |            |           | bcrypt compares, etc.); needs its own ticket.
-#   errorlint    |        205 | advisory  | PSY-762 will codemod the 200+ err == sentinel
-#                |            |           | sites; once that ships, flip to gate.
 #
 # Note on the PSY-760 attribution-deref rule:
 #   PSY-760 wants a custom rule that flags direct user.{Username,FirstName,Email}
@@ -49,6 +53,7 @@ linters:
   default: none
   enable:
     - govet
+    - errorlint
 
   settings:
     govet:

--- a/backend/cmd/scaffold/main.go
+++ b/backend/cmd/scaffold/main.go
@@ -845,6 +845,7 @@ type {{.NameTitle}}ListResponse struct {
 var tmplService = `package catalog
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -911,7 +912,7 @@ func (s *{{.NameTitle}}Service) Get{{.NameTitle}}({{.NameCamel}}ID uint) (*contr
 	var record models.{{.NameTitle}}
 	err := s.db.First(&record, {{.NameCamel}}ID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("{{.Name}} not found: %d", {{.NameCamel}}ID)
 		}
 		return nil, fmt.Errorf("failed to get {{.Name}}: %w", err)
@@ -929,7 +930,7 @@ func (s *{{.NameTitle}}Service) Get{{.NameTitle}}BySlug(slug string) (*contracts
 	var record models.{{.NameTitle}}
 	err := s.db.Where("slug = ?", slug).First(&record).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("{{.Name}} not found: %s", slug)
 		}
 		return nil, fmt.Errorf("failed to get {{.Name}}: %w", err)
@@ -1027,7 +1028,7 @@ func (s *{{.NameTitle}}Service) Update{{.NameTitle}}({{.NameCamel}}ID uint, req 
 
 	var record models.{{.NameTitle}}
 	if err := s.db.First(&record, {{.NameCamel}}ID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("{{.Name}} not found: %d", {{.NameCamel}}ID)
 		}
 		return nil, fmt.Errorf("failed to get {{.Name}}: %w", err)
@@ -1074,7 +1075,7 @@ func (s *{{.NameTitle}}Service) Delete{{.NameTitle}}({{.NameCamel}}ID uint) erro
 
 	var record models.{{.NameTitle}}
 	if err := s.db.First(&record, {{.NameCamel}}ID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("{{.Name}} not found: %d", {{.NameCamel}}ID)
 		}
 		return fmt.Errorf("failed to get {{.Name}}: %w", err)

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -14,6 +14,10 @@ import (
 	"psychic-homily-backend/internal/seeddata"
 	"psychic-homily-backend/internal/utils"
 
+	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	engagementm "psychic-homily-backend/internal/models/engagement"
+
 	"github.com/goccy/go-yaml"
 	"github.com/joho/godotenv"
 	"golang.org/x/crypto/bcrypt"
@@ -21,9 +25,6 @@ import (
 	"golang.org/x/text/language"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	authm "psychic-homily-backend/internal/models/auth"
-	catalogm "psychic-homily-backend/internal/models/catalog"
-	engagementm "psychic-homily-backend/internal/models/engagement"
 )
 
 type VenueData struct {
@@ -256,7 +257,7 @@ func parseShowFrontmatter(data []byte) (ShowData, error) {
 	var show ShowData
 	err := yaml.Unmarshal([]byte(parts[1]), &show)
 	if err != nil {
-		return ShowData{}, fmt.Errorf("failed to parse YAML: %v", err)
+		return ShowData{}, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
 	return show, nil
@@ -266,7 +267,7 @@ func createShowWithAssociations(db *gorm.DB, showData ShowData) error {
 	// Parse event date and convert to UTC
 	eventDate, err := time.Parse("2006-01-02T15:04:05-07:00", showData.EventDate)
 	if err != nil {
-		return fmt.Errorf("failed to parse event date: %v", err)
+		return fmt.Errorf("failed to parse event date: %w", err)
 	}
 
 	// Convert to UTC for database storage
@@ -309,7 +310,7 @@ func createShowWithAssociations(db *gorm.DB, showData ShowData) error {
 	return db.Transaction(func(tx *gorm.DB) error {
 		// Create the show
 		if err := tx.Create(show).Error; err != nil {
-			return fmt.Errorf("failed to create show: %v", err)
+			return fmt.Errorf("failed to create show: %w", err)
 		}
 
 		// Associate venues. Track the lowest venue.ID for the
@@ -338,7 +339,7 @@ func createShowWithAssociations(db *gorm.DB, showData ShowData) error {
 				VenueID: venue.ID,
 			}
 			if err := tx.Create(&showVenue).Error; err != nil {
-				return fmt.Errorf("failed to create show-venue association: %v", err)
+				return fmt.Errorf("failed to create show-venue association: %w", err)
 			}
 
 			if primaryVenueID == nil || venue.ID < *primaryVenueID {
@@ -384,7 +385,7 @@ func createShowWithAssociations(db *gorm.DB, showData ShowData) error {
 				VenueID:   primaryVenueID,
 			}
 			if err := tx.Create(&showArtist).Error; err != nil {
-				return fmt.Errorf("failed to create show-artist association: %v", err)
+				return fmt.Errorf("failed to create show-artist association: %w", err)
 			}
 		}
 

--- a/backend/internal/api/handlers/admin/admin_test.go
+++ b/backend/internal/api/handlers/admin/admin_test.go
@@ -233,8 +233,8 @@ func TestExportShowsHandler_InvalidDate(t *testing.T) {
 
 func adminShowHandler(opts ...func(*AdminShowHandler)) *AdminShowHandler {
 	h := &AdminShowHandler{
-		discordService:        &testhelpers.MockDiscordService{},
-		auditLogService:       &testhelpers.MockAuditLogService{},
+		discordService:  &testhelpers.MockDiscordService{},
+		auditLogService: &testhelpers.MockAuditLogService{},
 	}
 	for _, opt := range opts {
 		opt(h)

--- a/backend/internal/api/handlers/admin/test_fixtures_allowlist_test.go
+++ b/backend/internal/api/handlers/admin/test_fixtures_allowlist_test.go
@@ -56,9 +56,9 @@ var testFixturesAllowlistContractSkips = map[string]string{
 	"user_preferences":     "upsert-on-login; resetting would hide regressions",
 
 	// Cross-user behavior + audit — reset would destroy cross-test signal.
-	"audit_logs":              "audit trail is intentionally preserved across runs",
-	"entity_edit_audit_logs":  "audit trail (PSY-618 split-out for entity edits); preserved across runs like audit_logs",
-	"admin_stats_snapshots":   "aggregate rollups, not user-scoped test artifacts",
+	"audit_logs":             "audit trail is intentionally preserved across runs",
+	"entity_edit_audit_logs": "audit trail (PSY-618 split-out for entity edits); preserved across runs like audit_logs",
+	"admin_stats_snapshots":  "aggregate rollups, not user-scoped test artifacts",
 
 	// Comments / field notes — tests clean up via direct DELETE API calls,
 	// as called out in the PSY-432 ticket. Keep separate paths.

--- a/backend/internal/api/handlers/catalog/radio_test.go
+++ b/backend/internal/api/handlers/catalog/radio_test.go
@@ -1332,4 +1332,3 @@ func TestAdminBulkLinkPlays_ServiceError(t *testing.T) {
 	_, err := h.AdminBulkLinkPlaysHandler(radioAdminCtx(), req)
 	testhelpers.AssertHumaError(t, err, 500)
 }
-

--- a/backend/internal/api/handlers/catalog/release_integration_test.go
+++ b/backend/internal/api/handlers/catalog/release_integration_test.go
@@ -347,4 +347,3 @@ func (s *ReleaseHandlerIntegrationSuite) TestRemoveExternalLink_Success() {
 	s.Require().NoError(err)
 	s.Empty(refreshed.ExternalLinks)
 }
-

--- a/backend/internal/api/handlers/catalog/show_test.go
+++ b/backend/internal/api/handlers/catalog/show_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -196,8 +197,8 @@ func TestResolve_InstagramHandleTooLong(t *testing.T) {
 
 	found := false
 	for _, e := range errs {
-		detail, ok := e.(*huma.ErrorDetail)
-		if ok && detail.Location == "body.artists[0].instagram_handle" {
+		var detail *huma.ErrorDetail
+		if errors.As(e, &detail) && detail.Location == "body.artists[0].instagram_handle" {
 			found = true
 			break
 		}
@@ -222,8 +223,8 @@ func TestResolve_InstagramHandleValid(t *testing.T) {
 	errs := body.Resolve(nil)
 
 	for _, e := range errs {
-		detail, ok := e.(*huma.ErrorDetail)
-		if ok && detail.Location == "body.artists[0].instagram_handle" {
+		var detail *huma.ErrorDetail
+		if errors.As(e, &detail) && detail.Location == "body.artists[0].instagram_handle" {
 			t.Errorf("unexpected instagram_handle validation error: %v", detail)
 		}
 	}

--- a/backend/internal/api/handlers/shared/error_mappers_test.go
+++ b/backend/internal/api/handlers/shared/error_mappers_test.go
@@ -107,8 +107,8 @@ func TestMapCollectionError_LimitExceededCarriesStructuredDetail(t *testing.T) {
 		t.Errorf("limit-exceeded status = %d, want 403", s)
 	}
 
-	model, ok := got.(*huma.ErrorModel)
-	if !ok {
+	var model *huma.ErrorModel
+	if !stderrors.As(got, &model) {
 		t.Fatalf("expected *huma.ErrorModel, got %T", got)
 	}
 	if len(model.Errors) != 1 {

--- a/backend/internal/api/handlers/shared/url_validation_test.go
+++ b/backend/internal/api/handlers/shared/url_validation_test.go
@@ -339,7 +339,8 @@ func TestURLSchemeError_RejectsNonHTTPScheme(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for javascript: scheme, got nil")
 	}
-	if _, isHuma := err.(huma.StatusError); isHuma {
+	var isHuma huma.StatusError
+	if errors.As(err, &isHuma) {
 		t.Errorf("expected a plain error (not huma StatusError), got: %T", err)
 	}
 }

--- a/backend/internal/services/admin/api_token.go
+++ b/backend/internal/services/admin/api_token.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -111,7 +112,7 @@ func (s *APITokenService) ValidateToken(plainToken string) (*authm.User, *adminm
 	var token adminm.APIToken
 	err := s.db.Preload("User").Where("token_hash = ?", tokenHash).First(&token).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil, fmt.Errorf("invalid token")
 		}
 		return nil, nil, fmt.Errorf("failed to validate token: %w", err)
@@ -206,7 +207,7 @@ func (s *APITokenService) GetToken(userID uint, tokenID uint) (*contracts.APITok
 	var token adminm.APIToken
 	err := s.db.Where("id = ? AND user_id = ?", tokenID, userID).First(&token).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("token not found")
 		}
 		return nil, fmt.Errorf("failed to get token: %w", err)

--- a/backend/internal/services/admin/artist_report.go
+++ b/backend/internal/services/admin/artist_report.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -42,7 +43,7 @@ func (s *ArtistReportService) CreateReport(userID, artistID uint, reportType str
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("artist not found")
 		}
 		return nil, fmt.Errorf("failed to verify artist: %w", err)
@@ -89,7 +90,7 @@ func (s *ArtistReportService) GetUserReportForArtist(userID, artistID uint) (*co
 		First(&report).Error
 
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // No report found
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)
@@ -142,7 +143,7 @@ func (s *ArtistReportService) DismissReport(reportID, adminID uint, notes *strin
 
 	var report communitym.ArtistReport
 	if err := s.db.Preload("Artist").First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("report not found")
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)
@@ -174,7 +175,7 @@ func (s *ArtistReportService) ResolveReport(reportID, adminID uint, notes *strin
 
 	var report communitym.ArtistReport
 	if err := s.db.Preload("Artist").First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("report not found")
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)
@@ -206,7 +207,7 @@ func (s *ArtistReportService) GetReportByID(reportID uint) (*communitym.ArtistRe
 
 	var report communitym.ArtistReport
 	if err := s.db.Preload("Artist").First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("report not found")
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)

--- a/backend/internal/services/admin/auto_promotion.go
+++ b/backend/internal/services/admin/auto_promotion.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -344,7 +345,7 @@ func (s *AutoPromotionService) EvaluateUser(userID uint) (*contracts.UserEvaluat
 
 	var user authm.User
 	if err := s.db.First(&user, userID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrAutoPromotionUserNotFound()
 		}
 		return nil, apperrors.ErrAutoPromotionInternal(fmt.Errorf("failed to get user: %w", err))

--- a/backend/internal/services/admin/cleanup_test.go
+++ b/backend/internal/services/admin/cleanup_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	authm "psychic-homily-backend/internal/models/auth"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // stubUserService is a minimal stub for cleanup tests.

--- a/backend/internal/services/admin/data_sync.go
+++ b/backend/internal/services/admin/data_sync.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -386,7 +387,7 @@ func (s *DataSyncService) importArtist(artist *contracts.ExportedArtist, dryRun 
 			s.db.Model(&existing).Update("slug", slug)
 		}
 		return fmt.Sprintf("DUPLICATE: Artist '%s' already exists (ID: %d)", artist.Name, existing.ID), "duplicate"
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Sprintf("ERROR: Failed to check artist '%s': %v", artist.Name, err), "error"
 	}
 
@@ -448,7 +449,7 @@ func (s *DataSyncService) importVenue(venue *contracts.ExportedVenue, dryRun boo
 			s.db.Model(&existing).Update("slug", slug)
 		}
 		return fmt.Sprintf("DUPLICATE: Venue '%s' in %s already exists (ID: %d)", venue.Name, venue.City, existing.ID), "duplicate"
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Sprintf("ERROR: Failed to check venue '%s': %v", venue.Name, err), "error"
 	}
 
@@ -527,7 +528,7 @@ func (s *DataSyncService) importShow(show *contracts.ExportedShow, dryRun bool) 
 			}
 			return fmt.Sprintf("DUPLICATE: Show '%s' at %s on %s already exists (ID: %d)",
 				show.Title, venueName, eventDate.Format("2006-01-02"), existingShow.ID), "duplicate"
-		} else if err != gorm.ErrRecordNotFound {
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Sprintf("ERROR: Failed to check show '%s': %v", show.Title, err), "error"
 		}
 	}
@@ -601,7 +602,7 @@ func (s *DataSyncService) importShow(show *contracts.ExportedShow, dryRun bool) 
 			var venue catalogm.Venue
 			err := tx.Where("LOWER(name) = LOWER(?) AND LOWER(city) = LOWER(?)",
 				exportedVenue.Name, exportedVenue.City).First(&venue).Error
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				// Create venue with slug
 				venueBaseSlug := utils.GenerateVenueSlug(exportedVenue.Name, exportedVenue.City, exportedVenue.State)
 				venueSlug := utils.GenerateUniqueSlug(venueBaseSlug, func(candidate string) bool {
@@ -657,7 +658,7 @@ func (s *DataSyncService) importShow(show *contracts.ExportedShow, dryRun bool) 
 		for _, exportedArtist := range show.Artists {
 			var artist catalogm.Artist
 			err := tx.Where("LOWER(name) = LOWER(?)", exportedArtist.Name).First(&artist).Error
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				// Create artist with slug
 				artistBaseSlug := utils.GenerateArtistSlug(exportedArtist.Name)
 				artistSlug := utils.GenerateUniqueSlug(artistBaseSlug, func(candidate string) bool {

--- a/backend/internal/services/admin/entity_report.go
+++ b/backend/internal/services/admin/entity_report.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -108,7 +109,7 @@ func (s *EntityReportService) GetEntityReport(reportID uint) (*contracts.EntityR
 	var report communitym.EntityReport
 	err := s.db.Preload("Reporter").Preload("Reviewer").First(&report, reportID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to get entity report: %w", err))
@@ -190,7 +191,7 @@ func (s *EntityReportService) ResolveEntityReport(reportID uint, reviewerID uint
 
 	var report communitym.EntityReport
 	if err := s.db.First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrEntityReportNotFound()
 		}
 		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to get report: %w", err))
@@ -225,7 +226,7 @@ func (s *EntityReportService) DismissEntityReport(reportID uint, reviewerID uint
 
 	var report communitym.EntityReport
 	if err := s.db.First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrEntityReportNotFound()
 		}
 		return nil, apperrors.ErrEntityReportInternal(fmt.Errorf("failed to get report: %w", err))

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -148,7 +149,7 @@ func (s *PendingEditService) GetPendingEdit(editID uint) (*contracts.PendingEdit
 	var edit adminm.PendingEntityEdit
 	err := s.db.Preload("Submitter").Preload("Reviewer").First(&edit, editID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))
@@ -261,7 +262,7 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 
 	var edit adminm.PendingEntityEdit
 	if err := s.db.First(&edit, editID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrPendingEditNotFound()
 		}
 		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))
@@ -380,7 +381,7 @@ func (s *PendingEditService) RejectPendingEdit(editID uint, reviewerID uint, rea
 
 	var edit adminm.PendingEntityEdit
 	if err := s.db.First(&edit, editID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrPendingEditNotFound()
 		}
 		return nil, apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))
@@ -415,7 +416,7 @@ func (s *PendingEditService) CancelPendingEdit(editID uint, userID uint) error {
 
 	var edit adminm.PendingEntityEdit
 	if err := s.db.First(&edit, editID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrPendingEditNotFound()
 		}
 		return apperrors.ErrPendingEditInternal(fmt.Errorf("failed to get pending edit: %w", err))

--- a/backend/internal/services/admin/revision.go
+++ b/backend/internal/services/admin/revision.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -101,7 +102,7 @@ func (s *RevisionService) GetRevision(revisionID uint) (*adminm.Revision, error)
 	var revision adminm.Revision
 	err := s.db.Preload("User").First(&revision, revisionID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get revision: %w", err)

--- a/backend/internal/services/admin/show_report.go
+++ b/backend/internal/services/admin/show_report.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -43,7 +44,7 @@ func (s *ShowReportService) CreateReport(userID, showID uint, reportType string,
 	// Verify show exists
 	var show catalogm.Show
 	if err := s.db.First(&show, showID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("show not found")
 		}
 		return nil, fmt.Errorf("failed to verify show: %w", err)
@@ -90,7 +91,7 @@ func (s *ShowReportService) GetUserReportForShow(userID, showID uint) (*contract
 		First(&report).Error
 
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // No report found
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)
@@ -143,7 +144,7 @@ func (s *ShowReportService) DismissReport(reportID, adminID uint, notes *string)
 
 	var report communitym.ShowReport
 	if err := s.db.Preload("Show").First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("report not found")
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)
@@ -182,7 +183,7 @@ func (s *ShowReportService) ResolveReportWithFlag(reportID, adminID uint, notes 
 
 	var report communitym.ShowReport
 	if err := s.db.Preload("Show").First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("report not found")
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)
@@ -247,7 +248,7 @@ func (s *ShowReportService) GetReportByID(reportID uint) (*communitym.ShowReport
 
 	var report communitym.ShowReport
 	if err := s.db.Preload("Show").First(&report, reportID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("report not found")
 		}
 		return nil, fmt.Errorf("failed to get report: %w", err)

--- a/backend/internal/services/auth/apple.go
+++ b/backend/internal/services/auth/apple.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -128,7 +129,7 @@ func (s *AppleAuthService) FindOrCreateAppleUser(claims *contracts.AppleIdentity
 		return &user, nil
 	}
 
-	if result.Error != gorm.ErrRecordNotFound {
+	if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("database error: %w", result.Error)
 	}
 

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -42,7 +43,7 @@ func (s *ArtistService) CreateArtist(req *contracts.CreateArtistRequest) (*contr
 	err := s.db.Where("LOWER(name) = LOWER(?)", req.Name).First(&existingArtist).Error
 	if err == nil {
 		return nil, apperrors.ErrArtistExists(req.Name)
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("failed to check existing artist: %w", err)
 	}
 
@@ -90,7 +91,7 @@ func (s *ArtistService) GetArtist(artistID uint) (*contracts.ArtistDetailRespons
 	var artist catalogm.Artist
 	err := s.db.First(&artist, artistID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -110,7 +111,7 @@ func (s *ArtistService) GetArtistByName(name string) (*contracts.ArtistDetailRes
 	var artist catalogm.Artist
 	err := s.db.Where("LOWER(name) = LOWER(?)", name).First(&artist).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -128,7 +129,7 @@ func (s *ArtistService) GetArtistBySlug(slug string) (*contracts.ArtistDetailRes
 	var artist catalogm.Artist
 	err := s.db.Where("slug = ?", slug).First(&artist).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -213,7 +214,7 @@ func (s *ArtistService) UpdateArtist(artistID uint, req *contracts.UpdateArtistR
 		err := s.db.Where("LOWER(name) = LOWER(?) AND id != ?", name, artistID).First(&existingArtist).Error
 		if err == nil {
 			return nil, fmt.Errorf("artist with name '%s' already exists", name)
-		} else if err != gorm.ErrRecordNotFound {
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("failed to check existing artist: %w", err)
 		}
 		updates["name"] = name
@@ -287,7 +288,7 @@ func (s *ArtistService) DeleteArtist(artistID uint) error {
 	var artist catalogm.Artist
 	err := s.db.First(&artist, artistID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrArtistNotFound(artistID)
 		}
 		return fmt.Errorf("failed to get artist: %w", err)
@@ -619,7 +620,7 @@ func (s *ArtistService) GetLabelsForArtist(artistID uint) ([]*contracts.ArtistLa
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -670,7 +671,7 @@ func (s *ArtistService) GetShowsForArtist(artistID uint, timezone string, limit 
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, 0, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, 0, fmt.Errorf("failed to get artist: %w", err)
@@ -855,7 +856,7 @@ func (s *ArtistService) AddArtistAlias(artistID uint, alias string) (*contracts.
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -916,7 +917,7 @@ func (s *ArtistService) GetArtistAliases(artistID uint) ([]*contracts.ArtistAlia
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -960,7 +961,7 @@ func (s *ArtistService) MergeArtists(canonicalID, mergeFromID uint) (*contracts.
 	// Verify both artists exist
 	var canonical catalogm.Artist
 	if err := s.db.First(&canonical, canonicalID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(canonicalID)
 		}
 		return nil, fmt.Errorf("failed to get canonical artist: %w", err)
@@ -968,7 +969,7 @@ func (s *ArtistService) MergeArtists(canonicalID, mergeFromID uint) (*contracts.
 
 	var mergeFrom catalogm.Artist
 	if err := s.db.First(&mergeFrom, mergeFromID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(mergeFromID)
 		}
 		return nil, fmt.Errorf("failed to get merge-from artist: %w", err)

--- a/backend/internal/services/catalog/artist_relationship_service.go
+++ b/backend/internal/services/catalog/artist_relationship_service.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -78,7 +79,7 @@ func (s *ArtistRelationshipService) GetRelationship(artistA, artistB uint, relTy
 	err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
 		src, tgt, relType).First(&rel).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get relationship: %w", err)
@@ -195,7 +196,7 @@ func (s *ArtistRelationshipService) Vote(artistA, artistB uint, relType string, 
 	err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
 		src, tgt, relType).First(&rel).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("relationship not found between artists %d and %d (type: %s)", src, tgt, relType)
 		}
 		return fmt.Errorf("failed to verify relationship: %w", err)
@@ -212,7 +213,7 @@ func (s *ArtistRelationshipService) Vote(artistA, artistB uint, relType string, 
 		err := tx.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND user_id = ?",
 			src, tgt, relType, userID).First(&existing).Error
 
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			vote := catalogm.ArtistRelationshipVote{
 				SourceArtistID:   src,
 				TargetArtistID:   tgt,
@@ -264,7 +265,7 @@ func (s *ArtistRelationshipService) GetUserVote(artistA, artistB uint, relType s
 	err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND user_id = ?",
 		src, tgt, relType, userID).First(&vote).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get user vote: %w", err)
@@ -1018,7 +1019,7 @@ func (s *ArtistRelationshipService) DeriveSharedBills(minShows int) (int64, erro
 		err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
 			row.ArtistA, row.ArtistB, catalogm.RelationshipTypeSharedBills).First(&existing).Error
 
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			rel := &catalogm.ArtistRelationship{
 				SourceArtistID:   row.ArtistA,
 				TargetArtistID:   row.ArtistB,
@@ -1098,7 +1099,7 @@ func (s *ArtistRelationshipService) DeriveSharedLabels(minLabels int) (int64, er
 		err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
 			row.ArtistA, row.ArtistB, catalogm.RelationshipTypeSharedLabel).First(&existing).Error
 
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			rel := &catalogm.ArtistRelationship{
 				SourceArtistID:   row.ArtistA,
 				TargetArtistID:   row.ArtistB,

--- a/backend/internal/services/catalog/festival.go
+++ b/backend/internal/services/catalog/festival.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -83,7 +84,7 @@ func (s *FestivalService) GetFestival(festivalID uint) (*contracts.FestivalDetai
 	var festival catalogm.Festival
 	err := s.db.First(&festival, festivalID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalNotFound(festivalID)
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
@@ -101,7 +102,7 @@ func (s *FestivalService) GetFestivalBySlug(slug string) (*contracts.FestivalDet
 	var festival catalogm.Festival
 	err := s.db.Where("slug = ?", slug).First(&festival).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
@@ -320,7 +321,7 @@ func (s *FestivalService) UpdateFestival(festivalID uint, req *contracts.UpdateF
 	var festival catalogm.Festival
 	err := s.db.First(&festival, festivalID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalNotFound(festivalID)
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
@@ -402,7 +403,7 @@ func (s *FestivalService) DeleteFestival(festivalID uint) error {
 	var festival catalogm.Festival
 	err := s.db.First(&festival, festivalID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrFestivalNotFound(festivalID)
 		}
 		return fmt.Errorf("failed to get festival: %w", err)
@@ -426,7 +427,7 @@ func (s *FestivalService) GetFestivalArtists(festivalID uint, dayDate *string) (
 	// Verify festival exists
 	var festival catalogm.Festival
 	if err := s.db.First(&festival, festivalID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalNotFound(festivalID)
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
@@ -511,7 +512,7 @@ func (s *FestivalService) AddFestivalArtist(festivalID uint, req *contracts.AddF
 	// Verify festival exists
 	var festival catalogm.Festival
 	if err := s.db.First(&festival, festivalID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalNotFound(festivalID)
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
@@ -520,7 +521,7 @@ func (s *FestivalService) AddFestivalArtist(festivalID uint, req *contracts.AddF
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, req.ArtistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalArtistNotFound()
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -575,7 +576,7 @@ func (s *FestivalService) UpdateFestivalArtist(festivalID, artistID uint, req *c
 	var fa catalogm.FestivalArtist
 	err := s.db.Where("festival_id = ? AND artist_id = ?", festivalID, artistID).First(&fa).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalArtistNotInLineup()
 		}
 		return nil, fmt.Errorf("failed to get festival artist: %w", err)
@@ -659,7 +660,7 @@ func (s *FestivalService) GetFestivalVenues(festivalID uint) ([]*contracts.Festi
 	// Verify festival exists
 	var festival catalogm.Festival
 	if err := s.db.First(&festival, festivalID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalNotFound(festivalID)
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
@@ -722,7 +723,7 @@ func (s *FestivalService) AddFestivalVenue(festivalID uint, req *contracts.AddFe
 	// Verify festival exists
 	var festival catalogm.Festival
 	if err := s.db.First(&festival, festivalID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalNotFound(festivalID)
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)
@@ -731,7 +732,7 @@ func (s *FestivalService) AddFestivalVenue(festivalID uint, req *contracts.AddFe
 	// Verify venue exists
 	var venue catalogm.Venue
 	if err := s.db.First(&venue, req.VenueID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalVenueNotFound()
 		}
 		return nil, fmt.Errorf("failed to get venue: %w", err)
@@ -789,7 +790,7 @@ func (s *FestivalService) GetFestivalsForArtist(artistID uint) ([]*contracts.Art
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)

--- a/backend/internal/services/catalog/festival_intelligence.go
+++ b/backend/internal/services/catalog/festival_intelligence.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -136,7 +137,7 @@ func (s *FestivalIntelligenceService) GetSimilarFestivals(festivalID uint, limit
 	// Verify festival exists
 	var festival catalogm.Festival
 	if err := s.db.First(&festival, festivalID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFestivalIntelNotFound("festival not found")
 		}
 		return nil, fmt.Errorf("failed to get festival: %w", err)

--- a/backend/internal/services/catalog/label.go
+++ b/backend/internal/services/catalog/label.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -87,7 +88,7 @@ func (s *LabelService) GetLabel(labelID uint) (*contracts.LabelDetailResponse, e
 	var label catalogm.Label
 	err := s.db.First(&label, labelID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrLabelNotFound(labelID)
 		}
 		return nil, fmt.Errorf("failed to get label: %w", err)
@@ -105,7 +106,7 @@ func (s *LabelService) GetLabelBySlug(slug string) (*contracts.LabelDetailRespon
 	var label catalogm.Label
 	err := s.db.Where("slug = ?", slug).First(&label).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrLabelNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get label: %w", err)
@@ -309,7 +310,7 @@ func (s *LabelService) UpdateLabel(labelID uint, req *contracts.UpdateLabelReque
 	var label catalogm.Label
 	err := s.db.First(&label, labelID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrLabelNotFound(labelID)
 		}
 		return nil, fmt.Errorf("failed to get label: %w", err)
@@ -399,7 +400,7 @@ func (s *LabelService) DeleteLabel(labelID uint) error {
 	var label catalogm.Label
 	err := s.db.First(&label, labelID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrLabelNotFound(labelID)
 		}
 		return fmt.Errorf("failed to get label: %w", err)
@@ -423,7 +424,7 @@ func (s *LabelService) GetLabelRoster(labelID uint) ([]*contracts.LabelArtistRes
 	// Verify label exists
 	var label catalogm.Label
 	if err := s.db.First(&label, labelID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrLabelNotFound(labelID)
 		}
 		return nil, fmt.Errorf("failed to get label: %w", err)
@@ -470,7 +471,7 @@ func (s *LabelService) GetLabelCatalog(labelID uint) ([]*contracts.LabelReleaseR
 	// Verify label exists
 	var label catalogm.Label
 	if err := s.db.First(&label, labelID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrLabelNotFound(labelID)
 		}
 		return nil, fmt.Errorf("failed to get label: %w", err)
@@ -523,7 +524,7 @@ func (s *LabelService) AddArtistToLabel(labelID, artistID uint) error {
 	// Verify label exists
 	var label catalogm.Label
 	if err := s.db.First(&label, labelID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrLabelNotFound(labelID)
 		}
 		return fmt.Errorf("failed to get label: %w", err)
@@ -532,7 +533,7 @@ func (s *LabelService) AddArtistToLabel(labelID, artistID uint) error {
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("artist not found: %d", artistID)
 		}
 		return fmt.Errorf("failed to get artist: %w", err)
@@ -561,7 +562,7 @@ func (s *LabelService) AddReleaseToLabel(labelID, releaseID uint, catalogNumber 
 	// Verify label exists
 	var label catalogm.Label
 	if err := s.db.First(&label, labelID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrLabelNotFound(labelID)
 		}
 		return fmt.Errorf("failed to get label: %w", err)
@@ -570,7 +571,7 @@ func (s *LabelService) AddReleaseToLabel(labelID, releaseID uint, catalogNumber 
 	// Verify release exists
 	var release catalogm.Release
 	if err := s.db.First(&release, releaseID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("release not found: %d", releaseID)
 		}
 		return fmt.Errorf("failed to get release: %w", err)

--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -87,7 +88,7 @@ func (s *RadioService) GetStation(stationID uint) (*contracts.RadioStationDetail
 	var station catalogm.RadioStation
 	err := s.db.Preload("Network").First(&station, stationID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioStationNotFound(stationID)
 		}
 		return nil, fmt.Errorf("failed to get radio station: %w", err)
@@ -105,7 +106,7 @@ func (s *RadioService) GetStationBySlug(slug string) (*contracts.RadioStationDet
 	var station catalogm.RadioStation
 	err := s.db.Preload("Network").Where("slug = ?", slug).First(&station).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioStationNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get radio station: %w", err)
@@ -225,7 +226,7 @@ func (s *RadioService) UpdateStation(stationID uint, req *contracts.UpdateRadioS
 
 	var station catalogm.RadioStation
 	if err := s.db.First(&station, stationID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioStationNotFound(stationID)
 		}
 		return nil, fmt.Errorf("failed to get radio station: %w", err)
@@ -328,7 +329,7 @@ func (s *RadioService) CreateShow(stationID uint, req *contracts.CreateRadioShow
 	// Verify station exists
 	var station catalogm.RadioStation
 	if err := s.db.First(&station, stationID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioStationNotFound(stationID)
 		}
 		return nil, fmt.Errorf("failed to get radio station: %w", err)
@@ -374,7 +375,7 @@ func (s *RadioService) GetShow(showID uint) (*contracts.RadioShowDetailResponse,
 	var show catalogm.RadioShow
 	err := s.db.Preload("Station").First(&show, showID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioShowNotFound(showID)
 		}
 		return nil, fmt.Errorf("failed to get radio show: %w", err)
@@ -392,7 +393,7 @@ func (s *RadioService) GetShowBySlug(slug string) (*contracts.RadioShowDetailRes
 	var show catalogm.RadioShow
 	err := s.db.Preload("Station").Where("slug = ?", slug).First(&show).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioShowNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get radio show: %w", err)
@@ -467,7 +468,7 @@ func (s *RadioService) UpdateShow(showID uint, req *contracts.UpdateRadioShowReq
 
 	var show catalogm.RadioShow
 	if err := s.db.First(&show, showID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioShowNotFound(showID)
 		}
 		return nil, fmt.Errorf("failed to get radio show: %w", err)
@@ -579,7 +580,7 @@ func (s *RadioService) GetEpisodeByShowAndDate(showID uint, airDate string) (*co
 		Where("show_id = ? AND air_date = ?", showID, airDate).
 		First(&episode).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioEpisodeNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get episode: %w", err)
@@ -597,7 +598,7 @@ func (s *RadioService) GetEpisodeDetail(episodeID uint) (*contracts.RadioEpisode
 	var episode catalogm.RadioEpisode
 	err := s.db.Preload("Show.Station").First(&episode, episodeID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRadioEpisodeNotFound(episodeID)
 		}
 		return nil, fmt.Errorf("failed to get episode: %w", err)

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -407,7 +408,7 @@ func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImpor
 		return existing.ID, false, nil
 	}
 
-	if err != gorm.ErrRecordNotFound {
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return 0, false, fmt.Errorf("checking existing show by external_id: %w", err)
 	}
 
@@ -426,7 +427,7 @@ func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImpor
 		return existing.ID, false, nil
 	}
 
-	if err != gorm.ErrRecordNotFound {
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return 0, false, fmt.Errorf("checking existing show by slug: %w", err)
 	}
 
@@ -488,7 +489,7 @@ func (s *RadioService) importEpisode(showID uint, ep RadioEpisodeImport, provide
 		// Episode already exists — skip to avoid duplicates
 		return &contracts.EpisodeImportResult{}, nil
 	}
-	if err != gorm.ErrRecordNotFound {
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("checking existing episode: %w", err)
 	}
 

--- a/backend/internal/services/catalog/radio_provider_nts_test.go
+++ b/backend/internal/services/catalog/radio_provider_nts_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	catalogm "psychic-homily-backend/internal/models/catalog"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	catalogm "psychic-homily-backend/internal/models/catalog"
 )
 
 // =============================================================================

--- a/backend/internal/services/catalog/radio_unmatched.go
+++ b/backend/internal/services/catalog/radio_unmatched.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -350,7 +351,7 @@ func (s *RadioService) SyncAffinityToRelationships() (*contracts.SyncAffinityRes
 			First(&existing).Error
 
 		switch {
-		case err == gorm.ErrRecordNotFound:
+		case errors.Is(err, gorm.ErrRecordNotFound):
 			rel := &catalogm.ArtistRelationship{
 				SourceArtistID:   aff.ArtistAID,
 				TargetArtistID:   aff.ArtistBID,

--- a/backend/internal/services/catalog/release.go
+++ b/backend/internal/services/catalog/release.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -112,7 +113,7 @@ func (s *ReleaseService) GetRelease(releaseID uint) (*contracts.ReleaseDetailRes
 	var release catalogm.Release
 	err := s.db.Preload("ExternalLinks").First(&release, releaseID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrReleaseNotFound(releaseID)
 		}
 		return nil, fmt.Errorf("failed to get release: %w", err)
@@ -130,7 +131,7 @@ func (s *ReleaseService) GetReleaseBySlug(slug string) (*contracts.ReleaseDetail
 	var release catalogm.Release
 	err := s.db.Preload("ExternalLinks").Where("slug = ?", slug).First(&release).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrReleaseNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get release: %w", err)
@@ -277,7 +278,7 @@ func (s *ReleaseService) UpdateRelease(releaseID uint, req *contracts.UpdateRele
 	var release catalogm.Release
 	err := s.db.First(&release, releaseID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrReleaseNotFound(releaseID)
 		}
 		return nil, fmt.Errorf("failed to get release: %w", err)
@@ -332,7 +333,7 @@ func (s *ReleaseService) DeleteRelease(releaseID uint) error {
 	var release catalogm.Release
 	err := s.db.First(&release, releaseID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrReleaseNotFound(releaseID)
 		}
 		return fmt.Errorf("failed to get release: %w", err)
@@ -356,7 +357,7 @@ func (s *ReleaseService) GetReleasesForArtist(artistID uint) ([]*contracts.Relea
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -375,7 +376,7 @@ func (s *ReleaseService) GetReleasesForArtistWithRoles(artistID uint) ([]*contra
 	// Verify artist exists
 	var artist catalogm.Artist
 	if err := s.db.First(&artist, artistID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		}
 		return nil, fmt.Errorf("failed to get artist: %w", err)
@@ -435,7 +436,7 @@ func (s *ReleaseService) AddExternalLink(releaseID uint, platform, url string) (
 	// Verify release exists
 	var release catalogm.Release
 	if err := s.db.First(&release, releaseID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrReleaseNotFound(releaseID)
 		}
 		return nil, fmt.Errorf("failed to get release: %w", err)

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"log"
@@ -272,7 +273,7 @@ func (s *ShowService) GetShow(showID uint) (*contracts.ShowResponse, error) {
 	var show catalogm.Show
 	err := s.db.Preload("Venues").Preload("Artists").First(&show, showID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrShowNotFound(showID)
 		}
 		return nil, fmt.Errorf("failed to get show: %w", err)
@@ -290,7 +291,7 @@ func (s *ShowService) GetShowBySlug(slug string) (*contracts.ShowResponse, error
 	var show catalogm.Show
 	err := s.db.Preload("Venues").Preload("Artists").Where("slug = ?", slug).First(&show).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrShowNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get show: %w", err)
@@ -526,7 +527,7 @@ func (s *ShowService) UpdateShowWithRelations(
 func (s *ShowService) updateShowFields(tx *gorm.DB, showID uint, updates map[string]interface{}) (*catalogm.Show, error) {
 	var show catalogm.Show
 	if err := tx.First(&show, showID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrShowNotFound(showID)
 		}
 		return nil, fmt.Errorf("failed to find show: %w", err)
@@ -1287,7 +1288,7 @@ func (s *ShowService) ApproveShow(showID uint, verifyVenues bool) (*contracts.Sh
 		// Get the show
 		var show catalogm.Show
 		if err := tx.Preload("Venues").First(&show, showID).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return apperrors.ErrShowNotFound(showID)
 			}
 			return fmt.Errorf("failed to get show: %w", err)
@@ -1345,7 +1346,7 @@ func (s *ShowService) RejectShow(showID uint, reason string) (*contracts.ShowRes
 		// Get the show
 		var show catalogm.Show
 		if err := tx.First(&show, showID).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return apperrors.ErrShowNotFound(showID)
 			}
 			return fmt.Errorf("failed to get show: %w", err)
@@ -1443,7 +1444,7 @@ func (s *ShowService) UnpublishShow(showID uint, userID uint, isAdmin bool) (*co
 		// Get the show
 		var show catalogm.Show
 		if err := tx.First(&show, showID).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return apperrors.ErrShowNotFound(showID)
 			}
 			return fmt.Errorf("failed to get show: %w", err)
@@ -1494,7 +1495,7 @@ func (s *ShowService) MakePrivateShow(showID uint, userID uint, isAdmin bool) (*
 		// Get the show
 		var show catalogm.Show
 		if err := tx.First(&show, showID).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return apperrors.ErrShowNotFound(showID)
 			}
 			return fmt.Errorf("failed to get show: %w", err)
@@ -1547,7 +1548,7 @@ func (s *ShowService) PublishShow(showID uint, userID uint, isAdmin bool) (*cont
 		// Get the show with venues preloaded
 		var show catalogm.Show
 		if err := tx.Preload("Venues").First(&show, showID).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return apperrors.ErrShowNotFound(showID)
 			}
 			return fmt.Errorf("failed to get show: %w", err)
@@ -1604,7 +1605,7 @@ func (s *ShowService) associateVenues(tx *gorm.DB, showID uint, requestVenues []
 		if requestVenue.ID != nil {
 			var venueModel catalogm.Venue
 			err = tx.First(&venueModel, *requestVenue.ID).Error
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, fmt.Errorf("venue with ID %d not found", *requestVenue.ID)
 			} else if err != nil {
 				return nil, fmt.Errorf("failed to find venue with ID %d: %w", *requestVenue.ID, err)
@@ -1679,7 +1680,7 @@ func (s *ShowService) associateArtists(tx *gorm.DB, showID uint, requestArtists 
 		// If ID is provided, try to find existing artist by ID
 		if requestArtist.ID != nil {
 			err = tx.First(&artist, *requestArtist.ID).Error
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, fmt.Errorf("artist with ID %d not found", *requestArtist.ID)
 			} else if err != nil {
 				return nil, fmt.Errorf("failed to find artist with ID %d: %w", *requestArtist.ID, err)
@@ -1691,7 +1692,7 @@ func (s *ShowService) associateArtists(tx *gorm.DB, showID uint, requestArtists 
 			}
 
 			err = tx.Where("LOWER(name) = LOWER(?)", requestArtist.Name).First(&artist).Error
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				// Create new artist
 				artist = catalogm.Artist{
 					Name: requestArtist.Name,
@@ -1918,7 +1919,7 @@ func (s *ShowService) ExportShowToMarkdown(showID uint) ([]byte, string, error) 
 	var show catalogm.Show
 	err := s.db.Preload("Venues").Preload("Artists").First(&show, showID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, "", apperrors.ErrShowNotFound(showID)
 		}
 		return nil, "", fmt.Errorf("failed to get show: %w", err)
@@ -2192,7 +2193,7 @@ func (s *ShowService) PreviewShowImport(content []byte) (*contracts.ImportPrevie
 		if err == nil {
 			result.ExistingID = &venue.ID
 			result.WillCreate = false
-		} else if err == gorm.ErrRecordNotFound {
+		} else if errors.Is(err, gorm.ErrRecordNotFound) {
 			result.WillCreate = true
 		} else {
 			return nil, fmt.Errorf("failed to check venue: %w", err)
@@ -2216,7 +2217,7 @@ func (s *ShowService) PreviewShowImport(content []byte) (*contracts.ImportPrevie
 		if err == nil {
 			result.ExistingID = &artist.ID
 			result.WillCreate = false
-		} else if err == gorm.ErrRecordNotFound {
+		} else if errors.Is(err, gorm.ErrRecordNotFound) {
 			result.WillCreate = true
 		} else {
 			return nil, fmt.Errorf("failed to check artist: %w", err)
@@ -2409,7 +2410,7 @@ func (s *ShowService) SetShowSoldOut(showID uint, isSoldOut bool) (*contracts.Sh
 
 	var show catalogm.Show
 	if err := s.db.First(&show, showID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrShowNotFound(showID)
 		}
 		return nil, fmt.Errorf("failed to find show: %w", err)
@@ -2430,7 +2431,7 @@ func (s *ShowService) SetShowCancelled(showID uint, isCancelled bool) (*contract
 
 	var show catalogm.Show
 	if err := s.db.First(&show, showID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrShowNotFound(showID)
 		}
 		return nil, fmt.Errorf("failed to find show: %w", err)

--- a/backend/internal/services/catalog/tag_filter.go
+++ b/backend/internal/services/catalog/tag_filter.go
@@ -3,8 +3,9 @@ package catalog
 import (
 	"strings"
 
-	"gorm.io/gorm"
 	catalogm "psychic-homily-backend/internal/models/catalog"
+
+	"gorm.io/gorm"
 )
 
 // TagFilter captures the tag-filter inputs for browse-list queries

--- a/backend/internal/services/catalog/tag_hierarchy.go
+++ b/backend/internal/services/catalog/tag_hierarchy.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -43,7 +44,7 @@ func (s *TagService) GetTagAncestors(tagID uint) ([]*catalogm.Tag, error) {
 
 	var tag catalogm.Tag
 	if err := s.db.First(&tag, tagID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrTagNotFound(tagID)
 		}
 		return nil, fmt.Errorf("failed to load tag: %w", err)
@@ -61,7 +62,7 @@ func (s *TagService) GetTagAncestors(tagID uint) ([]*catalogm.Tag, error) {
 
 		var parent catalogm.Tag
 		if err := s.db.First(&parent, *currentParentID).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				// Orphaned parent_id pointing at a deleted row — stop walking.
 				break
 			}
@@ -145,7 +146,7 @@ func (s *TagService) SetTagParent(tagID uint, parentID *uint, actorUserID uint) 
 
 	var tag catalogm.Tag
 	if err := s.db.First(&tag, tagID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrTagNotFound(tagID)
 		}
 		return fmt.Errorf("failed to load tag: %w", err)
@@ -204,7 +205,7 @@ func (s *TagService) validateTagParent(tag *catalogm.Tag, parentID *uint) error 
 
 	var parent catalogm.Tag
 	if err := s.db.First(&parent, *parentID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrTagNotFound(*parentID)
 		}
 		return fmt.Errorf("failed to load proposed parent: %w", err)
@@ -235,7 +236,7 @@ func (s *TagService) validateTagParent(tag *catalogm.Tag, parentID *uint) error 
 
 		var anc catalogm.Tag
 		if err := s.db.First(&anc, *cursor).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil
 			}
 			return fmt.Errorf("failed to walk ancestors: %w", err)

--- a/backend/internal/services/catalog/tag_low_quality.go
+++ b/backend/internal/services/catalog/tag_low_quality.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -242,7 +243,7 @@ func (s *TagService) SnoozeLowQualityTag(tagID uint, actorUserID uint) error {
 
 	var tag catalogm.Tag
 	if err := s.db.First(&tag, tagID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrTagNotFound(tagID)
 		}
 		return fmt.Errorf("failed to get tag: %w", err)

--- a/backend/internal/services/catalog/tag_merge.go
+++ b/backend/internal/services/catalog/tag_merge.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -160,7 +161,7 @@ func (s *TagService) MergeTags(sourceID, targetID uint, actorUserID uint) (*cont
 		if err == nil && existingAlias.TagID != target.ID {
 			return apperrors.ErrTagMergeAliasConflict(source.Name, existingAlias.TagID)
 		}
-		if err != nil && err != gorm.ErrRecordNotFound {
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("failed to check alias collision: %w", err)
 		}
 
@@ -245,14 +246,14 @@ func (s *TagService) MergeTags(sourceID, targetID uint, actorUserID uint) (*cont
 func (s *TagService) loadMergeTags(db *gorm.DB, sourceID, targetID uint) (*catalogm.Tag, *catalogm.Tag, error) {
 	var source catalogm.Tag
 	if err := db.First(&source, sourceID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil, apperrors.ErrTagNotFound(sourceID)
 		}
 		return nil, nil, fmt.Errorf("failed to load source: %w", err)
 	}
 	var target catalogm.Tag
 	if err := db.First(&target, targetID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil, apperrors.ErrTagNotFound(targetID)
 		}
 		return nil, nil, fmt.Errorf("failed to load target: %w", err)
@@ -267,7 +268,7 @@ func (s *TagService) loadMergeTags(db *gorm.DB, sourceID, targetID uint) (*catal
 			fmt.Sprintf("'%s' is already an alias of '%s'", source.Name, target.Name),
 		)
 	}
-	if err != nil && err != gorm.ErrRecordNotFound {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, nil, fmt.Errorf("failed to check existing alias relationship: %w", err)
 	}
 

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -91,7 +92,7 @@ func (s *TagService) GetTag(tagID uint) (*catalogm.Tag, error) {
 	var tag catalogm.Tag
 	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").Preload("CreatedBy").First(&tag, tagID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get tag: %w", err)
@@ -110,7 +111,7 @@ func (s *TagService) GetTagBySlug(slug string) (*catalogm.Tag, error) {
 	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").Preload("CreatedBy").
 		Where("slug = ?", slug).First(&tag).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get tag by slug: %w", err)
@@ -255,7 +256,7 @@ func (s *TagService) UpdateTag(tagID uint, name *string, description *string, pa
 
 	var tag catalogm.Tag
 	if err := s.db.First(&tag, tagID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrTagNotFound(tagID)
 		}
 		return nil, fmt.Errorf("failed to get tag: %w", err)
@@ -366,7 +367,7 @@ func (s *TagService) AddTagToEntity(tagID uint, tagName string, entityType strin
 	if tagID > 0 {
 		var t catalogm.Tag
 		if err := s.db.First(&t, tagID).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, apperrors.ErrTagNotFound(tagID)
 			}
 			return nil, fmt.Errorf("failed to get tag: %w", err)
@@ -384,7 +385,7 @@ func (s *TagService) AddTagToEntity(tagID uint, tagName string, entityType strin
 			// Try direct name match
 			var t catalogm.Tag
 			if err := s.db.Where("LOWER(name) = LOWER(?)", tagName).First(&t).Error; err != nil {
-				if err == gorm.ErrRecordNotFound {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
 					// Tag not found — create inline if user has permission
 					newTag, createErr := s.createTagInline(tagName, category, userID)
 					if createErr != nil {
@@ -628,7 +629,7 @@ func (s *TagService) VoteOnTag(tagID uint, entityType string, entityID uint, use
 	err := s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ?", tagID, entityType, entityID).
 		First(&entityTag).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrEntityTagNotFound(tagID, entityType, entityID)
 		}
 		return fmt.Errorf("failed to verify entity tag: %w", err)
@@ -644,7 +645,7 @@ func (s *TagService) VoteOnTag(tagID uint, entityType string, entityID uint, use
 	err = s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ? AND user_id = ?",
 		tagID, entityType, entityID, userID).First(&existing).Error
 
-	if err == gorm.ErrRecordNotFound {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
 		vote := catalogm.TagVote{
 			TagID:      tagID,
 			EntityType: entityType,
@@ -694,7 +695,7 @@ func (s *TagService) CreateAlias(tagID uint, alias string) (*catalogm.TagAlias, 
 	// Verify tag exists
 	var tag catalogm.Tag
 	if err := s.db.First(&tag, tagID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrTagNotFound(tagID)
 		}
 		return nil, fmt.Errorf("failed to get tag: %w", err)
@@ -855,7 +856,7 @@ func (s *TagService) BulkImportAliases(items []contracts.BulkAliasImportItem) (*
 		err := s.db.Where("LOWER(slug) = LOWER(?) OR LOWER(name) = LOWER(?)", canonical, canonical).
 			First(&tag).Error
 		if err != nil {
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				result.Skipped = append(result.Skipped, contracts.BulkAliasImportSkipped{
 					Row:       row,
 					Alias:     alias,
@@ -919,7 +920,7 @@ func (s *TagService) ResolveAlias(alias string) (*catalogm.Tag, error) {
 	var tagAlias catalogm.TagAlias
 	err := s.db.Where("LOWER(alias) = LOWER(?)", alias).First(&tagAlias).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to resolve alias: %w", err)

--- a/backend/internal/services/catalog/venue.go
+++ b/backend/internal/services/catalog/venue.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -43,7 +44,7 @@ func (s *VenueService) CreateVenue(req *contracts.CreateVenueRequest, isAdmin bo
 	err := s.db.Where("LOWER(name) = LOWER(?) AND LOWER(city) = LOWER(?)", req.Name, req.City).First(&existingVenue).Error
 	if err == nil {
 		return nil, fmt.Errorf("venue with name '%s' already exists in %s", req.Name, req.City)
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("failed to check existing venue: %w", err)
 	}
 
@@ -94,7 +95,7 @@ func (s *VenueService) GetVenue(venueID uint) (*contracts.VenueDetailResponse, e
 	var venue catalogm.Venue
 	err := s.db.First(&venue, venueID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrVenueNotFound(venueID)
 		}
 		return nil, fmt.Errorf("failed to get venue: %w", err)
@@ -112,7 +113,7 @@ func (s *VenueService) GetVenueBySlug(slug string) (*contracts.VenueDetailRespon
 	var venue catalogm.Venue
 	err := s.db.Where("slug = ?", slug).First(&venue).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrVenueNotFound(0)
 		}
 		return nil, fmt.Errorf("failed to get venue: %w", err)
@@ -172,7 +173,7 @@ func (s *VenueService) UpdateVenue(venueID uint, req *contracts.UpdateVenueReque
 	var currentVenue catalogm.Venue
 	err := s.db.First(&currentVenue, venueID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrVenueNotFound(venueID)
 		}
 		return nil, fmt.Errorf("failed to get venue: %w", err)
@@ -195,7 +196,7 @@ func (s *VenueService) UpdateVenue(venueID uint, req *contracts.UpdateVenueReque
 	err = s.db.Where("LOWER(name) = LOWER(?) AND LOWER(city) = LOWER(?) AND id != ?", checkName, checkCity, venueID).First(&existingVenue).Error
 	if err == nil {
 		return nil, fmt.Errorf("venue with name '%s' already exists in %s", checkName, checkCity)
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("failed to check existing venue: %w", err)
 	}
 
@@ -275,7 +276,7 @@ func (s *VenueService) DeleteVenue(venueID uint) error {
 	var venue catalogm.Venue
 	err := s.db.First(&venue, venueID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrVenueNotFound(venueID)
 		}
 		return fmt.Errorf("failed to get venue: %w", err)
@@ -388,7 +389,7 @@ func (s *VenueService) FindOrCreateVenue(name, city, state string, address, zipc
 			query.Model(&venue).Update("slug", slug)
 		}
 		return &venue, false, nil
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, false, fmt.Errorf("failed to check existing venue: %w", err)
 	}
 
@@ -429,7 +430,7 @@ func (s *VenueService) VerifyVenue(venueID uint) (*contracts.VenueDetailResponse
 	var venue catalogm.Venue
 	err := s.db.First(&venue, venueID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrVenueNotFound(venueID)
 		}
 		return nil, fmt.Errorf("failed to get venue: %w", err)
@@ -627,7 +628,7 @@ func (s *VenueService) GetShowsForVenue(venueID uint, timezone string, limit int
 	// Verify venue exists
 	var venue catalogm.Venue
 	if err := s.db.First(&venue, venueID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, 0, apperrors.ErrVenueNotFound(venueID)
 		}
 		return nil, 0, fmt.Errorf("failed to get venue: %w", err)
@@ -889,7 +890,7 @@ func (s *VenueService) GetVenueModel(venueID uint) (*catalogm.Venue, error) {
 
 	var venue catalogm.Venue
 	if err := s.db.First(&venue, venueID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrVenueNotFound(venueID)
 		}
 		return nil, fmt.Errorf("failed to get venue: %w", err)

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -3,6 +3,7 @@ package community
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -124,7 +125,7 @@ func (s *CollectionService) loadUserForLimitCheck(userID uint) (*authm.User, err
 		Where("id = ?", userID).
 		First(&u).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to load user for limit check: %w", err)
@@ -337,7 +338,7 @@ func (s *CollectionService) CloneCollection(srcSlug string, callerID uint) (*con
 	// Load source.
 	var src communitym.Collection
 	if err := s.db.Where("slug = ?", srcSlug).First(&src).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(srcSlug)
 		}
 		return nil, fmt.Errorf("failed to load source collection: %w", err)
@@ -439,7 +440,7 @@ func (s *CollectionService) GetBySlug(slug string, viewerID uint) (*contracts.Co
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -787,12 +788,12 @@ func applyCollectionSort(query *gorm.DB, sort string) *gorm.DB {
 // applyCollectionSearchWhere appends the PSY-355 expanded-search OR clause
 // to the query, matching across:
 //
-//	1. collections.title           (exact field on the row)
-//	2. collections.description     (raw markdown source on the row)
-//	3. any item's notes            (correlated EXISTS over collection_items)
-//	4. any applied tag name/alias  (correlated EXISTS over entity_tags +
-//	                               tags + tag_aliases for the polymorphic
-//	                               collection entity)
+//  1. collections.title           (exact field on the row)
+//  2. collections.description     (raw markdown source on the row)
+//  3. any item's notes            (correlated EXISTS over collection_items)
+//  4. any applied tag name/alias  (correlated EXISTS over entity_tags +
+//     tags + tag_aliases for the polymorphic
+//     collection entity)
 //
 // Caller is responsible for trimming whitespace and short-circuiting the
 // empty case BEFORE invoking this helper — passing an empty searchTerm
@@ -871,7 +872,7 @@ func (s *CollectionService) UpdateCollection(slug string, userID uint, isAdmin b
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -944,7 +945,7 @@ func (s *CollectionService) DeleteCollection(slug string, userID uint, isAdmin b
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -972,7 +973,7 @@ func (s *CollectionService) AddItem(slug string, userID uint, req *contracts.Add
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -1055,7 +1056,7 @@ func (s *CollectionService) UpdateItem(slug string, itemID uint, userID uint, is
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -1064,7 +1065,7 @@ func (s *CollectionService) UpdateItem(slug string, itemID uint, userID uint, is
 	var item communitym.CollectionItem
 	err = s.db.Where("id = ? AND collection_id = ?", itemID, collection.ID).First(&item).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionItemNotFound(itemID)
 		}
 		return nil, fmt.Errorf("failed to get collection item: %w", err)
@@ -1117,7 +1118,7 @@ func (s *CollectionService) RemoveItem(slug string, itemID uint, userID uint, is
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -1126,7 +1127,7 @@ func (s *CollectionService) RemoveItem(slug string, itemID uint, userID uint, is
 	var item communitym.CollectionItem
 	err = s.db.Where("id = ? AND collection_id = ?", itemID, collection.ID).First(&item).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionItemNotFound(itemID)
 		}
 		return fmt.Errorf("failed to get collection item: %w", err)
@@ -1153,7 +1154,7 @@ func (s *CollectionService) ReorderItems(slug string, userID uint, req *contract
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -1187,7 +1188,7 @@ func (s *CollectionService) Subscribe(slug string, userID uint) error {
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -1226,7 +1227,7 @@ func (s *CollectionService) Unsubscribe(slug string, userID uint) error {
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -1257,7 +1258,7 @@ func (s *CollectionService) Like(slug string, userID uint) (*contracts.Collectio
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -1291,7 +1292,7 @@ func (s *CollectionService) Unlike(slug string, userID uint) (*contracts.Collect
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -1343,7 +1344,7 @@ func (s *CollectionService) MarkVisited(slug string, userID uint) error {
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -1369,7 +1370,7 @@ func (s *CollectionService) GetStats(slug string) (*contracts.CollectionStatsRes
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -1790,7 +1791,7 @@ func (s *CollectionService) SetFeatured(slug string, featured bool) error {
 	var collection communitym.Collection
 	err := s.db.Where("slug = ?", slug).First(&collection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -2331,7 +2332,7 @@ func (s *CollectionService) AddTagToCollection(slug string, userID uint, req *co
 
 	var collection communitym.Collection
 	if err := s.db.Where("slug = ?", slug).First(&collection).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)
@@ -2386,7 +2387,7 @@ func (s *CollectionService) RemoveTagFromCollection(slug string, tagID uint, use
 
 	var collection communitym.Collection
 	if err := s.db.Where("slug = ?", slug).First(&collection).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCollectionNotFound(slug)
 		}
 		return fmt.Errorf("failed to get collection: %w", err)
@@ -2628,7 +2629,7 @@ func (s *CollectionService) GetCollectionGraph(slug string, viewerID uint, types
 
 	var collection communitym.Collection
 	if err := s.db.Where("slug = ?", slug).First(&collection).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrCollectionNotFound(slug)
 		}
 		return nil, fmt.Errorf("failed to get collection: %w", err)

--- a/backend/internal/services/community/collection_test.go
+++ b/backend/internal/services/community/collection_test.go
@@ -184,7 +184,6 @@ func (suite *CollectionServiceIntegrationTestSuite) createPublicCollection(user 
 	return resp
 }
 
-
 func strPtrCollection(s string) *string {
 	return &s
 }

--- a/backend/internal/services/community/request.go
+++ b/backend/internal/services/community/request.go
@@ -1,6 +1,7 @@
 package community
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -74,7 +75,7 @@ func (s *RequestService) GetRequest(requestID uint) (*communitym.Request, error)
 	var request communitym.Request
 	err := s.db.Preload("Requester").Preload("Fulfiller").First(&request, requestID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get request: %w", err)
@@ -142,7 +143,7 @@ func (s *RequestService) UpdateRequest(requestID, userID uint, title, descriptio
 	var request communitym.Request
 	err := s.db.First(&request, requestID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrRequestNotFound(requestID)
 		}
 		return nil, fmt.Errorf("failed to get request: %w", err)
@@ -180,7 +181,7 @@ func (s *RequestService) DeleteRequest(requestID, userID uint, isAdmin bool) err
 	var request communitym.Request
 	err := s.db.First(&request, requestID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrRequestNotFound(requestID)
 		}
 		return fmt.Errorf("failed to get request: %w", err)
@@ -212,7 +213,7 @@ func (s *RequestService) Vote(requestID, userID uint, isUpvote bool) error {
 	// Verify request exists
 	var request communitym.Request
 	if err := s.db.First(&request, requestID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrRequestNotFound(requestID)
 		}
 		return fmt.Errorf("failed to get request: %w", err)
@@ -228,7 +229,7 @@ func (s *RequestService) Vote(requestID, userID uint, isUpvote bool) error {
 		var existingVote communitym.RequestVote
 		err := tx.Where("request_id = ? AND user_id = ?", requestID, userID).First(&existingVote).Error
 
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// New vote
 			vote := communitym.RequestVote{
 				RequestID: requestID,
@@ -261,7 +262,7 @@ func (s *RequestService) RemoveVote(requestID, userID uint) error {
 	// Verify request exists
 	var request communitym.Request
 	if err := s.db.First(&request, requestID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrRequestNotFound(requestID)
 		}
 		return fmt.Errorf("failed to get request: %w", err)
@@ -287,7 +288,7 @@ func (s *RequestService) FulfillRequest(requestID, fulfillerID uint, fulfilledEn
 	var request communitym.Request
 	err := s.db.First(&request, requestID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrRequestNotFound(requestID)
 		}
 		return fmt.Errorf("failed to get request: %w", err)
@@ -324,7 +325,7 @@ func (s *RequestService) CloseRequest(requestID, userID uint, isAdmin bool) erro
 	var request communitym.Request
 	err := s.db.First(&request, requestID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrRequestNotFound(requestID)
 		}
 		return fmt.Errorf("failed to get request: %w", err)
@@ -357,7 +358,7 @@ func (s *RequestService) GetUserVote(requestID, userID uint) (*communitym.Reques
 	var vote communitym.RequestVote
 	err := s.db.Where("request_id = ? AND user_id = ?", requestID, userID).First(&vote).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get user vote: %w", err)

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -5,8 +5,9 @@ package contracts
 import (
 	"time"
 
-	"gorm.io/gorm"
 	catalogm "psychic-homily-backend/internal/models/catalog"
+
+	"gorm.io/gorm"
 )
 
 // ──────────────────────────────────────────────
@@ -486,18 +487,18 @@ type UpdateArtistRequest struct {
 
 // ArtistDetailResponse represents the artist data returned to clients
 type ArtistDetailResponse struct {
-	ID               uint                 `json:"id"`
-	Slug             string               `json:"slug"`
-	Name             string               `json:"name"`
-	State            *string              `json:"state"`
-	City             *string              `json:"city"`
-	Country          *string              `json:"country,omitempty"` // PSY-558: optional country (Australia, UK, etc.)
-	BandcampEmbedURL *string              `json:"bandcamp_embed_url"`
-	Description      *string              `json:"description,omitempty"`
-	ImageURL         *string              `json:"image_url"` // Optional artist photo (PSY-521)
-	Social           SocialResponse       `json:"social"`
-	CreatedAt        time.Time            `json:"created_at"`
-	UpdatedAt        time.Time            `json:"updated_at"`
+	ID               uint           `json:"id"`
+	Slug             string         `json:"slug"`
+	Name             string         `json:"name"`
+	State            *string        `json:"state"`
+	City             *string        `json:"city"`
+	Country          *string        `json:"country,omitempty"` // PSY-558: optional country (Australia, UK, etc.)
+	BandcampEmbedURL *string        `json:"bandcamp_embed_url"`
+	Description      *string        `json:"description,omitempty"`
+	ImageURL         *string        `json:"image_url"` // Optional artist photo (PSY-521)
+	Social           SocialResponse `json:"social"`
+	CreatedAt        time.Time      `json:"created_at"`
+	UpdatedAt        time.Time      `json:"updated_at"`
 	// Stats is populated only by detail-page lookups (GetArtist /
 	// GetArtistBySlug — PSY-639). List, search, and mutation responses leave
 	// it nil so the omitempty tag drops it from the wire.

--- a/backend/internal/services/contracts/pending_edit.go
+++ b/backend/internal/services/contracts/pending_edit.go
@@ -83,8 +83,8 @@ type PendingEditResponse struct {
 	// the JSON encodes null for accounts that never set a username. Frontend
 	// renders the byline as a link to /users/:username when non-nil; nil
 	// renders as plain text. PSY-619.
-	SubmitterUsername *string                  `json:"submitter_username"`
-	FieldChanges      []adminm.FieldChange     `json:"field_changes"`
+	SubmitterUsername *string              `json:"submitter_username"`
+	FieldChanges      []adminm.FieldChange `json:"field_changes"`
 	// Summary is the raw markdown source of the contributor's reason for the
 	// edit; SummaryHTML is the sanitized rendered HTML produced on each read
 	// via utils.MarkdownRenderer (goldmark + bluemonday, comment-system

--- a/backend/internal/services/engagement/attendance.go
+++ b/backend/internal/services/engagement/attendance.go
@@ -1,6 +1,7 @@
 package engagement
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -49,7 +50,7 @@ func (s *AttendanceService) SetAttendance(userID, showID uint, status string) er
 	// Check that the show exists
 	var show catalogm.Show
 	if err := s.db.First(&show, showID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrAttendanceShowNotFound()
 		}
 		return apperrors.ErrAttendanceInternal(fmt.Errorf("failed to verify show: %w", err))
@@ -133,7 +134,7 @@ func (s *AttendanceService) GetUserAttendance(userID, showID uint) (string, erro
 	).First(&bookmark).Error
 
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", nil
 		}
 		return "", fmt.Errorf("failed to get attendance: %w", err)

--- a/backend/internal/services/engagement/calendar.go
+++ b/backend/internal/services/engagement/calendar.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -115,7 +116,7 @@ func (s *CalendarService) GetTokenStatus(userID uint) (*contracts.CalendarTokenS
 	var token engagementm.CalendarToken
 	err := s.db.Where("user_id = ?", userID).First(&token).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &contracts.CalendarTokenStatusResponse{HasToken: false}, nil
 		}
 		return nil, fmt.Errorf("failed to check token status: %w", err)
@@ -154,7 +155,7 @@ func (s *CalendarService) ValidateCalendarToken(plainToken string) (*authm.User,
 	var token engagementm.CalendarToken
 	err := s.db.Preload("User").Where("token_hash = ?", tokenHash).First(&token).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("invalid calendar token")
 		}
 		return nil, fmt.Errorf("failed to validate token: %w", err)

--- a/backend/internal/services/engagement/comment_vote_service.go
+++ b/backend/internal/services/engagement/comment_vote_service.go
@@ -1,6 +1,7 @@
 package engagement
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -41,7 +42,7 @@ func (s *CommentVoteService) Vote(userID uint, commentID uint, direction int) er
 	// Verify comment exists
 	var comment engagementm.Comment
 	if err := s.db.First(&comment, commentID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCommentVoteCommentNotFound()
 		}
 		return fmt.Errorf("failed to get comment: %w", err)
@@ -59,7 +60,7 @@ func (s *CommentVoteService) Vote(userID uint, commentID uint, direction int) er
 		var existingVote engagementm.CommentVote
 		err := tx.Where("comment_id = ? AND user_id = ?", commentID, userID).First(&existingVote).Error
 
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// New vote
 			vote := engagementm.CommentVote{
 				CommentID: commentID,
@@ -93,7 +94,7 @@ func (s *CommentVoteService) Unvote(userID uint, commentID uint) error {
 	// Verify comment exists
 	var comment engagementm.Comment
 	if err := s.db.First(&comment, commentID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrCommentVoteCommentNotFound()
 		}
 		return fmt.Errorf("failed to get comment: %w", err)
@@ -119,7 +120,7 @@ func (s *CommentVoteService) GetUserVote(userID uint, commentID uint) (*int, err
 	var vote engagementm.CommentVote
 	err := s.db.Where("comment_id = ? AND user_id = ?", commentID, userID).First(&vote).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get user vote: %w", err)

--- a/backend/internal/services/engagement/favorite_venue.go
+++ b/backend/internal/services/engagement/favorite_venue.go
@@ -1,6 +1,7 @@
 package engagement
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -40,7 +41,7 @@ func (s *FavoriteVenueService) FavoriteVenue(userID, venueID uint) error {
 	// Check if venue exists
 	var venue catalogm.Venue
 	if err := s.db.First(&venue, venueID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrVenueNotFound(venueID)
 		}
 		return fmt.Errorf("failed to verify venue: %w", err)

--- a/backend/internal/services/engagement/saved_show.go
+++ b/backend/internal/services/engagement/saved_show.go
@@ -1,6 +1,7 @@
 package engagement
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -42,7 +43,7 @@ func (s *SavedShowService) SaveShow(userID, showID uint) error {
 	// Check if show exists
 	var show catalogm.Show
 	if err := s.db.First(&show, showID).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return apperrors.ErrShowNotFound(showID)
 		}
 		return fmt.Errorf("failed to verify show: %w", err)

--- a/backend/internal/services/notification/filter_service.go
+++ b/backend/internal/services/notification/filter_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -111,7 +112,7 @@ func (s *NotificationFilterService) UpdateFilter(userID uint, filterID uint, inp
 
 	var filter notificationm.NotificationFilter
 	if err := s.db.Where("id = ? AND user_id = ?", filterID, userID).First(&filter).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrFilterNotFound()
 		}
 		return nil, apperrors.ErrFilterInternal(fmt.Errorf("failed to get filter: %w", err))
@@ -204,7 +205,7 @@ func (s *NotificationFilterService) GetFilter(userID uint, filterID uint) (*noti
 
 	var filter notificationm.NotificationFilter
 	if err := s.db.Where("id = ? AND user_id = ?", filterID, userID).First(&filter).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("filter not found")
 		}
 		return nil, fmt.Errorf("failed to get filter: %w", err)

--- a/backend/internal/services/notification/filter_service_test.go
+++ b/backend/internal/services/notification/filter_service_test.go
@@ -80,11 +80,11 @@ func TestGenerateFilterUnsubscribeURL(t *testing.T) {
 
 func TestCommentEntityPathAndTable(t *testing.T) {
 	cases := []struct {
-		in         string
-		wantPath   string
-		wantTable  string
+		in          string
+		wantPath    string
+		wantTable   string
 		wantNameCol string
-		wantOK     bool
+		wantOK      bool
 	}{
 		{"artist", "artists", "artists", "name", true},
 		{"venue", "venues", "venues", "name", true},

--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -247,7 +248,7 @@ func (s *DiscoveryService) importEvent(event *contracts.DiscoveredEvent, dryRun 
 			return s.updateShowFromEvent(&existing, event, dryRun)
 		}
 		return fmt.Sprintf("DUPLICATE: %s (ID: %s) already imported as show #%d", event.Title, event.ID, existing.ID), "duplicate"
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Sprintf("ERROR: Failed to check duplicate: %v", err), "error"
 	}
 
@@ -435,7 +436,7 @@ func (s *DiscoveryService) createShowFromEvent(event *contracts.DiscoveredEvent,
 			// Find or create artist
 			var artist catalogm.Artist
 			err := tx.Where("LOWER(name) = LOWER(?)", artistName).First(&artist).Error
-			if err == gorm.ErrRecordNotFound {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				artist = catalogm.Artist{Name: artistName}
 				if err := tx.Create(&artist).Error; err != nil {
 					return fmt.Errorf("failed to create artist %s: %w", artistName, err)

--- a/backend/internal/services/pipeline/discovery_test.go
+++ b/backend/internal/services/pipeline/discovery_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -318,7 +319,7 @@ func (v *testVenueFinderCreator) FindOrCreateVenue(name, city, state string, add
 			query.Model(&venue).Update("slug", slug)
 		}
 		return &venue, false, nil
-	} else if err != gorm.ErrRecordNotFound {
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, false, fmt.Errorf("failed to check existing venue: %w", err)
 	}
 

--- a/backend/internal/services/pipeline/venue_source_config.go
+++ b/backend/internal/services/pipeline/venue_source_config.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,7 +38,7 @@ func (s *VenueSourceConfigService) GetByVenueID(venueID uint) (*adminm.VenueSour
 	var config adminm.VenueSourceConfig
 	err := s.db.Where("venue_id = ?", venueID).First(&config).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get venue source config: %w", err)

--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -116,7 +117,7 @@ func (s *ContributorProfileService) GetPublicProfile(username string, viewerID *
 	var user authm.User
 	err := s.db.Where("username = ?", username).First(&user).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to find user: %w", err)
@@ -207,7 +208,7 @@ func (s *ContributorProfileService) GetOwnProfile(userID uint) (*contracts.Publi
 	var user authm.User
 	err := s.db.First(&user, userID).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to find user: %w", err)
@@ -669,7 +670,7 @@ func (s *ContributorProfileService) UpdateSection(userID uint, sectionID uint, u
 	var section authm.UserProfileSection
 	err := s.db.Where("id = ? AND user_id = ?", sectionID, userID).First(&section).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrProfileSectionNotFound()
 		}
 		return nil, apperrors.ErrProfileInternal(fmt.Errorf("failed to find profile section: %w", err))

--- a/backend/internal/services/user/test_helpers_test.go
+++ b/backend/internal/services/user/test_helpers_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"gorm.io/gorm"
 	adminm "psychic-homily-backend/internal/models/admin"
+
+	"gorm.io/gorm"
 )
 
 // stringPtr returns a pointer to a string. Test helper.

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -193,7 +194,7 @@ func (s *UserService) findOrCreateOAuthUser(gothUser goth.User, provider string,
 		return &user, nil
 	}
 
-	if result.Error != gorm.ErrRecordNotFound {
+	if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("database error: %w", result.Error)
 	}
 
@@ -205,7 +206,7 @@ func (s *UserService) findOrCreateOAuthUser(gothUser goth.User, provider string,
 			// User exists, link OAuth account
 			return s.linkOAuthAccount(&existingUser, gothUser, provider)
 		}
-		if result.Error != gorm.ErrRecordNotFound {
+		if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("database error: %w", result.Error)
 		}
 	}
@@ -497,7 +498,7 @@ func (s *UserService) linkOAuthAccount(user *authm.User, gothUser goth.User, pro
 		if err := s.db.Save(&existingOAuth).Error; err != nil {
 			return nil, fmt.Errorf("failed to update OAuth account: %w", err)
 		}
-	} else if err == gorm.ErrRecordNotFound {
+	} else if errors.Is(err, gorm.ErrRecordNotFound) {
 		// Create new OAuth account
 		oauthAccount := &authm.OAuthAccount{
 			UserID:            user.ID,
@@ -563,7 +564,7 @@ func (s *UserService) GetUserByEmail(email string) (*authm.User, error) {
 		First(&user)
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get user: %w", result.Error)
@@ -585,7 +586,7 @@ func (s *UserService) GetUserByUsername(username string) (*authm.User, error) {
 		First(&user)
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get user: %w", result.Error)
@@ -1335,7 +1336,7 @@ func (s *UserService) GetUserByEmailIncludingDeleted(email string) (*authm.User,
 		First(&user)
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get user: %w", result.Error)

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -843,8 +844,8 @@ func (suite *UserServiceIntegrationTestSuite) TestCreateUserWithPassword_Duplica
 	suite.Nil(user)
 
 	// Verify it's the right error type
-	authErr, ok := err.(*apperrors.AuthError)
-	suite.Require().True(ok)
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
 	suite.Equal(apperrors.CodeUserExists, authErr.Code)
 }
 
@@ -909,8 +910,8 @@ func (suite *UserServiceIntegrationTestSuite) TestAuthenticate_WrongPassword() {
 
 	suite.Require().Error(err)
 	suite.Nil(user)
-	authErr, ok := err.(*apperrors.AuthError)
-	suite.Require().True(ok)
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
 	suite.Equal(apperrors.CodeInvalidCredentials, authErr.Code)
 
 	// Verify failed attempts were incremented
@@ -926,8 +927,8 @@ func (suite *UserServiceIntegrationTestSuite) TestAuthenticate_NonexistentEmail(
 
 	suite.Require().Error(err)
 	suite.Nil(user)
-	authErr, ok := err.(*apperrors.AuthError)
-	suite.Require().True(ok)
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
 	suite.Equal(apperrors.CodeInvalidCredentials, authErr.Code)
 }
 
@@ -942,8 +943,8 @@ func (suite *UserServiceIntegrationTestSuite) TestAuthenticate_OAuthOnlyUser() {
 
 	suite.Require().Error(err)
 	suite.Nil(user)
-	authErr, ok := err.(*apperrors.AuthError)
-	suite.Require().True(ok)
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
 	suite.Equal(apperrors.CodeInvalidCredentials, authErr.Code)
 }
 
@@ -967,8 +968,8 @@ func (suite *UserServiceIntegrationTestSuite) TestAuthenticate_LockedAccount() {
 
 	suite.Require().Error(err)
 	suite.Nil(user)
-	authErr, ok := err.(*apperrors.AuthError)
-	suite.Require().True(ok)
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
 	suite.Equal(apperrors.CodeAccountLocked, authErr.Code)
 }
 
@@ -1081,8 +1082,8 @@ func (suite *UserServiceIntegrationTestSuite) TestUpdatePassword_WrongCurrent() 
 	err = suite.userService.UpdatePassword(user.ID, "WrongOld!", "NewPassword2!")
 	suite.Require().Error(err)
 
-	authErr, ok := err.(*apperrors.AuthError)
-	suite.Require().True(ok)
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
 	suite.Equal(apperrors.CodeInvalidCredentials, authErr.Code)
 }
 
@@ -1367,8 +1368,8 @@ func (suite *UserServiceIntegrationTestSuite) TestCreateUserWithoutPassword_Dupl
 	suite.Require().Error(err)
 	suite.Nil(user)
 
-	authErr, ok := err.(*apperrors.AuthError)
-	suite.Require().True(ok)
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
 	suite.Equal(apperrors.CodeUserExists, authErr.Code)
 }
 

--- a/backend/internal/utils/url_test.go
+++ b/backend/internal/utils/url_test.go
@@ -110,9 +110,9 @@ func TestValidateHTTPURL(t *testing.T) {
 			errSubstr: "host",
 		},
 		{
-			name:      "empty scheme with host-like value",
-			input:     "://example.com",
-			wantErr:   true,
+			name:    "empty scheme with host-like value",
+			input:   "://example.com",
+			wantErr: true,
 		},
 		{
 			name:      "scheme-relative URL",


### PR DESCRIPTION
## Summary

- Replaced 189 source-Go + 4 `cmd/scaffold` template sites of `err == gorm.ErrRecordNotFound` (and `!=`) with `errors.Is(err, gorm.ErrRecordNotFound)` so wrapped errors (`fmt.Errorf("...: %w", err)`) still match — the project wraps in 50+ places and the old comparison silently became InternalServerError once any wrapping was inserted between the GORM call and the comparison.
- Cleaned up 13 additional `errorlint` findings that surfaced after the gorm codemod so the linter could graduate cleanly: 5 `fmt.Errorf("...: %v", err)` → `%w` in `cmd/seed/main.go` and 8 `err.(*T)` test-file type assertions → `errors.As(err, &v)`.
- Moved `errorlint` from `backend/.golangci-advisory.yml` to `backend/.golangci.yml` (gated). CI will now fail on any new sentinel comparison or non-wrapping `fmt.Errorf("...%v", err)`.

## Codemod

Tool: `gofmt -r 'a == gorm.ErrRecordNotFound -> errors.Is(a, gorm.ErrRecordNotFound)' -w ./internal/ ./cmd/` (plus the negated form `a != ... -> !errors.Is(...)`). The wildcard `a` matches both `err` and `result.Error` LHS variants — survey confirmed only 4 unique LHS shapes backend-wide.

After codemod: `goimports -w ./internal/ ./cmd/` to add the `errors` import where the package was previously absent. `goimports` also normalized some pre-existing gofmt drift (struct-tag alignment, comment list reflow) — accepted as a one-time tax since `gofmt` would re-apply it on any future run.

Sites changed: 193 gorm comparisons → `errors.Is`. Before: 193 sites with `==`/`!=`. After: 0. Two pre-existing `errors.Is` call sites (`engagement/comment_service.go:466`, `admin/test_fixtures.go:244`) were already correct and are unchanged.

Sample diff (representative `errors.Is` swap from `internal/services/catalog/show.go`):

```diff
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, apperrors.ErrShowNotFound(showID)
 		}
 		return nil, fmt.Errorf("failed to get show: %w", err)
```

## Test plan

- [x] `cd backend && grep -rn "gorm.ErrRecordNotFound" --include="*.go" . | grep -E "(==|!=)" | grep -v "errors.Is"` — 0 sites
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./...` — all packages PASS (full suite ran to completion locally)
- [x] `cd backend && golangci-lint run -c .golangci.yml ./...` — 0 issues (errorlint now gated)
- [x] `cd backend && golangci-lint run -c .golangci-advisory.yml ./...` — runs (continue-on-error semantics); errorlint absent, remaining backlog matches prior PSY-772 inventory minus errorlint (102 issues across errcheck/ineffassign/staticcheck/unused, all pre-existing).

## Manual repro

Mode: `none` (backend tooling + codemod; no dev stack required).

Pre/post counts:
- Comparison sites backend-wide: **193 → 0**
- `errors.Is(err, gorm.ErrRecordNotFound)` call sites: **19 → 212**
- `errorlint` findings (full suite): **205 → 0**

Final gated lint output:

```
$ golangci-lint run -c .golangci.yml ./...
0 issues.
```

## Simplify

Code already clean — `/simplify` agents flagged nothing beyond gofmt's cosmetic normalization (struct-tag alignment, list-comment reflow). Reverting that drift would re-introduce gofmt-noncompliant whitespace that any future `goimports` run would re-fix; accepted as a one-time cleanup tax.

## Scope decision

Step 4 of the work plan: after the gorm codemod, `errorlint` had 13 remaining findings (NOT the ~19 the ticket predicted — and not sentinel comparisons). All 13 fell into the "1-30 of consistent shape" branch: 5 trivial `%v→%w` in seed scripts (real semantic improvement — proper error chains for `errors.Is`/`errors.As` downstream) and 8 test-file `err.(*T)` type assertions (mechanically equivalent to `errors.As(err, &v)` and what `errorlint` accepts). Extending the codemod scope was the correct call to ship errorlint=GATE in one PR rather than file a follow-up for 13 lines.

Closes PSY-762