### PR TITLE
PSY-826: streaming_discovery_status column + backfill on artists

### DIFF
--- a/backend/db/migrations/20260524213941_artists_add_streaming_discovery_status.down.sql
+++ b/backend/db/migrations/20260524213941_artists_add_streaming_discovery_status.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_artists_streaming_discovery_status;
+
+ALTER TABLE artists
+    DROP COLUMN IF EXISTS streaming_discovery_reason,
+    DROP COLUMN IF EXISTS streaming_discovery_status;

--- a/backend/db/migrations/20260524213941_artists_add_streaming_discovery_status.up.sql
+++ b/backend/db/migrations/20260524213941_artists_add_streaming_discovery_status.up.sql
@@ -1,0 +1,35 @@
+-- Track per-artist streaming-discovery review state so the admin worklist can
+-- exclude terminal-state rows (linked, no_links_found, skipped) and remember
+-- admin decisions across sessions. Without this, a new artist is
+-- indistinguishable from one that's already been reviewed and found empty.
+--
+-- States:
+--   unreviewed         — never touched by the discovery worklist (default)
+--   candidates_pending — provider lookups produced candidates awaiting review
+--   linked             — admin (or backfill) confirmed at least one streaming link
+--   no_links_found     — admin reviewed and the artist has no platform presence
+--   skipped            — admin opted to defer (ambiguous match, low priority, etc.)
+--
+-- VARCHAR + CHECK matches the convention established by
+-- collections.display_mode rather than the older CREATE TYPE ... AS ENUM
+-- pattern (show_status, etc.) — easier to extend, no separate type to manage.
+--
+-- streaming_discovery_reason holds the admin's optional note on no_links_found
+-- and skipped. NULL is normal for the other states.
+ALTER TABLE artists
+    ADD COLUMN streaming_discovery_status VARCHAR(32) NOT NULL DEFAULT 'unreviewed'
+        CHECK (streaming_discovery_status IN (
+            'unreviewed',
+            'candidates_pending',
+            'linked',
+            'no_links_found',
+            'skipped'
+        )),
+    ADD COLUMN streaming_discovery_reason TEXT NULL;
+
+-- Worklist filters on status (e.g. WHERE streaming_discovery_status = 'unreviewed').
+-- Added inline; the artists table is small enough today that a non-CONCURRENTLY
+-- index is fine, and inlining keeps the schema + index atomic for the
+-- round-trip test gate.
+CREATE INDEX idx_artists_streaming_discovery_status
+    ON artists(streaming_discovery_status);

--- a/backend/db/migrations/20260524213942_artists_backfill_streaming_discovery_status.down.sql
+++ b/backend/db/migrations/20260524213942_artists_backfill_streaming_discovery_status.down.sql
@@ -1,0 +1,13 @@
+-- Reverse the backfill so the schema-drop migration sees only the column
+-- default ('unreviewed'). This keeps the up→down→up round-trip clean and
+-- preserves the invariant that rows touched by an admin (any non-default
+-- status) aren't silently rewritten on rollback.
+UPDATE artists
+   SET streaming_discovery_status = 'unreviewed'
+ WHERE streaming_discovery_status = 'linked'
+   AND (
+       spotify    IS NOT NULL
+    OR bandcamp   IS NOT NULL
+    OR youtube    IS NOT NULL
+    OR soundcloud IS NOT NULL
+   );

--- a/backend/db/migrations/20260524213942_artists_backfill_streaming_discovery_status.up.sql
+++ b/backend/db/migrations/20260524213942_artists_backfill_streaming_discovery_status.up.sql
@@ -1,0 +1,16 @@
+-- Flip existing artists with any music-platform link to 'linked' so the
+-- worklist doesn't surface already-curated rows on first run.
+--
+-- "Music-platform link" = spotify | bandcamp | youtube | soundcloud.
+-- The other Social fields (instagram/facebook/twitter/website) aren't
+-- music-platform-specific — a band's Instagram doesn't constitute a
+-- streaming-discovery link.
+UPDATE artists
+   SET streaming_discovery_status = 'linked'
+ WHERE streaming_discovery_status = 'unreviewed'
+   AND (
+       spotify    IS NOT NULL
+    OR bandcamp   IS NOT NULL
+    OR youtube    IS NOT NULL
+    OR soundcloud IS NOT NULL
+   );

