### PR TITLE
PSY-834: pre-hydrate auth profile to fix hydration/auth race

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -87,12 +87,12 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  // PSY-834: pre-seed /auth/profile so client useProfile() resolves from
-  // cache on first paint — fixes the race where hydrated pages render
-  // auth-gated buttons interactive before the client profile fetch
-  // settles, routing first-load clicks to /auth instead of the intended
-  // mutation. Helper handles the no-cookie / 401 / 5xx cases so an
-  // anonymous render is not an error path.
+  // Pre-seed /auth/profile so client useProfile() resolves from cache on
+  // first paint — fixes the race where hydrated pages render auth-gated
+  // buttons interactive before the client profile fetch settles, routing
+  // first-load clicks to /auth instead of the intended mutation. Helper
+  // handles the no-cookie / 401 / 5xx cases so an anonymous render is
+  // not an error path.
   const authState = await prefetchAuthProfile()
 
   return (

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -47,6 +47,7 @@ import { JsonLd } from '@/components/seo/JsonLd'
 import { generateOrganizationSchema } from '@/lib/seo/jsonld'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
+import { prefetchAuthProfile } from '@/lib/auth-hydration'
 
 export const viewport: Viewport = {
   themeColor: [
@@ -81,11 +82,19 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  // PSY-834: pre-seed /auth/profile so client useProfile() resolves from
+  // cache on first paint — fixes the race where hydrated pages render
+  // auth-gated buttons interactive before the client profile fetch
+  // settles, routing first-load clicks to /auth instead of the intended
+  // mutation. Helper handles the no-cookie / 401 / 5xx cases so an
+  // anonymous render is not an error path.
+  const authState = await prefetchAuthProfile()
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -98,7 +107,7 @@ export default function RootLayout({
       <body
         className={`${clashDisplay.variable} ${satoshi.variable} ${spaceMono.variable} antialiased`}
       >
-        <Providers>
+        <Providers authState={authState}>
           <ThemeProvider
             attribute="class"
             defaultTheme="system"

--- a/frontend/components/layout/providers.tsx
+++ b/frontend/components/layout/providers.tsx
@@ -11,12 +11,12 @@ import { AuthProvider } from '@/lib/context/AuthContext'
 interface ProvidersProps {
     children: React.ReactNode
     /**
-     * Pre-hydrated TanStack Query state from the root layout (PSY-834).
-     * Today this only carries the `/auth/profile` cache entry so
-     * `useProfile` resolves from cache on first paint, eliminating the
-     * race where auth-gated buttons render interactive before the client
-     * profile fetch settles. Optional so callers that don't prefetch
-     * (e.g. unit tests) keep working without a noop placeholder.
+     * Pre-hydrated TanStack Query state from the root layout. Today this
+     * only carries the `/auth/profile` cache entry so `useProfile`
+     * resolves from cache on first paint, eliminating the race where
+     * auth-gated buttons render interactive before the client profile
+     * fetch settles. Optional so callers that don't prefetch (e.g. unit
+     * tests) keep working without a noop placeholder.
      */
     authState?: DehydratedState
 }

--- a/frontend/components/layout/providers.tsx
+++ b/frontend/components/layout/providers.tsx
@@ -1,19 +1,36 @@
 'use client'
 
-import { QueryClientProvider } from '@tanstack/react-query'
+import {
+    HydrationBoundary,
+    QueryClientProvider,
+    type DehydratedState,
+} from '@tanstack/react-query'
 import { getQueryClient } from '@/lib/queryClient'
 import { AuthProvider } from '@/lib/context/AuthContext'
 
 interface ProvidersProps {
     children: React.ReactNode
+    /**
+     * Pre-hydrated TanStack Query state from the root layout (PSY-834).
+     * Today this only carries the `/auth/profile` cache entry so
+     * `useProfile` resolves from cache on first paint, eliminating the
+     * race where auth-gated buttons render interactive before the client
+     * profile fetch settles. Optional so callers that don't prefetch
+     * (e.g. unit tests) keep working without a noop placeholder.
+     */
+    authState?: DehydratedState
 }
 
-export function Providers({ children }: ProvidersProps) {
+export function Providers({ children, authState }: ProvidersProps) {
     const queryClient = getQueryClient()
 
+    // HydrationBoundary must live inside QueryClientProvider so it seeds
+    // the same client the AuthProvider's useProfile hook will read from.
     return (
         <QueryClientProvider client={queryClient}>
-            <AuthProvider>{children}</AuthProvider>
+            <HydrationBoundary state={authState}>
+                <AuthProvider>{children}</AuthProvider>
+            </HydrationBoundary>
         </QueryClientProvider>
     )
 }

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -233,9 +233,14 @@ async function loginAs(
   await page.locator('#password').fill(password)
   await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
-  // Wait for redirect away from /auth (successful login)
+  // Wait for redirect away from /auth (successful login).
+  // CI dev-mode timing window: Turbopack cold-compiles the post-login
+  // destination route AND the root layout now awaits `prefetchAuthProfile`
+  // (PSY-834). Combined wall time has been observed at ~11s in CI runners
+  // for a fresh worker (passes immediately when the dev server is warm,
+  // including local). 30s gives headroom without masking a real regression.
   await page.waitForURL((url) => !url.pathname.startsWith('/auth'), {
-    timeout: 15_000,
+    timeout: 30_000,
   })
 }
 

--- a/frontend/lib/auth-hydration.ts
+++ b/frontend/lib/auth-hydration.ts
@@ -1,10 +1,10 @@
 /**
- * Server-only auth profile hydration helper (PSY-834).
+ * Server-only auth profile hydration helper.
  *
  * Pre-seeds the TanStack Query cache for `/auth/profile` on the server so
  * `useProfile()` resolves from cache on first paint. Without this, hydrated
- * detail pages (PSY-796 / PSY-797) paint instantly but auth-gated action
- * buttons (AttendanceButton, SaveButton, etc.) are interactive while
+ * detail pages paint instantly but auth-gated action buttons
+ * (AttendanceButton, SaveButton, etc.) are interactive while
  * `isAuthenticated` is still `false` — a click before the client profile
  * fetch settles routes the user to `/auth?returnTo=…` instead of firing
  * the intended POST.

--- a/frontend/lib/auth-hydration.ts
+++ b/frontend/lib/auth-hydration.ts
@@ -25,10 +25,13 @@
  * a client component will throw at build time.
  */
 
+import { cache } from 'react'
 import { cookies } from 'next/headers'
 import { dehydrate, type DehydratedState } from '@tanstack/react-query'
+import * as Sentry from '@sentry/nextjs'
 import { getQueryClient, queryKeys } from '@/lib/queryClient'
 import { API_BASE_URL } from '@/lib/api-base'
+import { AuthErrorCode } from '@/lib/errors'
 
 // Mirror the relevant subset of `UserProfile` from
 // features/auth/hooks/useAuth.ts. Duplicated here (rather than imported)
@@ -49,26 +52,30 @@ interface AuthProfilePayload {
 const UNAUTHENTICATED_PROFILE: AuthProfilePayload = {
   success: false,
   message: 'Authentication required',
-  error_code: 'TOKEN_MISSING',
+  error_code: AuthErrorCode.TOKEN_MISSING,
 }
 
 /**
  * Fetch `/auth/profile` server-side and hydrate the result into a
  * request-scoped QueryClient. Called once per request from the root
  * layout — `getQueryClient` returns a fresh client on the server, so
- * there's no cross-request cache leak.
+ * there's no cross-request cache leak. Wrapped in `React.cache()` so
+ * multiple server components in the same render can call it without
+ * triggering a duplicate backend fetch.
  */
-export async function prefetchAuthProfile(): Promise<DehydratedState> {
-  const queryClient = getQueryClient()
+export const prefetchAuthProfile = cache(
+  async (): Promise<DehydratedState> => {
+    const queryClient = getQueryClient()
 
-  const profile = await fetchAuthProfile()
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.auth.profile,
-    queryFn: () => profile,
-  })
+    const profile = await fetchAuthProfile()
+    await queryClient.prefetchQuery({
+      queryKey: queryKeys.auth.profile,
+      queryFn: () => profile,
+    })
 
-  return dehydrate(queryClient)
-}
+    return dehydrate(queryClient)
+  }
+)
 
 async function fetchAuthProfile(): Promise<AuthProfilePayload> {
   const cookieStore = await cookies()
@@ -88,20 +95,32 @@ async function fetchAuthProfile(): Promise<AuthProfilePayload> {
     })
 
     if (!response.ok) {
-      // 401, 403, 5xx — fall through to the unauthenticated sentinel so
-      // the client doesn't re-fetch and doesn't render an error state on
-      // first paint. If the user truly is logged in but the backend is
-      // temporarily 5xx, the client's stale-time-elapsed refetch will
-      // surface the error normally.
+      // 5xx is a real backend outage that would otherwise be invisible
+      // — every authenticated viewer silently falls back to the
+      // "logged out" sentinel until staleTime elapses and the client
+      // refetches. Capture so on-call sees the signal without waiting
+      // on user reports. 4xx (401/403) is the expected unauthenticated
+      // path and intentionally not captured.
+      if (response.status >= 500) {
+        Sentry.captureMessage(`SSR auth profile fetch failed: ${response.status}`, {
+          level: 'error',
+          tags: { service: 'auth', error_type: 'ssr_prefetch_failure' },
+          extra: { status: response.status },
+        })
+      }
       return UNAUTHENTICATED_PROFILE
     }
 
     return (await response.json()) as AuthProfilePayload
-  } catch {
+  } catch (error) {
     // Network failure (backend unreachable from the Next server, DNS,
-    // etc.) — same fallback as a non-2xx response. The client will
-    // refetch when the user takes an action that touches the query, and
-    // the real error will surface there.
+    // etc.) — fall back to the sentinel so first paint isn't an error
+    // page, but log so a sustained outage doesn't masquerade as
+    // "everyone is logged out".
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'auth', error_type: 'ssr_prefetch_network_failure' },
+    })
     return UNAUTHENTICATED_PROFILE
   }
 }

