### PR TITLE
PSY-813: KEXP list endpoint omits end_time/archive_url

### DIFF
--- a/backend/internal/services/catalog/radio_provider_kexp.go
+++ b/backend/internal/services/catalog/radio_provider_kexp.go
@@ -409,6 +409,17 @@ func (p *KEXPProvider) fetchProgramHostNames() (map[int]string, error) {
 }
 
 // parseKEXPEpisode converts a KEXP show (broadcast) into our episode import DTO.
+//
+// PSY-813: The /v2/shows/ LIST endpoint (used by FetchNewEpisodes) does NOT
+// include `end_time` or `archive_url` on its result objects — only the
+// /v2/shows/{id}/ DETAIL endpoint (used by FetchPlaylist) carries them. As a
+// result, episodes imported via FetchNewEpisodes ALWAYS land with
+// DurationMinutes == nil and ArchiveURL == nil. The defensive `!= ""` guards
+// below make that nil outcome graceful instead of a panic or garbage value.
+// If/when callers need duration or archive URL populated, they must round-trip
+// through the detail endpoint (currently only FetchPlaylist does so, and only
+// to compute its playlist time window — it does not back-fill the episode
+// record).
 func parseKEXPEpisode(show kexpShow, programExternalID string) RadioEpisodeImport {
 	ep := RadioEpisodeImport{
 		ExternalID:     strconv.Itoa(show.ID),

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -135,6 +135,10 @@ func TestParseKEXPEpisode(t *testing.T) {
 	assert.Equal(t, "https://kexp.org/archive/2026-01-15", *ep.ArchiveURL)
 }
 
+// TestParseKEXPEpisode_NoEndTime exercises the list-endpoint shape: KEXP's
+// /v2/shows/ list response omits both `end_time` and `archive_url`, so the
+// parser's defensive guards must leave DurationMinutes and ArchiveURL nil
+// without panicking (PSY-813).
 func TestParseKEXPEpisode_NoEndTime(t *testing.T) {
 	show := kexpShow{
 		ID:        9999,
@@ -146,6 +150,8 @@ func TestParseKEXPEpisode_NoEndTime(t *testing.T) {
 	assert.Equal(t, "9999", ep.ExternalID)
 	assert.Equal(t, "2026-01-15", ep.AirDate)
 	assert.Nil(t, ep.DurationMinutes)
+	assert.Nil(t, ep.ArchiveURL,
+		"PSY-813: list endpoint omits archive_url, parser must leave ArchiveURL nil")
 }
 
 // =============================================================================
@@ -295,6 +301,12 @@ func TestKEXPProvider_DiscoverShows_Pagination(t *testing.T) {
 	assert.Nil(t, shows[1].HostName)
 }
 
+// PSY-813: KEXP's /v2/shows/ LIST endpoint does NOT carry `end_time` or
+// `archive_url` on its results — only the /v2/shows/{id}/ DETAIL endpoint
+// does. The previous fixture set both fields and asserted DurationMinutes was
+// populated, which contradicted production behavior. The corrected fixture
+// matches the real API and the assertions document the contract: list-imported
+// episodes always land with DurationMinutes == nil and ArchiveURL == nil.
 func TestKEXPProvider_FetchNewEpisodes(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
@@ -307,8 +319,8 @@ func TestKEXPProvider_FetchNewEpisodes(t *testing.T) {
 					"program":      42,
 					"program_name": "The Morning Show",
 					"start_time":   "2026-01-15T06:00:00-08:00",
-					"end_time":     "2026-01-15T10:00:00-08:00",
-					"archive_url":  "https://kexp.org/archive/5678",
+					// end_time and archive_url intentionally omitted — the
+					// real /v2/shows/ list response does not include them.
 				},
 			},
 		})
@@ -328,8 +340,14 @@ func TestKEXPProvider_FetchNewEpisodes(t *testing.T) {
 	assert.Equal(t, "5678", episodes[0].ExternalID)
 	assert.Equal(t, "42", episodes[0].ShowExternalID)
 	assert.Equal(t, "2026-01-15", episodes[0].AirDate)
-	assert.NotNil(t, episodes[0].DurationMinutes)
-	assert.Equal(t, 240, *episodes[0].DurationMinutes)
+	// PSY-813: list-endpoint contract — duration + archive must be nil because
+	// the source payload omits end_time / archive_url. parseKEXPEpisode's
+	// defensive guards make this graceful; FetchPlaylist's detail-endpoint
+	// roundtrip is where these fields would be populated if backfilled.
+	assert.Nil(t, episodes[0].DurationMinutes,
+		"list endpoint omits end_time, so DurationMinutes must be nil")
+	assert.Nil(t, episodes[0].ArchiveURL,
+		"list endpoint omits archive_url, so ArchiveURL must be nil")
 }
 
 func TestKEXPProvider_FetchNewEpisodes_FiltersByProgram(t *testing.T) {
@@ -1131,6 +1149,10 @@ func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
 		// List endpoint serves both the PSY-509 host-map fetch and the
 		// FetchNewEpisodes filter. Both read the same `program` int field
 		// (alongside `host_names`, which only the host map uses).
+		//
+		// PSY-813: the real /v2/shows/ list response does NOT include
+		// `end_time` or `archive_url` — only the detail endpoint above does.
+		// Omitting them here keeps the fixture aligned with production behavior.
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 1,
 			"results": []map[string]interface{}{
@@ -1140,7 +1162,6 @@ func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
 					"program_name": "The Morning Show",
 					"host_names":   []string{"John Richards"},
 					"start_time":   "2026-01-15T06:00:00-08:00",
-					"end_time":     "2026-01-15T10:00:00-08:00",
 				},
 			},
 		})

