### PR TITLE
PSY-718: strengthen lib/hooks/admin tests

### DIFF
--- a/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
@@ -71,6 +71,34 @@ describe('usePendingArtistReports', () => {
     expect(url).toContain('limit=10')
     expect(url).toContain('offset=20')
   })
+
+  it('starts in loading state and resolves to success', async () => {
+    let resolveFetch: (value: unknown) => void = () => {}
+    const pending = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+    mockApiRequest.mockReturnValueOnce(pending)
+
+    const { result } = renderHook(() => usePendingArtistReports(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isLoading).toBe(true)
+
+    resolveFetch({ reports: [], total: 0 })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('surfaces fetch errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+    const { result } = renderHook(() => usePendingArtistReports(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
 })
 
 describe('useDismissArtistReport', () => {
@@ -135,6 +163,22 @@ describe('useDismissArtistReport', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(mockInvalidateArtistReports).toHaveBeenCalled()
+  })
+
+  it('surfaces mutation errors without invalidating', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Report not found'))
+
+    const { result } = renderHook(() => useDismissArtistReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 999 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Report not found')
+    expect(mockInvalidateArtistReports).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/lib/hooks/admin/useAdminArtists.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtists.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 import { server } from '@/test/mocks/server'
 
@@ -23,7 +22,12 @@ afterAll(() => {
 vi.mock('../../queryClient', () => ({
   queryKeys: {
     artists: {
+      all: ['artists'],
       detail: (id: number) => ['artists', 'detail', id],
+      aliases: (id: number) => ['artists', 'aliases', id],
+    },
+    shows: {
+      all: ['shows'],
     },
   },
 }))
@@ -35,15 +39,23 @@ import {
   useClearArtistBandcamp,
   useUpdateArtistSpotify,
   useClearArtistSpotify,
+  useArtistUpdate,
+  useArtistAliases,
+  useCreateArtistAlias,
+  useDeleteArtistAlias,
+  useMergeArtists,
   type DiscoverMusicResponse,
 } from './useAdminArtists'
 
 
-// Helper to mock successful fetch response
+// Helper to mock successful fetch response. Includes a Headers-like
+// object so `apiRequest`'s `response.headers.get(...)` call doesn't
+// blow up for hooks that go through apiRequest (vs raw fetch).
 function mockFetchResponse(data: unknown, ok = true, status = 200) {
   mockFetch.mockResolvedValueOnce({
     ok,
     status,
+    headers: new Headers(),
     json: async () => data,
   })
 }
@@ -53,6 +65,7 @@ function mockFetchError(message: string, status = 500) {
   mockFetch.mockResolvedValueOnce({
     ok: false,
     status,
+    headers: new Headers(),
     json: async () => ({ message, error: message }),
   })
 }
@@ -421,6 +434,228 @@ describe('useAdminArtists', () => {
       await waitFor(() => expect(result.current.isError).toBe(true))
 
       expect((result.current.error as Error).message).toBe('Clear failed')
+    })
+  })
+
+  describe('useArtistUpdate', () => {
+    it('PATCHes the admin artist endpoint with the edit payload', async () => {
+      // useArtistUpdate goes through apiRequest (not raw fetch), so the
+      // full http://localhost:8080 base is included in the URL.
+      mockFetchResponse({ id: 123, name: 'Renamed' })
+
+      const { result } = renderHook(() => useArtistUpdate(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          artistId: 123,
+          data: { name: 'Renamed', city: 'Phoenix' },
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const [url, init] = mockFetch.mock.calls[0]
+      expect(url).toMatch(/\/admin\/artists\/123$/)
+      expect(init).toMatchObject({
+        method: 'PATCH',
+        body: JSON.stringify({ name: 'Renamed', city: 'Phoenix' }),
+      })
+    })
+
+    it('invalidates artist detail, artists.all, AND shows.all on success', async () => {
+      // Updating an artist may rename them — show listings carry the artist
+      // name denormalised, so the shows scope also gets invalidated.
+      mockFetchResponse({ id: 456 })
+
+      const queryClient = createTestQueryClient()
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      const { result } = renderHook(() => useArtistUpdate(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          artistId: 456,
+          data: { name: 'New Name' },
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['artists', 'detail', 456],
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['artists'],
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['shows'],
+      })
+    })
+
+    it('surfaces update failures', async () => {
+      mockFetchError('Validation failed', 422)
+
+      const { result } = renderHook(() => useArtistUpdate(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          artistId: 123,
+          data: { name: '' },
+        })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Validation failed')
+    })
+  })
+
+  describe('useArtistAliases', () => {
+    it('fetches aliases for a positive artist id', async () => {
+      mockFetchResponse({ aliases: [{ id: 1, alias: 'X' }] })
+
+      const { result } = renderHook(() => useArtistAliases(42), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toMatch(/\/artists\/42\/aliases$/)
+    })
+
+    it('does not fetch when enabled=false', () => {
+      const { result } = renderHook(() => useArtistAliases(42, false), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('does not fetch when artistId is 0', () => {
+      const { result } = renderHook(() => useArtistAliases(0), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+  })
+
+  describe('useCreateArtistAlias', () => {
+    it('POSTs the alias body and invalidates that artist’s aliases', async () => {
+      mockFetchResponse({ id: 1, artist_id: 42, alias: 'New Alias' })
+
+      const queryClient = createTestQueryClient()
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      const { result } = renderHook(() => useCreateArtistAlias(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      await act(async () => {
+        result.current.mutate({ artistId: 42, alias: 'New Alias' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const [url, init] = mockFetch.mock.calls[0]
+      expect(url).toMatch(/\/admin\/artists\/42\/aliases$/)
+      expect(init).toMatchObject({
+        method: 'POST',
+        body: JSON.stringify({ alias: 'New Alias' }),
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['artists', 'aliases', 42],
+      })
+    })
+  })
+
+  describe('useDeleteArtistAlias', () => {
+    it('DELETEs and invalidates the artist’s aliases', async () => {
+      mockFetchResponse(undefined)
+
+      const queryClient = createTestQueryClient()
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      const { result } = renderHook(() => useDeleteArtistAlias(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      await act(async () => {
+        result.current.mutate({ artistId: 42, aliasId: 7 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const [url, init] = mockFetch.mock.calls[0]
+      expect(url).toMatch(/\/admin\/artists\/42\/aliases\/7$/)
+      expect(init).toMatchObject({ method: 'DELETE' })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['artists', 'aliases', 42],
+      })
+    })
+  })
+
+  describe('useMergeArtists', () => {
+    it('POSTs canonical + merge-from ids and invalidates artists + shows', async () => {
+      // Merge collapses two artists into one. Anywhere they appear (shows,
+      // listings, references) must refetch — guard the broad invalidation.
+      mockFetchResponse({
+        canonical_artist_id: 10,
+        merged_count: 5,
+      })
+
+      const queryClient = createTestQueryClient()
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      const { result } = renderHook(() => useMergeArtists(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          canonicalArtistId: 10,
+          mergeFromArtistId: 20,
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const [url, init] = mockFetch.mock.calls[0]
+      expect(url).toMatch(/\/admin\/artists\/merge$/)
+      expect(init).toMatchObject({
+        method: 'POST',
+        body: JSON.stringify({
+          canonical_artist_id: 10,
+          merge_from_artist_id: 20,
+        }),
+      })
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['artists'] })
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['shows'] })
+    })
+
+    it('surfaces merge errors', async () => {
+      mockFetchError('Cannot merge with self', 400)
+
+      const { result } = renderHook(() => useMergeArtists(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          canonicalArtistId: 10,
+          mergeFromArtistId: 10,
+        })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Cannot merge with self')
     })
   })
 })

--- a/frontend/lib/hooks/admin/useAdminAuditLogs.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminAuditLogs.test.tsx
@@ -67,4 +67,60 @@ describe('useAuditLogs', () => {
     expect(url).toContain('offset=40')
   })
 
+  it('starts in loading state and resolves to success', async () => {
+    // Hook contract: useQuery never blocks the initial render. We render
+    // first, observe the loading state, then let the promise resolve.
+    let resolveFetch: (value: unknown) => void = () => {}
+    const pending = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+    mockApiRequest.mockReturnValueOnce(pending)
+
+    const { result } = renderHook(() => useAuditLogs(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+
+    resolveFetch({ logs: [], total: 0 })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('surfaces fetch errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useAuditLogs(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('keys cache by limit AND offset', async () => {
+    // Two different paginations must produce two distinct query keys,
+    // not collide and skip the second fetch.
+    mockApiRequest
+      .mockResolvedValueOnce({ logs: [], total: 0 })
+      .mockResolvedValueOnce({ logs: [], total: 0 })
+
+    const { result: page1 } = renderHook(
+      () => useAuditLogs({ limit: 50, offset: 0 }),
+      { wrapper: createWrapper() }
+    )
+    await waitFor(() => expect(page1.current.isSuccess).toBe(true))
+
+    const { result: page2 } = renderHook(
+      () => useAuditLogs({ limit: 50, offset: 50 }),
+      { wrapper: createWrapper() }
+    )
+    await waitFor(() => expect(page2.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2)
+  })
 })

--- a/frontend/lib/hooks/admin/useAdminComments.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminComments.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { createWrapper } from '@/test/utils'
+import {
+  createWrapper,
+  createWrapperWithClient,
+  createTestQueryClient,
+} from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -23,6 +27,8 @@ import {
   useAdminRejectComment,
   useAdminHideComment,
   useAdminRestoreComment,
+  useAdminCommentEditHistory,
+  adminCommentQueryKeys,
 } from './useAdminComments'
 
 describe('useAdminPendingComments', () => {
@@ -179,5 +185,203 @@ describe('useAdminRestoreComment', () => {
       'http://localhost:8080/admin/comments/101/restore',
       { method: 'POST' }
     )
+  })
+
+  it('invalidates admin comments AND public comments on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useAdminRestoreComment(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(101)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: adminCommentQueryKeys.all,
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['comments'],
+    })
+  })
+})
+
+describe('adminCommentQueryKeys', () => {
+  it('generates stable keys for the moderation queue', () => {
+    expect(adminCommentQueryKeys.all).toEqual(['admin', 'comments'])
+    expect(adminCommentQueryKeys.pending({ limit: 25, offset: 0 })).toEqual([
+      'admin',
+      'comments',
+      'pending',
+      { limit: 25, offset: 0 },
+    ])
+    expect(adminCommentQueryKeys.edits(42)).toEqual([
+      'admin',
+      'comments',
+      'edits',
+      42,
+    ])
+  })
+})
+
+describe('invalidation on moderation mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('approve invalidates admin queue AND public comments', async () => {
+    // After approve the comment moves from pending → visible, so BOTH
+    // the moderation queue AND any entity-detail comment list must refetch.
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useAdminApproveComment(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(123)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: adminCommentQueryKeys.all,
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['comments'],
+    })
+  })
+
+  it('reject invalidates admin queue AND public comments', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useAdminRejectComment(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ commentId: 456, reason: 'spam' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: adminCommentQueryKeys.all,
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['comments'],
+    })
+  })
+
+  it('hide invalidates admin queue, public comments, AND entity reports', async () => {
+    // Hiding a comment usually resolves an entity report at the call site
+    // (the moderation queue couples both), so the entity-reports key is
+    // also invalidated so the queue clears the related row.
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useAdminHideComment(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ commentId: 789, reason: 'abusive' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: adminCommentQueryKeys.all,
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['comments'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['admin', 'entityReports'],
+    })
+  })
+
+  it('does not invalidate when a mutation fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Not found'))
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useAdminApproveComment(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(999)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useAdminCommentEditHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the edit history when enabled AND commentId > 0', async () => {
+    const mockHistory = {
+      comment_id: 42,
+      current_body: 'edited body',
+      edits: [
+        {
+          id: 1,
+          comment_id: 42,
+          old_body: 'original body',
+          edited_at: '2026-04-01T00:00:00Z',
+        },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockHistory)
+
+    const { result } = renderHook(
+      () => useAdminCommentEditHistory(42, true),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/comments/42/edits',
+      { method: 'GET' }
+    )
+    expect(result.current.data?.edits).toHaveLength(1)
+  })
+
+  it('defaults to disabled so we do not prefetch every comment’s history', () => {
+    // The hook's default `enabled=false` is load-bearing — it prevents the
+    // moderation queue from prefetching every comment's history on mount.
+    const { result } = renderHook(() => useAdminCommentEditHistory(42), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when commentId is 0 even if enabled', () => {
+    const { result } = renderHook(
+      () => useAdminCommentEditHistory(0, true),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
   })
 })

--- a/frontend/lib/hooks/admin/useAdminEntityReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminEntityReports.test.tsx
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateAdminEntityReports = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      ENTITY_REPORTS: {
+        LIST: '/admin/entity-reports',
+        RESOLVE: (reportId: string | number) =>
+          `/admin/entity-reports/${reportId}/resolve`,
+        DISMISS: (reportId: string | number) =>
+          `/admin/entity-reports/${reportId}/dismiss`,
+      },
+    },
+    COLLECTIONS: {
+      DETAIL: (slug: string) => `/collections/${slug}`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      entityReports: (params: Record<string, unknown>) =>
+        ['admin', 'entityReports', params],
+    },
+  },
+  createInvalidateQueries: () => ({
+    adminEntityReports: mockInvalidateAdminEntityReports,
+  }),
+}))
+
+import {
+  useAdminEntityReports,
+  useResolveEntityReport,
+  useDismissEntityReport,
+  useAdminHideCollection,
+} from './useAdminEntityReports'
+
+describe('useAdminEntityReports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches reports with default filters (status=pending)', async () => {
+    const mockResponse = {
+      reports: [
+        {
+          id: 1,
+          entity_type: 'collection',
+          entity_id: 42,
+          reported_by: 7,
+          reporter_username: 'alice',
+          report_type: 'spam',
+          status: 'pending',
+          created_at: '2026-04-01T00:00:00Z',
+        },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useAdminEntityReports(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/entity-reports')
+    expect(url).toContain('status=pending')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+    expect(url).not.toContain('entity_type=')
+    expect(result.current.data?.reports).toHaveLength(1)
+  })
+
+  it('passes entity_type filter when provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+    const { result } = renderHook(
+      () =>
+        useAdminEntityReports({
+          entity_type: 'collection',
+          limit: 25,
+          offset: 50,
+        }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('entity_type=collection')
+    expect(url).toContain('limit=25')
+    expect(url).toContain('offset=50')
+  })
+
+  it('omits status param when status is explicitly empty', async () => {
+    // When called with status='' the hook should skip the param so the
+    // backend default surface (all statuses) is used.
+    mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useAdminEntityReports({ status: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).not.toContain('status=')
+  })
+
+  it('surfaces fetch errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useAdminEntityReports(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
+})
+
+describe('useResolveEntityReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAdminEntityReports.mockReset()
+  })
+
+  it('POSTs to the resolve endpoint with notes', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'resolved' })
+
+    const { result } = renderHook(() => useResolveEntityReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1, notes: 'Reviewed' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/entity-reports/1/resolve',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ notes: 'Reviewed' }),
+      })
+    )
+  })
+
+  it('sends empty-string notes when omitted', async () => {
+    // The hook coerces undefined notes to '' so the backend never sees
+    // a missing field — this guards that contract.
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useResolveEntityReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/entity-reports/1/resolve',
+      expect.objectContaining({
+        body: JSON.stringify({ notes: '' }),
+      })
+    )
+  })
+
+  it('invalidates admin entity reports on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useResolveEntityReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateAdminEntityReports).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces mutation errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Report not found'))
+
+    const { result } = renderHook(() => useResolveEntityReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 999 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Report not found')
+    expect(mockInvalidateAdminEntityReports).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDismissEntityReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAdminEntityReports.mockReset()
+  })
+
+  it('POSTs to the dismiss endpoint with notes', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 2, status: 'dismissed' })
+
+    const { result } = renderHook(() => useDismissEntityReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 2, notes: 'Not actionable' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/entity-reports/2/dismiss',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ notes: 'Not actionable' }),
+      })
+    )
+  })
+
+  it('sends empty-string notes when omitted', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 2 })
+
+    const { result } = renderHook(() => useDismissEntityReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 2 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/entity-reports/2/dismiss',
+      expect.objectContaining({
+        body: JSON.stringify({ notes: '' }),
+      })
+    )
+  })
+
+  it('invalidates admin entity reports on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 2 })
+
+    const { result } = renderHook(() => useDismissEntityReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 2 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateAdminEntityReports).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useAdminHideCollection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAdminEntityReports.mockReset()
+  })
+
+  it('PUTs is_public=false to the collection detail endpoint', async () => {
+    // This hook re-uses the existing admin-permitted PUT /collections/{slug}
+    // rather than introducing a new endpoint. The body shape is the small
+    // {is_public: false} patch the moderation queue depends on.
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useAdminHideCollection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ slug: 'spammy-list' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/collections/spammy-list',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ is_public: false }),
+      })
+    )
+  })
+
+  it('invalidates admin entity reports AND collections on success', async () => {
+    // The moderation queue surface depends on both invalidations: the
+    // queue itself (so the related report disappears) AND the collections
+    // list (so the now-private record stops appearing in browse).
+    const { QueryClient, QueryClientProvider } = await import(
+      '@tanstack/react-query'
+    )
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useAdminHideCollection(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({ slug: 'spammy-list' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateAdminEntityReports).toHaveBeenCalledTimes(1)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['collections'],
+    })
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminEntityReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminEntityReports.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { createWrapper } from '@/test/utils'
+import {
+  createWrapper,
+  createWrapperWithClient,
+  createTestQueryClient,
+} from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateAdminEntityReports = vi.fn()
@@ -311,21 +315,14 @@ describe('useAdminHideCollection', () => {
     // The moderation queue surface depends on both invalidations: the
     // queue itself (so the related report disappears) AND the collections
     // list (so the now-private record stops appearing in browse).
-    const { QueryClient, QueryClientProvider } = await import(
-      '@tanstack/react-query'
-    )
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-    })
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
-
     mockApiRequest.mockResolvedValueOnce(undefined)
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-    const { result } = renderHook(() => useAdminHideCollection(), { wrapper })
+    const { result } = renderHook(() => useAdminHideCollection(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
 
     await act(async () => {
       result.current.mutate({ slug: 'spammy-list' })

--- a/frontend/lib/hooks/admin/useAdminPendingEdits.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminPendingEdits.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateAdminPendingEdits = vi.fn()
+const mockInvalidateArtists = vi.fn()
+const mockInvalidateVenues = vi.fn()
+const mockInvalidateFestivals = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      PENDING_EDITS: {
+        LIST: '/admin/pending-edits',
+        APPROVE: (editId: string | number) =>
+          `/admin/pending-edits/${editId}/approve`,
+        REJECT: (editId: string | number) =>
+          `/admin/pending-edits/${editId}/reject`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      pendingEdits: (params: Record<string, unknown>) =>
+        ['admin', 'pendingEdits', params],
+    },
+  },
+  createInvalidateQueries: () => ({
+    adminPendingEdits: mockInvalidateAdminPendingEdits,
+    artists: mockInvalidateArtists,
+    venues: mockInvalidateVenues,
+    festivals: mockInvalidateFestivals,
+  }),
+}))
+
+import {
+  useAdminPendingEdits,
+  useApprovePendingEdit,
+  useRejectPendingEdit,
+} from './useAdminPendingEdits'
+
+describe('useAdminPendingEdits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches pending edits with default filters', async () => {
+    const mockResponse = {
+      edits: [
+        {
+          id: 1,
+          entity_type: 'artist',
+          entity_id: 42,
+          submitted_by: 7,
+          submitter_username: 'alice',
+          field_changes: [],
+          summary: 'Fix typo',
+          status: 'pending',
+          created_at: '2026-04-01T00:00:00Z',
+          updated_at: '2026-04-01T00:00:00Z',
+        },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useAdminPendingEdits(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/pending-edits')
+    expect(url).toContain('status=pending')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+    expect(url).not.toContain('entity_type=')
+    expect(result.current.data?.edits).toHaveLength(1)
+  })
+
+  it('passes entity_type and pagination filters', async () => {
+    mockApiRequest.mockResolvedValueOnce({ edits: [], total: 0 })
+
+    const { result } = renderHook(
+      () =>
+        useAdminPendingEdits({
+          status: 'approved',
+          entity_type: 'venue',
+          limit: 10,
+          offset: 30,
+        }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('status=approved')
+    expect(url).toContain('entity_type=venue')
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=30')
+  })
+
+  it('omits status param when status is explicitly empty', async () => {
+    mockApiRequest.mockResolvedValueOnce({ edits: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useAdminPendingEdits({ status: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).not.toContain('status=')
+  })
+
+  it('surfaces fetch errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+    const { result } = renderHook(() => useAdminPendingEdits(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
+})
+
+describe('useApprovePendingEdit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAdminPendingEdits.mockReset()
+    mockInvalidateArtists.mockReset()
+    mockInvalidateVenues.mockReset()
+    mockInvalidateFestivals.mockReset()
+  })
+
+  it('POSTs to the approve endpoint with the edit id', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'approved' })
+
+    const { result } = renderHook(() => useApprovePendingEdit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/pending-edits/1/approve',
+      { method: 'POST' }
+    )
+  })
+
+  it('invalidates pending-edits AND each entity surface on success', async () => {
+    // Approve mutates the underlying entity, so the hook fans out
+    // invalidation across artists/venues/festivals plus the queue itself.
+    // We don't know the entity_type at mutation time (the API call only
+    // takes id), so fanning out is the safe contract — guard it.
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useApprovePendingEdit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateAdminPendingEdits).toHaveBeenCalledTimes(1)
+    expect(mockInvalidateArtists).toHaveBeenCalledTimes(1)
+    expect(mockInvalidateVenues).toHaveBeenCalledTimes(1)
+    expect(mockInvalidateFestivals).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invalidate on failure', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Conflict'))
+
+    const { result } = renderHook(() => useApprovePendingEdit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(999)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Conflict')
+    expect(mockInvalidateAdminPendingEdits).not.toHaveBeenCalled()
+    expect(mockInvalidateArtists).not.toHaveBeenCalled()
+  })
+})
+
+describe('useRejectPendingEdit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAdminPendingEdits.mockReset()
+    mockInvalidateArtists.mockReset()
+    mockInvalidateVenues.mockReset()
+    mockInvalidateFestivals.mockReset()
+  })
+
+  it('POSTs to the reject endpoint with the rejection reason', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'rejected' })
+
+    const { result } = renderHook(() => useRejectPendingEdit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ editId: 1, reason: 'Inaccurate' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/pending-edits/1/reject',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ reason: 'Inaccurate' }),
+      })
+    )
+  })
+
+  it('invalidates only pending-edits on reject (not entity surfaces)', async () => {
+    // Reject doesn't mutate the entity itself — only the queue state
+    // changes. Guard that the entity invalidations are NOT triggered so
+    // we don't waste round-trips refetching unaffected detail pages.
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useRejectPendingEdit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ editId: 1, reason: 'Spam' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateAdminPendingEdits).toHaveBeenCalledTimes(1)
+    expect(mockInvalidateArtists).not.toHaveBeenCalled()
+    expect(mockInvalidateVenues).not.toHaveBeenCalled()
+    expect(mockInvalidateFestivals).not.toHaveBeenCalled()
+  })
+
+  it('surfaces mutation errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Not found'))
+
+    const { result } = renderHook(() => useRejectPendingEdit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ editId: 999, reason: 'Bad' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Not found')
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminRadio.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminRadio.test.tsx
@@ -1,0 +1,798 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  createInvalidateQueries: () => ({}),
+}))
+
+import {
+  radioQueryKeys,
+  useAdminRadioStations,
+  useRadioStationDetail,
+  useRadioShows,
+  useRadioStats,
+  useCreateRadioStation,
+  useUpdateRadioStation,
+  useDeleteRadioStation,
+  useCreateRadioShow,
+  useUpdateRadioShow,
+  useDeleteRadioShow,
+  useFetchPlaylists,
+  useDiscoverShows,
+  useImportShowEpisodes,
+  useCreateImportJob,
+  useImportJob,
+  useCancelImportJob,
+  useShowImportJobs,
+  useUnmatchedPlays,
+  useBulkLinkPlays,
+} from './useAdminRadio'
+
+describe('radioQueryKeys', () => {
+  it('generates stable keys for stations and stats', () => {
+    expect(radioQueryKeys.all).toEqual(['radio'])
+    expect(radioQueryKeys.stations).toEqual(['radio', 'stations'])
+    expect(radioQueryKeys.stats).toEqual(['radio', 'stats'])
+  })
+
+  it('generates parameterised keys for station/show/job scopes', () => {
+    expect(radioQueryKeys.stationDetail(42)).toEqual(['radio', 'stations', 42])
+    expect(radioQueryKeys.shows(7)).toEqual(['radio', 'shows', 7])
+    expect(radioQueryKeys.importJob(99)).toEqual([
+      'radio',
+      'import-jobs',
+      99,
+    ])
+    expect(radioQueryKeys.showImportJobs(7)).toEqual([
+      'radio',
+      'show-import-jobs',
+      7,
+    ])
+    expect(radioQueryKeys.unmatched(0)).toEqual(['radio', 'unmatched', 0])
+  })
+})
+
+describe('useAdminRadioStations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches station list', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      stations: [
+        {
+          id: 1,
+          name: 'KEXP',
+          slug: 'kexp',
+          city: 'Seattle',
+          state: 'WA',
+          country: 'US',
+          broadcast_type: 'fm',
+          frequency_mhz: 90.3,
+          logo_url: null,
+          is_active: true,
+          show_count: 50,
+        },
+      ],
+      count: 1,
+    })
+
+    const { result } = renderHook(() => useAdminRadioStations(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('http://localhost:8080/radio-stations')
+    expect(result.current.data?.stations).toHaveLength(1)
+  })
+})
+
+describe('useRadioStationDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches station detail when enabled and stationId > 0', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 42, name: 'KEXP', slug: 'kexp' })
+
+    const { result } = renderHook(() => useRadioStationDetail(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/radio-stations/42'
+    )
+  })
+
+  it('does not fetch when stationId is 0', () => {
+    const { result } = renderHook(() => useRadioStationDetail(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useRadioStationDetail(42, false), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useRadioShows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches shows for a station with the station_id query param', async () => {
+    mockApiRequest.mockResolvedValueOnce({ shows: [], count: 0 })
+
+    const { result } = renderHook(() => useRadioShows(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/radio-shows?station_id=42'
+    )
+  })
+
+  it('does not fetch when stationId is 0', () => {
+    const { result } = renderHook(() => useRadioShows(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useRadioStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches overall radio stats', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      total_stations: 3,
+      total_shows: 50,
+      total_episodes: 1000,
+      total_plays: 50000,
+      matched_plays: 45000,
+      unique_artists: 8000,
+    })
+
+    const { result } = renderHook(() => useRadioStats(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('http://localhost:8080/radio/stats')
+    expect(result.current.data?.matched_plays).toBe(45000)
+  })
+})
+
+describe('useCreateRadioStation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs station payload and invalidates stations + stats', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'NTS', slug: 'nts' })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCreateRadioStation(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ name: 'NTS', broadcast_type: 'internet' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-stations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ name: 'NTS', broadcast_type: 'internet' }),
+      })
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stations'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stats'] })
+  })
+})
+
+describe('useUpdateRadioStation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('PUTs the station and invalidates list, detail, and stats', async () => {
+    // Update should invalidate the specific station detail (not just the
+    // list) so that any detail page picks up the change without a refresh.
+    mockApiRequest.mockResolvedValueOnce({ id: 42, name: 'KEXP Renamed' })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useUpdateRadioStation(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ id: 42, name: 'KEXP Renamed' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-stations/42',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ name: 'KEXP Renamed' }),
+      })
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stations'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'stations', 42],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stats'] })
+  })
+})
+
+describe('useDeleteRadioStation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('DELETEs and invalidates stations + stats', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useDeleteRadioStation(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-stations/42',
+      { method: 'DELETE' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stations'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stats'] })
+  })
+})
+
+describe('useCreateRadioShow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs to the station-scoped show endpoint and invalidates that station’s shows', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, station_id: 42, name: 'New Show' })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCreateRadioShow(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ stationId: 42, name: 'New Show' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-stations/42/shows',
+      expect.objectContaining({
+        method: 'POST',
+        // stationId is stripped from the payload because it's in the URL
+        body: JSON.stringify({ name: 'New Show' }),
+      })
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'shows', 42],
+    })
+  })
+})
+
+describe('useUpdateRadioShow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('PUTs to the show endpoint and invalidates the parent station’s shows', async () => {
+    // showId + stationId are stripped from the payload (URL carries showId;
+    // stationId is just needed for the cache invalidation key).
+    mockApiRequest.mockResolvedValueOnce({ id: 99, name: 'Updated Show' })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useUpdateRadioShow(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        showId: 99,
+        stationId: 42,
+        name: 'Updated Show',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-shows/99',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ name: 'Updated Show' }),
+      })
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'shows', 42],
+    })
+  })
+})
+
+describe('useDeleteRadioShow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('DELETEs and invalidates the parent station’s shows + stations + stats', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useDeleteRadioShow(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 99, stationId: 42 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-shows/99',
+      { method: 'DELETE' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'shows', 42],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stats'] })
+  })
+})
+
+describe('useFetchPlaylists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('triggers a fetch and invalidates stations + stats', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useFetchPlaylists(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-stations/42/fetch',
+      { method: 'POST' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio', 'stations'] })
+  })
+})
+
+describe('useDiscoverShows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs to discover and invalidates that station’s show list', async () => {
+    // onSuccess receives the stationId as the second argument (the
+    // mutation variable) and uses it to invalidate the precise show
+    // scope rather than the whole tree.
+    mockApiRequest.mockResolvedValueOnce({ shows_discovered: 3, show_names: [] })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useDiscoverShows(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-stations/42/discover',
+      { method: 'POST' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'shows', 42],
+    })
+  })
+})
+
+describe('useImportShowEpisodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs to the show-import endpoint with since/until', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      shows_discovered: 0,
+      episodes_imported: 5,
+      plays_imported: 100,
+      plays_matched: 80,
+    })
+
+    const { result } = renderHook(() => useImportShowEpisodes(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        showId: 99,
+        since: '2026-01-01',
+        until: '2026-02-01',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-shows/99/import',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          since: '2026-01-01',
+          until: '2026-02-01',
+        }),
+      })
+    )
+  })
+})
+
+describe('useCreateImportJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs to the import-job endpoint and invalidates that show’s jobs', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 1,
+      show_id: 99,
+      status: 'pending',
+    })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCreateImportJob(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        showId: 99,
+        since: '2026-01-01',
+        until: '2026-02-01',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-shows/99/import-job',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          since: '2026-01-01',
+          until: '2026-02-01',
+        }),
+      })
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'show-import-jobs', 99],
+    })
+  })
+})
+
+describe('useImportJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a completed job WITHOUT setting a polling interval', async () => {
+    // refetchInterval should be `false` for terminal states so we don't
+    // keep polling a job that will never change.
+    mockApiRequest.mockResolvedValueOnce({
+      id: 1,
+      show_id: 99,
+      status: 'completed',
+      episodes_imported: 5,
+      plays_imported: 100,
+    })
+
+    const { result } = renderHook(() => useImportJob(1), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio/import-jobs/1'
+    )
+    expect(result.current.data?.status).toBe('completed')
+  })
+
+  it('does not fetch when jobId is 0 or enabled=false', () => {
+    const { result: zero } = renderHook(() => useImportJob(0), {
+      wrapper: createWrapper(),
+    })
+    expect(zero.current.fetchStatus).toBe('idle')
+
+    const { result: disabled } = renderHook(() => useImportJob(1, false), {
+      wrapper: createWrapper(),
+    })
+    expect(disabled.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useCancelImportJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs to the cancel endpoint and invalidates job + radio.all', async () => {
+    // Cancelling a job invalidates the specific job key AND the broad
+    // ['radio'] umbrella so show-level lists pick up the new state.
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCancelImportJob(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio/import-jobs/42/cancel',
+      { method: 'POST' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'import-jobs', 42],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['radio'] })
+  })
+})
+
+describe('useShowImportJobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the job list for a show', async () => {
+    mockApiRequest.mockResolvedValueOnce({ jobs: [], count: 0 })
+
+    const { result } = renderHook(() => useShowImportJobs(99), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio-shows/99/import-jobs'
+    )
+  })
+
+  it('does not fetch when showId is 0', () => {
+    const { result } = renderHook(() => useShowImportJobs(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useUnmatchedPlays', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('passes station_id when > 0 and always passes pagination', async () => {
+    mockApiRequest.mockResolvedValueOnce({ groups: [], total: 0 })
+
+    const { result } = renderHook(() => useUnmatchedPlays(42, 25, 50), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/radio/unmatched')
+    expect(url).toContain('station_id=42')
+    expect(url).toContain('limit=25')
+    expect(url).toContain('offset=50')
+  })
+
+  it('omits station_id when stationId is 0 (all-stations view)', async () => {
+    // Backend treats absence of station_id as "all stations" — make sure
+    // the hook honors the 0-means-all sentinel rather than sending station_id=0.
+    mockApiRequest.mockResolvedValueOnce({ groups: [], total: 0 })
+
+    const { result } = renderHook(() => useUnmatchedPlays(0), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).not.toContain('station_id=')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+  })
+
+  it('keys cache entries by stationId AND pagination', async () => {
+    // The query key includes stationId/limit/offset so different paginations
+    // don't collide in the cache — guard that two different pagination
+    // calls produce TWO requests (rather than one hitting the cache).
+    mockApiRequest
+      .mockResolvedValueOnce({ groups: [], total: 0 })
+      .mockResolvedValueOnce({ groups: [], total: 0 })
+
+    const queryClient = createTestQueryClient()
+
+    const { result: page1 } = renderHook(() => useUnmatchedPlays(42, 50, 0), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+    await waitFor(() => expect(page1.current.isSuccess).toBe(true))
+
+    const { result: page2 } = renderHook(() => useUnmatchedPlays(42, 50, 50), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+    await waitFor(() => expect(page2.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2)
+    const url1 = mockApiRequest.mock.calls[0][0] as string
+    const url2 = mockApiRequest.mock.calls[1][0] as string
+    expect(url1).toContain('offset=0')
+    expect(url2).toContain('offset=50')
+  })
+})
+
+describe('useBulkLinkPlays', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs the bulk-link payload', async () => {
+    mockApiRequest.mockResolvedValueOnce({ updated: 12 })
+
+    const { result } = renderHook(() => useBulkLinkPlays(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        artistName: 'wednesday',
+        artistId: 42,
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/admin/radio/plays/bulk-link',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          artist_name: 'wednesday',
+          artist_id: 42,
+        }),
+      })
+    )
+  })
+
+  it('invalidates the broad unmatched scope and stats on success', async () => {
+    // The broad ['radio', 'unmatched'] key is used (not the per-station one)
+    // because the linking may affect multiple stations' unmatched lists.
+    mockApiRequest.mockResolvedValueOnce({ updated: 5 })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useBulkLinkPlays(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({ artistName: 'X', artistId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'unmatched'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['radio', 'stats'],
+    })
+  })
+
+  it('surfaces mutation errors without invalidating', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Artist not found'))
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useBulkLinkPlays(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({ artistName: 'X', artistId: 999 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Artist not found')
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminRadio.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminRadio.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import React from 'react'
 import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
@@ -754,11 +752,9 @@ describe('useBulkLinkPlays', () => {
     const queryClient = createTestQueryClient()
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-
-    const { result } = renderHook(() => useBulkLinkPlays(), { wrapper })
+    const { result } = renderHook(() => useBulkLinkPlays(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
 
     await act(async () => {
       result.current.mutate({ artistName: 'X', artistId: 1 })
@@ -776,16 +772,12 @@ describe('useBulkLinkPlays', () => {
   it('surfaces mutation errors without invalidating', async () => {
     mockApiRequest.mockRejectedValueOnce(new Error('Artist not found'))
 
-    const queryClient = new QueryClient({
-      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
-    })
+    const queryClient = createTestQueryClient()
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-
-    const { result } = renderHook(() => useBulkLinkPlays(), { wrapper })
+    const { result } = renderHook(() => useBulkLinkPlays(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
 
     await act(async () => {
       result.current.mutate({ artistName: 'X', artistId: 999 })

--- a/frontend/lib/hooks/admin/useAdminReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminReports.test.tsx
@@ -183,4 +183,55 @@ describe('useResolveReport', () => {
     expect(mockInvalidateShowReports).toHaveBeenCalled()
     expect(mockInvalidateShows).toHaveBeenCalled()
   })
+
+  it('surfaces mutation errors without invalidating', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Report not found'))
+
+    const { result } = renderHook(() => useResolveReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 999 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Report not found')
+    expect(mockInvalidateShowReports).not.toHaveBeenCalled()
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+  })
+})
+
+describe('error paths on list and dismiss', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShowReports.mockReset()
+  })
+
+  it('surfaces list fetch errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+    const { result } = renderHook(() => usePendingReports(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
+
+  it('surfaces dismiss errors without invalidating', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Already resolved'))
+
+    const { result } = renderHook(() => useDismissReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockInvalidateShowReports).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/lib/hooks/admin/useAdminShows.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminShows.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
@@ -21,6 +20,10 @@ vi.mock('../../api', () => ({
         BATCH_REJECT: '/admin/shows/batch-reject',
       },
     },
+    SHOWS: {
+      SET_SOLD_OUT: (showId: number) => `/shows/${showId}/sold-out`,
+      SET_CANCELLED: (showId: number) => `/shows/${showId}/cancelled`,
+    },
   },
   API_BASE_URL: 'http://localhost:8080',
 }))
@@ -40,6 +43,8 @@ import {
   useRejectShow,
   useBatchApproveShows,
   useBatchRejectShows,
+  useSetShowSoldOut,
+  useSetShowCancelled,
   adminQueryKeys,
 } from './useAdminShows'
 
@@ -115,6 +120,31 @@ describe('useAdminShows', () => {
       )
     })
 
+    it('appends venueId + source filters when provided', async () => {
+      // Both filters are optional on the admin moderation surface — verify
+      // they survive into the URL so the backend can scope correctly.
+      mockApiRequest.mockResolvedValueOnce({ shows: [], total: 0 })
+
+      const { result } = renderHook(
+        () => usePendingShows({ venueId: 7, source: 'ical' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      const url = mockApiRequest.mock.calls[0][0] as string
+      expect(url).toContain('venue_id=7')
+      expect(url).toContain('source=ical')
+    })
+
+    it('does not fetch when enabled=false', () => {
+      const { result } = renderHook(
+        () => usePendingShows({ enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockApiRequest).not.toHaveBeenCalled()
+    })
   })
 
   describe('useRejectedShows', () => {
@@ -167,6 +197,16 @@ describe('useAdminShows', () => {
       expect(calledUrl).toContain('search=query')
     })
 
+    it('surfaces fetch errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useRejectedShows(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
   })
 
   describe('useApproveShow', () => {
@@ -440,5 +480,126 @@ describe('useAdminShows', () => {
       })
     })
 
+  })
+
+  describe('useSetShowSoldOut', () => {
+    it('POSTs the sold-out toggle value (true)', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 1, is_sold_out: true })
+
+      const { result } = renderHook(() => useSetShowSoldOut(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ showId: 1, value: true })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/shows/1/sold-out',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ value: true }),
+        })
+      )
+    })
+
+    it('POSTs the sold-out toggle value (false) to clear', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 1, is_sold_out: false })
+
+      const { result } = renderHook(() => useSetShowSoldOut(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ showId: 1, value: false })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/shows/1/sold-out',
+        expect.objectContaining({
+          body: JSON.stringify({ value: false }),
+        })
+      )
+    })
+
+    it('invalidates the public shows scope on success', async () => {
+      // Sold-out display is denormalised across show listings, so the
+      // broad ['shows'] scope must invalidate. We assert via the shared
+      // invalidateQueries.shows() spy (mocked at module level).
+      mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+      const { result } = renderHook(() => useSetShowSoldOut(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ showId: 1, value: true })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockInvalidateShows).toHaveBeenCalled()
+    })
+
+    it('surfaces errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useSetShowSoldOut(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ showId: 1, value: true })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Forbidden')
+      expect(mockInvalidateShows).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('useSetShowCancelled', () => {
+    it('POSTs the cancelled toggle value', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 5, is_cancelled: true })
+
+      const { result } = renderHook(() => useSetShowCancelled(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ showId: 5, value: true })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/shows/5/cancelled',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ value: true }),
+        })
+      )
+      expect(mockInvalidateShows).toHaveBeenCalled()
+    })
+
+    it('clears the cancelled flag with value=false', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 5, is_cancelled: false })
+
+      const { result } = renderHook(() => useSetShowCancelled(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ showId: 5, value: false })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/shows/5/cancelled',
+        expect.objectContaining({
+          body: JSON.stringify({ value: false }),
+        })
+      )
+    })
   })
 })

