### PR TITLE
PSY-836: /explore read endpoints (upcoming/featured/shuffle)

### DIFF
--- a/backend/internal/api/handlers/explore/explore.go
+++ b/backend/internal/api/handlers/explore/explore.go
@@ -1,0 +1,141 @@
+// Package explore exposes the public read endpoints that back the
+// /explore landing page. The three endpoints — upcoming-shows,
+// featured, and shuffle-target — register on the public API group;
+// anonymous and authenticated callers see identical content (locked
+// product decision).
+//
+// Handler logic stays thin: validate the query envelope, delegate to
+// the service, surface 500s with a request-id breadcrumb on failure.
+// All the read shape + privacy logic lives in services/explore.
+package explore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ExploreHandler holds the service dependencies for the /explore
+// public endpoints. Constructed once at route-setup time.
+type ExploreHandler struct {
+	exploreService contracts.ExploreServiceInterface
+}
+
+// NewExploreHandler wires the explore service. The featured-slot
+// service is reached transitively through the explore service — the
+// handler does not call it directly.
+func NewExploreHandler(exploreService contracts.ExploreServiceInterface) *ExploreHandler {
+	return &ExploreHandler{exploreService: exploreService}
+}
+
+// ──────────────────────────────────────────────
+// GET /explore/upcoming-shows
+// ──────────────────────────────────────────────
+
+// GetUpcomingShowsRequest is the query envelope for the upcoming-shows
+// endpoint. Limit defaults to 20, capped at 50; offset is non-negative.
+// City filter is intentionally out of scope (PSY-840 follow-up) — adding
+// it later is additive and doesn't change the existing wire shape.
+type GetUpcomingShowsRequest struct {
+	Limit  int `query:"limit" minimum:"1" maximum:"50" default:"20" doc:"Number of shows per page (1-50)"`
+	Offset int `query:"offset" minimum:"0" default:"0" doc:"Offset for pagination"`
+}
+
+// GetUpcomingShowsResponse wraps the explore-shaped page response.
+type GetUpcomingShowsResponse struct {
+	Body contracts.ExploreUpcomingShowsResponse
+}
+
+// GetUpcomingShowsHandler handles GET /explore/upcoming-shows. Returns
+// approved shows with event_date >= NOW(), ordered chronologically by
+// (event_date ASC, id ASC). Deterministic across pages — two shows
+// sharing the same event_date sort by id, never randomly reshuffle.
+func (h *ExploreHandler) GetUpcomingShowsHandler(ctx context.Context, req *GetUpcomingShowsRequest) (*GetUpcomingShowsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	result, err := h.exploreService.GetUpcomingShows(req.Limit, req.Offset)
+	if err != nil {
+		logger.FromContext(ctx).Error("explore_upcoming_shows_failed",
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to load upcoming shows (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetUpcomingShowsResponse{Body: *result}, nil
+}
+
+// ──────────────────────────────────────────────
+// GET /explore/featured
+// ──────────────────────────────────────────────
+
+// GetFeaturedRequest has no inputs — the endpoint is a pure read.
+// Huma requires the request struct to exist; an empty struct works.
+type GetFeaturedRequest struct{}
+
+// GetFeaturedResponse wraps the explore-shaped featured response.
+type GetFeaturedResponse struct {
+	Body contracts.ExploreFeaturedResponse
+}
+
+// GetFeaturedHandler handles GET /explore/featured. Returns the
+// currently-active bill + collection from the admin-curated
+// featured_slots table (PSY-835). Both fields are nullable: the
+// frontend collapses the section when both are nil. A stale referent
+// (deleted / privacy-flipped / status-flipped) resolves to nil for
+// that field — never a 500.
+func (h *ExploreHandler) GetFeaturedHandler(ctx context.Context, _ *GetFeaturedRequest) (*GetFeaturedResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	result, err := h.exploreService.GetFeatured()
+	if err != nil {
+		logger.FromContext(ctx).Error("explore_featured_failed",
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to load featured picks (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetFeaturedResponse{Body: *result}, nil
+}
+
+// ──────────────────────────────────────────────
+// GET /explore/shuffle-target
+// ──────────────────────────────────────────────
+
+// GetShuffleTargetRequest has no inputs — random pick.
+type GetShuffleTargetRequest struct{}
+
+// GetShuffleTargetResponse wraps the explore-shaped shuffle response.
+type GetShuffleTargetResponse struct {
+	Body contracts.ExploreShuffleTargetResponse
+}
+
+// GetShuffleTargetHandler handles GET /explore/shuffle-target. Returns
+// one random artist drawn from the pool of artists with a show in the
+// ±90-day window. When the pool is empty, returns all-nil fields with
+// HTTP 200 — the frontend renders a graceful empty state.
+func (h *ExploreHandler) GetShuffleTargetHandler(ctx context.Context, _ *GetShuffleTargetRequest) (*GetShuffleTargetResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	result, err := h.exploreService.GetShuffleTarget()
+	if err != nil {
+		logger.FromContext(ctx).Error("explore_shuffle_target_failed",
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to pick shuffle target (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetShuffleTargetResponse{Body: *result}, nil
+}

--- a/backend/internal/api/handlers/explore/explore_test.go
+++ b/backend/internal/api/handlers/explore/explore_test.go
@@ -1,0 +1,182 @@
+package explore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// =============================================================================
+// Upcoming Shows
+// =============================================================================
+
+func TestExploreHandler_GetUpcomingShows_DelegatesToService(t *testing.T) {
+	want := &contracts.ExploreUpcomingShowsResponse{
+		Shows: []contracts.ExploreUpcomingShowItem{
+			{ID: 1, Title: "Show A", HeadlinerName: "Artist A", EventDate: time.Now()},
+		},
+		Total:  1,
+		Limit:  20,
+		Offset: 0,
+	}
+	mock := &testhelpers.MockExploreService{
+		GetUpcomingShowsFn: func(limit, offset int) (*contracts.ExploreUpcomingShowsResponse, error) {
+			assert.Equal(t, 20, limit)
+			assert.Equal(t, 0, offset)
+			return want, nil
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetUpcomingShowsHandler(context.Background(), &GetUpcomingShowsRequest{Limit: 20, Offset: 0})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, *want, resp.Body)
+}
+
+func TestExploreHandler_GetUpcomingShows_PropagatesLimitOffset(t *testing.T) {
+	mock := &testhelpers.MockExploreService{
+		GetUpcomingShowsFn: func(limit, offset int) (*contracts.ExploreUpcomingShowsResponse, error) {
+			assert.Equal(t, 5, limit)
+			assert.Equal(t, 10, offset)
+			return &contracts.ExploreUpcomingShowsResponse{Limit: limit, Offset: offset}, nil
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	_, err := handler.GetUpcomingShowsHandler(context.Background(), &GetUpcomingShowsRequest{Limit: 5, Offset: 10})
+	require.NoError(t, err)
+}
+
+func TestExploreHandler_GetUpcomingShows_ServiceErrorBecomes500(t *testing.T) {
+	mock := &testhelpers.MockExploreService{
+		GetUpcomingShowsFn: func(int, int) (*contracts.ExploreUpcomingShowsResponse, error) {
+			return nil, errors.New("db blew up")
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetUpcomingShowsHandler(context.Background(), &GetUpcomingShowsRequest{Limit: 20})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// =============================================================================
+// Featured
+// =============================================================================
+
+func TestExploreHandler_GetFeatured_NullableFieldsPassThrough(t *testing.T) {
+	mock := &testhelpers.MockExploreService{
+		GetFeaturedFn: func() (*contracts.ExploreFeaturedResponse, error) {
+			return &contracts.ExploreFeaturedResponse{
+				Bill:       nil,
+				Collection: nil,
+			}, nil
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetFeaturedHandler(context.Background(), &GetFeaturedRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Body.Bill)
+	assert.Nil(t, resp.Body.Collection)
+}
+
+func TestExploreHandler_GetFeatured_PopulatedSlotsPassThrough(t *testing.T) {
+	curatorNote := "smoke"
+	mock := &testhelpers.MockExploreService{
+		GetFeaturedFn: func() (*contracts.ExploreFeaturedResponse, error) {
+			return &contracts.ExploreFeaturedResponse{
+				Bill: &contracts.ExploreFeaturedBill{
+					ID: 42, Title: "Bill", HeadlinerName: "HL", CuratorNote: &curatorNote,
+				},
+				Collection: &contracts.ExploreFeaturedCollection{
+					ID: 100, Title: "Crate", Slug: "crate-slug",
+				},
+			}, nil
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetFeaturedHandler(context.Background(), &GetFeaturedRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Body.Bill)
+	assert.Equal(t, uint(42), resp.Body.Bill.ID)
+	require.NotNil(t, resp.Body.Collection)
+	assert.Equal(t, "crate-slug", resp.Body.Collection.Slug)
+}
+
+func TestExploreHandler_GetFeatured_ServiceErrorBecomes500(t *testing.T) {
+	mock := &testhelpers.MockExploreService{
+		GetFeaturedFn: func() (*contracts.ExploreFeaturedResponse, error) {
+			return nil, errors.New("fail")
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetFeaturedHandler(context.Background(), &GetFeaturedRequest{})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// =============================================================================
+// Shuffle Target
+// =============================================================================
+
+func TestExploreHandler_GetShuffleTarget_EmptyPoolPassesNilThrough(t *testing.T) {
+	mock := &testhelpers.MockExploreService{
+		GetShuffleTargetFn: func() (*contracts.ExploreShuffleTargetResponse, error) {
+			return &contracts.ExploreShuffleTargetResponse{}, nil
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetShuffleTargetHandler(context.Background(), &GetShuffleTargetRequest{})
+	require.NoError(t, err)
+	assert.Nil(t, resp.Body.ArtistID)
+	assert.Nil(t, resp.Body.ArtistName)
+}
+
+func TestExploreHandler_GetShuffleTarget_PopulatedPassThrough(t *testing.T) {
+	id := uint(7)
+	slug := "the-artist"
+	name := "The Artist"
+	mock := &testhelpers.MockExploreService{
+		GetShuffleTargetFn: func() (*contracts.ExploreShuffleTargetResponse, error) {
+			return &contracts.ExploreShuffleTargetResponse{
+				ArtistID:   &id,
+				ArtistSlug: &slug,
+				ArtistName: &name,
+			}, nil
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetShuffleTargetHandler(context.Background(), &GetShuffleTargetRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Body.ArtistID)
+	assert.Equal(t, uint(7), *resp.Body.ArtistID)
+	assert.Equal(t, "the-artist", *resp.Body.ArtistSlug)
+	assert.Equal(t, "The Artist", *resp.Body.ArtistName)
+}
+
+func TestExploreHandler_GetShuffleTarget_ServiceErrorBecomes500(t *testing.T) {
+	mock := &testhelpers.MockExploreService{
+		GetShuffleTargetFn: func() (*contracts.ExploreShuffleTargetResponse, error) {
+			return nil, errors.New("fail")
+		},
+	}
+	handler := NewExploreHandler(mock)
+
+	resp, err := handler.GetShuffleTargetHandler(context.Background(), &GetShuffleTargetRequest{})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/backend/internal/api/handlers/shared/testhelpers/integration_deps.go
+++ b/backend/internal/api/handlers/shared/testhelpers/integration_deps.go
@@ -15,6 +15,7 @@ import (
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/community"
 	"psychic-homily-backend/internal/services/engagement"
+	exploresvc "psychic-homily-backend/internal/services/explore"
 	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/pipeline"
 	usersvc "psychic-homily-backend/internal/services/user"
@@ -35,6 +36,7 @@ type IntegrationDeps struct {
 	UserService               *usersvc.UserService
 	AuditLogService           *adminsvc.AuditLogService
 	FeaturedSlotService       *adminsvc.FeaturedSlotService
+	ExploreService            *exploresvc.ExploreService
 	DiscordService            *notification.DiscordService
 	ExtractionService         *pipeline.ExtractionService
 	APITokenService           *adminsvc.APITokenService
@@ -63,6 +65,7 @@ func SetupIntegrationDeps(t *testing.T) *IntegrationDeps {
 
 	emptyCfg := &config.Config{}
 
+	featuredSlotSvc := adminsvc.NewFeaturedSlotService(db)
 	deps := &IntegrationDeps{
 		DB:                        db,
 		TestDB:                    testDB,
@@ -74,7 +77,8 @@ func SetupIntegrationDeps(t *testing.T) *IntegrationDeps {
 		ShowReportService:         adminsvc.NewShowReportService(db),
 		UserService:               usersvc.NewUserService(db),
 		AuditLogService:           adminsvc.NewAuditLogService(db),
-		FeaturedSlotService:       adminsvc.NewFeaturedSlotService(db),
+		FeaturedSlotService:       featuredSlotSvc,
+		ExploreService:            exploresvc.NewExploreService(db, featuredSlotSvc),
 		DiscordService:            notification.NewDiscordService(emptyCfg),
 		ExtractionService:         pipeline.NewExtractionService(db, emptyCfg, catalog.NewArtistService(db), catalog.NewVenueService(db)),
 		APITokenService:           adminsvc.NewAPITokenService(db),

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1531,6 +1531,35 @@ func (m *MockEntityReportService) DismissEntityReport(reportID uint, reviewerID 
 }
 
 // ============================================================================
+// Mock: ExploreServiceInterface
+// ============================================================================
+
+type MockExploreService struct {
+	GetUpcomingShowsFn func(int, int) (*contracts.ExploreUpcomingShowsResponse, error)
+	GetFeaturedFn      func() (*contracts.ExploreFeaturedResponse, error)
+	GetShuffleTargetFn func() (*contracts.ExploreShuffleTargetResponse, error)
+}
+
+func (m *MockExploreService) GetUpcomingShows(limit int, offset int) (*contracts.ExploreUpcomingShowsResponse, error) {
+	if m.GetUpcomingShowsFn != nil {
+		return m.GetUpcomingShowsFn(limit, offset)
+	}
+	return nil, nil
+}
+func (m *MockExploreService) GetFeatured() (*contracts.ExploreFeaturedResponse, error) {
+	if m.GetFeaturedFn != nil {
+		return m.GetFeaturedFn()
+	}
+	return nil, nil
+}
+func (m *MockExploreService) GetShuffleTarget() (*contracts.ExploreShuffleTargetResponse, error) {
+	if m.GetShuffleTargetFn != nil {
+		return m.GetShuffleTargetFn()
+	}
+	return nil, nil
+}
+
+// ============================================================================
 // Mock: ExtractionServiceInterface
 // ============================================================================
 
@@ -4061,6 +4090,7 @@ var _ contracts.DiscoveryServiceInterface = (*MockDiscoveryService)(nil)
 var _ contracts.EmailServiceInterface = (*MockEmailService)(nil)
 var _ contracts.EnrichmentServiceInterface = (*MockEnrichmentService)(nil)
 var _ contracts.EntityReportServiceInterface = (*MockEntityReportService)(nil)
+var _ contracts.ExploreServiceInterface = (*MockExploreService)(nil)
 var _ contracts.ExtractionServiceInterface = (*MockExtractionService)(nil)
 var _ contracts.FavoriteVenueServiceInterface = (*MockFavoriteVenueService)(nil)
 var _ contracts.FeaturedSlotServiceInterface = (*MockFeaturedSlotService)(nil)

--- a/backend/internal/api/routes/explore.go
+++ b/backend/internal/api/routes/explore.go
@@ -1,0 +1,24 @@
+package routes
+
+import (
+	"github.com/danielgtaylor/huma/v2"
+
+	exploreh "psychic-homily-backend/internal/api/handlers/explore"
+)
+
+// setupExploreRoutes registers the three public read endpoints that
+// back the /explore landing page. Anonymous and authenticated callers
+// both see identical content (locked decision), so all routes register
+// directly on the public API group with no JWT middleware.
+//
+//   - GET /explore/upcoming-shows — chronological, paginated.
+//   - GET /explore/featured       — admin-curated bill + collection.
+//   - GET /explore/shuffle-target — random artist from the
+//     currently-relevant pool.
+func setupExploreRoutes(rc RouteContext) {
+	handler := exploreh.NewExploreHandler(rc.SC.Explore)
+
+	huma.Get(rc.API, "/explore/upcoming-shows", handler.GetUpcomingShowsHandler)
+	huma.Get(rc.API, "/explore/featured", handler.GetFeaturedHandler)
+	huma.Get(rc.API, "/explore/shuffle-target", handler.GetShuffleTargetHandler)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -99,6 +99,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupCommentVoteRoutes(rc)
 	setupCommentSubscriptionRoutes(rc)
 	setupFieldNoteRoutes(rc)
+	setupExploreRoutes(rc)
 
 	// PSY-432: test-fixtures reset endpoint — only registered when the env
 	// flag is set. cmd/server/main.go refuses to boot if the flag is on and

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -12,6 +12,7 @@ import (
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/community"
 	"psychic-homily-backend/internal/services/engagement"
+	exploresvc "psychic-homily-backend/internal/services/explore"
 	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/pipeline"
 	usersvc "psychic-homily-backend/internal/services/user"
@@ -34,6 +35,7 @@ type ServiceContainer struct {
 	ArtistReport           *adminsvc.ArtistReportService
 	AuditLog               *adminsvc.AuditLogService
 	FeaturedSlot           *adminsvc.FeaturedSlotService
+	Explore                *exploresvc.ExploreService
 	Bookmark               *engagement.BookmarkService
 	Calendar               *engagement.CalendarService
 	Collection             *community.CollectionService
@@ -152,6 +154,13 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	tagSvc := catalog.NewTagService(database)
 	collectionSvc.SetTagService(tagSvc)
 
+	// /explore landing reads reuse the FeaturedSlot service to look up
+	// the admin-curated bill + collection. Construct FeaturedSlot up
+	// front so the explore service can take it as a dependency rather
+	// than reaching back through the container.
+	featuredSlotSvc := adminsvc.NewFeaturedSlotService(database)
+	exploreService := exploresvc.NewExploreService(database, featuredSlotSvc)
+
 	return &ServiceContainer{
 		// DB-only leaf services
 		AdminStats:             adminsvc.NewAdminStatsService(database),
@@ -165,7 +174,8 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		ContributorProfile:     usersvc.NewContributorProfileService(database),
 		ArtistReport:           adminsvc.NewArtistReportService(database),
 		AuditLog:               adminsvc.NewAuditLogService(database),
-		FeaturedSlot:           adminsvc.NewFeaturedSlotService(database),
+		FeaturedSlot:           featuredSlotSvc,
+		Explore:                exploreService,
 		Bookmark:               engagement.NewBookmarkService(database),
 		Calendar:               engagement.NewCalendarService(database, savedShow),
 		Collection:             collectionSvc,

--- a/backend/internal/services/contracts/explore.go
+++ b/backend/internal/services/contracts/explore.go
@@ -1,0 +1,147 @@
+package contracts
+
+import "time"
+
+// ──────────────────────────────────────────────
+// /explore landing — read-side DTOs + interface
+// ──────────────────────────────────────────────
+//
+// The /explore page surfaces three slices of content:
+//
+//  1. Upcoming Shows — chronological list (event_date ASC). No trending,
+//     no ranking; just "what's next" with deterministic pagination.
+//  2. Featured — the admin-curated bill + collection from
+//     featured_slots (admin sets via the surface introduced by PSY-835).
+//     Both fields are nullable: the frontend collapses the section when
+//     a curator hasn't picked one.
+//  3. Shuffle Target — a random pick from the "currently relevant"
+//     pool (artists with a show in a ±90-day window). Backs the
+//     "Surprise me" affordance.
+//
+// The shapes here are intentionally minimal — only the fields a tile or
+// hero card needs. We do NOT echo the full ShowResponse / Collection
+// detail because they're heavier (artists slice with social links,
+// preloaded items, etc.) and the /explore surface doesn't render them.
+// A dedicated DTO keeps the endpoint payload small and the JSON shape
+// explicit.
+
+// ExploreUpcomingShowItem is the wire shape for one row on the
+// Upcoming Shows list. Headliner is a denormalized convenience —
+// the frontend renders headliner-as-title and links to the show
+// detail page for the rest of the bill.
+type ExploreUpcomingShowItem struct {
+	ID        uint      `json:"id"`
+	Slug      string    `json:"slug"`
+	Title     string    `json:"title"`
+	EventDate time.Time `json:"event_date"`
+	// HeadlinerName is the name of the show's headliner artist
+	// (show_artists.set_type = 'headliner'). When the show has no
+	// headliner row, the first artist by position is used. Empty
+	// when the show has no artists at all (shouldn't happen but the
+	// pipeline doesn't enforce it).
+	HeadlinerName string `json:"headliner_name"`
+	// VenueName / VenueCity / VenueState carry the first associated
+	// venue. Most shows have exactly one; when there are multiple
+	// (unusual), we surface the first by ID so the tile renders.
+	VenueName  string  `json:"venue_name"`
+	VenueCity  string  `json:"venue_city"`
+	VenueState string  `json:"venue_state"`
+	City       *string `json:"city,omitempty"`
+	State      *string `json:"state,omitempty"`
+}
+
+// ExploreUpcomingShowsResponse wraps the page slice + pagination
+// metadata for GET /explore/upcoming-shows. Total is the count of
+// matching rows (event_date >= NOW(), status = approved) so the
+// frontend can render "showing N of M" or hide the next-page control
+// once the cursor reaches the end.
+type ExploreUpcomingShowsResponse struct {
+	Shows  []ExploreUpcomingShowItem `json:"shows"`
+	Total  int64                     `json:"total"`
+	Limit  int                       `json:"limit"`
+	Offset int                       `json:"offset"`
+}
+
+// ExploreFeaturedBill is the bill referent for the Featured slot.
+// CuratorNote / CuratorNoteHTML mirror the admin-side wire shape — raw
+// markdown source + sanitized HTML render (rendered fresh on each read,
+// per the same boundary policy collections + comments use).
+type ExploreFeaturedBill struct {
+	ID              uint      `json:"id"`
+	Slug            string    `json:"slug"`
+	Title           string    `json:"title"`
+	EventDate       time.Time `json:"event_date"`
+	HeadlinerName   string    `json:"headliner_name"`
+	VenueName       string    `json:"venue_name"`
+	VenueCity       string    `json:"venue_city"`
+	VenueState      string    `json:"venue_state"`
+	ImageURL        *string   `json:"image_url,omitempty"`
+	CuratorNote     *string   `json:"curator_note,omitempty"`
+	CuratorNoteHTML string    `json:"curator_note_html,omitempty"`
+}
+
+// ExploreFeaturedCollection is the collection referent for the
+// Featured slot. Only fields the /explore hero card renders are
+// surfaced — the full CollectionDetailResponse with items + tags
+// stays gated behind the dedicated collection-detail endpoint.
+type ExploreFeaturedCollection struct {
+	ID              uint    `json:"id"`
+	Slug            string  `json:"slug"`
+	Title           string  `json:"title"`
+	Description     string  `json:"description,omitempty"`
+	DescriptionHTML string  `json:"description_html,omitempty"`
+	CoverImageURL   *string `json:"cover_image_url,omitempty"`
+	CuratorNote     *string `json:"curator_note,omitempty"`
+	CuratorNoteHTML string  `json:"curator_note_html,omitempty"`
+}
+
+// ExploreFeaturedResponse is the wire shape for GET /explore/featured.
+// Both fields are nullable — when the admin hasn't curated a slot, the
+// referent has been deleted, or the referent is no longer publicly
+// visible (private collection), the corresponding field is nil. The
+// frontend collapses the section when both are nil.
+type ExploreFeaturedResponse struct {
+	Bill       *ExploreFeaturedBill       `json:"bill"`
+	Collection *ExploreFeaturedCollection `json:"collection"`
+}
+
+// ExploreShuffleTargetResponse is the wire shape for GET
+// /explore/shuffle-target — a single random artist drawn from the
+// "currently relevant" pool (any artist with a show in the ±90-day
+// window). The frontend uses ArtistID/ArtistSlug to navigate to the
+// artist detail page. Pointer fields so a truly empty database
+// (no qualifying artists) returns {artist_id: null, artist_slug: null,
+// artist_name: null} rather than a hard 404 — the surface gracefully
+// degrades.
+type ExploreShuffleTargetResponse struct {
+	ArtistID   *uint   `json:"artist_id"`
+	ArtistSlug *string `json:"artist_slug"`
+	ArtistName *string `json:"artist_name"`
+}
+
+// ExploreServiceInterface defines the contract for the /explore
+// read-side endpoints. Implementation lives at
+// internal/services/explore. The handler depends on this interface so
+// generated mocks (via the contracts scanner) cover unit tests.
+type ExploreServiceInterface interface {
+	// GetUpcomingShows returns approved shows with event_date >= NOW(),
+	// ordered by (event_date ASC, id ASC) for deterministic pagination.
+	// Limit is clamped to [1, 50]; offset must be non-negative. Returns
+	// the page + total count for matching rows.
+	GetUpcomingShows(limit, offset int) (*ExploreUpcomingShowsResponse, error)
+
+	// GetFeatured returns the currently-active bill + collection from
+	// featured_slots. Returns nil for either field when:
+	//   - the admin hasn't set that slot yet, OR
+	//   - the referent has been deleted, OR
+	//   - the referent is no longer publicly visible (private collection).
+	// Never returns an error solely because a slot is empty; only
+	// genuine I/O failures bubble up.
+	GetFeatured() (*ExploreFeaturedResponse, error)
+
+	// GetShuffleTarget returns one random artist from the pool of
+	// artists with a show within the past 90 days OR the next 90
+	// days. When the pool is empty (cold start, test fixture, etc.),
+	// returns a response with all-nil fields rather than an error.
+	GetShuffleTarget() (*ExploreShuffleTargetResponse, error)
+}

--- a/backend/internal/services/explore/explore.go
+++ b/backend/internal/services/explore/explore.go
@@ -44,15 +44,14 @@ const (
 const shuffleWindowDays = 90
 
 // ExploreService backs the /explore landing endpoints. The DB handle
-// falls back to the package singleton so older test paths constructing
-// the bare struct still resolve a connection. featuredSlots gives us
-// the admin-curated picks; md renders curator notes + collection
-// descriptions on read with the shared markdown stack.
+// falls back to the package singleton so the bare-struct construction
+// path used by older test fixtures still resolves a connection.
+// featuredSlots gives us the admin-curated picks; md renders curator
+// notes + collection descriptions on read with the shared markdown stack.
 type ExploreService struct {
 	db            *gorm.DB
 	featuredSlots contracts.FeaturedSlotServiceInterface
 	md            *utils.MarkdownRenderer
-	nowFn         func() time.Time
 }
 
 // NewExploreService constructs the /explore service with its
@@ -68,25 +67,7 @@ func NewExploreService(database *gorm.DB, featuredSlots contracts.FeaturedSlotSe
 		db:            database,
 		featuredSlots: featuredSlots,
 		md:            utils.NewMarkdownRenderer(),
-		nowFn:         time.Now,
 	}
-}
-
-// SetNowFn overrides the clock used for "now" comparisons. Tests use
-// this to make time-window queries deterministic — the alternative is
-// inserting shows at hard-coded relative offsets and hoping no
-// daylight-saving boundary shifts the assertion. Not for production use.
-func (s *ExploreService) SetNowFn(fn func() time.Time) {
-	if fn != nil {
-		s.nowFn = fn
-	}
-}
-
-func (s *ExploreService) now() time.Time {
-	if s.nowFn == nil {
-		return time.Now()
-	}
-	return s.nowFn()
 }
 
 // ──────────────────────────────────────────────
@@ -120,7 +101,7 @@ func (s *ExploreService) GetUpcomingShows(limit, offset int) (*contracts.Explore
 		offset = 0
 	}
 
-	now := s.now().UTC()
+	now := time.Now().UTC()
 
 	// Count first so the response carries an authoritative total
 	// without the page-size cap affecting it. Same WHERE clause as the
@@ -430,9 +411,10 @@ func (s *ExploreService) resolveFeaturedCollection() (*contracts.ExploreFeatured
 // activeSlotOrNil wraps FeaturedSlotService.GetActiveSlot but translates
 // the ErrFeaturedSlotNotFound sentinel into (nil, nil) so callers can
 // branch on the not-found case without importing the admin-service
-// sentinel themselves. Real I/O failures are propagated unchanged.
-// Tolerates a nil featuredSlots dependency for legacy test paths that
-// construct ExploreService without wiring the admin services.
+// sentinel themselves. Real I/O failures propagate unchanged. The
+// nil-dependency guard keeps the bare-struct construction path safe
+// (legitimately reachable by anything that builds ExploreService
+// without the FeaturedSlot wiring).
 func (s *ExploreService) activeSlotOrNil(slotType string) (*adminm.FeaturedSlot, error) {
 	if s.featuredSlots == nil {
 		return nil, nil
@@ -491,7 +473,7 @@ func (s *ExploreService) GetShuffleTarget() (*contracts.ExploreShuffleTargetResp
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	now := s.now().UTC()
+	now := time.Now().UTC()
 	windowStart := now.AddDate(0, 0, -shuffleWindowDays)
 	windowEnd := now.AddDate(0, 0, shuffleWindowDays)
 

--- a/backend/internal/services/explore/explore.go
+++ b/backend/internal/services/explore/explore.go
@@ -1,0 +1,536 @@
+// Package explore implements the read-side service for the /explore
+// landing page. The page renders three slices: upcoming shows
+// (chronological), the admin-curated featured bill + collection (from
+// featured_slots — see PSY-835), and a random "shuffle target" artist
+// for the surprise-me affordance.
+//
+// There is intentionally NO trending / ranking algorithm here. The
+// product decision (locked at the open-questions stage) is to start
+// chronological + editorial, and only add algorithmic ranking if a real
+// recommendations engine ever becomes warranted. Resist the temptation
+// to backfill heuristics — they erode trust when they're wrong.
+package explore
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	adminm "psychic-homily-backend/internal/models/admin"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
+	adminsvc "psychic-homily-backend/internal/services/admin"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/utils"
+)
+
+// Upper bound on the upcoming-shows page. Mirrors the bounds we use on
+// other public list endpoints — keeps a single request from pulling
+// thousands of rows + venue/artist joins.
+const (
+	maxUpcomingShowsLimit     = 50
+	defaultUpcomingShowsLimit = 20
+)
+
+// Shuffle pool window — artists with a show inside this window are
+// eligible to surface from the surprise-me affordance. Symmetric
+// past/future to bias the pool toward currently-relevant artists
+// (recent shows + upcoming shows both count). The 90-day choice is a
+// product call, not a derived constant; tighten / widen here if the
+// pool turns out to be too narrow or too broad in practice.
+const shuffleWindowDays = 90
+
+// ExploreService backs the /explore landing endpoints. The DB handle
+// falls back to the package singleton so older test paths constructing
+// the bare struct still resolve a connection. featuredSlots gives us
+// the admin-curated picks; md renders curator notes + collection
+// descriptions on read with the shared markdown stack.
+type ExploreService struct {
+	db            *gorm.DB
+	featuredSlots contracts.FeaturedSlotServiceInterface
+	md            *utils.MarkdownRenderer
+	nowFn         func() time.Time
+}
+
+// NewExploreService constructs the /explore service with its
+// dependencies. The featured-slot service is injected (rather than
+// constructed inline) so handler integration tests can swap in a
+// real instance from IntegrationDeps and unit tests can swap in a
+// mock without standing up a Postgres container.
+func NewExploreService(database *gorm.DB, featuredSlots contracts.FeaturedSlotServiceInterface) *ExploreService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &ExploreService{
+		db:            database,
+		featuredSlots: featuredSlots,
+		md:            utils.NewMarkdownRenderer(),
+		nowFn:         time.Now,
+	}
+}
+
+// SetNowFn overrides the clock used for "now" comparisons. Tests use
+// this to make time-window queries deterministic — the alternative is
+// inserting shows at hard-coded relative offsets and hoping no
+// daylight-saving boundary shifts the assertion. Not for production use.
+func (s *ExploreService) SetNowFn(fn func() time.Time) {
+	if fn != nil {
+		s.nowFn = fn
+	}
+}
+
+func (s *ExploreService) now() time.Time {
+	if s.nowFn == nil {
+		return time.Now()
+	}
+	return s.nowFn()
+}
+
+// ──────────────────────────────────────────────
+// Upcoming Shows
+// ──────────────────────────────────────────────
+
+// GetUpcomingShows returns approved shows with event_date >= NOW(),
+// ordered by event_date ASC then id ASC. The (event_date, id) tuple is
+// strictly monotonic across the pagination window, so offset-based
+// paging stays deterministic even when two shows share the same
+// timestamp (festival lineups, parallel matinee/evening pairings).
+//
+// We deliberately limit the response to a compact projection
+// (ExploreUpcomingShowItem) rather than the full ShowResponse — the
+// /explore tile only needs headliner + venue + date. Skipping the
+// per-show artist preload keeps the query at three round-trips total
+// (shows page, batch venue lookup, batch headliner lookup) instead of
+// the N+1 explosion the full ShowResponse builder would produce.
+func (s *ExploreService) GetUpcomingShows(limit, offset int) (*contracts.ExploreUpcomingShowsResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = defaultUpcomingShowsLimit
+	}
+	if limit > maxUpcomingShowsLimit {
+		limit = maxUpcomingShowsLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	now := s.now().UTC()
+
+	// Count first so the response carries an authoritative total
+	// without the page-size cap affecting it. Same WHERE clause as the
+	// data query — no JOINs needed.
+	var total int64
+	if err := s.db.Model(&catalogm.Show{}).
+		Where("event_date >= ? AND status = ?", now, catalogm.ShowStatusApproved).
+		Count(&total).Error; err != nil {
+		return nil, fmt.Errorf("failed to count upcoming shows: %w", err)
+	}
+
+	var shows []catalogm.Show
+	if err := s.db.
+		Where("event_date >= ? AND status = ?", now, catalogm.ShowStatusApproved).
+		Order("event_date ASC, id ASC").
+		Limit(limit).
+		Offset(offset).
+		Find(&shows).Error; err != nil {
+		return nil, fmt.Errorf("failed to list upcoming shows: %w", err)
+	}
+
+	items := make([]contracts.ExploreUpcomingShowItem, 0, len(shows))
+	if len(shows) == 0 {
+		return &contracts.ExploreUpcomingShowsResponse{
+			Shows:  items,
+			Total:  total,
+			Limit:  limit,
+			Offset: offset,
+		}, nil
+	}
+
+	showIDs := make([]uint, len(shows))
+	for i, sh := range shows {
+		showIDs[i] = sh.ID
+	}
+
+	// Batch-fetch first venue per show. Most shows have exactly one;
+	// when there are several we deterministically take the lowest
+	// venue ID per show so the response is stable across requests.
+	venueByShow := s.firstVenueByShow(showIDs)
+
+	// Batch-fetch headliner artist per show. Prefer the row with
+	// set_type='headliner'; fall back to position ASC if none.
+	headlinerByShow := s.headlinerNameByShow(showIDs)
+
+	for _, sh := range shows {
+		item := contracts.ExploreUpcomingShowItem{
+			ID:        sh.ID,
+			Title:     sh.Title,
+			EventDate: sh.EventDate,
+			City:      sh.City,
+			State:     sh.State,
+		}
+		if sh.Slug != nil {
+			item.Slug = *sh.Slug
+		}
+		if v, ok := venueByShow[sh.ID]; ok {
+			item.VenueName = v.Name
+			item.VenueCity = v.City
+			item.VenueState = v.State
+		}
+		if name, ok := headlinerByShow[sh.ID]; ok {
+			item.HeadlinerName = name
+		}
+		items = append(items, item)
+	}
+
+	return &contracts.ExploreUpcomingShowsResponse{
+		Shows:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	}, nil
+}
+
+// firstVenueByShow returns the lowest-ID venue per show ID. We index
+// the per-show join with ORDER BY venue_id ASC so a show with two
+// venue rows (rare) deterministically surfaces the same one across
+// pagination pages.
+func (s *ExploreService) firstVenueByShow(showIDs []uint) map[uint]catalogm.Venue {
+	out := make(map[uint]catalogm.Venue, len(showIDs))
+	if len(showIDs) == 0 {
+		return out
+	}
+
+	type row struct {
+		ShowID  uint
+		VenueID uint
+	}
+	var pairs []row
+	if err := s.db.Table("show_venues").
+		Select("show_id, venue_id").
+		Where("show_id IN ?", showIDs).
+		Order("show_id ASC, venue_id ASC").
+		Find(&pairs).Error; err != nil {
+		// Best-effort: empty map → empty venue fields on the response.
+		return out
+	}
+
+	venueIDs := make([]uint, 0, len(pairs))
+	firstVenueIDByShow := make(map[uint]uint, len(showIDs))
+	for _, p := range pairs {
+		if _, claimed := firstVenueIDByShow[p.ShowID]; claimed {
+			continue
+		}
+		firstVenueIDByShow[p.ShowID] = p.VenueID
+		venueIDs = append(venueIDs, p.VenueID)
+	}
+	if len(venueIDs) == 0 {
+		return out
+	}
+
+	var venues []catalogm.Venue
+	if err := s.db.Where("id IN ?", venueIDs).Find(&venues).Error; err != nil {
+		return out
+	}
+	venueByID := make(map[uint]catalogm.Venue, len(venues))
+	for _, v := range venues {
+		venueByID[v.ID] = v
+	}
+	for showID, venueID := range firstVenueIDByShow {
+		if v, ok := venueByID[venueID]; ok {
+			out[showID] = v
+		}
+	}
+	return out
+}
+
+// headlinerNameByShow returns the headliner artist name per show ID.
+// Selection rule: prefer set_type='headliner'; if no row is so flagged
+// for a show, fall back to position ASC (the bill's first listed
+// artist). Matches the existing convention in
+// services/engagement/saved_show.go where set_type='headliner' is the
+// canonical flag.
+func (s *ExploreService) headlinerNameByShow(showIDs []uint) map[uint]string {
+	out := make(map[uint]string, len(showIDs))
+	if len(showIDs) == 0 {
+		return out
+	}
+
+	var rows []catalogm.ShowArtist
+	if err := s.db.
+		Where("show_id IN ?", showIDs).
+		Order("show_id ASC, (set_type = 'headliner') DESC, position ASC, artist_id ASC").
+		Find(&rows).Error; err != nil {
+		return out
+	}
+
+	chosen := make(map[uint]uint, len(showIDs)) // show_id -> artist_id
+	artistIDs := make([]uint, 0, len(showIDs))
+	for _, r := range rows {
+		if _, taken := chosen[r.ShowID]; taken {
+			continue
+		}
+		chosen[r.ShowID] = r.ArtistID
+		artistIDs = append(artistIDs, r.ArtistID)
+	}
+	if len(artistIDs) == 0 {
+		return out
+	}
+
+	var artists []catalogm.Artist
+	if err := s.db.Where("id IN ?", artistIDs).Find(&artists).Error; err != nil {
+		return out
+	}
+	nameByID := make(map[uint]string, len(artists))
+	for _, a := range artists {
+		nameByID[a.ID] = a.Name
+	}
+	for showID, artistID := range chosen {
+		if name, ok := nameByID[artistID]; ok {
+			out[showID] = name
+		}
+	}
+	return out
+}
+
+// ──────────────────────────────────────────────
+// Featured (admin-curated)
+// ──────────────────────────────────────────────
+
+// GetFeatured returns the currently active featured bill + collection.
+//
+// IMPORTANT: featured_slots.entity_id is polymorphic with NO database
+// FK (the referent table varies by slot_type — shows or collections).
+// The referent may have been deleted, made private, or otherwise
+// removed from the public surface after the slot was set. We defensively
+// LEFT-JOIN here so a stale slot returns nil for that field rather
+// than 500-ing the entire response.
+//
+// Privacy rule for the collection slot: a collection that has been
+// flipped to private (is_public=false) is excluded — we don't want to
+// leak a private collection's title/description through the /explore
+// landing just because someone privately featured it earlier. A new
+// admin pick or a flip back to public restores visibility.
+func (s *ExploreService) GetFeatured() (*contracts.ExploreFeaturedResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	out := &contracts.ExploreFeaturedResponse{}
+
+	bill, err := s.resolveFeaturedBill()
+	if err != nil {
+		return nil, err
+	}
+	out.Bill = bill
+
+	coll, err := s.resolveFeaturedCollection()
+	if err != nil {
+		return nil, err
+	}
+	out.Collection = coll
+
+	return out, nil
+}
+
+// resolveFeaturedBill fetches the active bill slot and, if its
+// referent still exists + is publicly visible (approved status), hydrates
+// the response item. Returns (nil, nil) when there's no active slot or
+// the referent is gone — distinguishes "nothing curated" / "stale
+// referent" from real I/O failures.
+func (s *ExploreService) resolveFeaturedBill() (*contracts.ExploreFeaturedBill, error) {
+	slot, err := s.activeSlotOrNil(adminm.FeaturedSlotTypeBill)
+	if err != nil {
+		return nil, err
+	}
+	if slot == nil {
+		return nil, nil
+	}
+
+	var show catalogm.Show
+	err = s.db.
+		Where("id = ? AND status = ?", slot.EntityID, catalogm.ShowStatusApproved).
+		First(&show).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Referent deleted or no longer approved — collapse the
+			// slot gracefully rather than orphaning the response.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to load featured bill referent: %w", err)
+	}
+
+	venues := s.firstVenueByShow([]uint{show.ID})
+	headliners := s.headlinerNameByShow([]uint{show.ID})
+
+	item := &contracts.ExploreFeaturedBill{
+		ID:              show.ID,
+		Title:           show.Title,
+		EventDate:       show.EventDate,
+		ImageURL:        show.ImageURL,
+		CuratorNote:     slot.CuratorNote,
+		CuratorNoteHTML: s.renderCuratorNote(slot.CuratorNote),
+	}
+	if show.Slug != nil {
+		item.Slug = *show.Slug
+	}
+	if v, ok := venues[show.ID]; ok {
+		item.VenueName = v.Name
+		item.VenueCity = v.City
+		item.VenueState = v.State
+	}
+	if name, ok := headliners[show.ID]; ok {
+		item.HeadlinerName = name
+	}
+	return item, nil
+}
+
+// resolveFeaturedCollection mirrors resolveFeaturedBill for the
+// Featured Collection slot. Privacy guard: a collection flipped to
+// private after being featured collapses to nil here so the /explore
+// landing doesn't leak its title/description. A subsequent flip back
+// to public (or a new admin pick) restores the surface.
+func (s *ExploreService) resolveFeaturedCollection() (*contracts.ExploreFeaturedCollection, error) {
+	slot, err := s.activeSlotOrNil(adminm.FeaturedSlotTypeCollection)
+	if err != nil {
+		return nil, err
+	}
+	if slot == nil {
+		return nil, nil
+	}
+
+	var coll communitym.Collection
+	err = s.db.
+		Where("id = ? AND is_public = ?", slot.EntityID, true).
+		First(&coll).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to load featured collection referent: %w", err)
+	}
+
+	return &contracts.ExploreFeaturedCollection{
+		ID:              coll.ID,
+		Slug:            coll.Slug,
+		Title:           coll.Title,
+		Description:     coll.Description,
+		DescriptionHTML: s.renderMarkdown(coll.Description),
+		CoverImageURL:   coll.CoverImageURL,
+		CuratorNote:     slot.CuratorNote,
+		CuratorNoteHTML: s.renderCuratorNote(slot.CuratorNote),
+	}, nil
+}
+
+// activeSlotOrNil wraps FeaturedSlotService.GetActiveSlot but translates
+// the ErrFeaturedSlotNotFound sentinel into (nil, nil) so callers can
+// branch on the not-found case without importing the admin-service
+// sentinel themselves. Real I/O failures are propagated unchanged.
+// Tolerates a nil featuredSlots dependency for legacy test paths that
+// construct ExploreService without wiring the admin services.
+func (s *ExploreService) activeSlotOrNil(slotType string) (*adminm.FeaturedSlot, error) {
+	if s.featuredSlots == nil {
+		return nil, nil
+	}
+	slot, err := s.featuredSlots.GetActiveSlot(slotType)
+	if err != nil {
+		if errors.Is(err, adminsvc.ErrFeaturedSlotNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to load active featured slot (%s): %w", slotType, err)
+	}
+	return slot, nil
+}
+
+// renderCuratorNote delegates to FeaturedSlotService when available so
+// both surfaces (admin + /explore) share one rendering boundary. Falls
+// back to the local MarkdownRenderer when the dependency isn't wired
+// (test paths).
+func (s *ExploreService) renderCuratorNote(note *string) string {
+	if note == nil || *note == "" {
+		return ""
+	}
+	if s.featuredSlots != nil {
+		return s.featuredSlots.RenderCuratorNote(note)
+	}
+	return s.renderMarkdown(*note)
+}
+
+func (s *ExploreService) renderMarkdown(body string) string {
+	if body == "" {
+		return ""
+	}
+	if s.md == nil {
+		s.md = utils.NewMarkdownRenderer()
+	}
+	return s.md.Render(body)
+}
+
+// ──────────────────────────────────────────────
+// Shuffle Target
+// ──────────────────────────────────────────────
+
+// GetShuffleTarget returns one random artist drawn from the pool of
+// artists who have a show within ±90 days of NOW(). The pool is the
+// distinct set of show_artists.artist_id where the parent show's
+// event_date falls in the window. We use `ORDER BY random() LIMIT 1`
+// directly — the qualifying pool is small enough (low thousands at
+// peak) that the postgres sort scan is cheap, and we don't need
+// repeatable selection across requests.
+//
+// When the pool is empty (very early production, test environments,
+// etc.) all response fields are nil and the frontend can render a
+// graceful "nothing to shuffle to" affordance.
+func (s *ExploreService) GetShuffleTarget() (*contracts.ExploreShuffleTargetResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	now := s.now().UTC()
+	windowStart := now.AddDate(0, 0, -shuffleWindowDays)
+	windowEnd := now.AddDate(0, 0, shuffleWindowDays)
+
+	// Postgres rejects `ORDER BY random()` directly on a SELECT
+	// DISTINCT projection (the ORDER BY expression must appear in the
+	// select list). Two-step: dedupe the artist IDs in a subquery,
+	// then ORDER BY random() over the deduped pool. The optimizer
+	// folds this into a single index scan + sort.
+	type row struct {
+		ID   uint
+		Slug *string
+		Name string
+	}
+
+	subquery := s.db.Table("show_artists AS sa").
+		Select("DISTINCT sa.artist_id").
+		Joins("JOIN shows ON shows.id = sa.show_id").
+		Where("shows.event_date >= ? AND shows.event_date <= ? AND shows.status = ?",
+			windowStart, windowEnd, catalogm.ShowStatusApproved)
+
+	var picked row
+	err := s.db.Table("artists").
+		Select("artists.id, artists.slug, artists.name").
+		Where("artists.id IN (?)", subquery).
+		Order("random()").
+		Limit(1).
+		Scan(&picked).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to pick shuffle target: %w", err)
+	}
+
+	out := &contracts.ExploreShuffleTargetResponse{}
+	if picked.ID == 0 {
+		return out, nil
+	}
+	id := picked.ID
+	name := picked.Name
+	out.ArtistID = &id
+	out.ArtistSlug = picked.Slug
+	out.ArtistName = &name
+	return out, nil
+}

--- a/backend/internal/services/explore/explore_test.go
+++ b/backend/internal/services/explore/explore_test.go
@@ -1,0 +1,429 @@
+package explore
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
+	adminsvc "psychic-homily-backend/internal/services/admin"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// ExploreServiceIntegrationSuite drives the /explore reads against a
+// real Postgres testcontainer. The shape under test — chronological
+// ordering, polymorphic-referent defensive reads, ±90d shuffle pool
+// membership — only exercises end-to-end against actual rows + joins.
+// Pure-unit mocking the GORM layer would assert syntax, not behaviour.
+type ExploreServiceIntegrationSuite struct {
+	suite.Suite
+	testDB              *testutil.TestDatabase
+	db                  *gorm.DB
+	featuredSlotService *adminsvc.FeaturedSlotService
+	exploreService      *ExploreService
+}
+
+func (s *ExploreServiceIntegrationSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.featuredSlotService = adminsvc.NewFeaturedSlotService(s.db)
+	s.exploreService = NewExploreService(s.db, s.featuredSlotService)
+}
+
+func (s *ExploreServiceIntegrationSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *ExploreServiceIntegrationSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	// Order respects FKs — children before parents. featured_slots
+	// references users; collections/shows are independent leaves but
+	// they're referenced by show_artists/show_venues children.
+	for _, stmt := range []string{
+		"DELETE FROM featured_slots",
+		"DELETE FROM show_artists",
+		"DELETE FROM show_venues",
+		"DELETE FROM shows",
+		"DELETE FROM artists",
+		"DELETE FROM venues",
+		"DELETE FROM collection_items",
+		"DELETE FROM collections",
+		"DELETE FROM users",
+	} {
+		_, _ = sqlDB.Exec(stmt)
+	}
+}
+
+func TestExploreServiceIntegrationSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(ExploreServiceIntegrationSuite))
+}
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+func (s *ExploreServiceIntegrationSuite) createAdmin(label string) *authm.User {
+	email := fmt.Sprintf("%s-%d@test.com", label, time.Now().UnixNano())
+	user := &authm.User{
+		Email:         &email,
+		FirstName:     &label,
+		IsActive:      true,
+		IsAdmin:       true,
+		EmailVerified: true,
+	}
+	s.Require().NoError(s.db.Create(user).Error)
+	return user
+}
+
+// createShow inserts an approved show with one venue + one headliner
+// artist, dated relative to NOW(). Returns the show ID + artist ID for
+// downstream assertions.
+func (s *ExploreServiceIntegrationSuite) createShow(title string, daysFromNow int) (*catalogm.Show, *catalogm.Artist, *catalogm.Venue) {
+	city := "Phoenix"
+	state := "AZ"
+	slug := fmt.Sprintf("show-%s-%d", title, time.Now().UnixNano())
+	show := &catalogm.Show{
+		Title:     title,
+		Slug:      &slug,
+		EventDate: time.Now().UTC().AddDate(0, 0, daysFromNow),
+		City:      &city,
+		State:     &state,
+		Status:    catalogm.ShowStatusApproved,
+	}
+	s.Require().NoError(s.db.Create(show).Error)
+
+	venue := &catalogm.Venue{
+		Name:     title + " Venue",
+		City:     "Phoenix",
+		State:    "AZ",
+		Verified: true,
+	}
+	s.Require().NoError(s.db.Create(venue).Error)
+
+	artistSlug := fmt.Sprintf("artist-%s-%d", title, time.Now().UnixNano())
+	artist := &catalogm.Artist{
+		Name: title + " Artist",
+		Slug: &artistSlug,
+	}
+	s.Require().NoError(s.db.Create(artist).Error)
+
+	s.db.Exec("INSERT INTO show_venues (show_id, venue_id) VALUES (?, ?)", show.ID, venue.ID)
+	s.db.Exec(`INSERT INTO show_artists (show_id, artist_id, position, set_type, event_date, venue_id)
+	             VALUES (?, ?, 0, 'headliner', ?, ?)`,
+		show.ID, artist.ID, show.EventDate, venue.ID)
+
+	return show, artist, venue
+}
+
+// createCollection seeds a collection with the given visibility.
+// GORM-bool gotcha (per CLAUDE.md): IsPublic = false is the zero-value
+// so Create silently ignores it and the column default (true) wins.
+// Insert as public, then Update to flip private when needed.
+func (s *ExploreServiceIntegrationSuite) createCollection(creatorID uint, title string, isPublic bool) *communitym.Collection {
+	coll := &communitym.Collection{
+		Title:     title,
+		Slug:      fmt.Sprintf("%s-%d", title, time.Now().UnixNano()),
+		CreatorID: creatorID,
+		IsPublic:  true,
+	}
+	s.Require().NoError(s.db.Create(coll).Error)
+	if !isPublic {
+		s.Require().NoError(s.db.Model(coll).Update("is_public", false).Error)
+		coll.IsPublic = false
+	}
+	return coll
+}
+
+// ──────────────────────────────────────────────
+// GetUpcomingShows
+// ──────────────────────────────────────────────
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_Empty() {
+	resp, err := s.exploreService.GetUpcomingShows(20, 0)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(int64(0), resp.Total)
+	s.Empty(resp.Shows)
+	s.Equal(20, resp.Limit)
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_ChronologicalOrder() {
+	// Insert in non-chronological order so the test asserts SQL
+	// ORDER BY, not insertion order.
+	s.createShow("c-far", 30)
+	s.createShow("a-soon", 1)
+	s.createShow("b-mid", 7)
+
+	resp, err := s.exploreService.GetUpcomingShows(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Shows, 3)
+	s.Equal(int64(3), resp.Total)
+
+	// Verify ascending event_date order.
+	for i := 1; i < len(resp.Shows); i++ {
+		s.True(resp.Shows[i-1].EventDate.Before(resp.Shows[i].EventDate),
+			"shows must be in ascending event_date order")
+	}
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_ExcludesPast() {
+	// Past show should not surface even though it's approved.
+	s.createShow("past", -3)
+	future, _, _ := s.createShow("future", 5)
+
+	resp, err := s.exploreService.GetUpcomingShows(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Shows, 1)
+	s.Equal(future.ID, resp.Shows[0].ID)
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_ExcludesNonApproved() {
+	// Pending + Private + Rejected shows must not leak through.
+	city := "Phoenix"
+	state := "AZ"
+	for _, status := range []catalogm.ShowStatus{
+		catalogm.ShowStatusPending, catalogm.ShowStatusPrivate, catalogm.ShowStatusRejected,
+	} {
+		show := &catalogm.Show{
+			Title:     fmt.Sprintf("non-approved %s", status),
+			EventDate: time.Now().UTC().AddDate(0, 0, 5),
+			City:      &city,
+			State:     &state,
+			Status:    status,
+		}
+		s.Require().NoError(s.db.Create(show).Error)
+	}
+	visible, _, _ := s.createShow("approved", 5)
+
+	resp, err := s.exploreService.GetUpcomingShows(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Shows, 1)
+	s.Equal(visible.ID, resp.Shows[0].ID)
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_DeterministicPaginationOnTie() {
+	// Two shows with identical event_date — pagination must order by
+	// id ASC so the page boundary is reproducible across calls.
+	eventDate := time.Now().UTC().AddDate(0, 0, 7)
+	city := "Phoenix"
+	state := "AZ"
+	a := &catalogm.Show{Title: "tie-a", EventDate: eventDate, City: &city, State: &state, Status: catalogm.ShowStatusApproved}
+	b := &catalogm.Show{Title: "tie-b", EventDate: eventDate, City: &city, State: &state, Status: catalogm.ShowStatusApproved}
+	s.Require().NoError(s.db.Create(a).Error)
+	s.Require().NoError(s.db.Create(b).Error)
+
+	resp, err := s.exploreService.GetUpcomingShows(10, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Shows, 2)
+	s.True(resp.Shows[0].ID < resp.Shows[1].ID, "tied shows must sort by id ASC")
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_HeadlinerAndVenueHydrated() {
+	show, artist, venue := s.createShow("primary", 5)
+
+	resp, err := s.exploreService.GetUpcomingShows(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Shows, 1)
+	s.Equal(show.ID, resp.Shows[0].ID)
+	s.Equal(artist.Name, resp.Shows[0].HeadlinerName)
+	s.Equal(venue.Name, resp.Shows[0].VenueName)
+	s.Equal("Phoenix", resp.Shows[0].VenueCity)
+	s.Equal("AZ", resp.Shows[0].VenueState)
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_LimitClamped() {
+	for i := 0; i < 5; i++ {
+		s.createShow(fmt.Sprintf("show-%d", i), i+1)
+	}
+
+	// Limit 2 only returns 2 shows but total stays accurate.
+	resp, err := s.exploreService.GetUpcomingShows(2, 0)
+	s.Require().NoError(err)
+	s.Len(resp.Shows, 2)
+	s.Equal(int64(5), resp.Total)
+
+	// Out-of-range limit gets clamped to maxUpcomingShowsLimit.
+	resp, err = s.exploreService.GetUpcomingShows(9999, 0)
+	s.Require().NoError(err)
+	s.Equal(maxUpcomingShowsLimit, resp.Limit)
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetUpcomingShows_OffsetPaginates() {
+	for i := 0; i < 5; i++ {
+		s.createShow(fmt.Sprintf("show-%d", i), i+1)
+	}
+
+	page1, err := s.exploreService.GetUpcomingShows(2, 0)
+	s.Require().NoError(err)
+	s.Len(page1.Shows, 2)
+
+	page2, err := s.exploreService.GetUpcomingShows(2, 2)
+	s.Require().NoError(err)
+	s.Len(page2.Shows, 2)
+
+	// Page 2 IDs must be disjoint from page 1 IDs.
+	page1IDs := map[uint]bool{page1.Shows[0].ID: true, page1.Shows[1].ID: true}
+	for _, sh := range page2.Shows {
+		s.False(page1IDs[sh.ID], "page 2 must not overlap page 1")
+	}
+}
+
+// ──────────────────────────────────────────────
+// GetFeatured
+// ──────────────────────────────────────────────
+
+func (s *ExploreServiceIntegrationSuite) TestGetFeatured_EmptyReturnsNullSlots() {
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Nil(resp.Bill)
+	s.Nil(resp.Collection)
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetFeatured_PopulatedBillAndCollection() {
+	admin := s.createAdmin("admin1")
+	show, artist, _ := s.createShow("bill-show", 14)
+	coll := s.createCollection(admin.ID, "featured-coll", true)
+
+	note := "Best bill of the month"
+	_, err := s.featuredSlotService.SetActiveSlot("bill", show.ID, &note, admin.ID)
+	s.Require().NoError(err)
+
+	collNote := "Editor's pick"
+	_, err = s.featuredSlotService.SetActiveSlot("collection", coll.ID, &collNote, admin.ID)
+	s.Require().NoError(err)
+
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.Bill)
+	s.Equal(show.ID, resp.Bill.ID)
+	s.Equal(show.Title, resp.Bill.Title)
+	s.Equal(artist.Name, resp.Bill.HeadlinerName)
+	s.Equal("Best bill of the month", *resp.Bill.CuratorNote)
+	s.NotEmpty(resp.Bill.CuratorNoteHTML)
+
+	s.Require().NotNil(resp.Collection)
+	s.Equal(coll.ID, resp.Collection.ID)
+	s.Equal(coll.Title, resp.Collection.Title)
+	s.Equal("Editor's pick", *resp.Collection.CuratorNote)
+}
+
+// TestGetFeatured_DeletedReferentCollapsesGracefully is the canonical
+// defensive-read test the ticket calls out: a slot pointing at a row
+// that no longer exists must return nil rather than 500.
+func (s *ExploreServiceIntegrationSuite) TestGetFeatured_DeletedReferentCollapsesGracefully() {
+	admin := s.createAdmin("admin2")
+	show, _, _ := s.createShow("doomed", 14)
+
+	note := "Will be deleted"
+	_, err := s.featuredSlotService.SetActiveSlot("bill", show.ID, &note, admin.ID)
+	s.Require().NoError(err)
+
+	// Drop the show + its associations (FK cascade handles the
+	// show_artists / show_venues rows).
+	s.Require().NoError(s.db.Exec("DELETE FROM show_artists WHERE show_id = ?", show.ID).Error)
+	s.Require().NoError(s.db.Exec("DELETE FROM show_venues WHERE show_id = ?", show.ID).Error)
+	s.Require().NoError(s.db.Exec("DELETE FROM shows WHERE id = ?", show.ID).Error)
+
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err, "stale slot must NOT 500")
+	s.Nil(resp.Bill, "deleted referent collapses to nil")
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetFeatured_PrivateCollectionExcluded() {
+	admin := s.createAdmin("admin3")
+	// Featured a private collection — we must hide it from the public
+	// /explore landing even though the slot row exists.
+	coll := s.createCollection(admin.ID, "secret", false)
+
+	_, err := s.featuredSlotService.SetActiveSlot("collection", coll.ID, nil, admin.ID)
+	s.Require().NoError(err)
+
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Nil(resp.Collection, "private collection must not surface on /explore")
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetFeatured_NonApprovedBillExcluded() {
+	admin := s.createAdmin("admin4")
+	// Status-flip the show to pending after it was featured.
+	show, _, _ := s.createShow("pending-shift", 14)
+	s.Require().NoError(s.db.Model(show).Update("status", catalogm.ShowStatusPending).Error)
+
+	_, err := s.featuredSlotService.SetActiveSlot("bill", show.ID, nil, admin.ID)
+	s.Require().NoError(err)
+
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Nil(resp.Bill, "non-approved referent collapses to nil")
+}
+
+// ──────────────────────────────────────────────
+// GetShuffleTarget
+// ──────────────────────────────────────────────
+
+func (s *ExploreServiceIntegrationSuite) TestGetShuffleTarget_EmptyPoolReturnsNil() {
+	resp, err := s.exploreService.GetShuffleTarget()
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Nil(resp.ArtistID)
+	s.Nil(resp.ArtistName)
+}
+
+// TestGetShuffleTarget_ReturnsFromQualifyingPool asserts membership in
+// the ±90-day window. We seed three artists: one with a show 30 days
+// ago, one with a show 30 days in the future, one with a show 200 days
+// out. Repeated picks must come from the first two artists.
+func (s *ExploreServiceIntegrationSuite) TestGetShuffleTarget_ReturnsFromQualifyingPool() {
+	_, recentArtist, _ := s.createShow("recent", -30)    // within window (past)
+	_, upcomingArtist, _ := s.createShow("upcoming", 30) // within window (future)
+	_, farArtist, _ := s.createShow("far", 200)          // outside window
+
+	qualifying := map[uint]bool{
+		recentArtist.ID:   true,
+		upcomingArtist.ID: true,
+	}
+
+	// 10 picks — strict pool membership.
+	for i := 0; i < 10; i++ {
+		resp, err := s.exploreService.GetShuffleTarget()
+		s.Require().NoError(err)
+		s.Require().NotNil(resp.ArtistID)
+		s.True(qualifying[*resp.ArtistID],
+			"shuffle picked artist %d, expected one of {%d, %d}; far-out artist %d should never appear",
+			*resp.ArtistID, recentArtist.ID, upcomingArtist.ID, farArtist.ID)
+	}
+}
+
+func (s *ExploreServiceIntegrationSuite) TestGetShuffleTarget_RespectsApprovedStatus() {
+	// Insert a single artist whose only show is non-approved. Should
+	// not appear in the shuffle pool.
+	city := "Phoenix"
+	state := "AZ"
+	show := &catalogm.Show{
+		Title:     "pending-only",
+		EventDate: time.Now().UTC().AddDate(0, 0, 30),
+		City:      &city,
+		State:     &state,
+		Status:    catalogm.ShowStatusPending,
+	}
+	s.Require().NoError(s.db.Create(show).Error)
+	slug := "pending-artist"
+	artist := &catalogm.Artist{Name: "Pending Artist", Slug: &slug}
+	s.Require().NoError(s.db.Create(artist).Error)
+	s.Require().NoError(s.db.Exec(`INSERT INTO show_artists (show_id, artist_id, position, set_type)
+	                                  VALUES (?, ?, 0, 'headliner')`, show.ID, artist.ID).Error)
+
+	resp, err := s.exploreService.GetShuffleTarget()
+	s.Require().NoError(err)
+	s.Nil(resp.ArtistID, "artist with only non-approved shows must NOT be eligible")
+}


### PR DESCRIPTION
## Summary

Wires the three read endpoints that back the `/explore` landing page, building on PSY-835's `featured_slots` schema. Anonymous and authenticated callers see identical content (locked decision).

- `GET /explore/upcoming-shows` — approved shows with `event_date >= NOW()`, ordered `(event_date ASC, id ASC)` for deterministic offset pagination. **No trending formula, no min_saves threshold, no recently-added fallback** — chronological-only per the locked decision; ranking algorithms remain a separate spike if/when justified. City filter intentionally deferred to PSY-840.
- `GET /explore/featured` — currently-active bill + collection from `featured_slots`. Both fields nullable. Defensive read: stale referents (deleted, status-flipped non-approved, privacy-flipped collection) collapse to `null` for that slot rather than 500-ing.
- `GET /explore/shuffle-target` — one random artist from the ±90-day qualifying pool. Empty pool returns all-`null` fields with HTTP 200.

### `save_count` — omitted from v1

The ticket called for `save_count` from `show_saves`, but **`show_saves` does not exist** as a table. Shows are saved via the polymorphic `user_bookmarks` table (`entity_type='show', action='save'`). Per the no-speculative-implementation policy, the field is omitted from the v1 response shape (not silently re-keyed to a different table). Follow-up: file a separate ticket once product clarifies whether to surface `user_bookmarks`-derived counts on the /explore tile, and what additional aggregates (going / interested) belong there.

Closes PSY-836

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go generate ./... && git diff --exit-code` — mocks_gen.go is idempotent after re-run
- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test ./internal/api/handlers/explore/...` — passes (0.40s)
- [x] `cd backend && go test ./internal/services/explore/...` — passes (2.81s)
- [x] `cd backend && go test ./internal/services/admin/... ./internal/api/handlers/admin/...` — passes (PSY-835 not regressed)
- [x] Manual repro on isolated dispatch stack (see below)

### Test coverage

Service integration suite (real Postgres testcontainer):
- Upcoming Shows: empty, chronological ordering, excludes past, excludes non-approved, deterministic pagination on event_date tie, headliner + venue hydration, limit clamping, offset paginates without overlap.
- Featured: empty (both slots nil), populated bill + collection with curator notes, deleted-referent collapses to nil (NOT 500), private-collection excluded, non-approved bill excluded.
- Shuffle: empty pool returns nil fields, repeated picks are pool members, non-approved shows are excluded.

Handler unit suite (mocked service): each endpoint delegates correctly, propagates limit/offset, surfaces nullable fields end-to-end, service error becomes 500.

## Manual repro

Brought up the isolated dispatch stack against the worktree backend (`--mode=isolated`).

```
$ curl -s 'http://localhost:60184/explore/upcoming-shows?limit=2&offset=0' | python3 -m json.tool
{
    "$schema": "http://localhost:60184/schemas/ExploreUpcomingShowsResponse.json",
    "shows": [
        {
            "id": 57,
            "slug": "e2e-save-show-test",
            "title": "E2E [save-show-test]",
            "event_date": "2026-05-24T21:26:08.516431-07:00",
            "headliner_name": "Calexico",
            "venue_name": "E2E [favorite-venue-test]",
            "venue_city": "Phoenix",
            "venue_state": "AZ",
            "city": "Phoenix",
            "state": "AZ"
        },
        {
            "id": 58,
            "slug": "e2e-list-actions-test",
            "title": "E2E [list-actions-test]",
            "event_date": "2026-05-24T22:26:08.516431-07:00",
            "headliner_name": "Calexico",
            "venue_name": "E2E [favorite-venue-test]",
            "venue_city": "Phoenix",
            "venue_state": "AZ",
            "city": "Phoenix",
            "state": "AZ"
        }
    ],
    "total": 64,
    "limit": 2,
    "offset": 0
}
```

```
$ # Inserted a featured_slots bill row pointing at show_id=56:
$ # INSERT INTO featured_slots (slot_type, entity_id, curator_note, created_by) VALUES ('bill', 56, 'smoke test pick', 6);
$ curl -s http://localhost:60184/explore/featured | python3 -m json.tool
{
    "$schema": "http://localhost:60184/schemas/ExploreFeaturedResponse.json",
    "bill": {
        "id": 56,
        "slug": "e2e-collection-saved-show",
        "title": "E2E [collection-saved-show]",
        "event_date": "2026-05-24T20:26:08.516431-07:00",
        "headliner_name": "Calexico",
        "venue_name": "E2E [favorite-venue-test]",
        "venue_city": "Phoenix",
        "venue_state": "AZ",
        "curator_note": "smoke test pick — chronologically first show",
        "curator_note_html": "<p>smoke test pick — chronologically first show</p>\n"
    },
    "collection": null
}

$ # Defensive read: delete the featured show:
$ # DELETE FROM show_artists WHERE show_id = 56; DELETE FROM show_venues WHERE show_id = 56; DELETE FROM shows WHERE id = 56;
$ curl -s http://localhost:60184/explore/featured | python3 -m json.tool
{
    "$schema": "http://localhost:60184/schemas/ExploreFeaturedResponse.json",
    "bill": null,
    "collection": null
}
```

Defensive read works — HTTP 200, `bill: null` after delete (not a 500 with the orphan row).

```
$ for i in 1 2 3 4 5; do curl -s http://localhost:60184/explore/shuffle-target; done
artist_id=3 slug='the-maine' name='The Maine'
artist_id=10 slug='roar' name='ROAR'
artist_id=2 slug='jimmy-eat-world' name='Jimmy Eat World'
artist_id=5 slug='playboy-manbaby' name='Playboy Manbaby'
artist_id=3 slug='the-maine' name='The Maine'
```

All picks (artist IDs 2, 3, 5, 10) match the qualifying pool: `SELECT DISTINCT a.id FROM artists a JOIN show_artists sa ON sa.artist_id=a.id JOIN shows s ON s.id=sa.show_id WHERE s.event_date >= NOW() - INTERVAL '90 days' AND s.event_date <= NOW() + INTERVAL '90 days' AND s.status='approved'` returned ids 1..10.

## Simplify

Dropped unused `SetNowFn` / `nowFn` clock-injection hook (speculative API; no test used it) and tightened two docstrings — net −28 lines.

## Caveats

- The brief at `docs/open-questions/explore-landing.md` is gitignored (project policy) so my edits there will NOT land in this PR. Updated in the main repo working tree to strip the trending formula and align the Algorithmic Surfaces / IA sections with the locked chronological decision + PSY-836 endpoint URLs.
- Reviewers checking `mocks_gen.go`: the new `MockExploreService` is generated by `cd backend && go generate ./...`. The diff against `mocks_gen.go` is reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)