### PR TITLE
PSY-835: featured_slots schema + admin endpoints + service

### DIFF
--- a/backend/db/migrations/20260524214301_create_featured_slots.down.sql
+++ b/backend/db/migrations/20260524214301_create_featured_slots.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS featured_slots;

--- a/backend/db/migrations/20260524214301_create_featured_slots.up.sql
+++ b/backend/db/migrations/20260524214301_create_featured_slots.up.sql
@@ -1,0 +1,37 @@
+-- /explore landing has two admin-curated editorial slots — Featured Bill
+-- (a show) and Featured Collection — with no automated rotation. Admins
+-- curate on their own cadence; the currently active row stays visible
+-- until it is retired or replaced.
+--
+-- One active row per slot_type at a time, enforced by a partial unique
+-- index on (slot_type) WHERE active_until IS NULL. Retired rows keep the
+-- history so we can show "previously featured" surfaces later without
+-- mining the audit log.
+--
+-- entity_id is intentionally NOT a hard FK — the referent table varies
+-- by slot_type ('bill' → shows, 'collection' → collections), and the
+-- application layer (service.GetActiveSlot) resolves the right table.
+-- This mirrors the polymorphic entity_id pattern already used by
+-- pending_entity_edits and comments.
+
+CREATE TABLE featured_slots (
+    id BIGSERIAL PRIMARY KEY,
+    slot_type TEXT NOT NULL CHECK (slot_type IN ('bill', 'collection')),
+    entity_id BIGINT NOT NULL,
+    curator_note TEXT,
+    active_from TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    active_until TIMESTAMPTZ,
+    created_by BIGINT NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One currently-active row per slot_type. Retired rows (active_until
+-- IS NOT NULL) are excluded so history stacks freely.
+CREATE UNIQUE INDEX idx_featured_slots_active_per_type
+    ON featured_slots (slot_type)
+    WHERE active_until IS NULL;
+
+-- History lookups (admin "recent picks" listing) hit (slot_type, created_at).
+CREATE INDEX idx_featured_slots_slot_type_created_at
+    ON featured_slots (slot_type, created_at DESC);

--- a/backend/internal/api/handlers/admin/featured_slot.go
+++ b/backend/internal/api/handlers/admin/featured_slot.go
@@ -20,21 +20,21 @@ import (
 // raw markdown source) is also exposed so the admin UI can re-edit a
 // pick without round-tripping through the rendered form.
 type FeaturedSlotResponse struct {
-	ID             uint       `json:"id"`
-	SlotType       string     `json:"slot_type"`
-	EntityID       uint       `json:"entity_id"`
-	CuratorNote    *string    `json:"curator_note,omitempty"`
-	CuratorNoteHTML string    `json:"curator_note_html,omitempty"`
-	ActiveFrom     time.Time  `json:"active_from"`
-	ActiveUntil    *time.Time `json:"active_until,omitempty"`
-	CreatedBy      uint       `json:"created_by"`
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	ID              uint       `json:"id"`
+	SlotType        string     `json:"slot_type"`
+	EntityID        uint       `json:"entity_id"`
+	CuratorNote     *string    `json:"curator_note,omitempty"`
+	CuratorNoteHTML string     `json:"curator_note_html,omitempty"`
+	ActiveFrom      time.Time  `json:"active_from"`
+	ActiveUntil     *time.Time `json:"active_until,omitempty"`
+	CreatedBy       uint       `json:"created_by"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
 }
 
 // FeaturedSlotHandler exposes the admin-only featured-slot CRUD surface.
-// Routes register on rc.Admin (PSY-423) so the middleware enforces auth +
-// IsAdmin upstream; handlers do not call shared.RequireAdmin themselves.
+// Routes register on rc.Admin so the middleware enforces auth + IsAdmin
+// upstream; handlers do not call shared.RequireAdmin themselves.
 type FeaturedSlotHandler struct {
 	featuredSlotService contracts.FeaturedSlotServiceInterface
 	auditLogService     contracts.AuditLogServiceInterface

--- a/backend/internal/api/handlers/admin/featured_slot.go
+++ b/backend/internal/api/handlers/admin/featured_slot.go
@@ -1,0 +1,289 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	adminm "psychic-homily-backend/internal/models/admin"
+	adminsvc "psychic-homily-backend/internal/services/admin"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// FeaturedSlotResponse is the wire shape for a single featured-slot row.
+// CuratorNoteHTML carries the rendered + sanitized HTML; CuratorNote (the
+// raw markdown source) is also exposed so the admin UI can re-edit a
+// pick without round-tripping through the rendered form.
+type FeaturedSlotResponse struct {
+	ID             uint       `json:"id"`
+	SlotType       string     `json:"slot_type"`
+	EntityID       uint       `json:"entity_id"`
+	CuratorNote    *string    `json:"curator_note,omitempty"`
+	CuratorNoteHTML string    `json:"curator_note_html,omitempty"`
+	ActiveFrom     time.Time  `json:"active_from"`
+	ActiveUntil    *time.Time `json:"active_until,omitempty"`
+	CreatedBy      uint       `json:"created_by"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+// FeaturedSlotHandler exposes the admin-only featured-slot CRUD surface.
+// Routes register on rc.Admin (PSY-423) so the middleware enforces auth +
+// IsAdmin upstream; handlers do not call shared.RequireAdmin themselves.
+type FeaturedSlotHandler struct {
+	featuredSlotService contracts.FeaturedSlotServiceInterface
+	auditLogService     contracts.AuditLogServiceInterface
+}
+
+// NewFeaturedSlotHandler wires the featured-slot service + audit log.
+func NewFeaturedSlotHandler(
+	featuredSlotService contracts.FeaturedSlotServiceInterface,
+	auditLogService contracts.AuditLogServiceInterface,
+) *FeaturedSlotHandler {
+	return &FeaturedSlotHandler{
+		featuredSlotService: featuredSlotService,
+		auditLogService:     auditLogService,
+	}
+}
+
+// --- List / Get ---
+
+// ListFeaturedSlotsRequest is the Huma request for GET /admin/featured-slots.
+// HistoryLimit is per-slot — admin UI typically wants a small window
+// (default 5, capped at 50).
+type ListFeaturedSlotsRequest struct {
+	HistoryLimit int `query:"history_limit" default:"5" minimum:"1" maximum:"50" doc:"Number of historical rows to include per slot_type"`
+}
+
+// FeaturedSlotsPerType bundles the active row (or nil if none) plus the
+// recent-history rows for a single slot_type. Keeping the shape per-type
+// rather than a flat list lets the admin UI render two parallel columns
+// without re-grouping.
+type FeaturedSlotsPerType struct {
+	SlotType string                 `json:"slot_type"`
+	Active   *FeaturedSlotResponse  `json:"active,omitempty"`
+	History  []FeaturedSlotResponse `json:"history"`
+}
+
+// ListFeaturedSlotsResponse is the wire shape for GET /admin/featured-slots.
+type ListFeaturedSlotsResponse struct {
+	Body struct {
+		Slots []FeaturedSlotsPerType `json:"slots"`
+	}
+}
+
+// ListFeaturedSlotsHandler handles GET /admin/featured-slots — returns
+// the current active row + recent history for both slot types.
+func (h *FeaturedSlotHandler) ListFeaturedSlotsHandler(ctx context.Context, req *ListFeaturedSlotsRequest) (*ListFeaturedSlotsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	limit := req.HistoryLimit
+	if limit <= 0 {
+		limit = 5
+	}
+
+	slotTypes := []string{adminm.FeaturedSlotTypeBill, adminm.FeaturedSlotTypeCollection}
+	out := make([]FeaturedSlotsPerType, 0, len(slotTypes))
+
+	for _, slotType := range slotTypes {
+		entry := FeaturedSlotsPerType{SlotType: slotType, History: []FeaturedSlotResponse{}}
+
+		active, err := h.featuredSlotService.GetActiveSlot(slotType)
+		if err != nil && !errors.Is(err, adminsvc.ErrFeaturedSlotNotFound) {
+			logger.FromContext(ctx).Error("admin_list_featured_slots_get_active_failed",
+				"slot_type", slotType,
+				"error", err.Error(),
+				"request_id", requestID,
+			)
+			return nil, huma.Error500InternalServerError(
+				fmt.Sprintf("Failed to load featured slots (request_id: %s)", requestID),
+			)
+		}
+		if active != nil {
+			r := h.toResponse(active)
+			entry.Active = &r
+		}
+
+		history, err := h.featuredSlotService.ListRecent(slotType, limit)
+		if err != nil {
+			logger.FromContext(ctx).Error("admin_list_featured_slots_history_failed",
+				"slot_type", slotType,
+				"error", err.Error(),
+				"request_id", requestID,
+			)
+			return nil, huma.Error500InternalServerError(
+				fmt.Sprintf("Failed to load featured slots (request_id: %s)", requestID),
+			)
+		}
+		for i := range history {
+			entry.History = append(entry.History, h.toResponse(&history[i]))
+		}
+
+		out = append(out, entry)
+	}
+
+	resp := &ListFeaturedSlotsResponse{}
+	resp.Body.Slots = out
+	return resp, nil
+}
+
+// --- Set active slot ---
+
+// SetFeaturedSlotRequest is the Huma request for POST /admin/featured-slots.
+// EntityID is the show ID (slot_type=bill) or collection ID
+// (slot_type=collection); the service does not validate the referent
+// exists — that's the calling admin tool's job, mirroring how
+// pending_entity_edits trusts the referenced entity_id.
+type SetFeaturedSlotRequest struct {
+	Body struct {
+		SlotType    string  `json:"slot_type" doc:"One of 'bill' or 'collection'"`
+		EntityID    uint    `json:"entity_id" doc:"Show ID (for bill) or Collection ID (for collection)"`
+		CuratorNote *string `json:"curator_note,omitempty" doc:"Optional markdown curator note"`
+	}
+}
+
+// SetFeaturedSlotResponse wraps the new active row.
+type SetFeaturedSlotResponse struct {
+	Body FeaturedSlotResponse `json:"body"`
+}
+
+// SetFeaturedSlotHandler handles POST /admin/featured-slots — atomic
+// retire + insert. The previous active row's active_until is set to
+// NOW() and a new active row is inserted, both inside one transaction.
+func (h *FeaturedSlotHandler) SetFeaturedSlotHandler(ctx context.Context, req *SetFeaturedSlotRequest) (*SetFeaturedSlotResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+	user := middleware.GetUserFromContext(ctx)
+
+	if !adminm.IsValidFeaturedSlotType(req.Body.SlotType) {
+		return nil, huma.Error400BadRequest("slot_type must be 'bill' or 'collection'")
+	}
+	if req.Body.EntityID == 0 {
+		return nil, huma.Error400BadRequest("entity_id is required")
+	}
+	if req.Body.CuratorNote != nil && len(*req.Body.CuratorNote) > adminm.MaxFeaturedSlotCuratorNoteLength {
+		return nil, huma.Error400BadRequest(
+			fmt.Sprintf("curator_note exceeds maximum length of %d characters", adminm.MaxFeaturedSlotCuratorNoteLength),
+		)
+	}
+
+	logger.FromContext(ctx).Debug("admin_set_featured_slot_attempt",
+		"slot_type", req.Body.SlotType,
+		"entity_id", req.Body.EntityID,
+		"admin_id", user.ID,
+	)
+
+	slot, err := h.featuredSlotService.SetActiveSlot(req.Body.SlotType, req.Body.EntityID, req.Body.CuratorNote, user.ID)
+	if err != nil {
+		logger.FromContext(ctx).Error("admin_set_featured_slot_failed",
+			"slot_type", req.Body.SlotType,
+			"entity_id", req.Body.EntityID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error422UnprocessableEntity(
+			fmt.Sprintf("Failed to set featured slot (request_id: %s)", requestID),
+		)
+	}
+
+	h.auditLogService.LogAction(user.ID, "set_featured_slot", "featured_slot", slot.ID, map[string]interface{}{
+		"slot_type": slot.SlotType,
+		"entity_id": slot.EntityID,
+	})
+
+	logger.FromContext(ctx).Info("admin_set_featured_slot_success",
+		"slot_id", slot.ID,
+		"slot_type", slot.SlotType,
+		"entity_id", slot.EntityID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &SetFeaturedSlotResponse{Body: h.toResponse(slot)}, nil
+}
+
+// --- Retire active slot ---
+
+// DeleteFeaturedSlotRequest is the Huma request for DELETE /admin/featured-slots/{slot_type}.
+type DeleteFeaturedSlotRequest struct {
+	SlotType string `path:"slot_type" doc:"One of 'bill' or 'collection'"`
+}
+
+// DeleteFeaturedSlotResponse is the wire shape for the retire response.
+type DeleteFeaturedSlotResponse struct {
+	Body struct {
+		SlotType string `json:"slot_type"`
+		Message  string `json:"message"`
+	}
+}
+
+// DeleteFeaturedSlotHandler handles DELETE /admin/featured-slots/{slot_type} —
+// retires the active row without replacement. Idempotent at the API
+// surface: a second DELETE returns 404 (no active row to retire).
+func (h *FeaturedSlotHandler) DeleteFeaturedSlotHandler(ctx context.Context, req *DeleteFeaturedSlotRequest) (*DeleteFeaturedSlotResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+	user := middleware.GetUserFromContext(ctx)
+
+	if !adminm.IsValidFeaturedSlotType(req.SlotType) {
+		return nil, huma.Error400BadRequest("slot_type must be 'bill' or 'collection'")
+	}
+
+	logger.FromContext(ctx).Debug("admin_retire_featured_slot_attempt",
+		"slot_type", req.SlotType,
+		"admin_id", user.ID,
+	)
+
+	if err := h.featuredSlotService.RetireActiveSlot(req.SlotType, user.ID); err != nil {
+		if errors.Is(err, adminsvc.ErrFeaturedSlotNotFound) {
+			return nil, huma.Error404NotFound(
+				fmt.Sprintf("No active %s slot to retire", req.SlotType),
+			)
+		}
+		logger.FromContext(ctx).Error("admin_retire_featured_slot_failed",
+			"slot_type", req.SlotType,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error422UnprocessableEntity(
+			fmt.Sprintf("Failed to retire featured slot (request_id: %s)", requestID),
+		)
+	}
+
+	h.auditLogService.LogAction(user.ID, "retire_featured_slot", "featured_slot", 0, map[string]interface{}{
+		"slot_type": req.SlotType,
+	})
+
+	logger.FromContext(ctx).Info("admin_retire_featured_slot_success",
+		"slot_type", req.SlotType,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	resp := &DeleteFeaturedSlotResponse{}
+	resp.Body.SlotType = req.SlotType
+	resp.Body.Message = "Featured slot retired"
+	return resp, nil
+}
+
+// toResponse maps a FeaturedSlot model to the wire shape, rendering the
+// curator_note markdown to sanitized HTML in the same step. Keeps the
+// rendering boundary single — the markdown source on disk stays the
+// source of truth.
+func (h *FeaturedSlotHandler) toResponse(slot *adminm.FeaturedSlot) FeaturedSlotResponse {
+	return FeaturedSlotResponse{
+		ID:              slot.ID,
+		SlotType:        slot.SlotType,
+		EntityID:        slot.EntityID,
+		CuratorNote:     slot.CuratorNote,
+		CuratorNoteHTML: h.featuredSlotService.RenderCuratorNote(slot.CuratorNote),
+		ActiveFrom:      slot.ActiveFrom,
+		ActiveUntil:     slot.ActiveUntil,
+		CreatedBy:       slot.CreatedBy,
+		CreatedAt:       slot.CreatedAt,
+		UpdatedAt:       slot.UpdatedAt,
+	}
+}

--- a/backend/internal/api/handlers/admin/featured_slot_test.go
+++ b/backend/internal/api/handlers/admin/featured_slot_test.go
@@ -1,0 +1,244 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	adminm "psychic-homily-backend/internal/models/admin"
+)
+
+// FeaturedSlotHandlerIntegrationSuite exercises the admin featured-slot
+// endpoints end-to-end against a real Postgres test container. The
+// service layer is unit-tested separately
+// (services/admin/featured_slot_test.go); this suite focuses on the HTTP
+// boundary — validation, audit-log wiring, and atomic POST replace +
+// DELETE retire behaviour from the handler's perspective.
+type FeaturedSlotHandlerIntegrationSuite struct {
+	suite.Suite
+	deps               *testhelpers.IntegrationDeps
+	featuredSlotHandler *FeaturedSlotHandler
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) SetupSuite() {
+	s.deps = testhelpers.SetupIntegrationDeps(s.T())
+	s.featuredSlotHandler = NewFeaturedSlotHandler(
+		s.deps.FeaturedSlotService,
+		s.deps.AuditLogService,
+	)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TearDownTest() {
+	testhelpers.CleanupTables(s.deps.DB)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TearDownSuite() {
+	s.deps.TestDB.Cleanup()
+}
+
+func TestFeaturedSlotHandlerIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(FeaturedSlotHandlerIntegrationSuite))
+}
+
+// =============================================================================
+// List
+// =============================================================================
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestList_EmptyReturnsBothSlots() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	resp, err := s.featuredSlotHandler.ListFeaturedSlotsHandler(ctx, &ListFeaturedSlotsRequest{HistoryLimit: 5})
+	s.Require().NoError(err)
+	s.Require().Len(resp.Body.Slots, 2, "always returns both slot_type entries")
+	s.Equal(adminm.FeaturedSlotTypeBill, resp.Body.Slots[0].SlotType)
+	s.Nil(resp.Body.Slots[0].Active)
+	s.Empty(resp.Body.Slots[0].History)
+	s.Equal(adminm.FeaturedSlotTypeCollection, resp.Body.Slots[1].SlotType)
+	s.Nil(resp.Body.Slots[1].Active)
+	s.Empty(resp.Body.Slots[1].History)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestList_AfterSetIncludesActiveAndHistory() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	// Two bill picks → most-recent active, one in history.
+	note1 := "first"
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, &SetFeaturedSlotRequest{
+		Body: struct {
+			SlotType    string  `json:"slot_type" doc:"One of 'bill' or 'collection'"`
+			EntityID    uint    `json:"entity_id" doc:"Show ID (for bill) or Collection ID (for collection)"`
+			CuratorNote *string `json:"curator_note,omitempty" doc:"Optional markdown curator note"`
+		}{SlotType: adminm.FeaturedSlotTypeBill, EntityID: 1, CuratorNote: &note1},
+	})
+	s.Require().NoError(err)
+
+	note2 := "second"
+	_, err = s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, &SetFeaturedSlotRequest{
+		Body: struct {
+			SlotType    string  `json:"slot_type" doc:"One of 'bill' or 'collection'"`
+			EntityID    uint    `json:"entity_id" doc:"Show ID (for bill) or Collection ID (for collection)"`
+			CuratorNote *string `json:"curator_note,omitempty" doc:"Optional markdown curator note"`
+		}{SlotType: adminm.FeaturedSlotTypeBill, EntityID: 2, CuratorNote: &note2},
+	})
+	s.Require().NoError(err)
+
+	resp, err := s.featuredSlotHandler.ListFeaturedSlotsHandler(ctx, &ListFeaturedSlotsRequest{HistoryLimit: 5})
+	s.Require().NoError(err)
+	s.Require().Len(resp.Body.Slots, 2)
+
+	billSlot := resp.Body.Slots[0]
+	s.Require().NotNil(billSlot.Active)
+	s.Equal(uint(2), billSlot.Active.EntityID)
+	s.Len(billSlot.History, 2)
+}
+
+// =============================================================================
+// Set
+// =============================================================================
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_Success_FirstPick() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	note := "**killer** bill"
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeBill
+	req.Body.EntityID = 7
+	req.Body.CuratorNote = &note
+
+	resp, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	s.Require().NoError(err)
+	s.Equal(adminm.FeaturedSlotTypeBill, resp.Body.SlotType)
+	s.Equal(uint(7), resp.Body.EntityID)
+	s.Require().NotNil(resp.Body.CuratorNote)
+	s.Equal("**killer** bill", *resp.Body.CuratorNote)
+	s.Contains(resp.Body.CuratorNoteHTML, "<strong>killer</strong>")
+	s.Nil(resp.Body.ActiveUntil)
+	s.Equal(admin.ID, resp.Body.CreatedBy)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_AtomicallyReplacesPrior() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	first := &SetFeaturedSlotRequest{}
+	first.Body.SlotType = adminm.FeaturedSlotTypeBill
+	first.Body.EntityID = 1
+	firstResp, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, first)
+	s.Require().NoError(err)
+	firstID := firstResp.Body.ID
+
+	second := &SetFeaturedSlotRequest{}
+	second.Body.SlotType = adminm.FeaturedSlotTypeBill
+	second.Body.EntityID = 2
+	secondResp, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, second)
+	s.Require().NoError(err)
+	s.NotEqual(firstID, secondResp.Body.ID)
+
+	// List shows new active + old in history.
+	listResp, err := s.featuredSlotHandler.ListFeaturedSlotsHandler(ctx, &ListFeaturedSlotsRequest{HistoryLimit: 5})
+	s.Require().NoError(err)
+	billSlot := listResp.Body.Slots[0]
+	s.Require().NotNil(billSlot.Active)
+	s.Equal(uint(2), billSlot.Active.EntityID)
+	s.Len(billSlot.History, 2)
+
+	// Look up prior row in history — active_until must be set.
+	var priorEntry *FeaturedSlotResponse
+	for i := range billSlot.History {
+		if billSlot.History[i].ID == firstID {
+			priorEntry = &billSlot.History[i]
+			break
+		}
+	}
+	s.Require().NotNil(priorEntry)
+	s.Require().NotNil(priorEntry.ActiveUntil)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_InvalidSlotTypeRejected() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = "scene"
+	req.Body.EntityID = 1
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 400)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_ZeroEntityIDRejected() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeBill
+	req.Body.EntityID = 0
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 400)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_OverlengthCuratorNoteRejected() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	huge := make([]byte, adminm.MaxFeaturedSlotCuratorNoteLength+1)
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	note := string(huge)
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeBill
+	req.Body.EntityID = 1
+	req.Body.CuratorNote = &note
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 400)
+}
+
+// =============================================================================
+// Delete
+// =============================================================================
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestDelete_RetiresActive() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	setReq := &SetFeaturedSlotRequest{}
+	setReq.Body.SlotType = adminm.FeaturedSlotTypeBill
+	setReq.Body.EntityID = 1
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, setReq)
+	s.Require().NoError(err)
+
+	delResp, err := s.featuredSlotHandler.DeleteFeaturedSlotHandler(ctx, &DeleteFeaturedSlotRequest{SlotType: adminm.FeaturedSlotTypeBill})
+	s.Require().NoError(err)
+	s.Equal(adminm.FeaturedSlotTypeBill, delResp.Body.SlotType)
+
+	// List shows no active row + one historical row with active_until set.
+	listResp, err := s.featuredSlotHandler.ListFeaturedSlotsHandler(ctx, &ListFeaturedSlotsRequest{HistoryLimit: 5})
+	s.Require().NoError(err)
+	billSlot := listResp.Body.Slots[0]
+	s.Nil(billSlot.Active)
+	s.Len(billSlot.History, 1)
+	s.Require().NotNil(billSlot.History[0].ActiveUntil)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestDelete_NoActiveReturns404() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	_, err := s.featuredSlotHandler.DeleteFeaturedSlotHandler(ctx, &DeleteFeaturedSlotRequest{SlotType: adminm.FeaturedSlotTypeBill})
+	testhelpers.AssertHumaError(s.T(), err, 404)
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestDelete_InvalidSlotTypeRejected() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	_, err := s.featuredSlotHandler.DeleteFeaturedSlotHandler(ctx, &DeleteFeaturedSlotRequest{SlotType: "scene"})
+	testhelpers.AssertHumaError(s.T(), err, 400)
+}