--- a/backend/internal/models/catalog/artist.go
+++ b/backend/internal/models/catalog/artist.go
@@ -19,6 +19,12 @@ type Artist struct {
 	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
 	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
 
+	// Streaming discovery review state. Drives the admin worklist that walks
+	// artists missing music-platform links (spotify/bandcamp/youtube/soundcloud)
+	// and records the outcome of each review. CHECK-constrained at the DB.
+	StreamingDiscoveryStatus string  `json:"streaming_discovery_status" gorm:"column:streaming_discovery_status;size:32;not null;default:unreviewed"`
+	StreamingDiscoveryReason *string `json:"streaming_discovery_reason,omitempty" gorm:"column:streaming_discovery_reason;type:text"`
+
 	CreatedAt time.Time `gorm:"not null"`
 	UpdatedAt time.Time `gorm:"not null"`
 

--- a/backend/internal/models/catalog/artist.go
+++ b/backend/internal/models/catalog/artist.go
@@ -2,6 +2,21 @@ package catalog
 
 import "time"
 
+// StreamingDiscoveryStatus tracks where each artist sits in the admin
+// worklist that walks artists missing music-platform links (spotify /
+// bandcamp / youtube / soundcloud). Values are CHECK-constrained at the DB
+// — keep this list in sync with the streaming_discovery_status column
+// constraint.
+type StreamingDiscoveryStatus string
+
+const (
+	StreamingDiscoveryStatusUnreviewed        StreamingDiscoveryStatus = "unreviewed"
+	StreamingDiscoveryStatusCandidatesPending StreamingDiscoveryStatus = "candidates_pending"
+	StreamingDiscoveryStatusLinked            StreamingDiscoveryStatus = "linked"
+	StreamingDiscoveryStatusNoLinksFound      StreamingDiscoveryStatus = "no_links_found"
+	StreamingDiscoveryStatusSkipped           StreamingDiscoveryStatus = "skipped"
+)
+
 type Artist struct {
 	ID               uint    `gorm:"primaryKey"`
 	Name             string  `gorm:"uniqueIndex"`
@@ -19,11 +34,10 @@ type Artist struct {
 	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
 	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
 
-	// Streaming discovery review state. Drives the admin worklist that walks
-	// artists missing music-platform links (spotify/bandcamp/youtube/soundcloud)
-	// and records the outcome of each review. CHECK-constrained at the DB.
-	StreamingDiscoveryStatus string  `json:"streaming_discovery_status" gorm:"column:streaming_discovery_status;size:32;not null;default:unreviewed"`
-	StreamingDiscoveryReason *string `json:"streaming_discovery_reason,omitempty" gorm:"column:streaming_discovery_reason;type:text"`
+	// Streaming-discovery review state — see StreamingDiscoveryStatus const block.
+	// Reason holds the admin's optional note on no_links_found / skipped outcomes.
+	StreamingDiscoveryStatus StreamingDiscoveryStatus `json:"streaming_discovery_status" gorm:"column:streaming_discovery_status;size:32;not null;default:unreviewed"`
+	StreamingDiscoveryReason *string                  `json:"streaming_discovery_reason,omitempty" gorm:"column:streaming_discovery_reason;type:text"`
 
 	CreatedAt time.Time `gorm:"not null"`
 	UpdatedAt time.Time `gorm:"not null"`


### PR DESCRIPTION
## Summary
- Adds `streaming_discovery_status` (VARCHAR(32) + CHECK enum, indexed) and `streaming_discovery_reason` (TEXT) to `artists`. Default `'unreviewed'`. Drives the PSY-820 admin worklist (PSY-827/828 in follow-up).
- Separate backfill migration flips artists with any of spotify / bandcamp / youtube / soundcloud to `'linked'`. Non-music Social fields (instagram / facebook / twitter / website) intentionally excluded.
- GORM model exposes a typed `StreamingDiscoveryStatus` alias + const block (matches the existing `ShowStatus` / `ShowSource` precedent in the same package) so the upcoming worklist code isn't stringly-typed.

CHECK + VARCHAR convention follows the newer `collections.display_mode` migration over the older `CREATE TYPE ... AS ENUM` (show_status) — easier to extend the value set, no separate type to manage.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/models/... ./internal/services/catalog/...` — passed (catalog suite 33s including all `ArtistService.CreateArtist` test paths)
- [x] migration up + down + up round-trip — clean (verified against a fresh postgres:18 container)

## Manual repro
Stack mode: isolated (migration touches a populated table — racing against a shared DB would corrupt seed data). For the full round-trip verification I also ran against a clean ephemeral postgres:18 container outside the dispatch stack, since `stack-down` recreates the volume and loses test data.

`\d artists` (relevant excerpt):
```
 streaming_discovery_status | character varying(32)    |           | not null | 'unreviewed'::character varying
 streaming_discovery_reason | text                     |           |          |
Indexes:
    "idx_artists_streaming_discovery_status" btree (streaming_discovery_status)
Check constraints:
    "artists_streaming_discovery_status_check" CHECK (streaming_discovery_status::text = ANY (ARRAY['unreviewed'::character varying, 'candidates_pending'::character varying, 'linked'::character varying, 'no_links_found'::character varying, 'skipped'::character varying]::text[]))
```

Backfill distribution after seeding 4 music-platform rows + 1 non-music-social row + 1 empty row, then running up→down→up:
```
 streaming_discovery_status | count
----------------------------+-------
 linked                     |     4
 unreviewed                 |     2
```
Spotify / Bandcamp / YouTube / SoundCloud rows → `linked`. Non-music-social-only + empty rows correctly stayed `unreviewed`.

Round-trip: ran `migrate down 2` to drop both migrations, then `migrate up` to reapply. Both directions reported clean timing (<10ms each step). Schema fully dropped between (column, index, CHECK constraint all gone) and fully rebuilt.

## Simplify
Converted `StreamingDiscoveryStatus` from raw `string` to typed string alias + const block, matching the existing `ShowStatus` / `ShowSource` precedent in the same `models/catalog` package. Eliminates stringly-typed call sites in the upcoming worklist + frontend tickets.

Closes PSY-826