### PR TITLE
PSY-841: PPR + Suspense auth hydration

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import localFont from 'next/font/local'
 import { Space_Mono } from 'next/font/google'
+import { Suspense } from 'react'
 import './globals.css'
 
 /* PSY-647 editorial type system — Fontshare (ITF License, self-hosted) + Google Fonts.
@@ -41,6 +42,7 @@ import {
   CookieConsentBanner,
   PostHogProvider,
   SidebarLayout,
+  AuthHydrator,
 } from '@/components/layout'
 import { CookieConsentProvider } from '@/lib/context/CookieConsentContext'
 import { JsonLd } from '@/components/seo/JsonLd'
@@ -107,10 +109,14 @@ export default function RootLayout({
           >
             <CookieConsentProvider>
               <PostHogProvider>
-                <SidebarLayout>
-                  <main className="flex-1">{children}</main>
-                  <Footer />
-                </SidebarLayout>
+                <Suspense fallback={null}>
+                  <AuthHydrator>
+                    <SidebarLayout>
+                      <main className="flex-1">{children}</main>
+                      <Footer />
+                    </SidebarLayout>
+                  </AuthHydrator>
+                </Suspense>
                 <CookieConsentBanner />
                 <Analytics />
                 <SpeedInsights />

--- a/frontend/components/layout/AuthHydrator.tsx
+++ b/frontend/components/layout/AuthHydrator.tsx
@@ -12,16 +12,14 @@ interface AuthHydratorProps {
  * auth-gated action buttons (AttendanceButton, SaveButton, etc.) are
  * interactive while `isAuthenticated` is still `false` — a click before
  * the client profile fetch settles routes the user to
- * `/auth?returnTo=…` instead of firing the intended POST (the PSY-797
- * race).
+ * `/auth?returnTo=…` instead of firing the intended POST.
  *
  * The cookie read happens inside `prefetchAuthProfile`, NOT in the root
  * layout — wrapping this component in `<Suspense>` (see
  * `app/layout.tsx`) lets PPR keep the static shell prerendered and
  * stream only this subtree dynamically. Reading cookies in the root
  * layout directly would opt every route into dynamic rendering and
- * defeat ISR on every page that sets `next: { revalidate: 3600 }`
- * (PSY-834's regression — see PSY-841 for the fix).
+ * defeat ISR on every page that sets `next: { revalidate: 3600 }`.
  *
  * Must be placed INSIDE `<Providers>` so `<HydrationBoundary>` has
  * access to the QueryClientProvider context.

--- a/frontend/components/layout/AuthHydrator.tsx
+++ b/frontend/components/layout/AuthHydrator.tsx
@@ -1,0 +1,35 @@
+import { HydrationBoundary } from '@tanstack/react-query'
+import { prefetchAuthProfile } from '@/lib/auth-hydration'
+
+interface AuthHydratorProps {
+  children: React.ReactNode
+}
+
+/**
+ * Server component that pre-seeds the TanStack Query cache for
+ * `/auth/profile` so `useProfile()` resolves from cache on first paint.
+ * Without the seed, hydrated detail pages paint instantly but
+ * auth-gated action buttons (AttendanceButton, SaveButton, etc.) are
+ * interactive while `isAuthenticated` is still `false` — a click before
+ * the client profile fetch settles routes the user to
+ * `/auth?returnTo=…` instead of firing the intended POST (the PSY-797
+ * race).
+ *
+ * The cookie read happens inside `prefetchAuthProfile`, NOT in the root
+ * layout — wrapping this component in `<Suspense>` (see
+ * `app/layout.tsx`) lets PPR keep the static shell prerendered and
+ * stream only this subtree dynamically. Reading cookies in the root
+ * layout directly would opt every route into dynamic rendering and
+ * defeat ISR on every page that sets `next: { revalidate: 3600 }`
+ * (PSY-834's regression — see PSY-841 for the fix).
+ *
+ * Must be placed INSIDE `<Providers>` so `<HydrationBoundary>` has
+ * access to the QueryClientProvider context.
+ */
+export async function AuthHydrator({ children }: AuthHydratorProps) {
+  const dehydratedState = await prefetchAuthProfile()
+
+  return (
+    <HydrationBoundary state={dehydratedState}>{children}</HydrationBoundary>
+  )
+}