--- a/backend/internal/api/handlers/admin/featured_slot_test.go
+++ b/backend/internal/api/handlers/admin/featured_slot_test.go
@@ -17,7 +17,7 @@ import (
 // DELETE retire behaviour from the handler's perspective.
 type FeaturedSlotHandlerIntegrationSuite struct {
 	suite.Suite
-	deps               *testhelpers.IntegrationDeps
+	deps                *testhelpers.IntegrationDeps
 	featuredSlotHandler *FeaturedSlotHandler
 }
 
@@ -69,23 +69,19 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestList_AfterSetIncludesActiveAnd
 
 	// Two bill picks → most-recent active, one in history.
 	note1 := "first"
-	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, &SetFeaturedSlotRequest{
-		Body: struct {
-			SlotType    string  `json:"slot_type" doc:"One of 'bill' or 'collection'"`
-			EntityID    uint    `json:"entity_id" doc:"Show ID (for bill) or Collection ID (for collection)"`
-			CuratorNote *string `json:"curator_note,omitempty" doc:"Optional markdown curator note"`
-		}{SlotType: adminm.FeaturedSlotTypeBill, EntityID: 1, CuratorNote: &note1},
-	})
+	first := &SetFeaturedSlotRequest{}
+	first.Body.SlotType = adminm.FeaturedSlotTypeBill
+	first.Body.EntityID = 1
+	first.Body.CuratorNote = &note1
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, first)
 	s.Require().NoError(err)
 
 	note2 := "second"