--- a/frontend/e2e/pages/follow-and-attendance.spec.ts
+++ b/frontend/e2e/pages/follow-and-attendance.spec.ts
@@ -1,9 +1,23 @@
+import { type Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
 import {
   resetTestFixtures,
   lookupWorkerUserId,
 } from '../fixtures/test-fixtures-reset'
 import { USER_COUNT, userAuthFileForWorker } from '../global-setup'
+
+// Auth-gated buttons (FollowButton, AttendanceButton) redirect to /auth
+// when useAuthContext returns isAuthenticated=false at click time. The
+// buttons render regardless of auth state (only tooltip copy differs),
+// so visibility checks don't gate against the SSR-pre-hydration → client
+// propagation race window. The sidebar's "Library" link is rendered only
+// when isAuthenticated=true (Sidebar.tsx), so waiting on it is a reliable
+// signal that auth has propagated before we click an auth-gated button.
+async function waitForAuthHydrated(page: Page) {
+  await expect(
+    page.getByRole('link', { name: 'Library' })
+  ).toBeVisible({ timeout: 10_000 })
+}
 
 // PSY-457: backfill E2E coverage for follow + going/interested flows.
 // PSY-430: pin to reserved artist + show seeded by setup-db.sh so parallel
@@ -53,6 +67,8 @@ test.describe('Follow and attendance', () => {
         name: RESERVED_ARTIST_NAME,
       })
     ).toBeVisible({ timeout: 10_000 })
+
+    await waitForAuthHydrated(authenticatedPage)
 
     // FollowButton on the artist detail page renders as a BracketLink
     // (variant="bracket" since PSY-641). The bracket variant uses the
@@ -107,6 +123,8 @@ test.describe('Follow and attendance', () => {
       })
     ).toBeVisible({ timeout: 10_000 })
 
+    await waitForAuthHydrated(authenticatedPage)
+
     // Clicking the [Following] bracket link while isFollowing=true triggers
     // unfollow. Bracket variant has no hover-to-Unfollow state, so the
     // accessible name stays "Following" until the click resolves.
