### PR TITLE
PSY-832: staticcheck — fix SA4006+QF/ST backlog, graduate to gate

### DIFF
--- a/backend/.golangci-advisory.yml
+++ b/backend/.golangci-advisory.yml
@@ -17,9 +17,6 @@ linters:
     # 25 violations. Mix of dead test helpers + dead consts/types; needs
     # human review before deletion.
     - unused
-    # 36 violations. Mostly QF style suggestions, a few SA4006 unused-value
-    # bugs. Flip after cleanup ticket.
-    - staticcheck
     # 474 violations. Large legacy backlog (dropped resp.Body.Close, bcrypt
     # compares, etc.); needs its own ticket.
     - errcheck

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -12,7 +12,7 @@
 #   * .golangci-advisory.yml                — advisory linters; soft-fail in CI.
 #
 # Violation survey (2026-05-23, golangci-lint v2.12.2; errorlint updated 2026-05-24,
-# ineffassign updated 2026-05-24):
+# ineffassign updated 2026-05-24, staticcheck updated 2026-05-24):
 #   linter       | violations | decision  | rationale
 #   ----------- | ---------- | --------- | ------------------------------------------------
 #   govet        |          0 | GATE      | clean once the `inline` analyzer (advisory
@@ -28,11 +28,17 @@
 #                |            |           | deleted, 1 wasted allocation swapped for nil-slice
 #                |            |           | declaration). Gated to prevent regression of
 #                |            |           | ineffective-assignment patterns.
+#   staticcheck  |          0 | GATE      | PSY-832 cleaned the 32 sites (5 SA4006 dead
+#                |            |           | baseQuery reassignments deleted, 17 QF style
+#                |            |           | suggestions autofixed via `--fix` + 1 manual
+#                |            |           | De Morgan rewrite extracted to a named predicate,
+#                |            |           | 8 ST1005 error-string capitalization/punctuation
+#                |            |           | fixes, 1 S1011 slice-append + 1 ST1023 redundant
+#                |            |           | type-decl autofixes). Gated to prevent regression
+#                |            |           | of staticcheck-clean patterns.
 #   unused       |         25 | advisory  | mix of dead test helpers + dead consts/types;
 #                |            |           | needs human review (some may be live via
 #                |            |           | reflection or future use) before deletion.
-#   staticcheck  |         36 | advisory  | mostly QF style suggestions, a few SA4006
-#                |            |           | unused-assignment bugs; flip after cleanup.
 #   errcheck     |        474 | advisory  | large legacy backlog (dropped resp.Body.Close,
 #                |            |           | bcrypt compares, etc.); needs its own ticket.
 #
@@ -58,6 +64,7 @@ linters:
     - govet
     - errorlint
     - ineffassign
+    - staticcheck
 
   settings:
     govet:

--- a/backend/internal/api/handlers/admin/admin_data.go
+++ b/backend/internal/api/handlers/admin/admin_data.go
@@ -182,10 +182,11 @@ func (h *AdminDataHandler) ExportVenuesHandler(ctx context.Context, req *ExportV
 	}
 
 	// Parse verified filter
-	if req.Verified == "true" {
+	switch req.Verified {
+	case "true":
 		verified := true
 		params.Verified = &verified
-	} else if req.Verified == "false" {
+	case "false":
 		verified := false
 		params.Verified = &verified
 	}

--- a/backend/internal/api/handlers/admin/test_fixtures.go
+++ b/backend/internal/api/handlers/admin/test_fixtures.go
@@ -155,7 +155,7 @@ func ValidateTestFixturesEnvironment(getenv func(string) string) error {
 			allowed = append(allowed, k)
 		}
 		return fmt.Errorf(
-			"%s=1 requires ENVIRONMENT to be one of %v (got %q). Refusing to boot.",
+			"%s=1 requires ENVIRONMENT to be one of %v (got %q); refusing to boot",
 			EnableTestFixturesEnvVar, allowed, env,
 		)
 	}