--- a/frontend/lib/hooks/admin/useAdminStats.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminStats.test.tsx
@@ -87,4 +87,19 @@ describe('useAdminActivity', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data?.events).toEqual([])
   })
+
+  it('handles activity-feed API errors', async () => {
+    server.use(
+      http.get(`${TEST_API_BASE}/admin/activity`, () => {
+        return HttpResponse.json({ message: 'Forbidden' }, { status: 403 })
+      })
+    )
+
+    const { result } = renderHook(() => useAdminActivity(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toBeUndefined()
+  })
 })

--- a/frontend/lib/hooks/admin/useAdminUsers.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminUsers.test.tsx
@@ -68,4 +68,47 @@ describe('useAdminUsers', () => {
     expect(url).toContain('search=john')
   })
 
+  it('URL-encodes spaces in the search filter', async () => {
+    // Search-box copies frequently contain spaces (e.g. "alice doe") —
+    // make sure URLSearchParams produces a backend-parseable URL rather
+    // than a raw space that breaks the query.
+    mockApiRequest.mockResolvedValueOnce({ users: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useAdminUsers({ search: 'alice doe' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toMatch(/search=alice(\+|%20)doe/)
+  })
+
+  it('starts in loading state before resolving', async () => {
+    let resolveFetch: (value: unknown) => void = () => {}
+    const pending = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+    mockApiRequest.mockReturnValueOnce(pending)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isLoading).toBe(true)
+
+    resolveFetch({ users: [], total: 0 })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('surfaces fetch errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
 })

--- a/frontend/lib/hooks/admin/useAdminVenues.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminVenues.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
@@ -13,6 +12,7 @@ vi.mock('../../api', () => ({
   API_ENDPOINTS: {
     ADMIN: {
       VENUES: {
+        UNVERIFIED: '/admin/venues/unverified',
         VERIFY: (venueId: number) => `/admin/venues/${venueId}/verify`,
       },
     },
@@ -22,13 +22,19 @@ vi.mock('../../api', () => ({
 
 // Mock queryClient module
 vi.mock('../../queryClient', () => ({
+  queryKeys: {
+    admin: {
+      unverifiedVenues: (limit: number, offset: number) =>
+        ['admin', 'venues', 'unverified', { limit, offset }],
+    },
+  },
   createInvalidateQueries: () => ({
     venues: mockInvalidateVenues,
   }),
 }))
 
 // Import hooks after mocks are set up
-import { useVerifyVenue } from './useAdminVenues'
+import { useUnverifiedVenues, useVerifyVenue } from './useAdminVenues'
 
 
 describe('useAdminVenues', () => {
@@ -36,6 +42,57 @@ describe('useAdminVenues', () => {
     vi.clearAllMocks()
     mockApiRequest.mockReset()
     mockInvalidateVenues.mockReset()
+  })
+
+  describe('useUnverifiedVenues', () => {
+    it('fetches with default pagination', async () => {
+      mockApiRequest.mockResolvedValueOnce({ venues: [], total: 0 })
+
+      const { result } = renderHook(() => useUnverifiedVenues(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      const url = mockApiRequest.mock.calls[0][0] as string
+      expect(url).toContain('/admin/venues/unverified')
+      expect(url).toContain('limit=50')
+      expect(url).toContain('offset=0')
+    })
+
+    it('passes custom limit and offset', async () => {
+      mockApiRequest.mockResolvedValueOnce({ venues: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useUnverifiedVenues({ limit: 25, offset: 50 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      const url = mockApiRequest.mock.calls[0][0] as string
+      expect(url).toContain('limit=25')
+      expect(url).toContain('offset=50')
+    })
+
+    it('does not fetch when enabled=false', () => {
+      const { result } = renderHook(
+        () => useUnverifiedVenues({ enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockApiRequest).not.toHaveBeenCalled()
+    })
+
+    it('surfaces fetch errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useUnverifiedVenues(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
   })
 
   describe('useVerifyVenue', () => {
@@ -62,7 +119,9 @@ describe('useAdminVenues', () => {
       })
     })
 
-    it('invalidates venues and pending shows on success', async () => {
+    it('invalidates venues, pending shows, AND the unverified list on success', async () => {
+      // Verifying flips the venue out of the unverified queue — the queue
+      // itself must invalidate so the row disappears without a refresh.
       mockApiRequest.mockResolvedValueOnce({ id: 20, verified: true })
 
       const queryClient = createTestQueryClient()
@@ -81,6 +140,9 @@ describe('useAdminVenues', () => {
       expect(mockInvalidateVenues).toHaveBeenCalled()
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: ['admin', 'shows', 'pending'],
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['admin', 'venues', 'unverified'],
       })
     })
 

--- a/frontend/lib/hooks/admin/useAnalytics.test.tsx
+++ b/frontend/lib/hooks/admin/useAnalytics.test.tsx
@@ -182,6 +182,66 @@ describe('useAnalytics hooks', () => {
 
   })
 
+  describe('useGrowthMetrics error handling', () => {
+    it('surfaces fetch errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useGrowthMetrics(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Forbidden')
+      expect(result.current.data).toBeUndefined()
+    })
+
+    it('keys cache by months so 6 vs 12 don’t collide', async () => {
+      mockApiRequest
+        .mockResolvedValueOnce({
+          shows: [], artists: [], venues: [], releases: [], labels: [], users: [],
+        })
+        .mockResolvedValueOnce({
+          shows: [], artists: [], venues: [], releases: [], labels: [], users: [],
+        })
+
+      const { result: six } = renderHook(() => useGrowthMetrics(6), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(six.current.isSuccess).toBe(true))
+
+      const { result: twelve } = renderHook(() => useGrowthMetrics(12), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(twelve.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('useEngagementMetrics error handling', () => {
+    it('surfaces fetch errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useEngagementMetrics(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useCommunityHealth error handling', () => {
+    it('surfaces fetch errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useCommunityHealth(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
   describe('useDataQualityTrends', () => {
     it('fetches data quality trends with default months', async () => {
       const mockResponse = {
@@ -226,5 +286,14 @@ describe('useAnalytics hooks', () => {
       )
     })
 
+    it('surfaces fetch errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useDataQualityTrends(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
   })
 })

--- a/frontend/lib/hooks/admin/useDataQuality.test.tsx
+++ b/frontend/lib/hooks/admin/useDataQuality.test.tsx
@@ -54,8 +54,20 @@ describe('useDataQualitySummary', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(mockApiRequest).toHaveBeenCalledWith('/admin/data-quality', { method: 'GET' })
+    expect(result.current.data?.total_items).toBe(15)
+    expect(result.current.data?.categories).toHaveLength(2)
   })
 
+  it('surfaces fetch errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+    const { result } = renderHook(() => useDataQualitySummary(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
 })
 
 describe('useDataQualityCategory', () => {
@@ -115,5 +127,37 @@ describe('useDataQualityCategory', () => {
     )
 
     expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces fetch errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+    const { result } = renderHook(
+      () => useDataQualityCategory('missing_social'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
+
+  it('keys cache by category AND pagination', async () => {
+    mockApiRequest
+      .mockResolvedValueOnce({ items: [], total: 0 })
+      .mockResolvedValueOnce({ items: [], total: 0 })
+
+    const { result: socialPage1 } = renderHook(
+      () => useDataQualityCategory('missing_social', 50, 0),
+      { wrapper: createWrapper() }
+    )
+    await waitFor(() => expect(socialPage1.current.isSuccess).toBe(true))
+
+    const { result: noShowsPage1 } = renderHook(
+      () => useDataQualityCategory('no_shows', 50, 0),
+      { wrapper: createWrapper() }
+    )
+    await waitFor(() => expect(noShowsPage1.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary

- Expand `lib/hooks/admin/` coverage from render-only / thin tests to full mutation + cache-invalidation across the moderation surface.
- Add 3 new test files for previously untested hooks: `useAdminEntityReports`, `useAdminPendingEdits`, `useAdminRadio` (covers stations, shows, import jobs, matching).
- Extend 11 existing files with missing hook coverage (e.g. `useArtistUpdate` + alias/merge hooks, `useSetShowSoldOut`/`useSetShowCancelled`, `useUnverifiedVenues`, `useAdminCommentEditHistory`), error paths, loading-state assertions, and cache-key isolation checks.
- 77 → 183 tests (11 → 14 files).

## Test plan

- [x] `bun run test:run lib/hooks/admin` — passed (183 tests across 14 files)
- [x] `bun run typecheck` — passed
- [x] `/code-review` — surfaced two style cleanups (unnecessary dynamic import + inline `QueryClientProvider` wrapper); both applied in a follow-up commit. No correctness findings.

## Manual repro

Unit-test additions; manual repro = the test names + assertions documented below.

**3 new files**

- `useAdminEntityReports.test.tsx` (12 tests): default-filter URL shape, `entity_type` filter, empty-status omission, error surface; `useResolveEntityReport`/`useDismissEntityReport` POST body + notes-coerced-to-empty-string + invalidation; `useAdminHideCollection` PUTs `is_public: false` to the existing admin-permitted `/collections/{slug}` endpoint and invalidates both moderation queue + collections scope.
- `useAdminPendingEdits.test.tsx` (12 tests): list URL with status/entity_type/pagination, error surface; `useApprovePendingEdit` fans out invalidation to artists+venues+festivals (entity-type unknown at mutation time); `useRejectPendingEdit` invalidates ONLY the pending-edits scope (no entity mutation).
- `useAdminRadio.test.tsx` (30 tests): query keys; station/show/stats fetch + enabled-guards; CRUD on stations and shows (URL strips path-segment ids from body, invalidations include the specific station detail key); `useFetchPlaylists`/`useDiscoverShows`/`useImportShowEpisodes` triggers; `useCreateImportJob` invalidates per-show jobs; `useImportJob` skip-on-zero/disabled; `useCancelImportJob` invalidates job + `['radio']` umbrella; `useUnmatchedPlays` station_id=0-means-all-stations sentinel, cache-key isolation by pagination; `useBulkLinkPlays` POST body + broad unmatched invalidation + error-without-invalidate.

**Extended files**

- `useAdminArtists.test.tsx`: add `useArtistUpdate` (PATCH; invalidates artist detail+artists.all+shows.all because show listings carry denormalised names), `useArtistAliases` (enabled/0-guard), `useCreateArtistAlias`/`useDeleteArtistAlias` (alias-key invalidation), `useMergeArtists` (broad artists+shows invalidation + merge-with-self error). Updated `mockFetchResponse`/`mockFetchError` to include `headers: new Headers()` so `apiRequest`-routed hooks no longer crash on `response.headers.get`. Dropped dead `QueryClient` import. 14 → 24 tests.
- `useAdminShows.test.tsx`: `usePendingShows` venueId+source filters and `enabled=false`; `useRejectedShows` error surface; `useSetShowSoldOut` + `useSetShowCancelled` POST body for both true/false toggles, public shows invalidation, error-without-invalidate. Dropped dead `QueryClient` import. 19 → 28 tests.
- `useAdminComments.test.tsx`: invalidation assertions on approve/reject/hide/restore (queue + public + entity-reports for hide); error-without-invalidate; `useAdminCommentEditHistory` default-disabled guard. 6 → 17 tests.
- `useAdminVenues.test.tsx`: full `useUnverifiedVenues` coverage (default/custom pagination, `enabled=false`, error); strengthen `useVerifyVenue` to also assert unverified-list invalidation. Dropped dead `QueryClient` import. 3 → 7 tests.
- `useAdminUsers.test.tsx`: URL-encoded search, loading state, fetch error. 2 → 5 tests.
- `useAdminAuditLogs.test.tsx`: loading state, fetch error, cache-key isolation by pagination. 2 → 5 tests.
- `useAdminArtistReports.test.tsx`: loading state + fetch error + mutation-error-without-invalidate. 7 → 11 tests.
- `useAdminReports.test.tsx`: list/dismiss/resolve error paths without invalidation. 7 → 11 tests.
- `useAnalytics.test.tsx`: error paths for each of growth/engagement/community/data-quality; growth cache-key isolation by months. 7 → 12 tests.
- `useDataQuality.test.tsx`: error paths for summary + category; category cache-key isolation. 6 → 8 tests.
- `useAdminStats.test.tsx`: error path for activity feed. 5 → 6 tests.

Closes PSY-718