### PR TITLE
PSY-700: strengthen features/auth hook tests

### DIFF
--- a/frontend/features/auth/hooks/useAuth.test.tsx
+++ b/frontend/features/auth/hooks/useAuth.test.tsx
@@ -22,11 +22,12 @@ vi.mock('@/lib/api', () => ({
       CHANGE_PASSWORD: '/auth/change-password',
       MAGIC_LINK_SEND: '/auth/magic-link/send',
       MAGIC_LINK_VERIFY: '/auth/magic-link/verify',
-      DELETION_SUMMARY: '/auth/deletion-summary',
-      DELETE_ACCOUNT: '/auth/delete-account',
-      EXPORT_DATA: '/auth/export-data',
-      OAUTH_ACCOUNTS: '/auth/oauth-accounts',
-      OAUTH_UNLINK: (provider: string) => `/auth/oauth/${provider}/unlink`,
+      DELETION_SUMMARY: '/auth/account/deletion-summary',
+      DELETE_ACCOUNT: '/auth/account/delete',
+      EXPORT_DATA: '/auth/account/export',
+      OAUTH_ACCOUNTS: '/auth/oauth/accounts',
+      OAUTH_UNLINK: (provider: string) =>
+        `/auth/oauth/accounts/${provider}`,
       RECOVER_ACCOUNT: '/auth/recover-account',
       RECOVER_ACCOUNT_REQUEST: '/auth/recover-account/request',
       RECOVER_ACCOUNT_CONFIRM: '/auth/recover-account/confirm',
@@ -913,7 +914,7 @@ describe('useAuth hooks', () => {
       })
 
       expect(mockApiRequest).toHaveBeenCalledWith(
-        '/auth/delete-account',
+        '/auth/account/delete',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ password: 'pw', reason: 'no longer needed' }),
@@ -991,7 +992,7 @@ describe('useAuth hooks', () => {
       })
 
       expect(mockApiRequest).toHaveBeenCalledWith(
-        '/auth/export-data',
+        '/auth/account/export',
         expect.objectContaining({ method: 'GET' })
       )
       expect(returned).toEqual(exportPayload)
@@ -1041,7 +1042,7 @@ describe('useAuth hooks', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
       expect(mockApiRequest).toHaveBeenCalledWith(
-        '/auth/oauth-accounts',
+        '/auth/oauth/accounts',
         expect.objectContaining({ method: 'GET', credentials: 'include' })
       )
       expect(result.current.data).toEqual(response)
@@ -1108,7 +1109,7 @@ describe('useAuth hooks', () => {
       })
 
       expect(mockApiRequest).toHaveBeenCalledWith(
-        '/auth/oauth/google/unlink',
+        '/auth/oauth/accounts/google',
         expect.objectContaining({ method: 'DELETE' })
       )
     })

--- a/frontend/features/auth/hooks/useAuth.test.tsx
+++ b/frontend/features/auth/hooks/useAuth.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
-import { AuthErrorCode } from '@/lib/errors'
+import { AuthErrorCode, AuthError } from '@/lib/errors'
 
 // Create a mock for apiRequest that we can control
 const mockApiRequest = vi.fn()
+const mockInvalidateAuth = vi.fn()
 
 // Mock the api module
 vi.mock('@/lib/api', () => ({
@@ -19,6 +19,25 @@ vi.mock('@/lib/api', () => ({
       REFRESH: '/auth/refresh',
       VERIFY_EMAIL_SEND: '/auth/verify-email/send',
       VERIFY_EMAIL_CONFIRM: '/auth/verify-email/confirm',
+      CHANGE_PASSWORD: '/auth/change-password',
+      MAGIC_LINK_SEND: '/auth/magic-link/send',
+      MAGIC_LINK_VERIFY: '/auth/magic-link/verify',
+      DELETION_SUMMARY: '/auth/deletion-summary',
+      DELETE_ACCOUNT: '/auth/delete-account',
+      EXPORT_DATA: '/auth/export-data',
+      OAUTH_ACCOUNTS: '/auth/oauth-accounts',
+      OAUTH_UNLINK: (provider: string) => `/auth/oauth/${provider}/unlink`,
+      RECOVER_ACCOUNT: '/auth/recover-account',
+      RECOVER_ACCOUNT_REQUEST: '/auth/recover-account/request',
+      RECOVER_ACCOUNT_CONFIRM: '/auth/recover-account/confirm',
+      CLI_TOKEN: '/auth/cli-token',
+    },
+    ADMIN: {
+      TOKENS: {
+        LIST: '/admin/tokens',
+        CREATE: '/admin/tokens',
+        REVOKE: (id: number) => `/admin/tokens/${id}`,
+      },
     },
   },
   API_BASE_URL: 'http://localhost:8080',
@@ -48,7 +67,7 @@ vi.mock('@/lib/queryClient', () => ({
     },
   },
   createInvalidateQueries: () => ({
-    auth: vi.fn(),
+    auth: mockInvalidateAuth,
   }),
 }))
 
@@ -58,10 +77,21 @@ import {
   useRegister,
   useLogout,
   useProfile,
+  useUpdateProfile,
   useRefreshToken,
   useIsAuthenticated,
   useSendVerificationEmail,
   useConfirmVerification,
+  useChangePassword,
+  useSendMagicLink,
+  useVerifyMagicLink,
+  useDeleteAccount,
+  useExportData,
+  useOAuthAccounts,
+  useUnlinkOAuthAccount,
+  useRecoverAccount,
+  useRequestAccountRecovery,
+  useConfirmAccountRecovery,
 } from './useAuth'
 
 
@@ -69,6 +99,7 @@ describe('useAuth hooks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockApiRequest.mockReset()
+    mockInvalidateAuth.mockReset()
   })
 
   describe('useLogin', () => {
@@ -315,6 +346,101 @@ describe('useAuth hooks', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
     })
+
+    it('exposes the full user object (preserves is_admin, email_verified, user_tier)', async () => {
+      // The header reads `is_admin` to render the admin link, the
+      // verification banner reads `email_verified`, and trust-tier badges
+      // read `user_tier`. Locking the shape here surfaces any future
+      // contract drift in one place.
+      const payload = {
+        success: true,
+        message: 'ok',
+        user: {
+          id: '1',
+          email: 'test@example.com',
+          username: 'testuser',
+          is_admin: true,
+          email_verified: true,
+          user_tier: 'trusted_contributor',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+      }
+      mockApiRequest.mockResolvedValueOnce(payload)
+
+      const { result } = renderHook(() => useProfile(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data).toEqual(payload)
+    })
+
+    it('does NOT retry on token-expired errors (short-circuits to login)', async () => {
+      // Retrying on TOKEN_EXPIRED would burn extra refresh attempts and
+      // delay the redirect-to-login. The hook explicitly bails on
+      // shouldRedirectToLogin.
+      const tokenError = new AuthError(
+        'Token expired',
+        AuthErrorCode.TOKEN_EXPIRED,
+        { status: 401 }
+      )
+      mockApiRequest.mockRejectedValue(tokenError)
+
+      const { result } = renderHook(() => useProfile(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT retry on 403 forbidden', async () => {
+      const forbiddenError = new AuthError(
+        'Forbidden',
+        AuthErrorCode.UNAUTHORIZED,
+        { status: 403 }
+      )
+      mockApiRequest.mockRejectedValue(forbiddenError)
+
+      const { result } = renderHook(() => useProfile(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('caches profile across remount (uses 5-minute staleTime)', async () => {
+      // The profile is read from multiple places (header, gated buttons,
+      // settings) — they should share a single cache entry, not each
+      // trigger an independent fetch.
+      const queryClient = createTestQueryClient()
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        user: { id: '1', email: 'a@b.c' },
+      })
+
+      const { result, unmount } = renderHook(() => useProfile(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledTimes(1)
+
+      unmount()
+
+      const { result: result2 } = renderHook(() => useProfile(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      // Cached — still 1 call.
+      expect(result2.current.data).toEqual({
+        success: true,
+        user: { id: '1', email: 'a@b.c' },
+      })
+      expect(mockApiRequest).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('useRefreshToken', () => {
@@ -343,6 +469,50 @@ describe('useAuth hooks', () => {
       )
     })
 
+    it('invalidates auth queries on successful refresh (so profile re-fetches)', async () => {
+      // PSY-700 named "token refresh on expiry" as a critical scenario.
+      // When refresh succeeds, downstream auth queries must re-fetch so
+      // the just-renewed session info appears in the UI without a
+      // hard refresh.
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Token refreshed',
+      })
+
+      const { result } = renderHook(() => useRefreshToken(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate()
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockInvalidateAuth).toHaveBeenCalled()
+    })
+
+    it('does NOT invalidate auth on refresh response with success=false', async () => {
+      // Backend can return 200 with success=false (e.g. expired refresh
+      // token). Invalidating in that case would trigger a stale-data
+      // refetch on the soon-to-redirect page.
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Refresh token expired',
+        error_code: 'TOKEN_EXPIRED',
+      })
+
+      const { result } = renderHook(() => useRefreshToken(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate()
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockInvalidateAuth).not.toHaveBeenCalled()
+    })
+
     it('clears cache on refresh failure', async () => {
       const queryClient = createTestQueryClient()
       const clearSpy = vi.spyOn(queryClient, 'clear')
@@ -360,6 +530,22 @@ describe('useAuth hooks', () => {
       await waitFor(() => expect(result.current.isError).toBe(true))
 
       expect(clearSpy).toHaveBeenCalled()
+    })
+
+    it('surfaces refresh error to the caller', async () => {
+      const error = new Error('Network error')
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useRefreshToken(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate()
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error).toBe(error)
     })
   })
 
@@ -510,4 +696,609 @@ describe('useAuth hooks', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
     })
   })
+
+  describe('useUpdateProfile', () => {
+    it('calls PATCH /auth/profile with the update body', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Profile updated',
+        user: { id: '1', email: 'a@b.c', username: 'newname' },
+      })
+
+      const { result } = renderHook(() => useUpdateProfile(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ username: 'newname', bio: 'hi' })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/profile',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ username: 'newname', bio: 'hi' }),
+        })
+      )
+    })
+
+    it('throws AuthError when update fails', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Username taken',
+        error_code: 'VALIDATION_FAILED',
+      })
+
+      const { result } = renderHook(() => useUpdateProfile(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ username: 'taken' })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).name).toBe('AuthError')
+    })
+  })
+
+  describe('useChangePassword', () => {
+    it('sends current + new password to the change-password endpoint', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Password changed',
+      })
+
+      const { result } = renderHook(() => useChangePassword(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          current_password: 'old123',
+          new_password: 'new456',
+        })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/change-password',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            current_password: 'old123',
+            new_password: 'new456',
+          }),
+        })
+      )
+    })
+
+    it('throws AuthError when current password is wrong', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Current password incorrect',
+        error_code: 'INVALID_CREDENTIALS',
+      })
+
+      const { result } = renderHook(() => useChangePassword(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          current_password: 'wrong',
+          new_password: 'new456',
+        })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as unknown as { code: string }).code).toBe(
+        AuthErrorCode.INVALID_CREDENTIALS
+      )
+    })
+  })
+
+  describe('useSendMagicLink', () => {
+    it('calls the magic-link send endpoint with email', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'If eligible, sent',
+      })
+
+      const { result } = renderHook(() => useSendMagicLink(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ email: 'test@example.com' })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/magic-link/send',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ email: 'test@example.com' }),
+        })
+      )
+    })
+
+    it('does NOT throw on success=false (enumeration-safe path)', async () => {
+      // The backend returns 200 with success=false on cases like
+      // EMAIL_NOT_VERIFIED to avoid leaking which addresses exist. The
+      // hook must propagate this as a normal mutation result, not as
+      // an error — UI inspects `data.error_code`.
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Email not verified',
+        error_code: 'EMAIL_NOT_VERIFIED',
+      })
+
+      const { result } = renderHook(() => useSendMagicLink(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ email: 'test@example.com' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data?.success).toBe(false)
+      expect(result.current.data?.error_code).toBe('EMAIL_NOT_VERIFIED')
+      expect(result.current.isError).toBe(false)
+    })
+  })
+
+  describe('useVerifyMagicLink', () => {
+    it('calls verify endpoint with token', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Logged in',
+        user: { id: '1', email: 'a@b.c' },
+      })
+
+      const { result } = renderHook(() => useVerifyMagicLink(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync('magic-token-123')
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/magic-link/verify',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ token: 'magic-token-123' }),
+        })
+      )
+    })
+
+    it('throws AuthError on invalid/expired token', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Invalid or expired magic link',
+        error_code: 'TOKEN_EXPIRED',
+      })
+
+      const { result } = renderHook(() => useVerifyMagicLink(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate('bad-token')
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).name).toBe('AuthError')
+    })
+  })
+
+  describe('useDeleteAccount', () => {
+    it('sends password (and optional reason) to delete endpoint', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Account scheduled for deletion',
+        deletion_date: '2026-06-01',
+        grace_period_days: 7,
+      })
+
+      const { result } = renderHook(() => useDeleteAccount(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          password: 'pw',
+          reason: 'no longer needed',
+        })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/delete-account',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ password: 'pw', reason: 'no longer needed' }),
+        })
+      )
+    })
+
+    it('clears query cache on successful deletion', async () => {
+      const queryClient = createTestQueryClient()
+      const clearSpy = vi.spyOn(queryClient, 'clear')
+
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Account scheduled for deletion',
+      })
+
+      const { result } = renderHook(() => useDeleteAccount(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ password: 'pw' })
+      })
+
+      expect(clearSpy).toHaveBeenCalled()
+    })
+
+    it('throws AuthError on wrong password', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Incorrect password',
+        error_code: 'INVALID_CREDENTIALS',
+      })
+
+      const { result } = renderHook(() => useDeleteAccount(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ password: 'wrong' })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as unknown as { code: string }).code).toBe(
+        AuthErrorCode.INVALID_CREDENTIALS
+      )
+    })
+  })
+
+  describe('useExportData', () => {
+    it('calls export-data and returns the export payload', async () => {
+      const exportPayload = {
+        success: true,
+        message: 'Export ready',
+        exported_at: '2025-03-15T00:00:00Z',
+        export_version: '1.0',
+        profile: {
+          id: 1,
+          email: 'a@b.c',
+          is_admin: false,
+          email_verified: true,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+      }
+      mockApiRequest.mockResolvedValueOnce(exportPayload)
+
+      const { result } = renderHook(() => useExportData(), {
+        wrapper: createWrapper(),
+      })
+
+      let returned: unknown
+      await act(async () => {
+        returned = await result.current.mutateAsync()
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/export-data',
+        expect.objectContaining({ method: 'GET' })
+      )
+      expect(returned).toEqual(exportPayload)
+    })
+
+    it('throws AuthError when export fails', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Export disabled',
+      })
+
+      const { result } = renderHook(() => useExportData(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate()
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).name).toBe('AuthError')
+    })
+  })
+
+  describe('useOAuthAccounts (SSO state on page load)', () => {
+    it('fetches connected OAuth accounts', async () => {
+      // PSY-700 specifically called out "SSO state on page load" as a
+      // critical behavior to cover. useOAuthAccounts is the GET that
+      // populates the "Linked accounts" panel on settings — silent
+      // failures here mean the user can't tell whether Google/GitHub
+      // is actually linked.
+      const response = {
+        success: true,
+        accounts: [
+          {
+            provider: 'google',
+            email: 'test@gmail.com',
+            connected_at: '2024-01-01T00:00:00Z',
+          },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(response)
+
+      const { result } = renderHook(() => useOAuthAccounts(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/oauth-accounts',
+        expect.objectContaining({ method: 'GET', credentials: 'include' })
+      )
+      expect(result.current.data).toEqual(response)
+    })
+
+    it('exposes the full list of connected providers', async () => {
+      const response = {
+        success: true,
+        accounts: [
+          { provider: 'google', connected_at: '2024-01-01T00:00:00Z' },
+          { provider: 'github', connected_at: '2024-02-01T00:00:00Z' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(response)
+
+      const { result } = renderHook(() => useOAuthAccounts(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data?.accounts).toHaveLength(2)
+      expect(result.current.data?.accounts[0].provider).toBe('google')
+      expect(result.current.data?.accounts[1].provider).toBe('github')
+    })
+
+    it('returns empty accounts array when no SSO is linked', async () => {
+      mockApiRequest.mockResolvedValueOnce({ success: true, accounts: [] })
+
+      const { result } = renderHook(() => useOAuthAccounts(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data?.accounts).toEqual([])
+    })
+
+    it('surfaces 401 errors (so the settings page can prompt re-login)', async () => {
+      const error = new Error('Unauthorized')
+      Object.assign(error, { status: 401 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useOAuthAccounts(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.data).toBeUndefined()
+    })
+  })
+
+  describe('useUnlinkOAuthAccount', () => {
+    it('calls DELETE on the provider-specific unlink endpoint', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Unlinked',
+      })
+
+      const { result } = renderHook(() => useUnlinkOAuthAccount(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync('google')
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/oauth/google/unlink',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('invalidates the oauth-accounts query on success', async () => {
+      const queryClient = createTestQueryClient()
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Unlinked',
+      })
+
+      const { result } = renderHook(() => useUnlinkOAuthAccount(), {
+        wrapper: createWrapperWithClient(queryClient),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync('github')
+      })
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['auth', 'oauth-accounts'],
+      })
+    })
+
+    it('throws AuthError if unlink fails', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Cannot unlink — no other auth method',
+      })
+
+      const { result } = renderHook(() => useUnlinkOAuthAccount(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate('google')
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).name).toBe('AuthError')
+    })
+  })
+
+  describe('useRecoverAccount', () => {
+    it('calls recover endpoint with email + password', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Account recovered',
+        user: { id: '1', email: 'a@b.c' },
+      })
+
+      const { result } = renderHook(() => useRecoverAccount(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          email: 'a@b.c',
+          password: 'pw',
+        })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/recover-account',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ email: 'a@b.c', password: 'pw' }),
+        })
+      )
+    })
+
+    it('throws AuthError when recovery fails', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Account not eligible for recovery',
+      })
+
+      const { result } = renderHook(() => useRecoverAccount(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ email: 'a@b.c', password: 'pw' })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useRequestAccountRecovery (enumeration-safe)', () => {
+    it('does NOT throw on success=false (enumeration-safe acknowledgement)', async () => {
+      // Backend always returns a generic "if eligible, sent" body — the
+      // hook must propagate it as success so the UI shows the same
+      // neutral message regardless of account state.
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'If your account is eligible, an email was sent.',
+      })
+
+      const { result } = renderHook(() => useRequestAccountRecovery(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ email: 'a@b.c' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.isError).toBe(false)
+      expect(result.current.data?.message).toBe(
+        'If your account is eligible, an email was sent.'
+      )
+    })
+
+    it('returns the generic acknowledgement on success=true', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'If your account is eligible, an email was sent.',
+      })
+
+      const { result } = renderHook(() => useRequestAccountRecovery(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ email: 'a@b.c' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/recover-account/request',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+
+  describe('useConfirmAccountRecovery', () => {
+    it('calls confirm endpoint with token', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Recovered',
+        user: { id: '1', email: 'a@b.c' },
+      })
+
+      const { result } = renderHook(() => useConfirmAccountRecovery(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync('recovery-token-xyz')
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/recover-account/confirm',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ token: 'recovery-token-xyz' }),
+        })
+      )
+    })
+
+    it('throws AuthError on invalid token', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: false,
+        message: 'Invalid token',
+      })
+
+      const { result } = renderHook(() => useConfirmAccountRecovery(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate('bad-token')
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).name).toBe('AuthError')
+    })
+  })
+
+  // PSY-700 lists "multi-tab sync via BroadcastChannel" as a scenario to
+  // cover. As of this PR there is NO BroadcastChannel implementation in
+  // features/auth, frontend/lib, or anywhere else in the app code (only
+  // node_modules). The auth flow today is driven by HTTP-only cookies +
+  // TanStack Query — sibling tabs see updates on their next refetch
+  // (window-focus refetch in dev; staleTime expiry otherwise). There is
+  // nothing testable to assert here without first building the sync
+  // mechanism, which is out of scope for a test-strengthening ticket.
+  // Filing this as a documented gap; if a BroadcastChannel-based sync
+  // ships later, the new code should land with its own tests.
 })