-	_, err = s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, &SetFeaturedSlotRequest{
-		Body: struct {
-			SlotType    string  `json:"slot_type" doc:"One of 'bill' or 'collection'"`
-			EntityID    uint    `json:"entity_id" doc:"Show ID (for bill) or Collection ID (for collection)"`
-			CuratorNote *string `json:"curator_note,omitempty" doc:"Optional markdown curator note"`
-		}{SlotType: adminm.FeaturedSlotTypeBill, EntityID: 2, CuratorNote: &note2},
-	})
+	second := &SetFeaturedSlotRequest{}
+	second.Body.SlotType = adminm.FeaturedSlotTypeBill
+	second.Body.EntityID = 2
+	second.Body.CuratorNote = &note2
+	_, err = s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, second)
 	s.Require().NoError(err)
 
 	resp, err := s.featuredSlotHandler.ListFeaturedSlotsHandler(ctx, &ListFeaturedSlotsRequest{HistoryLimit: 5})

--- a/backend/internal/api/handlers/admin/test_fixtures_allowlist_test.go
+++ b/backend/internal/api/handlers/admin/test_fixtures_allowlist_test.go
@@ -107,6 +107,11 @@ var testFixturesAllowlistContractSkips = map[string]string{
 
 	// Profile — preferences-style rows, not test artifacts.
 	"user_profile_sections": "preferences-style; upserted, not user-mutated in E2E",
+
+	// Admin-curated /explore editorial slots — created_by FK is to the
+	// admin who set the pick, not to test fixture users; the slots are
+	// global, not per-user. Revisit if E2E adds an admin-curation flow.
+	"featured_slots": "admin-curated global picks; not part of per-user E2E mutating flows",
 }
 
 // TestAllowlistCoversAllUserFKTables queries information_schema for every