--- a/frontend/components/layout/index.ts
+++ b/frontend/components/layout/index.ts
@@ -1,5 +1,6 @@
 export { default as Footer } from './Footer'
 export { Providers } from './providers'
+export { AuthHydrator } from './AuthHydrator'
 export { ThemeProvider } from './theme-provider'
 export { ModeToggle } from './mode-toggle'
 export { CookieConsentBanner } from './CookieConsentBanner'

--- a/frontend/lib/auth-hydration.ts
+++ b/frontend/lib/auth-hydration.ts
@@ -1,0 +1,126 @@
+/**
+ * Server-only auth profile hydration helper.
+ *
+ * Pre-seeds the TanStack Query cache for `/auth/profile` on the server so
+ * `useProfile()` resolves from cache on first paint. Without this, hydrated
+ * detail pages paint instantly but auth-gated action buttons
+ * (AttendanceButton, SaveButton, etc.) are interactive while
+ * `isAuthenticated` is still `false` — a click before the client profile
+ * fetch settles routes the user to `/auth?returnTo=…` instead of firing
+ * the intended POST.
+ *
+ * The helper:
+ *   - Reads the viewer's `auth_token` cookie via `next/headers` so the
+ *     server fetch sees the same session as the browser would.
+ *   - Calls the backend with `cache: 'no-store'` so per-user profile data
+ *     never leaks across requests.
+ *   - On 401 (or network error) populates the cache with a "no user"
+ *     sentinel matching the `UserProfile` body shape the backend returns
+ *     for unauthenticated requests. This is what `useProfile`'s queryFn
+ *     would resolve to IF apiRequest didn't throw on 401 — the seed lets
+ *     the client skip the refetch + auth-error flash entirely.
+ *   - Returns `dehydrate(queryClient)` for `<HydrationBoundary>`.
+ *
+ * Server-only by virtue of importing `next/headers`. Importing this from
+ * a client component will throw at build time.
+ */
+
+import { cache } from 'react'
+import { cookies } from 'next/headers'
+import { dehydrate, type DehydratedState } from '@tanstack/react-query'
+import * as Sentry from '@sentry/nextjs'
+import { getQueryClient, queryKeys } from '@/lib/queryClient'
+import { API_BASE_URL } from '@/lib/api-base'
+import { AuthErrorCode } from '@/lib/errors'
+
+// Mirror the relevant subset of `UserProfile` from
+// features/auth/hooks/useAuth.ts. Duplicated here (rather than imported)
+// because that module is `'use client'` and pulling it into a server
+// helper would mark this file as client-only.
+interface AuthProfilePayload {
+  success: boolean
+  message?: string
+  error_code?: string
+  request_id?: string
+  user?: unknown
+}
+
+// Sentinel body for the unauthenticated case. Matches the backend's
+// /auth/profile 401 body shape so the cache entry is indistinguishable
+// from the parsed payload — no special "is this a seed?" branching in
+// the client.
+const UNAUTHENTICATED_PROFILE: AuthProfilePayload = {
+  success: false,
+  message: 'Authentication required',
+  error_code: AuthErrorCode.TOKEN_MISSING,
+}
+
+/**
+ * Fetch `/auth/profile` server-side and hydrate the result into a
+ * request-scoped QueryClient. Called once per request from the root
+ * layout — `getQueryClient` returns a fresh client on the server, so
+ * there's no cross-request cache leak. Wrapped in `React.cache()` so
+ * multiple server components in the same render can call it without
+ * triggering a duplicate backend fetch.
+ */
+export const prefetchAuthProfile = cache(
+  async (): Promise<DehydratedState> => {
+    const queryClient = getQueryClient()
+
+    const profile = await fetchAuthProfile()
+    await queryClient.prefetchQuery({
+      queryKey: queryKeys.auth.profile,
+      queryFn: () => profile,
+    })
+
+    return dehydrate(queryClient)
+  }
+)
+
+async function fetchAuthProfile(): Promise<AuthProfilePayload> {
+  const cookieStore = await cookies()
+  const authToken = cookieStore.get('auth_token')
+
+  // Anonymous visitor — short-circuit instead of round-tripping to the
+  // backend just to be told there's no session. Same sentinel either
+  // way, so the cache entry is identical whether we skip or fetch.
+  if (!authToken?.value) {
+    return UNAUTHENTICATED_PROFILE
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/profile`, {
+      headers: { Cookie: `auth_token=${authToken.value}` },
+      cache: 'no-store',
+    })
+
+    if (!response.ok) {
+      // 5xx is a real backend outage that would otherwise be invisible
+      // — every authenticated viewer silently falls back to the
+      // "logged out" sentinel until staleTime elapses and the client
+      // refetches. Capture so on-call sees the signal without waiting
+      // on user reports. 4xx (401/403) is the expected unauthenticated
+      // path and intentionally not captured.
+      if (response.status >= 500) {
+        Sentry.captureMessage(`SSR auth profile fetch failed: ${response.status}`, {
+          level: 'error',
+          tags: { service: 'auth', error_type: 'ssr_prefetch_failure' },
+          extra: { status: response.status },
+        })
+      }
+      return UNAUTHENTICATED_PROFILE
+    }
+
+    return (await response.json()) as AuthProfilePayload
+  } catch (error) {
+    // Network failure (backend unreachable from the Next server, DNS,
+    // etc.) — fall back to the sentinel so first paint isn't an error
+    // page, but log so a sustained outage doesn't masquerade as
+    // "everyone is logged out".
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'auth', error_type: 'ssr_prefetch_network_failure' },
+    })
+    return UNAUTHENTICATED_PROFILE
+  }
+}

--- a/frontend/lib/auth-hydration.ts
+++ b/frontend/lib/auth-hydration.ts
@@ -57,11 +57,11 @@ const UNAUTHENTICATED_PROFILE: AuthProfilePayload = {
 
 /**
  * Fetch `/auth/profile` server-side and hydrate the result into a
- * request-scoped QueryClient. Called once per request from the root
- * layout — `getQueryClient` returns a fresh client on the server, so
- * there's no cross-request cache leak. Wrapped in `React.cache()` so
- * multiple server components in the same render can call it without
- * triggering a duplicate backend fetch.
+ * request-scoped QueryClient. Called once per request from the
+ * `<AuthHydrator>` server component — `getQueryClient` returns a fresh
+ * client on the server, so there's no cross-request cache leak.
+ * Wrapped in `React.cache()` so multiple server components in the same
+ * render can call it without triggering a duplicate backend fetch.
  */
 export const prefetchAuthProfile = cache(
   async (): Promise<DehydratedState> => {

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -68,6 +68,23 @@ function isSessionExpiredError(error: unknown): boolean {
   )
 }
 
+// `useProfile` resolves its queryFn to a `UserProfile` shape — when the
+// user is logged out the payload is `{ success: false, ... }` rather than
+// an error. Used by the global error handlers below so a sibling query's
+// 401 doesn't re-invalidate a profile that already knows it's anonymous
+// (either via the SSR auth-profile seed in `prefetchAuthProfile` or a
+// prior 401).
+function profileAlreadyKnowsAnonymous(
+  client: QueryClient | undefined
+): boolean {
+  if (!client) return false
+  const state = client.getQueryState(queryKeys.auth.profile)
+  if (!state) return false
+  if (state.status === 'error') return true
+  const data = state.data as { success?: boolean } | undefined
+  return data?.success === false
+}
+
 // Function to create query client (for use in provider)
 function makeQueryClient() {
   // Create caches with global error handlers
@@ -79,8 +96,14 @@ function makeQueryClient() {
       // again, creating an infinite cascade of clears and refetches.
       if (isSessionExpiredError(error)) {
         if (query.queryKey[0] !== 'auth' || query.queryKey[1] !== 'profile') {
-          const profileState = browserQueryClient?.getQueryState(queryKeys.auth.profile)
-          if (profileState?.status !== 'error') {
+          // Skip the invalidation if the profile cache already encodes
+          // the "logged out" answer — either as an error from a prior
+          // 401, or as the `{ success: false }` payload seeded by the
+          // SSR pre-hydration. Invalidating in that case turns the
+          // SSR-seeded cache into a wasted client refetch that races
+          // with the very auth-gated buttons the seed was meant to
+          // make safe.
+          if (!profileAlreadyKnowsAnonymous(browserQueryClient)) {
             browserQueryClient?.invalidateQueries({ queryKey: queryKeys.auth.profile })
           }
         }
@@ -93,8 +116,7 @@ function makeQueryClient() {
       // When a session expires during a mutation, invalidate profile to update
       // auth state. Same rationale as above — don't clear the entire cache.
       if (isSessionExpiredError(error)) {
-        const profileState = browserQueryClient?.getQueryState(queryKeys.auth.profile)
-        if (profileState?.status !== 'error') {
+        if (!profileAlreadyKnowsAnonymous(browserQueryClient)) {
           browserQueryClient?.invalidateQueries({ queryKey: queryKeys.auth.profile })
         }
       }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,6 +3,16 @@ import { withSentryConfig } from "@sentry/nextjs";
 import withBundleAnalyzer from "@next/bundle-analyzer";
 
 const nextConfig: NextConfig = {
+  // PSY-841: Cache Components (Next 16's successor to `experimental.ppr`)
+  // is the supported way to enable Partial Prerendering. The legacy
+  // `experimental.ppr = 'incremental'` opt-in is a hard-deprecated
+  // config error in Next 16; `cacheComponents` is the only switch and
+  // enables PPR globally. Every route's static shell prerenders;
+  // anything wrapped in `<Suspense>` (here, `<AuthHydrator>` in the
+  // root layout) streams dynamically. ISR (`next: { revalidate: 3600 }`
+  // on the 8 hydrated entity routes) is preserved because the route
+  // body — the part with the `fetch`'d cache hint — stays static.
+  cacheComponents: true,
   experimental: {
     // Optimize barrel imports for common libraries
     // Only list packages that are actually installed

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,15 +3,16 @@ import { withSentryConfig } from "@sentry/nextjs";
 import withBundleAnalyzer from "@next/bundle-analyzer";
 
 const nextConfig: NextConfig = {
-  // PSY-841: Cache Components (Next 16's successor to `experimental.ppr`)
-  // is the supported way to enable Partial Prerendering. The legacy
-  // `experimental.ppr = 'incremental'` opt-in is a hard-deprecated
-  // config error in Next 16; `cacheComponents` is the only switch and
-  // enables PPR globally. Every route's static shell prerenders;
-  // anything wrapped in `<Suspense>` (here, `<AuthHydrator>` in the
-  // root layout) streams dynamically. ISR (`next: { revalidate: 3600 }`
-  // on the 8 hydrated entity routes) is preserved because the route
-  // body — the part with the `fetch`'d cache hint — stays static.
+  // Cache Components is Next 16's successor to `experimental.ppr` and
+  // the supported way to enable Partial Prerendering. The legacy
+  // `experimental.ppr` config (boolean OR `'incremental'`) is a
+  // hard-deprecated config error in Next 16; `cacheComponents` is the
+  // only switch and enables PPR globally. Every route's static shell
+  // prerenders; anything wrapped in `<Suspense>` (here, `<AuthHydrator>`
+  // in the root layout) streams dynamically. Per-route ISR
+  // (`next: { revalidate: 3600 }` on the hydrated entity routes) is
+  // preserved because the route body — the part with the `fetch` cache
+  // hint — stays in the static shell.
   cacheComponents: true,
   experimental: {
     // Optimize barrel imports for common libraries


### PR DESCRIPTION
## Summary
- Pre-hydrate `/auth/profile` in a server component (`<AuthHydrator>`) wrapped in `<Suspense>`, with Cache Components enabled (`cacheComponents: true`). Static shells + ISR are preserved; only the auth-dependent subtree streams dynamically.
- Replaces PSY-834 (cancelled, PR #798 closed) which called `cookies()` in the root layout and broke ISR globally + caused CI E2E to flake under parallel-login contention.
- Reuses PSY-834's `lib/auth-hydration.ts` helper (server-only, `React.cache()`-wrapped, `AuthErrorCode.TOKEN_MISSING` sentinel for anonymous viewers, Sentry capture on 5xx + network failures) and the `queryClient.ts` `profileAlreadyKnowsAnonymous` guard.

## Architecture note (Next 16 deviation from ticket)
The ticket assumed Next.js's `experimental.ppr = 'incremental'` mode is still available. It is NOT in Next 16: `experimental.ppr` is a hard-deprecated config error and per-route `export const experimental_ppr = true` is rejected when `cacheComponents` is on. The Next 16 replacement is the top-level `cacheComponents: true` boolean, which enables PPR for every route. Effective behaviour is what the ticket wants — static shells preserved, dynamic auth subtree streams — just configured globally instead of per-route. No per-route opt-ins were added.

## PPR verification (`bun run build` route table)
All 8 hydrated entity routes report as **◐ Partial Prerender**, not ƒ Dynamic:

```
├ ◐ /artists                                                                    1h      1y
├ ◐ /artists/[slug]
├ ◐ /venues                                                                     1h      1y
├ ◐ /venues/[slug]
├ ◐ /shows                                                                      1h      1y
├ ◐ /shows/[slug]
├ ◐ /releases
├ ◐ /releases/[slug]
├ ◐ /labels
├ ◐ /labels/[slug]
├ ◐ /festivals
├ ◐ /festivals/[slug]
├ ◐ /collections
├ ◐ /collections/[slug]
├ ◐ /tags
├ ◐ /tags/[slug]
```

ISR is preserved on listings (`1h` revalidate / `1y` expire) and applies to the static shell. The root `/` and marketing routes (`/privacy`, `/terms`, etc.) all show ◐ as well. The only ƒ Dynamic routes are API handlers (`/api/[...path]`, `/api/ai/extract-show`, etc.), `/sitemap.xml`, and the `opengraph-image` route — all expected.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed (clean tsc output)
- [x] `cd frontend && bun run test:run` — 403 files, 4595 tests, all passed (53.66s)
- [x] `cd frontend && bun run test:e2e -- e2e/pages/follow-and-attendance.spec.ts` — 2/2 passed (34.8s), including the post-login round-trip canary that historically tripped PSY-834's CI flake under parallel-login contention
- [x] `cd frontend && bun run build` — succeeded, route table above

## Manual repro
Skipped in this run because the targeted E2E spec already exercises the exact scenario PSY-797 is concerned with (authenticated user, click `Going` immediately after the show page renders, expects POST `/shows/{id}/attendance` not a redirect to `/auth`) and both tests pass. Recommend a Vercel preview spot-check (auth flow + an anonymous artist page) before merge.

## Simplify
Stripped ticket-ID references from production doc comments (per `feedback_strip_ticket_refs_from_doc_comments.md`); fixed a stale "called from the root layout" reference in the `prefetchAuthProfile` docblock to point at the actual caller (`<AuthHydrator>`). Comment-only — no behaviour change.

## Unblocks
PSY-797 PR #796 rebases on top of this; its failing E2E race should resolve.

Closes PSY-841