### PR TITLE
PSY-781: fix EntityTagList.test.tsx flake on debounced search waits

### DIFF
--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -4,6 +4,15 @@ import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
 
+// AddTagForm debounces the search input by 300ms (real setTimeout, not fake
+// timers). Under parallel test-runner contention the real-clock 300ms can be
+// delayed by the OS scheduler + React render budget, and the
+// @testing-library default waitFor / findBy* timeout (1000ms) is too tight.
+// Generic 3000ms slack on the "wait for search results / no-match copy" calls
+// covers full-suite parallel-load runs while still catching genuine
+// regressions inside one test runtime.
+const DEBOUNCE_TIMEOUT = { timeout: 3000 }
+
 // PSY-460 introduces a mobile "Show all tags" Sheet alongside the existing
 // desktop top-5 cap. Both rows render in the DOM (swapped via Tailwind's
 // `sm:hidden` / `hidden sm:flex` utilities — jsdom does not apply those
@@ -224,10 +233,9 @@ describe('EntityTagList add-tag dialog accessibility', () => {
     const input = screen.getByPlaceholderText('Search tags or type a new one...')
     await user.type(input, 'punk')
 
-    // Wait for search results to appear
-    await waitFor(() => {
-      expect(screen.getByText('punk')).toBeInTheDocument()
-    })
+    // Wait for search results to appear (debounce + render under
+    // parallel-load contention — see DEBOUNCE_TIMEOUT).
+    expect(await screen.findByText('punk', undefined, DEBOUNCE_TIMEOUT)).toBeInTheDocument()
 
     // Press Enter
     await user.keyboard('{Enter}')
@@ -369,9 +377,7 @@ describe('EntityTagList add-tag dialog alias caption', () => {
 
     await openDialogAndSearch('punk-rock')
 
-    await waitFor(() => {
-      expect(screen.getByText('punk')).toBeInTheDocument()
-    })
+    expect(await screen.findByText('punk', undefined, DEBOUNCE_TIMEOUT)).toBeInTheDocument()
 
     const caption = screen.getByTestId('tag-autocomplete-matched-alias')
     expect(caption).toBeInTheDocument()
@@ -383,9 +389,7 @@ describe('EntityTagList add-tag dialog alias caption', () => {
     // mirrors the "user typed the canonical form" case.
     await openDialogAndSearch('punk')
 
-    await waitFor(() => {
-      expect(screen.getByText('punk')).toBeInTheDocument()
-    })
+    expect(await screen.findByText('punk', undefined, DEBOUNCE_TIMEOUT)).toBeInTheDocument()
 
     expect(
       screen.queryByTestId('tag-autocomplete-matched-alias')
@@ -420,10 +424,13 @@ describe('EntityTagList add-tag dialog alias caption', () => {
 
     await openDialogAndSearch('punk')
 
+    // Both rows must be present before checking caption count; keep the
+    // multi-assertion waitFor (findBy* is single-element) but use the
+    // longer debounce-aware timeout for parallel-load slack.
     await waitFor(() => {
       expect(screen.getByText('punk')).toBeInTheDocument()
       expect(screen.getByText('post-punk')).toBeInTheDocument()
-    })
+    }, DEBOUNCE_TIMEOUT)
 
     // Exactly one row has a caption — the one whose match came through the
     // alias table.
@@ -483,11 +490,9 @@ describe('EntityTagList add-tag dialog already-applied short-circuit', () => {
 
     await openDialogAndSearch('rock-music')
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('tag-autocomplete-already-applied')
-      ).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByTestId('tag-autocomplete-already-applied', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     const row = screen.getByTestId('tag-autocomplete-already-applied')
     expect(row).toHaveTextContent(/[“"]rock[”"] is already applied/)
@@ -524,11 +529,9 @@ describe('EntityTagList add-tag dialog already-applied short-circuit', () => {
 
     await openDialogAndSearch('indie')
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('tag-autocomplete-already-applied')
-      ).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByTestId('tag-autocomplete-already-applied', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     expect(
       screen.getByTestId('tag-autocomplete-already-applied')
@@ -552,9 +555,9 @@ describe('EntityTagList add-tag dialog already-applied short-circuit', () => {
 
     await openDialogAndSearch('brand-new-tag')
 
-    await waitFor(() => {
-      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByText('No matching tags found.', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     expect(
       screen.queryByTestId('tag-autocomplete-already-applied')
@@ -582,11 +585,9 @@ describe('EntityTagList add-tag dialog already-applied short-circuit', () => {
 
     const user = await openDialogAndSearch('rock-music')
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('tag-autocomplete-already-applied')
-      ).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByTestId('tag-autocomplete-already-applied', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     await user.keyboard('{Enter}')
 
@@ -630,9 +631,9 @@ describe('EntityTagList add-tag dialog create-tag tier gating', () => {
     mockAuthUser = { user_tier: 'new_user' }
     await openDialogAndSearch('brand-new-tag')
 
-    await waitFor(() => {
-      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByText('No matching tags found.', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     // No Create affordance at all — neither enabled nor disabled. The old
     // PSY-443 disabled-button + tooltip wrapper are both gone.
@@ -665,9 +666,9 @@ describe('EntityTagList add-tag dialog create-tag tier gating', () => {
     mockAuthUser = { user_tier: 'new_user' }
     const user = await openDialogAndSearch('brand-new-tag')
 
-    await waitFor(() => {
-      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByText('No matching tags found.', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     await user.keyboard('{Enter}')
     expect(mockAddMutate).not.toHaveBeenCalled()
@@ -677,9 +678,9 @@ describe('EntityTagList add-tag dialog create-tag tier gating', () => {
     mockAuthUser = { user_tier: 'contributor' }
     await openDialogAndSearch('brand-new-tag')
 
-    await waitFor(() => {
-      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByText('No matching tags found.', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     const createButton = screen.getByRole('button', {
       name: /Create "brand-new-tag"/,
@@ -694,9 +695,9 @@ describe('EntityTagList add-tag dialog create-tag tier gating', () => {
     mockAuthUser = { user_tier: 'trusted_contributor' }
     await openDialogAndSearch('brand-new-tag')
 
-    await waitFor(() => {
-      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByText('No matching tags found.', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     const createButton = screen.getByRole('button', {
       name: /Create "brand-new-tag"/,
@@ -716,9 +717,9 @@ describe('EntityTagList add-tag dialog create-tag tier gating', () => {
     mockAuthUser = { user_tier: 'new_user', is_admin: true }
     await openDialogAndSearch('brand-new-tag')
 
-    await waitFor(() => {
-      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByText('No matching tags found.', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     const createButton = screen.getByRole('button', {
       name: /Create "brand-new-tag"/,
@@ -1568,9 +1569,9 @@ describe('AddTagDialog standalone (PSY-654)', () => {
     const input = screen.getByPlaceholderText('Search tags or type a new one...')
     await user.type(input, 'doom')
 
-    await waitFor(() => {
-      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByText('No matching tags found.', undefined, DEBOUNCE_TIMEOUT)
+    ).toBeInTheDocument()
 
     await user.click(
       screen.getByRole('button', { name: /Create "doom"/ })


### PR DESCRIPTION
## Summary
- Root cause: `AddTagForm`'s 300ms real-clock debounce + render slack can exceed the @testing-library default `waitFor` / `findBy*` 1000ms timeout under parallel Vitest worker contention — the 12 `waitFor(() => expect(getBy*).toBeInTheDocument())` sites that fire immediately after `await user.type(input, ...)` are the exposed surface (matches the "intermittent `waitFor`-after-`user.click` timeout" called out in the PSY-701 PR #743 body).
- Fix: migrate those 12 sites to `findBy*` with an explicit shared 3000ms `DEBOUNCE_TIMEOUT`; keep the one multi-assertion `waitFor` (alias-caption mixed-result test, needs both `punk` and `post-punk` before counting captions) but adopt the same longer timeout. Click-fast `waitFor` calls (dialog/sheet open after `user.click`, hover-card open after tap, mutation onSuccess callback) are unchanged — they aren't debounce-dependent.

## Test plan
- [x] `bun run test:run features/tags/components/EntityTagList.test.tsx` — 49/49 pass in isolation
- [x] `bun run test:run features --maxWorkers=8` x10 iterations (post-fix) — 10/10 pass, 2595/2595 each
- [x] `bun run test:run features` x5 iterations (post-fix default workers) — separately confirmed; baseline 15 pre-fix runs at varying contention levels also all passed (flake is known intermittent — never reproduced in this worktree, fix is structural)
- [x] `bun run typecheck` — passed
- [x] `/code-review` — 0 findings (test-only diff; mechanical `waitFor + getBy* → findBy*` migration with documented timeout for a known real-clock debounce)

## Manual repro
Flake reported by the PSY-701 PR (#743) body as "one intermittent pre-existing flake in `features/tags/components/EntityTagList.test.tsx` (a `waitFor`-on-`user.click` timeout under parallel load), unrelated to this change and passing 49/49 in isolation".

Direct repro NOT achieved on this machine despite 15 full-features runs (10 with `--maxWorkers=8` for extra contention). Honest disclosure: the fix is justified by the structural mechanism, not by direct before/after repro.

Mechanism evidence:
- `AddTagForm` (frontend/features/tags/components/EntityTagList.tsx:731-736): `useEffect` schedules a real `setTimeout(300)` on every `searchQuery` change; `setDebouncedQuery` only fires after.
- Test file uses NO `vi.useFakeTimers()` — the 300ms is wall-clock.
- `@testing-library/dom` default `waitFor` timeout: 1000ms (see https://testing-library.com/docs/dom-testing-library/api-async/#waitfor).
- Isolated-run timings show each affected test at 360-400ms (close to the 300ms baseline). Add OS scheduler jitter from 8+ parallel workers and the 1000ms budget evaporates.

After fix:
- `Test Files  1 passed (1) / Tests  49 passed (49) / Duration  7.05s` (isolated)
- 10x `bun run test:run features --maxWorkers=8`: each iteration `Tests  2595 passed (2595)`, no failures.

Closes PSY-781