### PR TITLE
PSY-830: graduate ineffassign to gated golangci-lint config

### DIFF
--- a/backend/.golangci-advisory.yml
+++ b/backend/.golangci-advisory.yml
@@ -14,8 +14,6 @@ run:
 linters:
   default: none
   enable:
-    # 4 violations (2026-05-23). Trivial to fix; flip to gate after cleanup.
-    - ineffassign
     # 25 violations. Mix of dead test helpers + dead consts/types; needs
     # human review before deletion.
     - unused

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -11,7 +11,8 @@
 #   * this file (.golangci.yml)             — gated linters; non-zero exit fails CI.
 #   * .golangci-advisory.yml                — advisory linters; soft-fail in CI.
 #
-# Violation survey (2026-05-23, golangci-lint v2.12.2; errorlint updated 2026-05-24):
+# Violation survey (2026-05-23, golangci-lint v2.12.2; errorlint updated 2026-05-24,
+# ineffassign updated 2026-05-24):
 #   linter       | violations | decision  | rationale
 #   ----------- | ---------- | --------- | ------------------------------------------------
 #   govet        |          0 | GATE      | clean once the `inline` analyzer (advisory
@@ -23,8 +24,10 @@
 #                |            |           | the 13 stragglers (5 fmt.Errorf %v→%w in cmd/seed +
 #                |            |           | 8 test-file `err.(*T)`→`errors.As(err, &v)`). Gated
 #                |            |           | to prevent regression of err-wrap discipline.
-#   ineffassign  |          4 | advisory  | trivial fixes, but spec says do not widen
-#                |            |           | scope; flip to gate after cleanup ticket.
+#   ineffassign  |          0 | GATE      | PSY-830 cleaned the 4 sites (3 dead assignments
+#                |            |           | deleted, 1 wasted allocation swapped for nil-slice
+#                |            |           | declaration). Gated to prevent regression of
+#                |            |           | ineffective-assignment patterns.
 #   unused       |         25 | advisory  | mix of dead test helpers + dead consts/types;
 #                |            |           | needs human review (some may be live via
 #                |            |           | reflection or future use) before deletion.
@@ -54,6 +57,7 @@ linters:
   enable:
     - govet
     - errorlint
+    - ineffassign
 
   settings:
     govet:

--- a/backend/internal/api/handlers/auth/oauth_handlers_test.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers_test.go
@@ -136,9 +136,9 @@ func oauthLoginRequest(provider string) (*httptest.ResponseRecorder, *http.Reque
 
 func TestOAuthLoginHTTPHandler_NoProvider(t *testing.T) {
 	handler := NewOAuthHTTPHandler(nil, nil)
-	w, req := oauthLoginRequest("")
-	// Clear chi context so URLParam returns ""
-	req = httptest.NewRequest("GET", "/auth/login", nil)
+	// Build request with no chi context so URLParam("provider") returns "".
+	req := httptest.NewRequest("GET", "/auth/login", nil)
+	w := httptest.NewRecorder()
 
 	handler.OAuthLoginHTTPHandler(w, req)
 

--- a/backend/internal/api/handlers/engagement/calendar.go
+++ b/backend/internal/api/handlers/engagement/calendar.go
@@ -88,15 +88,8 @@ func (h *CalendarHandler) CreateCalendarTokenHandler(ctx context.Context, req *C
 		return nil, huma.Error401Unauthorized("Authentication required")
 	}
 
-	// Derive the API base URL from config
-	// In production this is the backend's public URL (e.g. https://api.psychichomily.com)
-	apiBaseURL := h.config.Email.FrontendURL
-	if apiBaseURL == "" {
-		apiBaseURL = "http://localhost:8080"
-	}
-	// The feed URL should use the API domain, not the frontend domain
-	// Derive from the MusicDiscovery FrontendURL pattern, but use the API URL
-	apiBaseURL = getAPIBaseURL(h.config)
+	// Feed URLs use the API domain, not the frontend domain.
+	apiBaseURL := getAPIBaseURL(h.config)
 
 	result, err := h.calendarService.CreateToken(user.ID, apiBaseURL)
 	if err != nil {

--- a/backend/internal/services/admin/auto_promotion_test.go
+++ b/backend/internal/services/admin/auto_promotion_test.go
@@ -733,20 +733,13 @@ func (s *AutoPromotionIntegrationTestSuite) TestRolling30dIncludesRevisions() {
 	s.createPendingEditWithStatus(user.ID, "artist", artist.ID, adminm.PendingEditStatusRejected, time.Now().Add(-5*24*time.Hour))
 	s.createPendingEditWithStatus(user.ID, "artist", artist.ID, adminm.PendingEditStatusRejected, time.Now().Add(-4*24*time.Hour))
 
-	// 7 recent revisions (count as approved) in 30d window
-	for i := 0; i < 7; i++ {
+	// 8 recent revisions (count as approved) in 30d window so 8/(8+2) = 80%,
+	// exactly at the demotion threshold (not below).
+	for i := 0; i < 8; i++ {
 		s.createRevision(user.ID, "artist", artist.ID, time.Now().Add(-time.Duration(i+1)*24*time.Hour))
 	}
 
 	result, err := s.svc.EvaluateUser(user.ID)
-	s.Require().NoError(err)
-	// Rolling 30d: 7 approved (revisions) + 0 pending approved / (7 + 2 total) = 77.7%
-	// Wait, let me recalculate: 7 revisions + 2 pending rejected = 9 total, 7/9 = 77.7% < 80%
-	// Actually the user should be demoted because 7/9 = 77.7% < 80%
-	// Let me add one more revision to get 8/10 = 80%
-	s.createRevision(user.ID, "artist", artist.ID, time.Now().Add(-8*24*time.Hour))
-
-	result, err = s.svc.EvaluateUser(user.ID)
 	s.Require().NoError(err)
 	// 8 revisions + 2 rejected = 10 total, 8/10 = 80% — at threshold, not below
 	s.False(result.Changed)

--- a/backend/internal/services/admin/auto_promotion_test.go
+++ b/backend/internal/services/admin/auto_promotion_test.go
@@ -741,6 +741,5 @@ func (s *AutoPromotionIntegrationTestSuite) TestRolling30dIncludesRevisions() {
 
 	result, err := s.svc.EvaluateUser(user.ID)
 	s.Require().NoError(err)
-	// 8 revisions + 2 rejected = 10 total, 8/10 = 80% — at threshold, not below
 	s.False(result.Changed)
 }

--- a/backend/internal/services/catalog/artist_relationship_service.go
+++ b/backend/internal/services/catalog/artist_relationship_service.go
@@ -746,7 +746,7 @@ func (s *ArtistRelationshipService) GetArtistBillComposition(artistID uint, mont
 	}
 
 	// 5. Cap graph to top N by total shared_count.
-	graphIDs := make([]uint, 0, billCompositionMaxNodes)
+	var graphIDs []uint
 	{
 		sorted := make([]uint, len(graphOrder))
 		copy(sorted, graphOrder)


### PR DESCRIPTION
## Summary
- Clean the 4 pre-existing `ineffassign` violations (3 dead assignments deleted, 1 wasted slice allocation swapped for a nil-slice declaration), then move `ineffassign` from `backend/.golangci-advisory.yml` to `backend/.golangci.yml` so future ineffective-assignment patterns fail CI rather than only surfacing in the advisory job.
- Update the `.golangci.yml` survey-table comment to flip `ineffassign` from `advisory` to `GATE` with the PSY-830 rationale.

## Fixes
Per-site disposition:
- `backend/internal/api/handlers/auth/oauth_handlers_test.go:139` — restructure: the test calls `oauthLoginRequest("")` only to discard `req` and rebuild it immediately. Build the no-chi-context request directly with `httptest.NewRequest` + `httptest.NewRecorder` so intent is local.
- `backend/internal/api/handlers/engagement/calendar.go:95` — delete: the `apiBaseURL := h.config.Email.FrontendURL` + `if apiBaseURL == "" { ... }` block is dead code — `getAPIBaseURL(h.config)` unconditionally overwrites on the next line. Collapsed to a single assignment.
- `backend/internal/services/admin/auto_promotion_test.go:741` — restructure: vestigial first `EvaluateUser` call from test-math iteration (the in-line comments document the author recalculating). Collapsed to a single setup (8 revisions at -1d..-8d) + one assertion at the 8/10 = 80% threshold. Same final DB state, same assertion target.
- `backend/internal/services/catalog/artist_relationship_service.go:749` — restructure: `make([]uint, 0, billCompositionMaxNodes)` is wasted — the next block scope unconditionally reassigns `graphIDs = sorted`. Swapped for `var graphIDs []uint`.

## Test plan
- [x] `cd backend && ~/go/bin/golangci-lint run --no-config --enable-only=ineffassign ./...` — 0 issues
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./...` — passed (all packages, including the 4 touched: handlers/auth, handlers/engagement, services/admin, services/catalog)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues (ineffassign now gated)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci-advisory.yml ./...` — ineffassign no longer listed (errcheck/staticcheck/unused remain)

## Manual repro
- Pre: 4 ineffassign sites enumerated by `golangci-lint run --no-config --enable-only=ineffassign ./...`.
- Post: 0 sites; gated config (`.golangci.yml`) exits 0 with ineffassign enabled.

## Simplify
Run clean. One trim: removed a now-redundant assertion comment in `auto_promotion_test.go` (the loop comment two lines above already states the 80% threshold math). Separate commit.

Closes PSY-830