--- a/frontend/lib/auth-hydration.ts
+++ b/frontend/lib/auth-hydration.ts
@@ -1,0 +1,107 @@
+/**
+ * Server-only auth profile hydration helper (PSY-834).
+ *
+ * Pre-seeds the TanStack Query cache for `/auth/profile` on the server so
+ * `useProfile()` resolves from cache on first paint. Without this, hydrated
+ * detail pages (PSY-796 / PSY-797) paint instantly but auth-gated action
+ * buttons (AttendanceButton, SaveButton, etc.) are interactive while
+ * `isAuthenticated` is still `false` — a click before the client profile
+ * fetch settles routes the user to `/auth?returnTo=…` instead of firing
+ * the intended POST.
+ *
+ * The helper:
+ *   - Reads the viewer's `auth_token` cookie via `next/headers` so the
+ *     server fetch sees the same session as the browser would.
+ *   - Calls the backend with `cache: 'no-store'` so per-user profile data
+ *     never leaks across requests.
+ *   - On 401 (or network error) populates the cache with a "no user"
+ *     sentinel matching the `UserProfile` body shape the backend returns
+ *     for unauthenticated requests. This is what `useProfile`'s queryFn
+ *     would resolve to IF apiRequest didn't throw on 401 — the seed lets
+ *     the client skip the refetch + auth-error flash entirely.
+ *   - Returns `dehydrate(queryClient)` for `<HydrationBoundary>`.
+ *
+ * Server-only by virtue of importing `next/headers`. Importing this from
+ * a client component will throw at build time.
+ */
+
+import { cookies } from 'next/headers'
+import { dehydrate, type DehydratedState } from '@tanstack/react-query'
+import { getQueryClient, queryKeys } from '@/lib/queryClient'
+import { API_BASE_URL } from '@/lib/api-base'
+
+// Mirror the relevant subset of `UserProfile` from
+// features/auth/hooks/useAuth.ts. Duplicated here (rather than imported)
+// because that module is `'use client'` and pulling it into a server
+// helper would mark this file as client-only.
+interface AuthProfilePayload {
+  success: boolean
+  message?: string
+  error_code?: string
+  request_id?: string
+  user?: unknown
+}
+
+// Sentinel body for the unauthenticated case. Matches the backend's
+// /auth/profile 401 body shape so the cache entry is indistinguishable
+// from the parsed payload — no special "is this a seed?" branching in
+// the client.
+const UNAUTHENTICATED_PROFILE: AuthProfilePayload = {
+  success: false,
+  message: 'Authentication required',
+  error_code: 'TOKEN_MISSING',
+}
+
+/**
+ * Fetch `/auth/profile` server-side and hydrate the result into a
+ * request-scoped QueryClient. Called once per request from the root
+ * layout — `getQueryClient` returns a fresh client on the server, so
+ * there's no cross-request cache leak.
+ */
+export async function prefetchAuthProfile(): Promise<DehydratedState> {
+  const queryClient = getQueryClient()
+
+  const profile = await fetchAuthProfile()
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.auth.profile,
+    queryFn: () => profile,
+  })
+
+  return dehydrate(queryClient)
+}
+
+async function fetchAuthProfile(): Promise<AuthProfilePayload> {
+  const cookieStore = await cookies()
+  const authToken = cookieStore.get('auth_token')
+
+  // Anonymous visitor — short-circuit instead of round-tripping to the
+  // backend just to be told there's no session. Same sentinel either
+  // way, so the cache entry is identical whether we skip or fetch.
+  if (!authToken?.value) {
+    return UNAUTHENTICATED_PROFILE
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/profile`, {
+      headers: { Cookie: `auth_token=${authToken.value}` },
+      cache: 'no-store',
+    })
+
+    if (!response.ok) {
+      // 401, 403, 5xx — fall through to the unauthenticated sentinel so
+      // the client doesn't re-fetch and doesn't render an error state on
+      // first paint. If the user truly is logged in but the backend is
+      // temporarily 5xx, the client's stale-time-elapsed refetch will
+      // surface the error normally.
+      return UNAUTHENTICATED_PROFILE
+    }
+
+    return (await response.json()) as AuthProfilePayload
+  } catch {
+    // Network failure (backend unreachable from the Next server, DNS,
+    // etc.) — same fallback as a non-2xx response. The client will
+    // refetch when the user takes an action that touches the query, and
+    // the real error will surface there.
+    return UNAUTHENTICATED_PROFILE
+  }
+}

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -68,6 +68,22 @@ function isSessionExpiredError(error: unknown): boolean {
   )
 }
 
+// `useProfile` resolves its queryFn to a `UserProfile` shape — when the
+// user is logged out the payload is `{ success: false, ... }` rather than
+// an error. Used by the global error handlers below so a sibling query's
+// 401 doesn't re-invalidate a profile that already knows it's anonymous
+// (either via SSR seed from `prefetchAuthProfile` or a prior 401).
+function profileAlreadyKnowsAnonymous(
+  client: QueryClient | undefined
+): boolean {
+  if (!client) return false
+  const state = client.getQueryState(queryKeys.auth.profile)
+  if (!state) return false
+  if (state.status === 'error') return true
+  const data = state.data as { success?: boolean } | undefined
+  return data?.success === false
+}
+
 // Function to create query client (for use in provider)
 function makeQueryClient() {
   // Create caches with global error handlers
@@ -79,8 +95,14 @@ function makeQueryClient() {
       // again, creating an infinite cascade of clears and refetches.
       if (isSessionExpiredError(error)) {
         if (query.queryKey[0] !== 'auth' || query.queryKey[1] !== 'profile') {
-          const profileState = browserQueryClient?.getQueryState(queryKeys.auth.profile)
-          if (profileState?.status !== 'error') {
+          // Skip the invalidation if the profile cache already encodes
+          // the "logged out" answer — either as an error from a prior
+          // 401, or as the `{ success: false }` payload seeded by the
+          // SSR pre-hydration (PSY-834). Invalidating in that case
+          // turns the SSR-seeded cache into a wasted client refetch
+          // that races with the very auth-gated buttons the seed was
+          // meant to make safe.
+          if (!profileAlreadyKnowsAnonymous(browserQueryClient)) {
             browserQueryClient?.invalidateQueries({ queryKey: queryKeys.auth.profile })
           }
         }
@@ -93,8 +115,7 @@ function makeQueryClient() {
       // When a session expires during a mutation, invalidate profile to update
       // auth state. Same rationale as above — don't clear the entire cache.
       if (isSessionExpiredError(error)) {
-        const profileState = browserQueryClient?.getQueryState(queryKeys.auth.profile)
-        if (profileState?.status !== 'error') {
+        if (!profileAlreadyKnowsAnonymous(browserQueryClient)) {
           browserQueryClient?.invalidateQueries({ queryKey: queryKeys.auth.profile })
         }
       }

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -72,7 +72,8 @@ function isSessionExpiredError(error: unknown): boolean {
 // user is logged out the payload is `{ success: false, ... }` rather than
 // an error. Used by the global error handlers below so a sibling query's
 // 401 doesn't re-invalidate a profile that already knows it's anonymous
-// (either via SSR seed from `prefetchAuthProfile` or a prior 401).
+// (either via the SSR auth-profile seed in `prefetchAuthProfile` or a
+// prior 401).
 function profileAlreadyKnowsAnonymous(
   client: QueryClient | undefined
 ): boolean {
@@ -98,10 +99,10 @@ function makeQueryClient() {
           // Skip the invalidation if the profile cache already encodes
           // the "logged out" answer — either as an error from a prior
           // 401, or as the `{ success: false }` payload seeded by the
-          // SSR pre-hydration (PSY-834). Invalidating in that case
-          // turns the SSR-seeded cache into a wasted client refetch
-          // that races with the very auth-gated buttons the seed was
-          // meant to make safe.
+          // SSR pre-hydration. Invalidating in that case turns the
+          // SSR-seeded cache into a wasted client refetch that races
+          // with the very auth-gated buttons the seed was meant to
+          // make safe.
           if (!profileAlreadyKnowsAnonymous(browserQueryClient)) {
             browserQueryClient?.invalidateQueries({ queryKey: queryKeys.auth.profile })
           }


### PR DESCRIPTION
## Summary
- Pre-hydrate `/auth/profile` in the root layout so `useProfile()` resolves from cache on first paint. Eliminates the race that PSY-797's hydration surfaced — auth-gated click handlers (`AttendanceButton` etc.) now see correct `isAuthenticated` from the first render.
- Server-side fetch forwards HttpOnly cookies via `next/headers` `cookies()`; uses `cache: 'no-store'` so per-user data never leaks across requests. Anonymous visitors short-circuit the backend call entirely.
- Unauthenticated visits cache a `{success: false, error_code: 'TOKEN_MISSING'}` sentinel matching what the backend returns for the same case — no client refetch, no auth-error flash.
- Updates `queryClient.ts` global 401 handler so a sibling query's 401 doesn't invalidate the SSR-seeded "anonymous" profile and trigger the very refetch the seed exists to skip.
- `prefetchAuthProfile` wrapped in `React.cache()` (defensive against multiple server components calling it in the same render), and uses `AuthErrorCode.TOKEN_MISSING` enum from `lib/errors` instead of a hardcoded string.
- Sentry captures backend 5xx + network failures during the SSR profile fetch so a sustained outage doesn't silently masquerade as "everyone is logged out." 401/403 (expected unauthenticated path) intentionally not captured.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run` — passed (403 files, 4595 tests)
- [x] `cd frontend && bun run test:e2e -- e2e/pages/follow-and-attendance.spec.ts` — passed (includes the "mark show as going round-trip" test that failed on PSY-797 PR #796)

## Manual repro
- **Authenticated**: signed in as `e2e-user@test.local` via the dispatch stack; navigated to `/shows/e2e-attendance-test`; clicked `Going` immediately after page load. `POST /api/shows/60/attendance [200]` fired; no `/auth?returnTo` redirect; button updated to "Going 1". Profile cache on first paint: `{status: 'success', isInvalidated: false, data.user.id: 1}`.
- **Unauthenticated**: cleared cookies; navigated to `/artists/calexico`; page rendered cleanly; no `/api/auth/profile` request fired (verified in DevTools + Next dev log). Profile cache: `{status: 'success', isInvalidated: false, data: {success: false, ...}}`.
- Backend `/auth/profile` unauth shape verified via curl: `401` with `{"success":false,"message":"Authentication required","error_code":"TOKEN_MISSING","request_id":"..."}` — cache sentinel mirrors this minus `request_id`.

## Known limitation — ISR loss (filed [PSY-841](https://linear.app/psychic-homily/issue/PSY-841))
Calling `cookies()` from `app/layout.tsx` opts the entire app into dynamic rendering. This **defeats ISR on every page that sets `next: { revalidate: 3600 }`** — the 8 hydrated entity routes (artist/venue/show/release/label/festival/collection/tag) plus static marketing pages.

This is accepted as a temporary trade-off to unblock PSY-797 immediately. [PSY-841](https://linear.app/psychic-homily/issue/PSY-841) migrates to the proper 2026 pattern: Next.js 16 stable Partial Prerendering (PPR) + `<Suspense>` boundary + per-route `experimental_ppr = true` opt-in. The static shell preserves ISR; only the auth-dependent subtree streams dynamically. Should be picked up before this PR's perf impact compounds.

## `/simplify` outcomes
- Initial pass: stripped 4 `PSY-834` ticket refs from production doc comments per the project's strip-ticket-refs convention.
- Three-agent review surfaced one architectural finding (the ISR loss, captured above + PSY-841) and three easy fixes (AuthErrorCode enum, `React.cache()` wrap, Sentry capture on 5xx + network) — all applied in commit `9692f0ab`.

## Unblocks
PSY-797 PR #796 rebases on top of this; its failing E2E should pass.

Closes PSY-834