--- a/backend/internal/api/handlers/shared/testhelpers/integration_deps.go
+++ b/backend/internal/api/handlers/shared/testhelpers/integration_deps.go
@@ -34,6 +34,7 @@ type IntegrationDeps struct {
 	ShowReportService         *adminsvc.ShowReportService
 	UserService               *usersvc.UserService
 	AuditLogService           *adminsvc.AuditLogService
+	FeaturedSlotService       *adminsvc.FeaturedSlotService
 	DiscordService            *notification.DiscordService
 	ExtractionService         *pipeline.ExtractionService
 	APITokenService           *adminsvc.APITokenService
@@ -73,6 +74,7 @@ func SetupIntegrationDeps(t *testing.T) *IntegrationDeps {
 		ShowReportService:         adminsvc.NewShowReportService(db),
 		UserService:               usersvc.NewUserService(db),
 		AuditLogService:           adminsvc.NewAuditLogService(db),
+		FeaturedSlotService:       adminsvc.NewFeaturedSlotService(db),
 		DiscordService:            notification.NewDiscordService(emptyCfg),
 		ExtractionService:         pipeline.NewExtractionService(db, emptyCfg, catalog.NewArtistService(db), catalog.NewVenueService(db)),
 		APITokenService:           adminsvc.NewAPITokenService(db),
@@ -148,6 +150,8 @@ func CleanupTables(db *gorm.DB) {
 	// drop tags before users so tag cleanup doesn't see orphaned rows.
 	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
 	_, _ = sqlDB.Exec("DELETE FROM tags")
+	// featured_slots.created_by FK → users; clear before users.
+	_, _ = sqlDB.Exec("DELETE FROM featured_slots")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1603,6 +1603,49 @@ func (m *MockFavoriteVenueService) GetFavoriteVenueIDs(userID uint, venueIDs []u
 }
 
 // ============================================================================
+// Mock: FeaturedSlotServiceInterface
+// ============================================================================
+
+type MockFeaturedSlotService struct {
+	GetActiveSlotFn     func(string) (*adminm.FeaturedSlot, error)
+	ListRecentFn        func(string, int) ([]adminm.FeaturedSlot, error)
+	SetActiveSlotFn     func(string, uint, *string, uint) (*adminm.FeaturedSlot, error)
+	RetireActiveSlotFn  func(string, uint) error
+	RenderCuratorNoteFn func(*string) string
+}
+
+func (m *MockFeaturedSlotService) GetActiveSlot(slotType string) (*adminm.FeaturedSlot, error) {
+	if m.GetActiveSlotFn != nil {
+		return m.GetActiveSlotFn(slotType)
+	}
+	return nil, nil
+}
+func (m *MockFeaturedSlotService) ListRecent(slotType string, limit int) ([]adminm.FeaturedSlot, error) {
+	if m.ListRecentFn != nil {
+		return m.ListRecentFn(slotType, limit)
+	}
+	return nil, nil
+}
+func (m *MockFeaturedSlotService) SetActiveSlot(slotType string, entityID uint, curatorNote *string, userID uint) (*adminm.FeaturedSlot, error) {
+	if m.SetActiveSlotFn != nil {
+		return m.SetActiveSlotFn(slotType, entityID, curatorNote, userID)
+	}
+	return nil, nil
+}
+func (m *MockFeaturedSlotService) RetireActiveSlot(slotType string, userID uint) error {
+	if m.RetireActiveSlotFn != nil {
+		return m.RetireActiveSlotFn(slotType, userID)
+	}
+	return nil
+}
+func (m *MockFeaturedSlotService) RenderCuratorNote(note *string) string {
+	if m.RenderCuratorNoteFn != nil {
+		return m.RenderCuratorNoteFn(note)
+	}
+	return ""
+}
+
+// ============================================================================
 // Mock: FestivalIntelligenceServiceInterface
 // ============================================================================
 
@@ -4020,6 +4063,7 @@ var _ contracts.EnrichmentServiceInterface = (*MockEnrichmentService)(nil)
 var _ contracts.EntityReportServiceInterface = (*MockEntityReportService)(nil)
 var _ contracts.ExtractionServiceInterface = (*MockExtractionService)(nil)
 var _ contracts.FavoriteVenueServiceInterface = (*MockFavoriteVenueService)(nil)
+var _ contracts.FeaturedSlotServiceInterface = (*MockFeaturedSlotService)(nil)
 var _ contracts.FestivalIntelligenceServiceInterface = (*MockFestivalIntelligenceService)(nil)
 var _ contracts.FestivalServiceInterface = (*MockFestivalService)(nil)
 var _ contracts.FieldNoteServiceInterface = (*MockFieldNoteService)(nil)

--- a/backend/internal/api/routes/admin.go
+++ b/backend/internal/api/routes/admin.go
@@ -103,4 +103,12 @@ func setupAdminRoutes(rc RouteContext) {
 	huma.Get(rc.Admin, "/admin/analytics/engagement", analyticsHandler.GetEngagementMetricsHandler)
 	huma.Get(rc.Admin, "/admin/analytics/community", analyticsHandler.GetCommunityHealthHandler)
 	huma.Get(rc.Admin, "/admin/analytics/data-quality", analyticsHandler.GetDataQualityTrendsHandler)
+
+	// Admin featured-slot endpoints (PSY-835): the /explore landing has two
+	// admin-curated editorial slots — Featured Bill + Featured Collection —
+	// curated on whatever cadence the admin chooses.
+	featuredSlotHandler := adminh.NewFeaturedSlotHandler(rc.SC.FeaturedSlot, rc.SC.AuditLog)
+	huma.Get(rc.Admin, "/admin/featured-slots", featuredSlotHandler.ListFeaturedSlotsHandler)
+	huma.Post(rc.Admin, "/admin/featured-slots", featuredSlotHandler.SetFeaturedSlotHandler)
+	huma.Delete(rc.Admin, "/admin/featured-slots/{slot_type}", featuredSlotHandler.DeleteFeaturedSlotHandler)
 }

--- a/backend/internal/api/routes/admin.go
+++ b/backend/internal/api/routes/admin.go
@@ -104,8 +104,8 @@ func setupAdminRoutes(rc RouteContext) {
 	huma.Get(rc.Admin, "/admin/analytics/community", analyticsHandler.GetCommunityHealthHandler)
 	huma.Get(rc.Admin, "/admin/analytics/data-quality", analyticsHandler.GetDataQualityTrendsHandler)
 
-	// Admin featured-slot endpoints (PSY-835): the /explore landing has two
-	// admin-curated editorial slots — Featured Bill + Featured Collection —
+	// Admin featured-slot endpoints — the /explore landing has two
+	// admin-curated editorial slots (Featured Bill + Featured Collection)
 	// curated on whatever cadence the admin chooses.
 	featuredSlotHandler := adminh.NewFeaturedSlotHandler(rc.SC.FeaturedSlot, rc.SC.AuditLog)
 	huma.Get(rc.Admin, "/admin/featured-slots", featuredSlotHandler.ListFeaturedSlotsHandler)

--- a/backend/internal/models/admin/featured_slot.go
+++ b/backend/internal/models/admin/featured_slot.go
@@ -1,0 +1,53 @@
+package admin
+
+import (
+	"time"
+
+	"psychic-homily-backend/internal/models/auth"
+)
+
+// Featured-slot type discriminators. The /explore landing has two
+// admin-curated editorial slots: a Featured Bill (a show) and a Featured
+// Collection. entity_id resolves to the corresponding table by slot_type
+// at the service layer — there is no DB-level FK because the referent
+// table varies (polymorphic, mirrors pending_entity_edits).
+const (
+	FeaturedSlotTypeBill       = "bill"
+	FeaturedSlotTypeCollection = "collection"
+)
+
+// MaxFeaturedSlotCuratorNoteLength caps the per-pick editorial note. The
+// 10,000-character mirror of comment / field-note bodies keeps the
+// markdown renderer / sanitizer policy consistent across surfaces.
+const MaxFeaturedSlotCuratorNoteLength = 10000
+
+// IsValidFeaturedSlotType reports whether s is one of the recognised
+// slot types. Used by service + handler input validation before hitting
+// the DB CHECK constraint.
+func IsValidFeaturedSlotType(s string) bool {
+	return s == FeaturedSlotTypeBill || s == FeaturedSlotTypeCollection
+}
+
+// FeaturedSlot is a single admin-curated pick for the /explore landing.
+// One row per slot_type is active at a time (active_until IS NULL),
+// enforced by a partial unique index. Setting a new active row retires
+// the previous one (active_until = NOW()) atomically inside a
+// transaction so the unique-index invariant always holds.
+type FeaturedSlot struct {
+	ID          uint       `gorm:"primaryKey"`
+	SlotType    string     `gorm:"column:slot_type;not null"`
+	EntityID    uint       `gorm:"column:entity_id;not null"`
+	CuratorNote *string    `gorm:"column:curator_note"`
+	ActiveFrom  time.Time  `gorm:"column:active_from;not null"`
+	ActiveUntil *time.Time `gorm:"column:active_until"`
+	CreatedBy   uint       `gorm:"column:created_by;not null"`
+	CreatedAt   time.Time  `gorm:"not null"`
+	UpdatedAt   time.Time  `gorm:"not null"`
+
+	Creator auth.User `gorm:"foreignKey:CreatedBy"`
+}
+
+// TableName specifies the table name for FeaturedSlot.
+func (FeaturedSlot) TableName() string {
+	return "featured_slots"
+}

--- a/backend/internal/services/admin/featured_slot.go
+++ b/backend/internal/services/admin/featured_slot.go
@@ -1,0 +1,187 @@
+package admin
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	adminm "psychic-homily-backend/internal/models/admin"
+	"psychic-homily-backend/internal/utils"
+)
+
+// ErrFeaturedSlotNotFound is returned when no active slot exists for the
+// requested slot_type, or no row matches a more specific lookup. Allows
+// the handler to distinguish "no active pick" (which is a 404 — the
+// slot simply isn't curated yet) from real I/O errors.
+var ErrFeaturedSlotNotFound = errors.New("featured slot not found")
+
+// FeaturedSlotService manages the admin-curated /explore editorial slots.
+// One row per slot_type is active at any time (active_until IS NULL);
+// activation atomically retires the previous active row inside a
+// transaction so the partial unique index always holds.
+//
+// The curator_note column is markdown rendered with the shared
+// utils.MarkdownRenderer (goldmark + bluemonday) on read. Sanitization
+// happens at the rendering boundary, mirroring how CollectionService
+// treats Collection.Description.
+type FeaturedSlotService struct {
+	db *gorm.DB
+	md *utils.MarkdownRenderer
+}
+
+// NewFeaturedSlotService creates a new featured-slot service. The DB
+// handle falls back to the package singleton so older test paths using
+// the bare-struct literal still resolve a connection.
+func NewFeaturedSlotService(database *gorm.DB) *FeaturedSlotService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &FeaturedSlotService{
+		db: database,
+		md: utils.NewMarkdownRenderer(),
+	}
+}
+
+// GetActiveSlot returns the currently active row for slot_type (the one
+// with active_until IS NULL), preloading the curator. Returns
+// (nil, ErrFeaturedSlotNotFound) when the slot has never been set or is
+// currently retired without replacement; callers map that to HTTP 404.
+func (s *FeaturedSlotService) GetActiveSlot(slotType string) (*adminm.FeaturedSlot, error) {
+	if !adminm.IsValidFeaturedSlotType(slotType) {
+		return nil, fmt.Errorf("invalid slot type: %s", slotType)
+	}
+
+	var slot adminm.FeaturedSlot
+	err := s.db.Preload("Creator").
+		Where("slot_type = ? AND active_until IS NULL", slotType).
+		First(&slot).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrFeaturedSlotNotFound
+		}
+		return nil, fmt.Errorf("failed to get active featured slot: %w", err)
+	}
+	return &slot, nil
+}
+
+// ListRecent returns the last `limit` rows for slot_type ordered by
+// created_at DESC, including retired and currently-active entries. Used
+// by the admin "recent picks" listing so curators can see what they've
+// shipped without trawling the audit log.
+func (s *FeaturedSlotService) ListRecent(slotType string, limit int) ([]adminm.FeaturedSlot, error) {
+	if !adminm.IsValidFeaturedSlotType(slotType) {
+		return nil, fmt.Errorf("invalid slot type: %s", slotType)
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	var slots []adminm.FeaturedSlot
+	err := s.db.Preload("Creator").
+		Where("slot_type = ?", slotType).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&slots).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list featured slots: %w", err)
+	}
+	return slots, nil
+}
+
+// SetActiveSlot atomically retires the currently active row (if any)
+// for slot_type by setting its active_until to NOW(), then inserts a
+// new active row. Wrapped in a transaction so the partial unique index
+// (slot_type WHERE active_until IS NULL) never sees two active rows in
+// the same window — a concurrent set on the same slot_type fails fast
+// with a 23505 unique violation rather than corrupting state.
+//
+// curatorNote is stored verbatim (markdown source); rendering happens at
+// the handler / response boundary via RenderCuratorNote.
+func (s *FeaturedSlotService) SetActiveSlot(slotType string, entityID uint, curatorNote *string, userID uint) (*adminm.FeaturedSlot, error) {
+	if !adminm.IsValidFeaturedSlotType(slotType) {
+		return nil, fmt.Errorf("invalid slot type: %s", slotType)
+	}
+	if entityID == 0 {
+		return nil, fmt.Errorf("entity_id is required")
+	}
+	if userID == 0 {
+		return nil, fmt.Errorf("user_id is required")
+	}
+	if curatorNote != nil && len(*curatorNote) > adminm.MaxFeaturedSlotCuratorNoteLength {
+		return nil, fmt.Errorf("curator_note exceeds maximum length of %d characters", adminm.MaxFeaturedSlotCuratorNoteLength)
+	}
+
+	var created adminm.FeaturedSlot
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		now := time.Now().UTC()
+		// Retire the currently active row, if any. Update returns 0
+		// rows affected on first-ever set, which is fine.
+		if err := tx.Model(&adminm.FeaturedSlot{}).
+			Where("slot_type = ? AND active_until IS NULL", slotType).
+			Update("active_until", now).Error; err != nil {
+			return fmt.Errorf("failed to retire active featured slot: %w", err)
+		}
+
+		created = adminm.FeaturedSlot{
+			SlotType:    slotType,
+			EntityID:    entityID,
+			CuratorNote: curatorNote,
+			ActiveFrom:  now,
+			CreatedBy:   userID,
+		}
+		if err := tx.Create(&created).Error; err != nil {
+			return fmt.Errorf("failed to create featured slot: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Re-fetch with Creator preloaded so the response carries the same
+	// shape as GetActiveSlot.
+	return s.GetActiveSlot(slotType)
+}
+
+// RetireActiveSlot retires the currently active row for slot_type
+// without replacement. Returns ErrFeaturedSlotNotFound if no row is
+// currently active. The slot then has no active row until a curator
+// sets a new one via SetActiveSlot.
+func (s *FeaturedSlotService) RetireActiveSlot(slotType string, userID uint) error {
+	if !adminm.IsValidFeaturedSlotType(slotType) {
+		return fmt.Errorf("invalid slot type: %s", slotType)
+	}
+	if userID == 0 {
+		return fmt.Errorf("user_id is required")
+	}
+
+	now := time.Now().UTC()
+	res := s.db.Model(&adminm.FeaturedSlot{}).
+		Where("slot_type = ? AND active_until IS NULL", slotType).
+		Update("active_until", now)
+	if res.Error != nil {
+		return fmt.Errorf("failed to retire featured slot: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrFeaturedSlotNotFound
+	}
+	return nil
+}
+
+// RenderCuratorNote returns the sanitized HTML for a slot's curator
+// note, or "" when the note is empty or nil. Centralised here so the
+// admin handler and any future read-side consumer share one rendering
+// path — the markdown source on disk is always the source of truth and
+// sanitization is applied on every render.
+func (s *FeaturedSlotService) RenderCuratorNote(note *string) string {
+	if note == nil || *note == "" {
+		return ""
+	}
+	if s.md == nil {
+		s.md = utils.NewMarkdownRenderer()
+	}
+	return s.md.Render(*note)
+}

--- a/backend/internal/services/admin/featured_slot_test.go
+++ b/backend/internal/services/admin/featured_slot_test.go
@@ -1,0 +1,338 @@
+package admin
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	adminm "psychic-homily-backend/internal/models/admin"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// INTEGRATION TESTS (Real Postgres via testcontainers)
+// =============================================================================
+
+type FeaturedSlotServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB              *testutil.TestDatabase
+	db                  *gorm.DB
+	featuredSlotService *FeaturedSlotService
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.featuredSlotService = NewFeaturedSlotService(suite.testDB.DB)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM featured_slots")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestFeaturedSlotServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(FeaturedSlotServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) createAdmin(name string) *authm.User {
+	email := fmt.Sprintf("%s-%d@test.com", name, time.Now().UnixNano())
+	user := &authm.User{
+		Email:         &email,
+		FirstName:     &name,
+		IsActive:      true,
+		IsAdmin:       true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+// =============================================================================
+// GetActiveSlot
+// =============================================================================
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestGetActiveSlot_EmptyReturnsNotFound() {
+	_, err := suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotNotFound))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestGetActiveSlot_InvalidSlotTypeRejected() {
+	_, err := suite.featuredSlotService.GetActiveSlot("not-a-slot")
+	suite.Require().Error(err)
+	suite.False(errors.Is(err, ErrFeaturedSlotNotFound))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestGetActiveSlot_PreloadsCreator() {
+	admin := suite.createAdmin("curator")
+	note := "First pick"
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 42, &note, admin.ID)
+	suite.Require().NoError(err)
+
+	slot, err := suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)
+	suite.Require().NoError(err)
+	suite.Equal(uint(42), slot.EntityID)
+	suite.Equal(admin.ID, slot.Creator.ID)
+	suite.Equal(*admin.Email, *slot.Creator.Email)
+}
+
+// =============================================================================
+// SetActiveSlot — atomic retire + insert is the load-bearing behavior
+// =============================================================================
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_FirstPick() {
+	admin := suite.createAdmin("curator")
+
+	note := "Killer bill"
+	slot, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 7, &note, admin.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(slot)
+	suite.Equal(adminm.FeaturedSlotTypeBill, slot.SlotType)
+	suite.Equal(uint(7), slot.EntityID)
+	suite.Require().NotNil(slot.CuratorNote)
+	suite.Equal("Killer bill", *slot.CuratorNote)
+	suite.Nil(slot.ActiveUntil, "first active row must have NULL active_until")
+	suite.Equal(admin.ID, slot.CreatedBy)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_ReplacesPriorAtomically() {
+	admin := suite.createAdmin("curator")
+
+	first, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	suite.Require().NoError(err)
+	firstID := first.ID
+
+	// Replace.
+	second, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 2, nil, admin.ID)
+	suite.Require().NoError(err)
+	suite.NotEqual(firstID, second.ID, "replacement must insert a new row")
+
+	// Verify exactly one active row of this slot_type exists.
+	var activeCount int64
+	suite.db.Model(&adminm.FeaturedSlot{}).
+		Where("slot_type = ? AND active_until IS NULL", adminm.FeaturedSlotTypeBill).
+		Count(&activeCount)
+	suite.Equal(int64(1), activeCount, "exactly one active row per slot_type")
+
+	// Verify the first row is now retired.
+	var prior adminm.FeaturedSlot
+	suite.Require().NoError(suite.db.First(&prior, firstID).Error)
+	suite.Require().NotNil(prior.ActiveUntil)
+	suite.True(prior.ActiveUntil.Before(time.Now().Add(time.Second)) || prior.ActiveUntil.Equal(time.Now()),
+		"prior active_until must be set to roughly NOW()")
+
+	// GetActiveSlot returns the new row.
+	active, err := suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)
+	suite.Require().NoError(err)
+	suite.Equal(second.ID, active.ID)
+	suite.Equal(uint(2), active.EntityID)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_SlotsIndependent() {
+	admin := suite.createAdmin("curator")
+
+	bill, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	suite.Require().NoError(err)
+	collection, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, 99, nil, admin.ID)
+	suite.Require().NoError(err)
+	suite.NotEqual(bill.ID, collection.ID)
+
+	// Both slot types have one active row each.
+	var billCount, collectionCount int64
+	suite.db.Model(&adminm.FeaturedSlot{}).
+		Where("slot_type = ? AND active_until IS NULL", adminm.FeaturedSlotTypeBill).
+		Count(&billCount)
+	suite.db.Model(&adminm.FeaturedSlot{}).
+		Where("slot_type = ? AND active_until IS NULL", adminm.FeaturedSlotTypeCollection).
+		Count(&collectionCount)
+	suite.Equal(int64(1), billCount)
+	suite.Equal(int64(1), collectionCount)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_InvalidSlotType() {
+	admin := suite.createAdmin("curator")
+	_, err := suite.featuredSlotService.SetActiveSlot("scene", 1, nil, admin.ID)
+	suite.Require().Error(err)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_ZeroEntityIDRejected() {
+	admin := suite.createAdmin("curator")
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 0, nil, admin.ID)
+	suite.Require().Error(err)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_ZeroUserIDRejected() {
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, 0)
+	suite.Require().Error(err)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_OverLengthNoteRejected() {
+	admin := suite.createAdmin("curator")
+	huge := make([]byte, adminm.MaxFeaturedSlotCuratorNoteLength+1)
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	note := string(huge)
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, &note, admin.ID)
+	suite.Require().Error(err)
+}
+
+// =============================================================================
+// Partial unique index — direct DB poke proves the constraint is real
+// =============================================================================
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestPartialUniqueIndex_RejectsTwoActiveOfSameType() {
+	admin := suite.createAdmin("curator")
+
+	// First active row via the service (one row, NULL active_until).
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	suite.Require().NoError(err)
+
+	// Direct INSERT bypassing the service to prove the partial unique
+	// index is what's holding the invariant, not just the service's
+	// transaction wrapper.
+	raw := suite.db.Exec(
+		"INSERT INTO featured_slots (slot_type, entity_id, created_by) VALUES (?, ?, ?)",
+		adminm.FeaturedSlotTypeBill, 2, admin.ID,
+	)
+	suite.Require().Error(raw.Error, "second active row of same slot_type must fail")
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestPartialUniqueIndex_AllowsManyRetiredOfSameType() {
+	admin := suite.createAdmin("curator")
+
+	// Three sets in sequence — at the end, one active + two retired.
+	for i := uint(1); i <= 3; i++ {
+		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, i, nil, admin.ID)
+		suite.Require().NoError(err)
+	}
+
+	var total, active int64
+	suite.db.Model(&adminm.FeaturedSlot{}).
+		Where("slot_type = ?", adminm.FeaturedSlotTypeBill).
+		Count(&total)
+	suite.db.Model(&adminm.FeaturedSlot{}).
+		Where("slot_type = ? AND active_until IS NULL", adminm.FeaturedSlotTypeBill).
+		Count(&active)
+	suite.Equal(int64(3), total)
+	suite.Equal(int64(1), active)
+}
+
+// =============================================================================
+// RetireActiveSlot
+// =============================================================================
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRetireActiveSlot_Success() {
+	admin := suite.createAdmin("curator")
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.featuredSlotService.RetireActiveSlot(adminm.FeaturedSlotTypeBill, admin.ID))
+
+	_, err = suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)
+	suite.True(errors.Is(err, ErrFeaturedSlotNotFound))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRetireActiveSlot_NoActiveReturnsNotFound() {
+	admin := suite.createAdmin("curator")
+	err := suite.featuredSlotService.RetireActiveSlot(adminm.FeaturedSlotTypeBill, admin.ID)
+	suite.True(errors.Is(err, ErrFeaturedSlotNotFound))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRetireActiveSlot_LeavesHistoryIntact() {
+	admin := suite.createAdmin("curator")
+	first, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.featuredSlotService.RetireActiveSlot(adminm.FeaturedSlotTypeBill, admin.ID))
+
+	// History row still exists, with active_until set.
+	var prior adminm.FeaturedSlot
+	suite.Require().NoError(suite.db.First(&prior, first.ID).Error)
+	suite.NotNil(prior.ActiveUntil)
+}
+
+// =============================================================================
+// ListRecent
+// =============================================================================
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_OrdersDescByCreatedAt() {
+	admin := suite.createAdmin("curator")
+
+	for i := uint(1); i <= 3; i++ {
+		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, i, nil, admin.ID)
+		suite.Require().NoError(err)
+		time.Sleep(2 * time.Millisecond) // ensure distinct created_at
+	}
+
+	history, err := suite.featuredSlotService.ListRecent(adminm.FeaturedSlotTypeBill, 5)
+	suite.Require().NoError(err)
+	suite.Len(history, 3)
+	// Most recent first — entity_id=3 was set last.
+	suite.Equal(uint(3), history[0].EntityID)
+	suite.Equal(uint(2), history[1].EntityID)
+	suite.Equal(uint(1), history[2].EntityID)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_RespectsLimit() {
+	admin := suite.createAdmin("curator")
+	for i := uint(1); i <= 5; i++ {
+		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, i, nil, admin.ID)
+		suite.Require().NoError(err)
+	}
+	history, err := suite.featuredSlotService.ListRecent(adminm.FeaturedSlotTypeBill, 2)
+	suite.Require().NoError(err)
+	suite.Len(history, 2)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_NoCrossContamination() {
+	admin := suite.createAdmin("curator")
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	suite.Require().NoError(err)
+	_, err = suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, 99, nil, admin.ID)
+	suite.Require().NoError(err)
+
+	bills, err := suite.featuredSlotService.ListRecent(adminm.FeaturedSlotTypeBill, 10)
+	suite.Require().NoError(err)
+	suite.Len(bills, 1)
+	suite.Equal(uint(1), bills[0].EntityID)
+}
+
+// =============================================================================
+// RenderCuratorNote
+// =============================================================================
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRenderCuratorNote_EmptyAndNil() {
+	suite.Equal("", suite.featuredSlotService.RenderCuratorNote(nil))
+	empty := ""
+	suite.Equal("", suite.featuredSlotService.RenderCuratorNote(&empty))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRenderCuratorNote_MarkdownToSanitizedHTML() {
+	note := "**bold** + *em*"
+	html := suite.featuredSlotService.RenderCuratorNote(&note)
+	suite.Contains(html, "<strong>bold</strong>")
+	suite.Contains(html, "<em>em</em>")
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRenderCuratorNote_StripsScript() {
+	note := "good text <script>alert(1)</script>"
+	html := suite.featuredSlotService.RenderCuratorNote(&note)
+	suite.NotContains(html, "<script>")
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -33,6 +33,7 @@ type ServiceContainer struct {
 	ContributorProfile     *usersvc.ContributorProfileService
 	ArtistReport           *adminsvc.ArtistReportService
 	AuditLog               *adminsvc.AuditLogService
+	FeaturedSlot           *adminsvc.FeaturedSlotService
 	Bookmark               *engagement.BookmarkService
 	Calendar               *engagement.CalendarService
 	Collection             *community.CollectionService
@@ -164,6 +165,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		ContributorProfile:     usersvc.NewContributorProfileService(database),
 		ArtistReport:           adminsvc.NewArtistReportService(database),
 		AuditLog:               adminsvc.NewAuditLogService(database),
+		FeaturedSlot:           adminsvc.NewFeaturedSlotService(database),
 		Bookmark:               engagement.NewBookmarkService(database),
 		Calendar:               engagement.NewCalendarService(database, savedShow),
 		Collection:             collectionSvc,

--- a/backend/internal/services/contracts/admin.go
+++ b/backend/internal/services/contracts/admin.go
@@ -472,3 +472,19 @@ type AnalyticsServiceInterface interface {
 	GetCommunityHealth() (*CommunityHealthResponse, error)
 	GetDataQualityTrends(months int) (*DataQualityTrendsResponse, error)
 }
+
+// ──────────────────────────────────────────────
+// Featured Slot Service Interface
+// ──────────────────────────────────────────────
+
+// FeaturedSlotServiceInterface defines the contract for the admin-curated
+// /explore editorial slots (Featured Bill + Featured Collection). One row
+// per slot_type is active at a time; activation atomically retires the
+// previous active row inside a transaction.
+type FeaturedSlotServiceInterface interface {
+	GetActiveSlot(slotType string) (*adminm.FeaturedSlot, error)
+	ListRecent(slotType string, limit int) ([]adminm.FeaturedSlot, error)
+	SetActiveSlot(slotType string, entityID uint, curatorNote *string, userID uint) (*adminm.FeaturedSlot, error)
+	RetireActiveSlot(slotType string, userID uint) error
+	RenderCuratorNote(note *string) string
+}


### PR DESCRIPTION
## Summary

- New `featured_slots` table + GORM model + service + 3 admin endpoints behind `rc.Admin` to support the two admin-curated editorial slots (Featured Bill, Featured Collection) on `/explore`. One active row per `slot_type` at a time, enforced by a partial unique index `(slot_type) WHERE active_until IS NULL`. Replacing a slot is an atomic retire-then-insert inside a transaction.
- No weekly-cadence framing in the implementation — admins curate on whatever cadence they choose; the active row stays visible until retired or replaced. Brief at `docs/open-questions/explore-landing.md` updated inline (docs/ is gitignored so it lives in the main repo, not this PR).
- Curator note is markdown rendered through the shared `utils.MarkdownRenderer` (goldmark + bluemonday) — no parallel sanitizer.

## Test plan

- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test ./internal/services/admin/... -run FeaturedSlot -v` — 20 service tests passed (atomic retire+insert, partial unique index direct-DB rejection, render+sanitize)
- [x] `cd backend && go test ./internal/api/handlers/admin/... -run FeaturedSlotHandler -v` — 10 handler tests passed
- [x] `cd backend && go test ./internal/api/handlers/admin/... ./internal/services/admin/...` — full package suites green
- [x] `cd backend && go test ./internal/models/admin/... ./internal/api/routes/...` — green
- [x] `cd backend && go test ./internal/services/...` — all services green (admin/auth/catalog/community/engagement/notification/pipeline/shared/user)
- [x] Migration round-trip — `migrate up` → `migrate down 1` → `migrate up 1` against ephemeral Postgres 18 container; table dropped + recreated cleanly. Partial unique index verified via `\d featured_slots`.
- [x] Partial unique index verified — direct `INSERT` of a second active row for the same `slot_type` rejected with `duplicate key value violates unique constraint "idx_featured_slots_active_per_type"` (Postgres 23505).

## Manual repro

Stack mode: `isolated` (per-worktree backend + Postgres). Authenticated as the E2E admin user (`e2e-admin@test.local`).

POST set bill (entity_id=56):
```
$ curl -sX POST $STACK_BACKEND_URL/admin/featured-slots -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"slot_type":"bill","entity_id":56,"curator_note":"**Killer** opening pick"}'
{
    "id": 1,
    "slot_type": "bill",
    "entity_id": 56,
    "curator_note": "**Killer** opening pick",
    "curator_note_html": "<p><strong>Killer</strong> opening pick</p>\n",
    "active_from": "2026-05-24T14:55:33.977845-07:00",
    "created_by": 6,
    "created_at": "2026-05-24T14:55:33.983649-07:00",
    "updated_at": "2026-05-24T14:55:33.983649-07:00"
}
```

GET list (active + history per slot_type):
```
$ curl -s $STACK_BACKEND_URL/admin/featured-slots -H "Authorization: Bearer $TOKEN"
{
    "slots": [
        {
            "slot_type": "bill",
            "active": {"id": 1, "slot_type": "bill", "entity_id": 56, ...},
            "history": [{"id": 1, ...}]
        },
        {"slot_type": "collection", "history": []}
    ]
}
```

POST replace bill (entity_id=57) — atomic retire+insert:
```
$ curl -sX POST $STACK_BACKEND_URL/admin/featured-slots -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"slot_type":"bill","entity_id":57,"curator_note":"Replacement pick"}'
{"id": 2, "slot_type": "bill", "entity_id": 57, "curator_note": "Replacement pick", ...}
```

POST collection (entity_id=1) — independent slot:
```
$ curl -sX POST $STACK_BACKEND_URL/admin/featured-slots ... -d '{"slot_type":"collection","entity_id":1,"curator_note":"Curated list"}'
{"id": 3, "slot_type": "collection", "entity_id": 1, ...}
```

DELETE bill — retire without replacement:
```
$ curl -sX DELETE $STACK_BACKEND_URL/admin/featured-slots/bill -H "Authorization: Bearer $TOKEN"
{"slot_type": "bill", "message": "Featured slot retired"}
```

DELETE bill again — 404 (no active row to retire):
```
$ curl -s -o /tmp/out.json -w 'HTTP_STATUS=%{http_code}\n' -X DELETE $STACK_BACKEND_URL/admin/featured-slots/bill ...
HTTP_STATUS=404
{"title":"Not Found","status":404,"detail":"No active bill slot to retire"}
```

psql history snapshot — rows 1+2 retired (active_until set, row #1's active_until equals row #2's active_from → atomic), row #3 collection still active:
```
$ psql $STACK_POSTGRES_URL -c "SELECT id, slot_type, entity_id, active_from, active_until FROM featured_slots ORDER BY id;"
 id | slot_type  | entity_id |          active_from          |         active_until
----+------------+-----------+-------------------------------+-------------------------------
  1 | bill       |        56 | 2026-05-24 21:55:33.977845+00 | 2026-05-24 21:55:42.496928+00
  2 | bill       |        57 | 2026-05-24 21:55:42.496928+00 | 2026-05-24 21:56:00.978677+00
  3 | collection |         1 | 2026-05-24 21:55:57.058515+00 |
(3 rows)
```

Partial unique index — direct INSERT bypassing the service rejects a duplicate active row:
```
$ psql $STACK_POSTGRES_URL -c "INSERT INTO featured_slots (slot_type, entity_id, created_by) VALUES ('collection', 999, 6);"
ERROR:  duplicate key value violates unique constraint "idx_featured_slots_active_per_type"
DETAIL:  Key (slot_type)=(collection) already exists.
```

## Simplify

Stripped two PSY-{N} refs from production doc comments (per `feedback_strip_ticket_refs_from_doc_comments`). Replaced anonymous struct literals with named-pointer-then-field-assign in one test for consistency with the rest of the suite. gofmt normalised `FeaturedSlotResponse` field alignment.

## Out of scope (per ticket)

- `/api/explore/*` consumer endpoints (PSY-836).
- Frontend admin page (PSY-838).
- Additional slot types beyond `bill` + `collection`.
- Automatic rotation / scheduling.

Closes PSY-835