@@ -140,6 +158,8 @@ test.describe('Follow and attendance', () => {
         .getByRole('navigation', { name: 'Breadcrumb' })
         .getByText(RESERVED_SHOW_TITLE)
     ).toBeVisible({ timeout: 10_000 })
+
+    await waitForAuthHydrated(authenticatedPage)
 
     // Going button initial state: no count suffix on a fresh reserved show
     // (accessible name = "Going").
@@ -185,6 +205,8 @@ test.describe('Follow and attendance', () => {
         .getByRole('navigation', { name: 'Breadcrumb' })
         .getByText(RESERVED_SHOW_TITLE)
     ).toBeVisible({ timeout: 10_000 })
+
+    await waitForAuthHydrated(authenticatedPage)
 
     await Promise.all([
       authenticatedPage.waitForResponse(


### PR DESCRIPTION
## Summary

Two unrelated changes shipped together to unblock PR CI:

1. **PSY-813 (original scope):** test fixtures for `parseKEXPEpisode` realigned to match the actual KEXP `/v2/shows/` LIST endpoint shape (omits `end_time` and `archive_url`). Doc-comment added describing the list-vs-detail asymmetry. `parseKEXPEpisode` was already defensive (`if show.EndTime != ""` / `if show.ArchiveURL != ""`); the bug was test fixtures lying about reality, masking the nil contract. Production code: 1 doc-comment-only change.

2. **PSY-851 (cherry-picked):** test-only E2E flake fix on `follow-and-attendance.spec.ts`. The `E2E Smoke (PR)` CI check on this PR's prior push timed out on `waitForResponse` for POST `/shows/{id}/attendance` — root cause is the auth-hydration race in `AttendanceButton.tsx:51-55` (redirects to `/auth` when `isAuthenticated=false` at click time, so the test's visibility check doesn't gate against the SSR-pre-hydration → client propagation window). Cherry-picked the fix from [PR #820](https://github.com/mtrifilo/psychic-homily-web/pull/820) directly into this branch so CI can pass; PR #820 is being closed as superseded.

## Why two commits in one PR
The PSY-813 diff is backend-only and structurally innocent of the E2E flake. But the flake was blocking this PR's CI, and the PSY-851 fix is small (22 inserts, test-file only). Cherry-pick is faster than waiting for PR #820 to merge first + rebase. Reviewer sees both commits separately in the file tree.

## Scope
- `backend/internal/services/catalog/radio_provider_kexp.go` — doc-comment on `parseKEXPEpisode` describing the list-vs-detail asymmetry
- `backend/internal/services/catalog/radio_provider_test.go` — fixture realignment + nil contract assertions in 3 places (`TestKEXPProvider_FetchNewEpisodes`, `TestParseKEXPEpisode_NoEndTime`, `TestImportStation_Success` LIST branch only — DETAIL branch keeps `end_time` for `FetchPlaylist`'s time window)
- `frontend/e2e/pages/follow-and-attendance.spec.ts` (cherry-picked from PSY-851) — `Page` type import + `waitForAuthHydrated(page)` helper + 4 call sites (initial action + cleanup in each of the 2 smoke tests)

## Test plan
- [x] `go build ./...` — passed (whole-graph compile clean)
- [x] `go test ./internal/services/catalog/...` — passed (full package, 148s; KEXP-scoped subset 0.6s; integration suite 17s; `TestImportStation_Success` + `TestKEXPProvider_FetchNewEpisodes` + `TestParseKEXPEpisode_NoEndTime` all green)
- [x] `/code-review` — clean; max-effort 5-angle review on the PSY-813 diff surfaced 0 findings; PSY-851's diff is test-file-only and low-effort review explicitly skips test/spec files
- [x] **Local E2E run** (the part missing from the prior push): `cd frontend && bun run test:e2e -- e2e/pages/follow-and-attendance.spec.ts --grep @smoke` — **2/2 passed both consecutive runs** (25.5s, then 18.7s) via per-worktree isolated stack (`scripts/dispatch/stack-up.sh --mode=isolated`). Backend logs confirm POST `/shows/60/attendance` fires with auth (user_id=1) — the race is avoided.

## Manual repro
**Backend (PSY-813):** Integration test `TestKEXPProvider_FetchNewEpisodes` now serves a list-shape fixture without `end_time`/`archive_url` and asserts `episodes[0].DurationMinutes == nil && episodes[0].ArchiveURL == nil`. Verified pass. End-to-end via `TestImportStation_Success` LIST branch confirms the import pipeline accepts the realistic shape (1 episode + 2 plays imported, no errors).

**Frontend (PSY-851):** Local Playwright run (twice) — `2 passed (25.5s)` and `2 passed (18.7s)`. Backend logs show the auth-gated POST + DELETE pair completing successfully in both runs. The `waitForAuthHydrated(page)` helper waits for the sidebar's auth-only "Library" link (only rendered when `isAuthenticated=true`) before each `Promise.all(waitForResponse + click)` block.

## Note for the merge
This PR was force-pushed (rebased onto current main + cherry-picked PSY-851). Previous CI runs were against the stale base. The current head SHA is post-rebase. PR #820 (PSY-851 standalone) is being closed as superseded.

Closes PSY-813
Closes PSY-851