--- a/frontend/features/auth/hooks/useCalendarFeed.test.tsx
+++ b/frontend/features/auth/hooks/useCalendarFeed.test.tsx
@@ -391,17 +391,6 @@ describe('useCalendarTokenStatus + useCreateCalendarToken integration', () => {
     mockInvalidateCalendar.mockReset()
   })
 
-  it('exposes shared queryKey so invalidation reaches the status query', async () => {
-    // Sanity check: queryKey object exported by queryClient matches the
-    // key the status query uses. If the keys drift, invalidation becomes
-    // a silent no-op — the very "fails silently" pattern PSY-700 is
-    // hardening against.
-    const { queryKeys } = await import('@/lib/queryClient')
-
-    expect(queryKeys.calendar.tokenStatus).toEqual(['calendar', 'tokenStatus'])
-    expect(queryKeys.calendar.all).toEqual(['calendar'])
-  })
-
   it('caches token status under a stable key (no refetch on remount with shared client)', async () => {
     const queryClient = createTestQueryClient()
     mockApiRequest.mockResolvedValueOnce({

--- a/frontend/features/auth/hooks/useCalendarFeed.test.tsx
+++ b/frontend/features/auth/hooks/useCalendarFeed.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { createWrapper } from '@/test/utils'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -84,6 +84,20 @@ describe('useCalendarTokenStatus', () => {
     expect(result.current.fetchStatus).toBe('idle')
   })
 
+  it('starts in loading state before resolution', async () => {
+    // Hang the request so we can observe the loading state.
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    // isPending is true on initial mount while the query is in-flight.
+    expect(result.current.isPending).toBe(true)
+    expect(result.current.isSuccess).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
   it('returns no created_at when user has no token', async () => {
     mockApiRequest.mockResolvedValueOnce({ has_token: false })
 
@@ -97,7 +111,32 @@ describe('useCalendarTokenStatus', () => {
     expect(result.current.data?.created_at).toBeUndefined()
   })
 
-  it('handles API errors', async () => {
+  it('exposes the full token status payload on success', async () => {
+    // The hook is the ONLY caller of GET /calendar/token from the frontend,
+    // so the test must assert the entire shape — silent field-drop here
+    // would surface in the "Connect calendar" UI as missing metadata.
+    mockApiRequest.mockResolvedValueOnce({
+      has_token: true,
+      created_at: '2025-03-01T12:00:00Z',
+    })
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual({
+      has_token: true,
+      created_at: '2025-03-01T12:00:00Z',
+    })
+  })
+
+  it('surfaces API errors to the caller (does not swallow)', async () => {
+    // The "feed generation fails silently" risk in PSY-700 hinges on
+    // errors reaching the consuming component. The hook MUST surface
+    // the error via .error / .isError; if either is missing the
+    // calendar UI would silently render a stale or empty state.
     const error = new Error('Unauthorized')
     Object.assign(error, { status: 401 })
     mockApiRequest.mockRejectedValueOnce(error)
@@ -108,7 +147,24 @@ describe('useCalendarTokenStatus', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true))
 
+    expect(result.current.error).toBeTruthy()
     expect((result.current.error as Error).message).toBe('Unauthorized')
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('marks 500 server errors as errors (does not silently treat as success)', async () => {
+    const error = new Error('Internal Server Error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.isSuccess).toBe(false)
+    expect((result.current.error as Error).message).toBe('Internal Server Error')
   })
 })
 
@@ -141,7 +197,35 @@ describe('useCreateCalendarToken', () => {
     expect(mockInvalidateCalendar).toHaveBeenCalled()
   })
 
-  it('handles creation errors', async () => {
+  it('returns the full token + feed_url payload to the caller', async () => {
+    // The settings page renders feed_url directly; if the hook drops the
+    // field on success, the user sees an empty Copy button. Lock the
+    // contract here.
+    const mockResponse = {
+      token: 'abc123token',
+      feed_url: 'https://api.psychichomily.com/calendar/feed/abc123token',
+      created_at: '2025-03-15T10:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useCreateCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    let returned: unknown
+    await act(async () => {
+      returned = await result.current.mutateAsync()
+    })
+
+    expect(returned).toEqual(mockResponse)
+    await waitFor(() => expect(result.current.data).toEqual(mockResponse))
+  })
+
+  it('surfaces errors to the caller and does NOT silently invalidate', async () => {
+    // Core PSY-700 risk for this hook: if the mutation swallowed the
+    // rejection, the calendar UI would show "success" while no token
+    // exists server-side. The mutation MUST reject mutateAsync AND skip
+    // invalidation so the cache doesn't refetch the (still-missing) status.
     const error = new Error('Server error')
     Object.assign(error, { status: 500 })
     mockApiRequest.mockRejectedValueOnce(error)
@@ -150,15 +234,79 @@ describe('useCreateCalendarToken', () => {
       wrapper: createWrapper(),
     })
 
+    // mutateAsync rejects so consumers in `try { await mutateAsync(); ... }`
+    // hit the catch instead of the success branch.
+    let caught: unknown
     await act(async () => {
       try {
         await result.current.mutateAsync()
       } catch (e) {
-        expect((e as Error).message).toBe('Server error')
+        caught = e
       }
     })
 
+    expect(caught).toBe(error)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeTruthy()
+    expect((result.current.error as { status?: number }).status).toBe(500)
     expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+
+  it('surfaces 401 auth errors with the original error preserved', async () => {
+    // If a user's session expires mid-flow, the calendar UI must see the
+    // 401 so it can trigger a re-auth prompt instead of "looks fine".
+    const authError = new Error('Token expired')
+    Object.assign(authError, { status: 401, code: 'TOKEN_EXPIRED' })
+    mockApiRequest.mockRejectedValueOnce(authError)
+
+    const { result } = renderHook(() => useCreateCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    // Fire-and-forget so the rejection lands as TanStack state instead
+    // of being swallowed by a manual try/catch.
+    act(() => {
+      result.current.mutate()
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBe(authError)
+    expect((result.current.error as { status?: number }).status).toBe(401)
+    expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+
+  it('isPending toggles during in-flight mutation', async () => {
+    let resolveMutation: (v: unknown) => void
+    mockApiRequest.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveMutation = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useCreateCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(false)
+
+    act(() => {
+      result.current.mutate()
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolveMutation!({
+        token: 't',
+        feed_url: 'https://example.com',
+        created_at: 'now',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.isSuccess).toBe(true)
   })
 })
 
@@ -190,7 +338,9 @@ describe('useDeleteCalendarToken', () => {
     expect(mockInvalidateCalendar).toHaveBeenCalled()
   })
 
-  it('handles deletion errors', async () => {
+  it('surfaces errors to the caller and skips invalidation on failure', async () => {
+    // Same risk class as Create: silent swallow here would leave the UI
+    // claiming the feed is disabled while the backend record persists.
     const error = new Error('Not found')
     Object.assign(error, { status: 404 })
     mockApiRequest.mockRejectedValueOnce(error)
@@ -199,14 +349,82 @@ describe('useDeleteCalendarToken', () => {
       wrapper: createWrapper(),
     })
 
+    let caught: unknown
     await act(async () => {
       try {
         await result.current.mutateAsync()
       } catch (e) {
-        expect((e as Error).message).toBe('Not found')
+        caught = e
       }
     })
 
+    expect(caught).toBe(error)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeTruthy()
+    expect((result.current.error as { status?: number }).status).toBe(404)
     expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+
+  it('does not invalidate on 500 server errors', async () => {
+    const error = new Error('Internal Server Error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useDeleteCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.mutate()
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+})
+
+describe('useCalendarTokenStatus + useCreateCalendarToken integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateCalendar.mockReset()
+  })
+
+  it('exposes shared queryKey so invalidation reaches the status query', async () => {
+    // Sanity check: queryKey object exported by queryClient matches the
+    // key the status query uses. If the keys drift, invalidation becomes
+    // a silent no-op — the very "fails silently" pattern PSY-700 is
+    // hardening against.
+    const { queryKeys } = await import('@/lib/queryClient')
+
+    expect(queryKeys.calendar.tokenStatus).toEqual(['calendar', 'tokenStatus'])
+    expect(queryKeys.calendar.all).toEqual(['calendar'])
+  })
+
+  it('caches token status under a stable key (no refetch on remount with shared client)', async () => {
+    const queryClient = createTestQueryClient()
+    mockApiRequest.mockResolvedValueOnce({
+      has_token: true,
+      created_at: '2025-03-01T12:00:00Z',
+    })
+
+    const { result, unmount } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    // Remount with the same client: query is still fresh (staleTime=5min)
+    // so no second network call should fire.
+    const { result: result2 } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    expect(result2.current.data?.has_token).toBe(true)
+    expect(mockApiRequest).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/features/auth/hooks/useContributorProfile.test.tsx
+++ b/frontend/features/auth/hooks/useContributorProfile.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { createWrapper } from '@/test/utils'
+import {
+  createWrapper,
+  createWrapperWithClient,
+  createTestQueryClient,
+} from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -14,6 +18,8 @@ vi.mock('@/lib/api', () => ({
     USERS: {
       PROFILE: (username: string) => `/users/${username}`,
       CONTRIBUTIONS: (username: string) => `/users/${username}/contributions`,
+      ACTIVITY_HEATMAP: (username: string) => `/users/${username}/activity-heatmap`,
+      RANKINGS: (username: string) => `/users/${username}/rankings`,
     },
     CONTRIBUTOR: {
       OWN_PROFILE: '/auth/profile/contributor',
@@ -36,6 +42,8 @@ vi.mock('@/lib/queryClient', () => ({
       contributions: (username: string) => ['contributor', 'contributions', username],
       ownContributions: ['contributor', 'ownContributions'],
       ownSections: ['contributor', 'ownSections'],
+      activityHeatmap: (username: string) => ['contributor', 'activityHeatmap', username],
+      rankings: (username: string) => ['contributor', 'rankings', username],
     },
   },
   createInvalidateQueries: () => ({
@@ -48,6 +56,8 @@ vi.mock('@/lib/queryClient', () => ({
 import {
   usePublicProfile,
   usePublicContributions,
+  useActivityHeatmap,
+  usePercentileRankings,
   useOwnContributorProfile,
   useOwnContributions,
   useOwnSections,
@@ -115,6 +125,195 @@ describe('usePublicProfile', () => {
     await waitFor(() => expect(result.current.isError).toBe(true))
 
     expect((result.current.error as Error).message).toBe('User not found')
+  })
+
+  it('isPending is true while the initial fetch is in flight', () => {
+    // Hang the request so we can observe loading state.
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+
+    const { result } = renderHook(() => usePublicProfile('testuser'), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(true)
+    expect(result.current.isSuccess).toBe(false)
+  })
+
+  it('caches profile under the username key and skips refetch on remount', async () => {
+    // Profile pages link to each other — if the cache key doesn't match
+    // the username, navigating user A → user B → user A would re-fetch
+    // every time. Verify the queryKey is stable per username and the
+    // staleTime=5min window prevents the second call.
+    const queryClient = createTestQueryClient()
+    const profile = {
+      username: 'testuser',
+      bio: 'bio',
+      profile_visibility: 'public',
+      user_tier: 'contributor',
+      joined_at: '2024-01-01T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(profile)
+
+    const { result, unmount } = renderHook(
+      () => usePublicProfile('testuser'),
+      { wrapper: createWrapperWithClient(queryClient) }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    // Remount with the same client + same username — should hit cache.
+    const { result: result2 } = renderHook(
+      () => usePublicProfile('testuser'),
+      { wrapper: createWrapperWithClient(queryClient) }
+    )
+
+    expect(result2.current.data).toEqual(profile)
+    expect(mockApiRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('issues a separate fetch for a different username', async () => {
+    // Companion to the cache test above: distinct usernames must NOT share
+    // a cache entry.
+    const queryClient = createTestQueryClient()
+    mockApiRequest.mockResolvedValueOnce({
+      username: 'a',
+      bio: '',
+      profile_visibility: 'public',
+      user_tier: 'contributor',
+      joined_at: '2024-01-01T00:00:00Z',
+    })
+
+    const { result } = renderHook(() => usePublicProfile('a'), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    mockApiRequest.mockResolvedValueOnce({
+      username: 'b',
+      bio: '',
+      profile_visibility: 'public',
+      user_tier: 'contributor',
+      joined_at: '2024-01-01T00:00:00Z',
+    })
+
+    const { result: result2 } = renderHook(() => usePublicProfile('b'), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+    await waitFor(() => expect(result2.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2)
+    expect(mockApiRequest.mock.calls[0][0]).toBe('/users/a')
+    expect(mockApiRequest.mock.calls[1][0]).toBe('/users/b')
+  })
+})
+
+describe('useActivityHeatmap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the activity heatmap for a username', async () => {
+    const heatmap = {
+      days: [
+        { date: '2025-01-01', count: 3 },
+        { date: '2025-01-02', count: 0 },
+      ],
+      total_contributions: 3,
+      max_day_count: 3,
+    }
+    mockApiRequest.mockResolvedValueOnce(heatmap)
+
+    const { result } = renderHook(() => useActivityHeatmap('testuser'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/users/testuser/activity-heatmap', {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(heatmap)
+  })
+
+  it('does not fetch when username is empty', () => {
+    const { result } = renderHook(() => useActivityHeatmap(''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces server errors instead of returning empty heatmap', async () => {
+    // The contributor profile page renders a year-long grid; if errors
+    // were swallowed, the user would see "0 contributions" for every day
+    // when the backend was actually down.
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useActivityHeatmap('testuser'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toBeUndefined()
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})
+
+describe('usePercentileRankings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches percentile rankings for a username', async () => {
+    const rankings = {
+      shows_submitted: { value: 42, percentile: 87 },
+      venues_submitted: { value: 5, percentile: 50 },
+      total_contributions: { value: 50, percentile: 80 },
+    }
+    mockApiRequest.mockResolvedValueOnce(rankings)
+
+    const { result } = renderHook(() => usePercentileRankings('testuser'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/users/testuser/rankings', {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(rankings)
+  })
+
+  it('does not fetch when username is empty', () => {
+    const { result } = renderHook(() => usePercentileRankings(''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does NOT retry on 404 (rankings unavailable)', async () => {
+    // The hook deliberately disables retry to surface the "not available"
+    // state fast. Verify a single attempt regardless of retry settings.
+    const error = new Error('Not Found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValue(error)
+
+    const { result } = renderHook(() => usePercentileRankings('testuser'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -248,6 +447,22 @@ describe('useOwnContributorProfile', () => {
     })
   })
 
+  it('surfaces auth errors (401) to the caller', async () => {
+    // The "Your profile" panel must distinguish "logged out" from "loaded
+    // but empty" — silently treating 401 as undefined would render a
+    // skeleton forever.
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useOwnContributorProfile(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toBeUndefined()
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
 })
 
 describe('useOwnContributions', () => {

--- a/frontend/features/auth/hooks/useFavoriteCities.test.tsx
+++ b/frontend/features/auth/hooks/useFavoriteCities.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { createWrapper } from '@/test/utils'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -161,5 +161,141 @@ describe('useSetFavoriteCities', () => {
     })
 
     await waitFor(() => expect(result.current.isPending).toBe(false))
+  })
+
+  it('invalidates the profile query on success so favorites propagate', async () => {
+    // The hook's whole reason for invalidation is to make the new favorites
+    // visible everywhere profile.preferences.favorite_cities is read. If the
+    // invalidation key drifts from ['auth','profile'], the user adds a city,
+    // hits Save, and nothing in the header / city pills updates without a
+    // page refresh.
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    mockApiRequest.mockResolvedValueOnce({
+      success: true,
+      message: 'Updated',
+      cities: [{ city: 'Phoenix', state: 'AZ' }],
+    })
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync([{ city: 'Phoenix', state: 'AZ' }])
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['auth', 'profile'],
+    })
+  })
+
+  it('does NOT invalidate profile on mutation failure', async () => {
+    // Symmetric to the success case: a failed save must leave the cache
+    // untouched so the user keeps seeing whatever was previously persisted.
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const error = new Error('Validation failed')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    let caught: unknown
+    await act(async () => {
+      try {
+        await result.current.mutateAsync([{ city: '', state: '' }])
+      } catch (e) {
+        caught = e
+      }
+    })
+
+    expect(caught).toBe(error)
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('surfaces server errors via the mutation error state', async () => {
+    // Persistence problem must reach the calling component so the user
+    // can see "save failed" rather than a phantom green confirmation.
+    const error = new Error('Network unreachable')
+    Object.assign(error, { status: 0 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.mutate([{ city: 'Phoenix', state: 'AZ' }])
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBe(error)
+    expect((result.current.error as Error).message).toBe('Network unreachable')
+  })
+
+  it('preserves the order of cities passed in the payload', async () => {
+    // The backend stores order; the hook must not reorder client-side.
+    mockApiRequest.mockResolvedValueOnce({
+      success: true,
+      message: 'Updated',
+      cities: [],
+    })
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    const cities = [
+      { city: 'Phoenix', state: 'AZ' },
+      { city: 'New York', state: 'NY' },
+      { city: 'Tokyo', state: 'Tokyo' },
+    ]
+
+    await act(async () => {
+      await result.current.mutateAsync(cities)
+    })
+
+    const callBody = JSON.parse(
+      (mockApiRequest.mock.calls[0][1] as { body: string }).body
+    )
+    expect(callBody.cities).toEqual(cities)
+  })
+
+  it('supports back-to-back saves without state leaking across mutations', async () => {
+    // The Cities settings page allows the user to add a city, save, then
+    // add another, save again. Each call must hit the API with its own
+    // payload — earlier reset() logic regressions would re-send the prior
+    // batch.
+    mockApiRequest.mockResolvedValue({
+      success: true,
+      message: 'Updated',
+      cities: [],
+    })
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync([{ city: 'A', state: 'AA' }])
+    })
+    await act(async () => {
+      await result.current.mutateAsync([{ city: 'B', state: 'BB' }])
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2)
+    const firstBody = JSON.parse(
+      (mockApiRequest.mock.calls[0][1] as { body: string }).body
+    )
+    const secondBody = JSON.parse(
+      (mockApiRequest.mock.calls[1][1] as { body: string }).body
+    )
+    expect(firstBody.cities).toEqual([{ city: 'A', state: 'AA' }])
+    expect(secondBody.cities).toEqual([{ city: 'B', state: 'BB' }])
   })
 })

--- a/frontend/features/auth/hooks/useFavoriteVenues.test.tsx
+++ b/frontend/features/auth/hooks/useFavoriteVenues.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { createWrapper } from '@/test/utils'
+import {
+  createWrapper,
+  createWrapperWithClient,
+  createTestQueryClient,
+} from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateFavoriteVenues = vi.fn()
@@ -33,10 +37,12 @@ vi.mock('@/lib/queryClient', () => ({
 }))
 
 import {
+  useFavoriteVenues,
   useIsVenueFavorited,
   useFavoriteVenue,
   useUnfavoriteVenue,
   useFavoriteVenueToggle,
+  useFavoriteVenueShows,
 } from './useFavoriteVenues'
 
 
@@ -81,6 +87,7 @@ describe('useFavoriteVenue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockApiRequest.mockReset()
+    mockInvalidateFavoriteVenues.mockReset()
   })
 
   it('calls favorite API and invalidates queries on success', async () => {
@@ -97,6 +104,52 @@ describe('useFavoriteVenue', () => {
     expect(mockApiRequest).toHaveBeenCalledWith('/favorite-venues/42', {
       method: 'POST',
     })
+    expect(mockInvalidateFavoriteVenues).toHaveBeenCalled()
+  })
+
+  it('invalidates the specific venue check key on success', async () => {
+    // The Favorited badge on the venue card uses the check key. If the
+    // mutation forgets to invalidate it, the user clicks "favorite" and
+    // the badge stays grey until they hard-refresh.
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useFavoriteVenue(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync(42)
+    })
+
+    // First call: top-level "favoriteVenues" prefix via the factory.
+    // Second call: the per-venue check key.
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['favoriteVenues', 'check', '42'],
+    })
+  })
+
+  it('surfaces server errors to the caller and does not invalidate', async () => {
+    const error = new Error('Venue already favorited')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useFavoriteVenue(), {
+      wrapper: createWrapper(),
+    })
+
+    let caught: unknown
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(42)
+      } catch (e) {
+        caught = e
+      }
+    })
+
+    expect(caught).toBe(error)
+    expect(mockInvalidateFavoriteVenues).not.toHaveBeenCalled()
   })
 })
 
@@ -104,6 +157,7 @@ describe('useUnfavoriteVenue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockApiRequest.mockReset()
+    mockInvalidateFavoriteVenues.mockReset()
   })
 
   it('calls unfavorite API', async () => {
@@ -120,6 +174,29 @@ describe('useUnfavoriteVenue', () => {
     expect(mockApiRequest).toHaveBeenCalledWith('/favorite-venues/42', {
       method: 'DELETE',
     })
+    expect(mockInvalidateFavoriteVenues).toHaveBeenCalled()
+  })
+
+  it('surfaces server errors to the caller and does not invalidate', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useUnfavoriteVenue(), {
+      wrapper: createWrapper(),
+    })
+
+    let caught: unknown
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(42)
+      } catch (e) {
+        caught = e
+      }
+    })
+
+    expect(caught).toBe(error)
+    expect(mockInvalidateFavoriteVenues).not.toHaveBeenCalled()
   })
 })
 
@@ -348,5 +425,159 @@ describe('useFavoriteVenueToggle', () => {
     })
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+})
+
+describe('useFavoriteVenues (list)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches favorite venues list with default pagination', async () => {
+    const list = {
+      venues: [
+        { id: 1, name: 'Venue A', favorited_at: '2025-03-01T00:00:00Z' },
+        { id: 2, name: 'Venue B', favorited_at: '2025-02-01T00:00:00Z' },
+      ],
+      total: 2,
+      limit: 50,
+      offset: 0,
+    }
+    mockApiRequest.mockResolvedValueOnce(list)
+
+    const { result } = renderHook(() => useFavoriteVenues(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('/favorite-venues')
+    expect(calledUrl).toContain('limit=50')
+    expect(calledUrl).toContain('offset=0')
+    expect(result.current.data).toEqual(list)
+  })
+
+  it('honors custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      venues: [],
+      total: 0,
+      limit: 10,
+      offset: 30,
+    })
+
+    const { result } = renderHook(
+      () => useFavoriteVenues({ limit: 10, offset: 30 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('limit=10')
+    expect(calledUrl).toContain('offset=30')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useFavoriteVenues({ enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces 401 unauthorized errors to the caller', async () => {
+    // If the list silently 401'd to empty, an authenticated user with
+    // expired session would see "no favorites" instead of being prompted
+    // to re-login.
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useFavoriteVenues(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toBeUndefined()
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+})
+
+describe('useFavoriteVenueShows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches favorite venue shows with default timezone', async () => {
+    const shows = {
+      shows: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+    }
+    mockApiRequest.mockResolvedValueOnce(shows)
+
+    const { result } = renderHook(() => useFavoriteVenueShows(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/favorite-venues/shows')
+    // The hook resolves a timezone from Intl; just assert the query
+    // parameter is present, not its specific value (jsdom timezone
+    // varies per environment).
+    expect(calledUrl).toMatch(/timezone=/)
+    expect(calledUrl).toContain('limit=50')
+    expect(calledUrl).toContain('offset=0')
+  })
+
+  it('honors explicit timezone option', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      shows: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+    })
+
+    const { result } = renderHook(
+      () => useFavoriteVenueShows({ timezone: 'America/Phoenix' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0] as string
+    expect(calledUrl).toContain('timezone=America%2FPhoenix')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useFavoriteVenueShows({ enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces errors instead of returning empty shows array', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useFavoriteVenueShows(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toBeUndefined()
+    expect((result.current.error as Error).message).toBe('Server error')
   })
 })


### PR DESCRIPTION
## Summary
- `useAuth.test.tsx`: 18 → 51 tests. Add coverage for `useUpdateProfile`, `useChangePassword`, `useSendMagicLink` (enumeration-safe), `useVerifyMagicLink`, `useDeleteAccount`, `useExportData`, `useOAuthAccounts` (SSO state on page load), `useUnlinkOAuthAccount`, `useRecoverAccount`, `useRequestAccountRecovery` (enumeration-safe), `useConfirmAccountRecovery`. Strengthen `useProfile` (full-shape, retry suppression on `TOKEN_EXPIRED` / 403, cache-hit across remount) and `useRefreshToken` (success invalidation, success=false short-circuit, error surfacing).
- `useCalendarFeed.test.tsx`: 9 → 17 tests. Tackle the named "feed generation fails silently" risk — explicit assertions that 401/404/500 errors reach the caller AND skip invalidation so the cache doesn't claim success on a still-broken backend. Add cache stability across remount.
- `useContributorProfile.test.tsx`: 20 → 30 tests. Add `useActivityHeatmap` and `usePercentileRankings` (previously untested), profile cache hit / distinct-username miss, and `useOwnContributorProfile` 401 surfacing.
- `useFavoriteCities.test.tsx`: 5 → 10 tests. Verify the invalidation key matches `['auth','profile']`, no-invalidate-on-error, error surfacing, payload order preservation, and back-to-back save isolation.
- `useFavoriteVenues.test.tsx`: 15 → 26 tests. Add `useFavoriteVenues` (list, previously untested) and `useFavoriteVenueShows` (previously untested), error surfacing for each, and check-key invalidation on `useFavoriteVenue`.

## Test plan
- [x] `bun run test:run features/auth/hooks` — passed (139 tests across 6 files; up from 72)
- [x] `bun run typecheck` — passed
- [x] `/code-review` — found 4 mock-vs-real URL mismatches in `useAuth.test.tsx` (mocks matched my own assertions but not the real `API_ENDPOINTS` in `lib/api.ts`, so the URL `expect(...toHaveBeenCalledWith)` assertions were tautological) and 1 tautological queryKey test in `useCalendarFeed.test.tsx`. Both fixed in the second commit.

## Manual repro
Unit-test additions; manual repro = the test names + assertions documented below.

### useAuth.test.tsx (new/strengthened tests)
- `useProfile > exposes the full user object (preserves is_admin, email_verified, user_tier)` — asserts `result.current.data` equals the full payload including admin/verification/tier fields
- `useProfile > does NOT retry on token-expired errors (short-circuits to login)` — asserts only 1 `apiRequest` call after a `TOKEN_EXPIRED` rejection
- `useProfile > does NOT retry on 403 forbidden` — asserts only 1 call after 403
- `useProfile > caches profile across remount (uses 5-minute staleTime)` — asserts 2nd renderHook with same QueryClient still has only 1 network call
- `useRefreshToken > invalidates auth queries on successful refresh (so profile re-fetches)` — asserts `mockInvalidateAuth` called on success
- `useRefreshToken > does NOT invalidate auth on refresh response with success=false` — asserts NOT called on `{success:false}` body
- `useRefreshToken > surfaces refresh error to the caller` — asserts `result.current.error` is the rejection
- `useUpdateProfile > calls PATCH /auth/profile with the update body` — asserts method/body shape
- `useUpdateProfile > throws AuthError when update fails` — asserts `error.name === 'AuthError'`
- `useChangePassword > sends current + new password to the change-password endpoint` — asserts URL + body
- `useChangePassword > throws AuthError when current password is wrong` — asserts `error.code === INVALID_CREDENTIALS`
- `useSendMagicLink > calls the magic-link send endpoint with email` — asserts URL + body
- `useSendMagicLink > does NOT throw on success=false (enumeration-safe path)` — asserts `isSuccess === true`, `data.error_code` propagated
- `useVerifyMagicLink > calls verify endpoint with token` / `> throws AuthError on invalid/expired token` — asserts URL/body + error.name
- `useDeleteAccount > sends password (and optional reason) to delete endpoint` — asserts URL+body
- `useDeleteAccount > clears query cache on successful deletion` — asserts `queryClient.clear` spy called
- `useDeleteAccount > throws AuthError on wrong password` — asserts `error.code === INVALID_CREDENTIALS`
- `useExportData > calls export-data and returns the export payload` — asserts URL + returned payload
- `useExportData > throws AuthError when export fails` — asserts `error.name === 'AuthError'`
- `useOAuthAccounts > fetches connected OAuth accounts` — asserts URL + payload (SSO state on page load)
- `useOAuthAccounts > exposes the full list of connected providers` — asserts `accounts[]` length + provider names
- `useOAuthAccounts > returns empty accounts array when no SSO is linked` — asserts `data.accounts === []`
- `useOAuthAccounts > surfaces 401 errors (so the settings page can prompt re-login)` — asserts `isError === true`, `data === undefined`
- `useUnlinkOAuthAccount > calls DELETE on the provider-specific unlink endpoint` — asserts URL + method
- `useUnlinkOAuthAccount > invalidates the oauth-accounts query on success` — asserts `invalidateQueries` called with `['auth','oauth-accounts']`
- `useUnlinkOAuthAccount > throws AuthError if unlink fails` — asserts `error.name === 'AuthError'`
- `useRecoverAccount > calls recover endpoint with email + password` / `> throws AuthError when recovery fails`
- `useRequestAccountRecovery > does NOT throw on success=false (enumeration-safe acknowledgement)` — asserts `isSuccess === true`, generic message propagated
- `useRequestAccountRecovery > returns the generic acknowledgement on success=true` — asserts URL
- `useConfirmAccountRecovery > calls confirm endpoint with token` / `> throws AuthError on invalid token`
- BroadcastChannel multi-tab sync — documented as not-yet-implemented (no BroadcastChannel calls anywhere in app code; only in `node_modules`), so there is nothing to test without first building the sync mechanism. Comment in test file flags this as a gap.

### useCalendarFeed.test.tsx (new/strengthened tests)
- `useCalendarTokenStatus > starts in loading state before resolution` — asserts `isPending === true` on initial mount
- `useCalendarTokenStatus > exposes the full token status payload on success` — asserts full payload shape
- `useCalendarTokenStatus > surfaces API errors to the caller (does not swallow)` — asserts `error` truthy, `data` undefined on 401
- `useCalendarTokenStatus > marks 500 server errors as errors (does not silently treat as success)` — asserts `isSuccess === false` on 500
- `useCreateCalendarToken > returns the full token + feed_url payload to the caller` — asserts returned payload equals input mock + `data` matches
- `useCreateCalendarToken > surfaces errors to the caller and does NOT silently invalidate` — asserts `caught === error`, `error.status === 500`, `mockInvalidateCalendar` NOT called
- `useCreateCalendarToken > surfaces 401 auth errors with the original error preserved` — asserts `error === authError` (referential)
- `useCreateCalendarToken > isPending toggles during in-flight mutation` — observes pending/idle transitions
- `useDeleteCalendarToken > surfaces errors to the caller and skips invalidation on failure` — same pattern, 404
- `useDeleteCalendarToken > does not invalidate on 500 server errors` — same pattern, 500
- `useCalendarTokenStatus + useCreateCalendarToken integration > caches token status under a stable key (no refetch on remount with shared client)` — asserts 2nd renderHook = 1 network call

### useContributorProfile.test.tsx (new/strengthened tests)
- `usePublicProfile > isPending is true while the initial fetch is in flight`
- `usePublicProfile > caches profile under the username key and skips refetch on remount`
- `usePublicProfile > issues a separate fetch for a different username`
- `useActivityHeatmap > fetches the activity heatmap for a username` / `> does not fetch when username is empty` / `> surfaces server errors instead of returning empty heatmap`
- `usePercentileRankings > fetches percentile rankings for a username` / `> does not fetch when username is empty` / `> does NOT retry on 404 (rankings unavailable)`
- `useOwnContributorProfile > surfaces auth errors (401) to the caller`

### useFavoriteCities.test.tsx (new/strengthened tests)
- `invalidates the profile query on success so favorites propagate` — asserts `invalidateQueries({queryKey: ['auth','profile']})` called
- `does NOT invalidate profile on mutation failure` — asserts NOT called on 422
- `surfaces server errors via the mutation error state` — asserts `error` propagated
- `preserves the order of cities passed in the payload` — asserts JSON body matches order
- `supports back-to-back saves without state leaking across mutations` — asserts each call has its own payload

### useFavoriteVenues.test.tsx (new/strengthened tests)
- `useFavoriteVenue > invalidates the specific venue check key on success` — asserts `invalidateQueries({queryKey: ['favoriteVenues','check','42']})`
- `useFavoriteVenue > surfaces server errors to the caller and does not invalidate` — asserts `caught === error`
- `useUnfavoriteVenue > surfaces server errors to the caller and does not invalidate`
- `useFavoriteVenues (list) > fetches favorite venues list with default pagination` / `> honors custom limit and offset` / `> does not fetch when enabled is false` / `> surfaces 401 unauthorized errors to the caller`
- `useFavoriteVenueShows > fetches favorite venue shows with default timezone` / `> honors explicit timezone option` / `> does not fetch when enabled is false` / `> surfaces errors instead of returning empty shows array`

Closes PSY-700