--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -1837,7 +1837,8 @@ func (h *AuthHandler) UpdateProfileHandler(ctx context.Context, req *UpdateProfi
 		}
 		// Only allow alphanumeric, underscores, and hyphens
 		for _, c := range username {
-			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
+			allowed := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-'
+			if !allowed {
 				resp.Body.Success = false
 				resp.Body.Message = "Username may only contain letters, numbers, underscores, and hyphens"
 				resp.Body.ErrorCode = autherrors.CodeValidationFailed

--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -166,9 +166,10 @@ type ListRadioStationsResponse struct {
 // ListRadioStationsHandler handles GET /radio-stations
 func (h *RadioHandler) ListRadioStationsHandler(ctx context.Context, req *ListRadioStationsRequest) (*ListRadioStationsResponse, error) {
 	filters := make(map[string]interface{})
-	if req.IsActive == "true" {
+	switch req.IsActive {
+	case "true":
 		filters["is_active"] = true
-	} else if req.IsActive == "false" {
+	case "false":
 		filters["is_active"] = false
 	}
 

--- a/backend/internal/api/handlers/community/show_report.go
+++ b/backend/internal/api/handlers/community/show_report.go
@@ -319,10 +319,7 @@ func (h *ShowReportHandler) ResolveReportHandler(ctx context.Context, req *Resol
 	}
 
 	// Determine if we should set the show flag
-	setShowFlag := false
-	if req.Body.SetShowFlag != nil && *req.Body.SetShowFlag {
-		setShowFlag = true
-	}
+	setShowFlag := req.Body.SetShowFlag != nil && *req.Body.SetShowFlag
 
 	logger.FromContext(ctx).Debug("admin_resolve_report_attempt",
 		"report_id", reportID,

--- a/backend/internal/api/handlers/notification/notification_filter_test.go
+++ b/backend/internal/api/handlers/notification/notification_filter_test.go
@@ -517,6 +517,6 @@ func TestInt64ArrayToSlice(t *testing.T) {
 // create a circular dependency in test setup).
 func computeTestFilterSig(filterID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("unsubscribe:filter:%d", filterID)))
+	fmt.Fprintf(mac, "unsubscribe:filter:%d", filterID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/api/routes/auth_rate_limit.go
+++ b/backend/internal/api/routes/auth_rate_limit.go
@@ -51,7 +51,7 @@ func ValidateAuthRateLimitEnvironment(getenv func(string) string) error {
 			allowed = append(allowed, k)
 		}
 		return fmt.Errorf(
-			"%s=1 requires ENVIRONMENT to be one of %v (got %q). Refusing to boot.",
+			"%s=1 requires ENVIRONMENT to be one of %v (got %q); refusing to boot",
 			DisableAuthRateLimitsEnvVar, allowed, env,
 		)
 	}

--- a/backend/internal/services/auth/apple.go
+++ b/backend/internal/services/auth/apple.go
@@ -104,7 +104,7 @@ func (s *AppleAuthService) ValidateIdentityToken(identityToken string) (*contrac
 	}
 
 	if !token.Valid {
-		return nil, fmt.Errorf("Apple identity token is not valid")
+		return nil, fmt.Errorf("apple identity token is not valid")
 	}
 
 	return claims, nil
@@ -254,7 +254,7 @@ func (s *AppleAuthService) getApplePublicKey(kid string) (*rsa.PublicKey, error)
 
 	key, ok := s.keys[kid]
 	if !ok {
-		return nil, fmt.Errorf("Apple public key not found for kid: %s", kid)
+		return nil, fmt.Errorf("apple public key not found for kid: %s", kid)
 	}
 
 	return key, nil
@@ -273,7 +273,7 @@ func (s *AppleAuthService) fetchAppleKeys() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Apple keys endpoint returned status %d", resp.StatusCode)
+		return fmt.Errorf("apple keys endpoint returned status %d", resp.StatusCode)
 	}
 
 	var jwkSet appleJWKSet

--- a/backend/internal/services/auth/apple_test.go
+++ b/backend/internal/services/auth/apple_test.go
@@ -100,7 +100,7 @@ func TestValidateIdentityToken(t *testing.T) {
 	// Create a mock Apple keys server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Encode public key as JWK
-		nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.N.Bytes())
+		nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes())
 		eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
 		eBase64 := base64.RawURLEncoding.EncodeToString(eBytes)
 
@@ -158,7 +158,7 @@ func TestValidateIdentityToken(t *testing.T) {
 
 		_, err := svc.ValidateIdentityToken(token)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Apple public key not found")
+		assert.Contains(t, err.Error(), "apple public key not found")
 	})
 
 	t.Run("wrong_signing_key_rejected", func(t *testing.T) {
@@ -204,7 +204,7 @@ func TestAppleKeyFetching(t *testing.T) {
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
-			nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.N.Bytes())
+			nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes())
 			eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
 			eBase64 := base64.RawURLEncoding.EncodeToString(eBytes)
 			w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"cached-kid","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))
@@ -231,7 +231,7 @@ func TestAppleKeyFetching(t *testing.T) {
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
-			nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.N.Bytes())
+			nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes())
 			eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
 			eBase64 := base64.RawURLEncoding.EncodeToString(eBytes)
 			w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"known-kid","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -688,24 +688,19 @@ func (s *ArtistService) GetShowsForArtist(artistID uint, timezone string, limit 
 	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 	startOfTodayUTC := startOfToday.UTC()
 
-	// Build base query
-	baseQuery := s.db.Table("show_artists").
-		Joins("JOIN shows ON show_artists.show_id = shows.id").
-		Where("show_artists.artist_id = ? AND shows.status = ?", artistID, catalogm.ShowStatusApproved)
-
-	// Apply time filter and determine ordering
+	// Apply time filter and determine ordering. countQuery + showQuery are
+	// built independently below and re-apply the same dateCondition string;
+	// no shared base-query handle is needed.
 	var dateCondition string
 	var orderDirection string
 	switch timeFilter {
 	case "past":
-		baseQuery = baseQuery.Where("shows.event_date < ?", startOfTodayUTC)
 		dateCondition = "shows.event_date < ?"
 		orderDirection = "shows.event_date DESC" // Most recent past shows first
 	case "all":
 		dateCondition = "" // No date filter
 		orderDirection = "shows.event_date ASC"
 	default: // "upcoming"
-		baseQuery = baseQuery.Where("shows.event_date >= ?", startOfTodayUTC)
 		dateCondition = "shows.event_date >= ?"
 		orderDirection = "shows.event_date ASC" // Soonest upcoming shows first
 	}

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -688,9 +688,7 @@ func (s *ArtistService) GetShowsForArtist(artistID uint, timezone string, limit 
 	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 	startOfTodayUTC := startOfToday.UTC()
 
-	// Apply time filter and determine ordering. countQuery + showQuery are
-	// built independently below and re-apply the same dateCondition string;
-	// no shared base-query handle is needed.
+	// Apply time filter and determine ordering
 	var dateCondition string
 	var orderDirection string
 	switch timeFilter {

--- a/backend/internal/services/catalog/artist_relationship_service.go
+++ b/backend/internal/services/catalog/artist_relationship_service.go
@@ -1213,9 +1213,7 @@ func (s *ArtistRelationshipService) computeFestivalCobillCenterEdges(centerID ui
 	// Collect (artistA, artistB) pairs to fetch their representative
 	// festival names in a single batch query.
 	pairs := make([]festivalCobillRow, 0, len(rows))
-	for _, r := range rows {
-		pairs = append(pairs, r)
-	}
+	pairs = append(pairs, rows...)
 	nameMap, err := s.queryFestivalCobillNames(pairs)
 	if err != nil {
 		// Tooltip names are best-effort — log nothing, return whatever we have.

--- a/backend/internal/services/catalog/festival_intelligence.go
+++ b/backend/internal/services/catalog/festival_intelligence.go
@@ -565,7 +565,7 @@ func (s *FestivalIntelligenceService) GetFestivalBreakouts(festivalID uint) (*co
 
 		// Build trajectory
 		trajectory := make([]contracts.TrajectoryEntry, len(hist))
-		var bestRank int = 99
+		var bestRank = 99
 		for i, h := range hist {
 			trajectory[i] = contracts.TrajectoryEntry{
 				FestivalName: h.Name,

--- a/backend/internal/services/catalog/radio_unmatched.go
+++ b/backend/internal/services/catalog/radio_unmatched.go
@@ -26,9 +26,6 @@ func (s *RadioService) GetUnmatchedPlays(stationID uint, limit, offset int) ([]*
 		limit = 50
 	}
 
-	// countQuery + groupQuery below are each built independently and re-apply
-	// the same station-scope filter; no shared base-query handle is needed.
-
 	// Count total distinct artist names
 	var total int64
 	countQuery := s.db.Table("radio_plays rp").

--- a/backend/internal/services/catalog/radio_unmatched.go
+++ b/backend/internal/services/catalog/radio_unmatched.go
@@ -26,16 +26,8 @@ func (s *RadioService) GetUnmatchedPlays(stationID uint, limit, offset int) ([]*
 		limit = 50
 	}
 
-	// Build base query for grouping unmatched plays by artist_name
-	baseQuery := s.db.Table("radio_plays rp").
-		Where("rp.artist_id IS NULL")
-
-	if stationID > 0 {
-		baseQuery = baseQuery.
-			Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
-			Joins("JOIN radio_shows rsh ON rsh.id = re.show_id").
-			Where("rsh.station_id = ?", stationID)
-	}
+	// countQuery + groupQuery below are each built independently and re-apply
+	// the same station-scope filter; no shared base-query handle is needed.
 
 	// Count total distinct artist names
 	var total int64

--- a/backend/internal/services/catalog/tag_merge.go
+++ b/backend/internal/services/catalog/tag_merge.go
@@ -100,9 +100,10 @@ func countVoteMovesBySign(db *gorm.DB, sourceID, targetID uint) (up, down int64,
 		return 0, 0, fmt.Errorf("failed to split vote moves by sign: %w", err)
 	}
 	for _, r := range rows {
-		if r.Vote == 1 {
+		switch r.Vote {
+		case 1:
 			up = r.Count
-		} else if r.Vote == -1 {
+		case -1:
 			down = r.Count
 		}
 	}

--- a/backend/internal/services/catalog/venue.go
+++ b/backend/internal/services/catalog/venue.go
@@ -645,9 +645,7 @@ func (s *VenueService) GetShowsForVenue(venueID uint, timezone string, limit int
 	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 	startOfTodayUTC := startOfToday.UTC()
 
-	// Apply time filter. countQuery + showQuery are built independently below
-	// and re-apply the same dateCondition string; no shared base-query handle
-	// is needed.
+	// Apply time filter
 	var dateCondition string
 	var orderDirection string
 	switch timeFilter {

--- a/backend/internal/services/catalog/venue.go
+++ b/backend/internal/services/catalog/venue.go
@@ -645,24 +645,19 @@ func (s *VenueService) GetShowsForVenue(venueID uint, timezone string, limit int
 	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 	startOfTodayUTC := startOfToday.UTC()
 
-	// Build base query
-	baseQuery := s.db.Table("show_venues").
-		Joins("JOIN shows ON show_venues.show_id = shows.id").
-		Where("show_venues.venue_id = ? AND shows.status = ?", venueID, catalogm.ShowStatusApproved)
-
-	// Apply time filter
+	// Apply time filter. countQuery + showQuery are built independently below
+	// and re-apply the same dateCondition string; no shared base-query handle
+	// is needed.
 	var dateCondition string
 	var orderDirection string
 	switch timeFilter {
 	case "past":
-		baseQuery = baseQuery.Where("shows.event_date < ?", startOfTodayUTC)
 		dateCondition = "shows.event_date < ?"
 		orderDirection = "shows.event_date DESC" // Most recent past shows first
 	case "all":
 		dateCondition = "" // No date filter
 		orderDirection = "shows.event_date ASC"
 	default: // "upcoming"
-		baseQuery = baseQuery.Where("shows.event_date >= ?", startOfTodayUTC)
 		dateCondition = "shows.event_date >= ?"
 		orderDirection = "shows.event_date ASC" // Soonest upcoming shows first
 	}

--- a/backend/internal/services/engagement/collection_digest.go
+++ b/backend/internal/services/engagement/collection_digest.go
@@ -547,6 +547,6 @@ func VerifyCollectionDigestUnsubscribeSignature(userID uint, signature, secret s
 // one notification type can't be replayed against another.
 func ComputeCollectionDigestUnsubscribeSignature(userID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("unsubscribe:collection-digest:%d", userID)))
+	fmt.Fprintf(mac, "unsubscribe:collection-digest:%d", userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/comment_notification.go
+++ b/backend/internal/services/engagement/comment_notification.go
@@ -581,7 +581,7 @@ func VerifyCommentSubscriptionUnsubscribeSignature(userID uint, entityType strin
 // as long as the JWT secret doesn't rotate.
 func ComputeCommentSubscriptionUnsubscribeSignature(userID uint, entityType string, entityID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("unsubscribe:comment-subscription:%d:%s:%d", userID, entityType, entityID)))
+	fmt.Fprintf(mac, "unsubscribe:comment-subscription:%d:%s:%d", userID, entityType, entityID)
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
@@ -603,6 +603,6 @@ func VerifyMentionUnsubscribeSignature(userID uint, signature, secret string) bo
 // ComputeMentionUnsubscribeSignature hashes userID under secret.
 func ComputeMentionUnsubscribeSignature(userID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("unsubscribe:mention:%d", userID)))
+	fmt.Fprintf(mac, "unsubscribe:mention:%d", userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/reminder.go
+++ b/backend/internal/services/engagement/reminder.go
@@ -221,6 +221,6 @@ func VerifyUnsubscribeSignature(userID uint, signature, secret string) bool {
 // ComputeUnsubscribeSignature computes HMAC-SHA256 of the user ID
 func ComputeUnsubscribeSignature(userID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("unsubscribe:show-reminders:%d", userID)))
+	fmt.Fprintf(mac, "unsubscribe:show-reminders:%d", userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/unsubscribe_scope.go
+++ b/backend/internal/services/engagement/unsubscribe_scope.go
@@ -24,7 +24,7 @@ const (
 // tier-change and edit-review categories.
 func ComputeScopedUnsubscribeSignature(userID uint, scope, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("unsubscribe:%s:%d", scope, userID)))
+	fmt.Fprintf(mac, "unsubscribe:%s:%d", scope, userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }
 

--- a/backend/internal/services/notification/email.go
+++ b/backend/internal/services/notification/email.go
@@ -817,21 +817,17 @@ func (s *EmailService) SendCollectionDigestEmail(toEmail string, groups []contra
 	// Render each group as its own block.
 	var groupsHTML strings.Builder
 	for _, g := range groups {
-		groupsHTML.WriteString(fmt.Sprintf(
-			`<div style="margin-bottom: 24px;">
+		fmt.Fprintf(&groupsHTML, `<div style="margin-bottom: 24px;">
 				<h3 style="margin: 0 0 8px; color: #1a1a1a;"><a href="%s" style="color: #1a1a1a; text-decoration: none;">%s</a></h3>
 				<ul style="margin: 0; padding-left: 20px; color: #444;">`,
 			g.CollectionURL,
-			htmlEscape(g.CollectionTitle),
-		))
+			htmlEscape(g.CollectionTitle))
 		for _, item := range g.Items {
-			groupsHTML.WriteString(fmt.Sprintf(
-				`<li style="margin-bottom: 4px;"><a href="%s" style="color: #f97316; text-decoration: none;">%s</a> <span style="color: #888;">(%s, added by %s)</span></li>`,
+			fmt.Fprintf(&groupsHTML, `<li style="margin-bottom: 4px;"><a href="%s" style="color: #f97316; text-decoration: none;">%s</a> <span style="color: #888;">(%s, added by %s)</span></li>`,
 				item.EntityURL,
 				htmlEscape(item.EntityName),
 				htmlEscape(item.EntityType),
-				htmlEscape(item.AddedBy),
-			))
+				htmlEscape(item.AddedBy))
 		}
 		groupsHTML.WriteString(`</ul></div>`)
 	}

--- a/backend/internal/services/notification/filter_service.go
+++ b/backend/internal/services/notification/filter_service.go
@@ -969,7 +969,7 @@ func VerifyFilterUnsubscribeSignature(filterID uint, signature, secret string) b
 // ComputeFilterUnsubscribeSignature computes HMAC-SHA256 of the filter ID.
 func ComputeFilterUnsubscribeSignature(filterID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("unsubscribe:filter:%d", filterID)))
+	fmt.Fprintf(mac, "unsubscribe:filter:%d", filterID)
 	return hex.EncodeToString(mac.Sum(nil))
 }
 

--- a/backend/internal/services/pipeline/extraction.go
+++ b/backend/internal/services/pipeline/extraction.go
@@ -318,7 +318,7 @@ func (s *ExtractionService) sendAnthropicRequest(reqBody anthropicRequest) (stri
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("Anthropic API request failed: %w", err)
+		return "", fmt.Errorf("anthropic API request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -328,7 +328,7 @@ func (s *ExtractionService) sendAnthropicRequest(reqBody anthropicRequest) (stri
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Anthropic API error (status %d): %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("anthropic API error (status %d): %s", resp.StatusCode, string(body))
 	}
 
 	var apiResp anthropicResponse
@@ -337,7 +337,7 @@ func (s *ExtractionService) sendAnthropicRequest(reqBody anthropicRequest) (stri
 	}
 
 	if apiResp.Error != nil {
-		return "", fmt.Errorf("Anthropic API error: %s", apiResp.Error.Message)
+		return "", fmt.Errorf("anthropic API error: %s", apiResp.Error.Message)
 	}
 
 	// Extract text from response content blocks


### PR DESCRIPTION
## Summary
- Cleaned the staticcheck advisory backlog (32 sites uncapped) and graduated the linter from `.golangci-advisory.yml` to `.golangci.yml`. Future PRs that re-introduce SA4006 / QF / ST / S violations now fail CI instead of only surfacing in the advisory job.
- Three commits: (1) SA4006 dead-code deletions (potentially behaviour-relevant), (2) QF/ST/S autofix + manual sweep + config flip, (3) drop /simplify-flagged narration comments.

## Re-baseline (uncapped, `--max-issues-per-linter=0 --max-same-issues=0`)
Total: **32**. The ~36 in the original PSY-772 survey was capped; current true count differs slightly (some checks evolved with v2.12.2).

| Rule | Count | Family |
| --- | --- | --- |
| SA4006 | 5 | unused-value (potentially behaviour-relevant) |
| ST1005 | 8 | error string formatting |
| ST1023 | 1 | redundant type decl |
| S1011 | 1 | append-slice |
| QF1012 | 9 | `fmt.Fprintf` vs `Write([]byte(Sprintf))` |
| QF1008 | 3 | redundant embedded-field selector |
| QF1003 | 3 | tagged switch on string |
| QF1007 | 1 | merge conditional into decl |
| QF1001 | 1 | De Morgan's |

## SA4006 fixes (potentially behaviour-changing — none turned out to be real bugs)
All 5 sites were the same refactoring-leftover pattern: build a `baseQuery` GORM handle, mutate it under a switch/if, then never consume it. The downstream `countQuery` / `showQuery` / `groupQuery` are independently constructed from scratch and re-apply the same filter via param strings.

| File:line | Disposition |
| --- | --- |
| `services/catalog/artist.go:701,708` | Delete dead `baseQuery = baseQuery.Where(...)` reassignments. `countQuery` + `showQuery` re-apply `dateCondition` directly. |
| `services/catalog/venue.go:658,665` | Same pattern as artist.go. Delete reassignments. |
| `services/catalog/radio_unmatched.go:34` | Delete dead `baseQuery = baseQuery.Joins/Where(...)` block. `countQuery` + `groupQuery` re-apply station-scope filter directly. |

Verified by reading consumer sites — no missing data path. Catalog service tests pass unchanged. **No regression tests required** — the assigned values were dead, not silently dropped meaningful data.

## QF/ST/S autofixes (no-op refactors)
- **17 autofixed** via `golangci-lint --fix`:
    - QF1003 (3): `if x == "true"` → tagged switch (admin_data, radio, tag_merge).
    - QF1007 (1): collapse `var x = false; if cond { x = true }` into a single bool expr (show_report).
    - QF1008 (3): drop redundant `.PublicKey` on embedded `*rsa.PrivateKey` (apple_test).
    - QF1012 (9): `fmt.Fprintf(w, ...)` instead of `w.Write([]byte(fmt.Sprintf(...)))` — across HMAC builders + collection-digest HTML builder. Strict allocation win.
    - S1011 (1): `append(pairs, rows...)` for a copy loop (artist_relationship_service).
    - ST1023 (1): drop redundant `int` type decl on `var bestRank = 99` (festival_intelligence).

- **1 QF1001 manual rewrite** (auth.go username validator). Autofixer produced two equivalent De Morgan expansions and skipped on conflict. Extracted the predicate to a named `allowed` bool, side-stepping the outer-negation question while preserving the original "list of permitted ranges" reading.

- **8 ST1005 manual fixes**: lowercase leading word + drop trailing punctuation on error strings. `apple.go` + `extraction.go` now use `"apple"` / `"anthropic"` lowercase (Go convention treats error strings as sentence fragments). `apple_test.go:161` assertion updated to match the new lowercase form. Two env-validation errors (test_fixtures + auth_rate_limit) drop the trailing period and replace `"Refusing to boot."` with `"; refusing to boot"`.

## Test plan
- [x] `cd backend && ~/go/bin/golangci-lint run --no-config --enable-only=staticcheck --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./...` — passed (incl auth tests after assertion update)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues (staticcheck now gated)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci-advisory.yml ./...` — staticcheck no longer present (only errcheck + unused remain)

## Manual repro
Pre: 32 total staticcheck violations (uncapped). Post: 0. Final gated lint: `0 issues.` Stack-up used `--mode=none` (backend-only ticket — no frontend stack needed; the lint outputs themselves are the manual repro).

## Simplify
Reviewed code-reuse, code-quality, and efficiency rubrics inline (no Task tool available in this sub-agent context). Found one cleanup: dropped three "countQuery + showQuery are built independently below..." narration comments added in commit 1 — they were narrating the deletion rather than documenting a load-bearing invariant. With baseQuery gone there's no scar, so the explanatory comment is also gone. Committed as `6ac8c1b7`. Reuse pass noted: the 5 `ComputeXxxUnsubscribeSignature` functions duplicate a clear pattern that could be consolidated with `ComputeScopedUnsubscribeSignature`, but that's out of this PR's mechanical-cleanup scope — flag for a follow-up.

Closes PSY-832