### PR TITLE
PSY-838: /admin/featured page (FeaturedAdmin)

### DIFF
--- a/frontend/app/admin/featured/page.tsx
+++ b/frontend/app/admin/featured/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { FeaturedAdmin } from '@/features/admin/components/FeaturedAdmin'
+
+/**
+ * /admin/featured — admin curation surface for the /explore landing's
+ * editorial slots. Sits under the admin layout, which delegates auth +
+ * IsAdmin gating to `<AdminGuard>` so this page only renders for
+ * authenticated admins.
+ *
+ * Implementation lives at frontend/features/admin/components/FeaturedAdmin.
+ */
+export default function AdminFeaturedPage() {
+  return <FeaturedAdmin />
+}

--- a/frontend/features/admin/components/FeaturedAdmin/FeaturedAdmin.test.tsx
+++ b/frontend/features/admin/components/FeaturedAdmin/FeaturedAdmin.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+
+import type {
+  ExploreFeaturedBill,
+  ExploreFeaturedCollection,
+  ExploreFeaturedResponse,
+} from './types'
+
+const mockUseExploreFeatured = vi.fn()
+const mockUseSetFeaturedSlot = vi.fn()
+const mockUseRetireFeaturedSlot = vi.fn()
+
+vi.mock('./useFeaturedSlots', () => ({
+  useExploreFeatured: () => mockUseExploreFeatured(),
+  useSetFeaturedSlot: () => mockUseSetFeaturedSlot(),
+  useRetireFeaturedSlot: () => mockUseRetireFeaturedSlot(),
+}))
+
+// useEntitySearch (cross-entity search hook) makes seven backend calls
+// in its real implementation. The bill picker doesn't render in the
+// admin-only initial state, but the hook still mounts under the
+// SetBillForm — stub it so tests don't hit fetch.
+vi.mock('@/lib/hooks/common/useEntitySearch', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/hooks/common/useEntitySearch')
+  >('@/lib/hooks/common/useEntitySearch')
+  return {
+    ...actual,
+    useEntitySearch: () => ({
+      data: {
+        artists: [],
+        venues: [],
+        shows: [],
+        releases: [],
+        labels: [],
+        festivals: [],
+        tags: [],
+      },
+      isSearching: false,
+      searchError: false,
+      totalResults: 0,
+    }),
+  }
+})
+
+import { FeaturedAdmin } from './FeaturedAdmin'
+
+function makeBill(overrides: Partial<ExploreFeaturedBill> = {}): ExploreFeaturedBill {
+  return {
+    id: 101,
+    slug: 'faetooth-at-valley-bar',
+    title: 'Faetooth at Valley Bar',
+    event_date: '2026-06-01T03:00:00Z',
+    headliner_name: 'Faetooth',
+    venue_name: 'Valley Bar',
+    venue_city: 'Phoenix',
+    venue_state: 'AZ',
+    image_url: null,
+    curator_note: '**Sharp bill.**',
+    curator_note_html: '<p><strong>Sharp bill.</strong></p>',
+    ...overrides,
+  }
+}
+
+function makeCollection(
+  overrides: Partial<ExploreFeaturedCollection> = {}
+): ExploreFeaturedCollection {
+  return {
+    id: 42,
+    slug: 'phx-noise-2026',
+    title: 'PHX Noise 2026',
+    description: 'A snapshot of the noise scene.',
+    description_html: '<p>A snapshot of the noise scene.</p>',
+    cover_image_url: null,
+    curator_note: 'Bookmark this.',
+    curator_note_html: '<p>Bookmark this.</p>',
+    ...overrides,
+  }
+}
+
+function mockExploreFeatured(data: ExploreFeaturedResponse | null) {
+  mockUseExploreFeatured.mockReturnValue({
+    data,
+    isLoading: false,
+    isError: false,
+  })
+}
+
+function defaultMutationStubs() {
+  mockUseSetFeaturedSlot.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  })
+  mockUseRetireFeaturedSlot.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  })
+}
+
+describe('FeaturedAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    defaultMutationStubs()
+  })
+
+  it('renders both Bill and Collection panels', () => {
+    mockExploreFeatured({ bill: null, collection: null })
+
+    renderWithProviders(<FeaturedAdmin />)
+
+    expect(
+      screen.getByTestId('featured-admin-panel-bill')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('featured-admin-panel-collection')
+    ).toBeInTheDocument()
+  })
+
+  it('shows the empty-state card when no active slot is set', () => {
+    mockExploreFeatured({ bill: null, collection: null })
+
+    renderWithProviders(<FeaturedAdmin />)
+
+    expect(
+      screen.getByTestId('featured-admin-empty-bill')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('featured-admin-empty-collection')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the active bill card with name, venue, and curator note', () => {
+    mockExploreFeatured({
+      bill: makeBill(),
+      collection: null,
+    })
+
+    renderWithProviders(<FeaturedAdmin />)
+
+    const card = screen.getByTestId('featured-admin-active-bill')
+    expect(card).toBeInTheDocument()
+    // Headliner is what the consumer (curator) recognises.
+    expect(card).toHaveTextContent('Faetooth')
+    expect(card).toHaveTextContent('Valley Bar')
+    // Curator-note HTML rendered (markdown bold survives the renderer).
+    const note = screen.getByTestId('featured-admin-active-bill-note')
+    expect(note.innerHTML).toContain('<strong>Sharp bill.</strong>')
+    // Retire button surfaces only on the active panel.
+    expect(
+      screen.getByTestId('featured-admin-retire-bill')
+    ).toBeEnabled()
+  })
+
+  it('renders the active collection card with title and curator note', () => {
+    mockExploreFeatured({
+      bill: null,
+      collection: makeCollection(),
+    })
+
+    renderWithProviders(<FeaturedAdmin />)
+
+    const card = screen.getByTestId('featured-admin-active-collection')
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveTextContent('PHX Noise 2026')
+    const note = screen.getByTestId('featured-admin-active-collection-note')
+    expect(note.innerHTML).toContain('Bookmark this.')
+    expect(
+      screen.getByTestId('featured-admin-retire-collection')
+    ).toBeEnabled()
+  })
+
+  it('shows a fallback error banner when the explore endpoint errors', () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    })
+
+    renderWithProviders(<FeaturedAdmin />)
+
+    expect(
+      screen.getByTestId('featured-admin-load-error')
+    ).toBeInTheDocument()
+  })
+
+  it('shows the spinner placeholder while the active state is loading', () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    })
+
+    renderWithProviders(<FeaturedAdmin />)
+
+    expect(
+      screen.getByTestId('featured-admin-loading-bill')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('featured-admin-loading-collection')
+    ).toBeInTheDocument()
+  })
+
+  it('disables the Save button until an entity is picked', () => {
+    mockExploreFeatured({ bill: null, collection: null })
+
+    renderWithProviders(<FeaturedAdmin />)
+
+    expect(screen.getByTestId('featured-admin-save-bill')).toBeDisabled()
+    expect(
+      screen.getByTestId('featured-admin-save-collection')
+    ).toBeDisabled()
+  })
+})

--- a/frontend/features/admin/components/FeaturedAdmin/FeaturedAdmin.tsx
+++ b/frontend/features/admin/components/FeaturedAdmin/FeaturedAdmin.tsx
@@ -1,0 +1,868 @@
+'use client'
+
+/**
+ * /admin/featured — admin UI for the /explore landing's two editorial
+ * slots (Featured Bill + Featured Collection). Wires up PSY-835 backend
+ * (PSY-838 frontend).
+ *
+ * Layout: two parallel panels (Bill / Collection). Each panel has
+ *   - the current active card (read from /explore/featured for hydrated
+ *     referent details; the admin list endpoint returns only entity_id).
+ *   - a "Set new" form (entity picker → curator note → Save).
+ *
+ * No cadence UI — admin sets a slot whenever they want; current pick
+ * stays visible until retired or replaced (locked product decision per
+ * docs/open-questions/explore-landing.md).
+ *
+ * Mutation feedback follows the project convention
+ * (pattern_mutation_feedback.md): inline banners via StatusBanner /
+ * InlineErrorBanner. No toast library.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import {
+  CalendarDays,
+  Eye,
+  Library,
+  Loader2,
+  Search,
+  Sparkles,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { InlineErrorBanner, StatusBanner } from '@/components/shared'
+import { useEntitySearch } from '@/lib/hooks/common/useEntitySearch'
+import {
+  ENTITY_SEARCH_UNAVAILABLE_MESSAGE,
+  type EntitySearchResult,
+} from '@/lib/hooks/common/useEntitySearch'
+import { useDebounce } from 'use-debounce'
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import {
+  MarkdownContent,
+  MarkdownEditor,
+} from '@/features/collections/components/MarkdownEditor'
+import {
+  useExploreFeatured,
+  useRetireFeaturedSlot,
+  useSetFeaturedSlot,
+} from './useFeaturedSlots'
+import {
+  FEATURED_SLOT_LABEL,
+  MAX_CURATOR_NOTE_LENGTH,
+  type ExploreFeaturedBill,
+  type ExploreFeaturedCollection,
+  type FeaturedSlotType,
+} from './types'
+
+// ──────────────────────────────────────────────
+// Collection search
+// ──────────────────────────────────────────────
+//
+// `useEntitySearch` covers artists/venues/shows/releases/labels/festivals/
+// tags — collections are intentionally excluded from the cross-entity
+// search (they're a meta-entity over the others). For the Featured
+// Collection picker we hit `GET /collections?search=` directly. The
+// result shape is `CollectionListResponse` — title + slug + id +
+// cover_image_url is everything the picker tile needs.
+
+interface CollectionSearchItem {
+  id: number
+  title: string
+  slug: string
+  cover_image_url?: string | null
+  creator_name?: string
+}
+
+interface CollectionListResponseEnvelope {
+  collections: CollectionSearchItem[]
+  total: number
+}
+
+function useCollectionSearch(query: string, enabled: boolean) {
+  const [debouncedQuery] = useDebounce(query.trim(), 300)
+  const isLongEnough = debouncedQuery.length >= 2
+  return useQuery({
+    queryKey: ['collections', 'admin-featured-search', debouncedQuery],
+    queryFn: () =>
+      apiRequest<CollectionListResponseEnvelope>(
+        `${API_ENDPOINTS.COLLECTIONS.LIST}?search=${encodeURIComponent(debouncedQuery)}&limit=10`
+      ),
+    enabled: enabled && isLongEnough,
+    staleTime: 30 * 1000,
+  })
+}
+
+// ──────────────────────────────────────────────
+// Active-card sub-components
+// ──────────────────────────────────────────────
+
+function ActiveBillCard({
+  bill,
+  onRetire,
+  isRetiring,
+}: {
+  bill: ExploreFeaturedBill
+  onRetire: () => void
+  isRetiring: boolean
+}) {
+  const eventDate = new Date(bill.event_date)
+  const dateLabel = Number.isNaN(eventDate.getTime())
+    ? null
+    : eventDate.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+
+  return (
+    <div
+      className="rounded-lg border border-border/60 bg-card p-4 space-y-3"
+      data-testid="featured-admin-active-bill"
+    >
+      <div className="flex items-start gap-3">
+        <div className="h-14 w-14 shrink-0 rounded bg-muted/50 flex items-center justify-center overflow-hidden">
+          {bill.image_url ? (
+            <Image
+              src={bill.image_url}
+              alt=""
+              width={56}
+              height={56}
+              className="h-full w-full object-cover"
+              unoptimized
+            />
+          ) : (
+            <CalendarDays className="h-5 w-5 text-muted-foreground/60" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <Link
+            href={`/shows/${bill.slug}`}
+            className="text-base font-semibold hover:underline truncate block"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {bill.headliner_name || bill.title || `Show #${bill.id}`}
+          </Link>
+          <p className="text-xs text-muted-foreground truncate">
+            {bill.venue_name}
+            {bill.venue_city && bill.venue_state ? ` · ${bill.venue_city}, ${bill.venue_state}` : ''}
+            {dateLabel ? ` · ${dateLabel}` : ''}
+          </p>
+        </div>
+      </div>
+
+      {bill.curator_note_html && (
+        <div className="rounded-md border border-border/30 bg-muted/20 px-3 py-2">
+          <div className="flex items-center gap-1 text-[11px] uppercase tracking-wide text-muted-foreground mb-1">
+            <Sparkles className="h-3 w-3" />
+            Curator note
+          </div>
+          <MarkdownContent
+            html={bill.curator_note_html}
+            testId="featured-admin-active-bill-note"
+          />
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-2 border-t border-border/40 pt-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onRetire}
+          disabled={isRetiring}
+          data-testid="featured-admin-retire-bill"
+        >
+          {isRetiring ? (
+            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          Retire current
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function ActiveCollectionCard({
+  collection,
+  onRetire,
+  isRetiring,
+}: {
+  collection: ExploreFeaturedCollection
+  onRetire: () => void
+  isRetiring: boolean
+}) {
+  return (
+    <div
+      className="rounded-lg border border-border/60 bg-card p-4 space-y-3"
+      data-testid="featured-admin-active-collection"
+    >
+      <div className="flex items-start gap-3">
+        <div className="h-14 w-14 shrink-0 rounded bg-muted/50 flex items-center justify-center overflow-hidden">
+          {collection.cover_image_url ? (
+            <Image
+              src={collection.cover_image_url}
+              alt=""
+              width={56}
+              height={56}
+              className="h-full w-full object-cover"
+              unoptimized
+            />
+          ) : (
+            <Library className="h-5 w-5 text-muted-foreground/60" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <Link
+            href={`/collections/${collection.slug}`}
+            className="text-base font-semibold hover:underline truncate block"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {collection.title || `Collection #${collection.id}`}
+          </Link>
+          {collection.description && (
+            <p className="text-xs text-muted-foreground truncate">
+              {collection.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {collection.curator_note_html && (
+        <div className="rounded-md border border-border/30 bg-muted/20 px-3 py-2">
+          <div className="flex items-center gap-1 text-[11px] uppercase tracking-wide text-muted-foreground mb-1">
+            <Sparkles className="h-3 w-3" />
+            Curator note
+          </div>
+          <MarkdownContent
+            html={collection.curator_note_html}
+            testId="featured-admin-active-collection-note"
+          />
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-2 border-t border-border/40 pt-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onRetire}
+          disabled={isRetiring}
+          data-testid="featured-admin-retire-collection"
+        >
+          {isRetiring ? (
+            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          Retire current
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function NoActivePick({ slotType }: { slotType: FeaturedSlotType }) {
+  return (
+    <div
+      className="rounded-lg border border-dashed border-border/60 bg-muted/10 p-6 text-center"
+      data-testid={`featured-admin-empty-${slotType}`}
+    >
+      <p className="text-sm text-muted-foreground">
+        No active {FEATURED_SLOT_LABEL[slotType]}. Pick one below — the
+        /explore page collapses this slot until you do.
+      </p>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Set-new form — bill (delegates to useEntitySearch.shows)
+// ──────────────────────────────────────────────
+
+interface PickedShow {
+  id: number
+  name: string
+  href: string
+  subtitle?: string | null
+}
+
+function SetBillForm() {
+  const [query, setQuery] = useState('')
+  const [picked, setPicked] = useState<PickedShow | null>(null)
+  const [note, setNote] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const setMutation = useSetFeaturedSlot()
+  // useEntitySearch fans out to seven endpoints; the bill picker only
+  // surfaces `shows` so the other groups are ignored at render time.
+  const { data: searchResults, isSearching, searchError } = useEntitySearch({
+    query,
+    enabled: !picked,
+  })
+
+  const showResults = searchResults?.shows ?? []
+
+  const handlePick = useCallback((r: EntitySearchResult) => {
+    setPicked({ id: r.id, name: r.name, href: r.href, subtitle: r.subtitle })
+    setQuery('')
+  }, [])
+
+  const handleSave = useCallback(() => {
+    if (!picked) return
+    setError(null)
+    setSuccessMessage(null)
+    setMutation.mutate(
+      {
+        slot_type: 'bill',
+        entity_id: picked.id,
+        curator_note: note.trim() ? note.trim() : null,
+      },
+      {
+        onSuccess: () => {
+          setSuccessMessage(`Featured Bill set to "${picked.name}"`)
+          setPicked(null)
+          setNote('')
+        },
+        onError: (err) => {
+          setError(err instanceof Error ? err.message : 'Failed to set Featured Bill.')
+        },
+      }
+    )
+  }, [picked, note, setMutation])
+
+  return (
+    <div className="space-y-3" data-testid="featured-admin-set-bill-form">
+      <h3 className="text-sm font-semibold flex items-center gap-1.5">
+        <Sparkles className="h-3.5 w-3.5" />
+        Set new Featured Bill
+      </h3>
+
+      {/* Banners */}
+      {successMessage && (
+        <StatusBanner
+          variant="success"
+          dismissAfterMs={4000}
+          onDismiss={() => setSuccessMessage(null)}
+          testId="featured-admin-set-bill-success"
+        >
+          <p className="text-sm">{successMessage}</p>
+        </StatusBanner>
+      )}
+      {error && (
+        <InlineErrorBanner testId="featured-admin-set-bill-error">
+          {error}
+        </InlineErrorBanner>
+      )}
+
+      {/* Picker — search until something is chosen, then show the selected card. */}
+      {!picked ? (
+        <>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="Search shows by headliner, venue, date..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-9"
+              data-testid="featured-admin-bill-search-input"
+              aria-label="Search shows"
+            />
+          </div>
+
+          {query.trim().length >= 2 && (
+            <div className="max-h-64 overflow-y-auto rounded-md border border-border/40 bg-card">
+              {isSearching ? (
+                <div className="flex items-center justify-center py-4">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              ) : searchError ? (
+                <div className="p-3">
+                  <InlineErrorBanner>
+                    {ENTITY_SEARCH_UNAVAILABLE_MESSAGE}
+                  </InlineErrorBanner>
+                </div>
+              ) : showResults.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-3 text-center">
+                  No shows match &quot;{query}&quot;
+                </p>
+              ) : (
+                <ul className="divide-y divide-border/30">
+                  {showResults.map((r) => (
+                    <li key={r.id}>
+                      <button
+                        type="button"
+                        onClick={() => handlePick(r)}
+                        className="w-full text-left p-2 hover:bg-muted/50 flex items-center gap-3"
+                        data-testid={`featured-admin-bill-result-${r.id}`}
+                      >
+                        <CalendarDays className="h-4 w-4 text-muted-foreground/60 shrink-0" />
+                        <span className="text-sm truncate">{r.name}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        <div
+          className="rounded-md border border-border/60 bg-card p-3 flex items-start gap-3"
+          data-testid="featured-admin-bill-selected"
+        >
+          <CalendarDays className="h-5 w-5 text-muted-foreground/70 shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">{picked.name}</p>
+            {picked.subtitle && (
+              <p className="text-xs text-muted-foreground truncate">
+                {picked.subtitle}
+              </p>
+            )}
+            <Link
+              href={picked.href}
+              target="_blank"
+              rel="noreferrer"
+              className="text-[11px] text-muted-foreground hover:underline inline-flex items-center gap-0.5 mt-1"
+            >
+              <Eye className="h-3 w-3" />
+              View on site
+            </Link>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setPicked(null)}
+            aria-label="Clear selection"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Curator note — markdown editor, same primitive as comment composer. */}
+      <div className="space-y-1.5">
+        <Label htmlFor="bill-curator-note" className="text-sm">
+          Curator note <span className="text-muted-foreground">(optional, markdown)</span>
+        </Label>
+        <MarkdownEditor
+          id="bill-curator-note"
+          value={note}
+          onChange={setNote}
+          rows={3}
+          maxLength={MAX_CURATOR_NOTE_LENGTH}
+          placeholder="Why this bill? 1–2 sentences from the curator."
+          testId="featured-admin-bill-curator-note"
+          ariaLabel="Curator note for Featured Bill"
+          disabled={setMutation.isPending}
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!picked || setMutation.isPending || note.length > MAX_CURATOR_NOTE_LENGTH}
+          data-testid="featured-admin-save-bill"
+        >
+          {setMutation.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            'Save Featured Bill'
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Set-new form — collection (uses GET /collections?search=)
+// ──────────────────────────────────────────────
+
+interface PickedCollection {
+  id: number
+  title: string
+  slug: string
+  cover_image_url?: string | null
+}
+
+function SetCollectionForm() {
+  const [query, setQuery] = useState('')
+  const [picked, setPicked] = useState<PickedCollection | null>(null)
+  const [note, setNote] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const setMutation = useSetFeaturedSlot()
+  const { data, isFetching, isError } = useCollectionSearch(query, !picked)
+
+  const handlePick = useCallback((c: CollectionSearchItem) => {
+    setPicked({
+      id: c.id,
+      title: c.title,
+      slug: c.slug,
+      cover_image_url: c.cover_image_url,
+    })
+    setQuery('')
+  }, [])
+
+  const handleSave = useCallback(() => {
+    if (!picked) return
+    setError(null)
+    setSuccessMessage(null)
+    setMutation.mutate(
+      {
+        slot_type: 'collection',
+        entity_id: picked.id,
+        curator_note: note.trim() ? note.trim() : null,
+      },
+      {
+        onSuccess: () => {
+          setSuccessMessage(`Featured Collection set to "${picked.title}"`)
+          setPicked(null)
+          setNote('')
+        },
+        onError: (err) => {
+          setError(
+            err instanceof Error ? err.message : 'Failed to set Featured Collection.'
+          )
+        },
+      }
+    )
+  }, [picked, note, setMutation])
+
+  return (
+    <div className="space-y-3" data-testid="featured-admin-set-collection-form">
+      <h3 className="text-sm font-semibold flex items-center gap-1.5">
+        <Sparkles className="h-3.5 w-3.5" />
+        Set new Featured Collection
+      </h3>
+
+      {successMessage && (
+        <StatusBanner
+          variant="success"
+          dismissAfterMs={4000}
+          onDismiss={() => setSuccessMessage(null)}
+          testId="featured-admin-set-collection-success"
+        >
+          <p className="text-sm">{successMessage}</p>
+        </StatusBanner>
+      )}
+      {error && (
+        <InlineErrorBanner testId="featured-admin-set-collection-error">
+          {error}
+        </InlineErrorBanner>
+      )}
+
+      {!picked ? (
+        <>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="Search public collections by title..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-9"
+              data-testid="featured-admin-collection-search-input"
+              aria-label="Search collections"
+            />
+          </div>
+
+          {query.trim().length >= 2 && (
+            <div className="max-h-64 overflow-y-auto rounded-md border border-border/40 bg-card">
+              {isFetching ? (
+                <div className="flex items-center justify-center py-4">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              ) : isError ? (
+                <div className="p-3">
+                  <InlineErrorBanner>
+                    Could not search collections. Try again in a moment.
+                  </InlineErrorBanner>
+                </div>
+              ) : !data || data.collections.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-3 text-center">
+                  No collections match &quot;{query}&quot;
+                </p>
+              ) : (
+                <ul className="divide-y divide-border/30">
+                  {data.collections.map((c) => (
+                    <li key={c.id}>
+                      <button
+                        type="button"
+                        onClick={() => handlePick(c)}
+                        className="w-full text-left p-2 hover:bg-muted/50 flex items-center gap-3"
+                        data-testid={`featured-admin-collection-result-${c.id}`}
+                      >
+                        <Library className="h-4 w-4 text-muted-foreground/60 shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm truncate">{c.title}</p>
+                          {c.creator_name && (
+                            <p className="text-xs text-muted-foreground truncate">
+                              by {c.creator_name}
+                            </p>
+                          )}
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        <div
+          className="rounded-md border border-border/60 bg-card p-3 flex items-start gap-3"
+          data-testid="featured-admin-collection-selected"
+        >
+          <Library className="h-5 w-5 text-muted-foreground/70 shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">{picked.title}</p>
+            <Link
+              href={`/collections/${picked.slug}`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-[11px] text-muted-foreground hover:underline inline-flex items-center gap-0.5 mt-1"
+            >
+              <Eye className="h-3 w-3" />
+              View on site
+            </Link>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setPicked(null)}
+            aria-label="Clear selection"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="collection-curator-note" className="text-sm">
+          Curator note <span className="text-muted-foreground">(optional, markdown)</span>
+        </Label>
+        <MarkdownEditor
+          id="collection-curator-note"
+          value={note}
+          onChange={setNote}
+          rows={3}
+          maxLength={MAX_CURATOR_NOTE_LENGTH}
+          placeholder="Why this collection? 1–2 sentences from the curator."
+          testId="featured-admin-collection-curator-note"
+          ariaLabel="Curator note for Featured Collection"
+          disabled={setMutation.isPending}
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!picked || setMutation.isPending || note.length > MAX_CURATOR_NOTE_LENGTH}
+          data-testid="featured-admin-save-collection"
+        >
+          {setMutation.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            'Save Featured Collection'
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Panel (one per slot type)
+// ──────────────────────────────────────────────
+
+interface FeaturedSlotPanelProps {
+  slotType: FeaturedSlotType
+  /** Hydrated active referent from /explore/featured, or null. */
+  activeBill: ExploreFeaturedBill | null
+  activeCollection: ExploreFeaturedCollection | null
+  /** Skeleton while the first fetch is in flight. */
+  isLoading: boolean
+}
+
+function FeaturedSlotPanel({
+  slotType,
+  activeBill,
+  activeCollection,
+  isLoading,
+}: FeaturedSlotPanelProps) {
+  const retireMutation = useRetireFeaturedSlot()
+  const [retireError, setRetireError] = useState<string | null>(null)
+  const [retireSuccess, setRetireSuccess] = useState<string | null>(null)
+
+  const handleRetire = useCallback(() => {
+    setRetireError(null)
+    setRetireSuccess(null)
+    retireMutation.mutate(slotType, {
+      onSuccess: () => {
+        setRetireSuccess(`${FEATURED_SLOT_LABEL[slotType]} retired.`)
+      },
+      onError: (err) => {
+        setRetireError(
+          err instanceof Error
+            ? err.message
+            : `Failed to retire ${FEATURED_SLOT_LABEL[slotType]}.`
+        )
+      },
+    })
+  }, [slotType, retireMutation])
+
+  const hasActive = slotType === 'bill' ? !!activeBill : !!activeCollection
+
+  return (
+    <section
+      className="rounded-xl border border-border/60 bg-card/40 p-5 space-y-4"
+      data-testid={`featured-admin-panel-${slotType}`}
+      aria-label={`${FEATURED_SLOT_LABEL[slotType]} controls`}
+    >
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight">
+          {FEATURED_SLOT_LABEL[slotType]}
+        </h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Pick the {slotType === 'bill' ? 'show' : 'collection'} that appears in the
+          {' '}Featured slot on /explore. Stays visible until you retire or
+          replace it.
+        </p>
+      </div>
+
+      {retireSuccess && (
+        <StatusBanner
+          variant="success"
+          dismissAfterMs={4000}
+          onDismiss={() => setRetireSuccess(null)}
+          testId={`featured-admin-retire-${slotType}-success`}
+        >
+          <p className="text-sm">{retireSuccess}</p>
+        </StatusBanner>
+      )}
+      {retireError && (
+        <InlineErrorBanner testId={`featured-admin-retire-${slotType}-error`}>
+          {retireError}
+        </InlineErrorBanner>
+      )}
+
+      {/* Current active card OR empty state OR skeleton */}
+      <div className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+          Current active
+        </div>
+        {isLoading ? (
+          <div
+            className="rounded-lg border border-border/40 bg-card p-4 flex items-center justify-center"
+            data-testid={`featured-admin-loading-${slotType}`}
+          >
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          </div>
+        ) : hasActive && slotType === 'bill' && activeBill ? (
+          <ActiveBillCard
+            bill={activeBill}
+            onRetire={handleRetire}
+            isRetiring={retireMutation.isPending}
+          />
+        ) : hasActive && slotType === 'collection' && activeCollection ? (
+          <ActiveCollectionCard
+            collection={activeCollection}
+            onRetire={handleRetire}
+            isRetiring={retireMutation.isPending}
+          />
+        ) : (
+          <NoActivePick slotType={slotType} />
+        )}
+      </div>
+
+      <div className="border-t border-border/40 pt-4">
+        {slotType === 'bill' ? <SetBillForm /> : <SetCollectionForm />}
+      </div>
+    </section>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Top-level component
+// ──────────────────────────────────────────────
+
+export function FeaturedAdmin() {
+  const { data: featured, isLoading, isError } = useExploreFeatured()
+
+  const activeBill = useMemo(() => featured?.bill ?? null, [featured])
+  const activeCollection = useMemo(
+    () => featured?.collection ?? null,
+    [featured]
+  )
+
+  return (
+    <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header>
+          <div className="flex items-center gap-2 mb-1">
+            <Sparkles className="h-5 w-5 text-primary" />
+            <h1 className="text-2xl font-bold tracking-tight">Featured curation</h1>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Set the active Featured Bill and Featured Collection that appear
+            on the /explore landing. No cadence requirement — pick whenever,
+            stays live until retired or replaced.
+          </p>
+        </header>
+
+        {isError && (
+          <InlineErrorBanner
+            variant="queryFallback"
+            testId="featured-admin-load-error"
+          >
+            Could not load the current featured picks. The admin endpoints may
+            be unreachable — try refreshing in a moment.
+          </InlineErrorBanner>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+          <FeaturedSlotPanel
+            slotType="bill"
+            activeBill={activeBill}
+            activeCollection={null}
+            isLoading={isLoading}
+          />
+          <FeaturedSlotPanel
+            slotType="collection"
+            activeBill={null}
+            activeCollection={activeCollection}
+            isLoading={isLoading}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FeaturedAdmin

--- a/frontend/features/admin/components/FeaturedAdmin/FeaturedAdmin.tsx
+++ b/frontend/features/admin/components/FeaturedAdmin/FeaturedAdmin.tsx
@@ -44,6 +44,7 @@ import {
 import { useDebounce } from 'use-debounce'
 import { useQuery } from '@tanstack/react-query'
 import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { formatShowDate } from '@/lib/utils/formatters'
 import {
   MarkdownContent,
   MarkdownEditor,
@@ -112,14 +113,9 @@ function ActiveBillCard({
   onRetire: () => void
   isRetiring: boolean
 }) {
-  const eventDate = new Date(bill.event_date)
-  const dateLabel = Number.isNaN(eventDate.getTime())
+  const dateLabel = Number.isNaN(new Date(bill.event_date).getTime())
     ? null
-    : eventDate.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-      })
+    : formatShowDate(bill.event_date, bill.venue_state, true)
 
   return (
     <div

--- a/frontend/features/admin/components/FeaturedAdmin/index.ts
+++ b/frontend/features/admin/components/FeaturedAdmin/index.ts
@@ -1,0 +1,23 @@
+export { FeaturedAdmin } from './FeaturedAdmin'
+export {
+  useExploreFeatured,
+  useFeaturedSlots,
+  useRetireFeaturedSlot,
+  useSetFeaturedSlot,
+} from './useFeaturedSlots'
+export type {
+  ExploreFeaturedBill,
+  ExploreFeaturedCollection,
+  ExploreFeaturedResponse,
+  FeaturedSlotResponse,
+  FeaturedSlotsPerType,
+  FeaturedSlotType,
+  ListFeaturedSlotsResponse,
+  RetireFeaturedSlotResponse,
+  SetFeaturedSlotInput,
+} from './types'
+export {
+  FEATURED_SLOT_LABEL,
+  FEATURED_SLOT_TYPES,
+  MAX_CURATOR_NOTE_LENGTH,
+} from './types'

--- a/frontend/features/admin/components/FeaturedAdmin/types.ts
+++ b/frontend/features/admin/components/FeaturedAdmin/types.ts
@@ -1,0 +1,121 @@
+/**
+ * Wire-shape types for the admin featured-slot endpoints (PSY-835).
+ * Mirrors `backend/internal/api/handlers/admin/featured_slot.go`.
+ *
+ * `slot_type` is the only discriminator — `entity_id` resolves to a
+ * show ID (`bill`) or collection ID (`collection`). The backend does
+ * not validate the referent exists; the admin tool is responsible for
+ * picking a real entity via the entity-search primitive.
+ */
+
+export type FeaturedSlotType = 'bill' | 'collection'
+
+export const FEATURED_SLOT_TYPES: readonly FeaturedSlotType[] = [
+  'bill',
+  'collection',
+] as const
+
+/**
+ * Backend response shape for a single featured-slot row.
+ * `curator_note` is the raw markdown source so the admin can re-edit a
+ * pick without round-tripping through the rendered HTML.
+ */
+export interface FeaturedSlotResponse {
+  id: number
+  slot_type: FeaturedSlotType
+  entity_id: number
+  curator_note?: string | null
+  curator_note_html?: string
+  active_from: string
+  active_until?: string | null
+  created_by: number
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * One slot type's bundle: the currently-active pick (or null) plus
+ * recent retired history. Backend returns one entry per slot type.
+ */
+export interface FeaturedSlotsPerType {
+  slot_type: FeaturedSlotType
+  active?: FeaturedSlotResponse | null
+  history: FeaturedSlotResponse[]
+}
+
+export interface ListFeaturedSlotsResponse {
+  slots: FeaturedSlotsPerType[]
+}
+
+export interface SetFeaturedSlotInput {
+  slot_type: FeaturedSlotType
+  entity_id: number
+  curator_note?: string | null
+}
+
+/**
+ * The single-slot response wrapper backend returns from POST
+ * /admin/featured-slots — Huma nests the row under `body`.
+ */
+export interface SetFeaturedSlotResponse {
+  body: FeaturedSlotResponse
+}
+
+export interface RetireFeaturedSlotResponse {
+  slot_type: FeaturedSlotType
+  message: string
+}
+
+/**
+ * Mirrors the backend `MaxFeaturedSlotCuratorNoteLength` constant
+ * (10,000) so the editor's character counter and the server-side cap
+ * stay in sync. Also matches the comment / field-note body limits the
+ * same renderer is shared with.
+ */
+export const MAX_CURATOR_NOTE_LENGTH = 10_000
+
+export const FEATURED_SLOT_LABEL: Record<FeaturedSlotType, string> = {
+  bill: 'Featured Bill',
+  collection: 'Featured Collection',
+}
+
+// ──────────────────────────────────────────────
+// Hydrated referent shapes (from /explore/featured)
+// ──────────────────────────────────────────────
+//
+// The admin endpoint returns only `entity_id` for the active row.
+// `/explore/featured` (PSY-835 public read endpoint) returns the same
+// active picks with referent details hydrated — name, thumbnail,
+// curator-note-rendered-HTML. The admin page uses the explore
+// endpoint as the read source for the "current active" cards so the
+// curator can see WHAT they picked without an extra backend round-trip.
+
+export interface ExploreFeaturedBill {
+  id: number
+  slug: string
+  title: string
+  event_date: string
+  headliner_name: string
+  venue_name: string
+  venue_city: string
+  venue_state: string
+  image_url?: string | null
+  curator_note?: string | null
+  curator_note_html?: string
+}
+
+export interface ExploreFeaturedCollection {
+  id: number
+  slug: string
+  title: string
+  description?: string
+  description_html?: string
+  cover_image_url?: string | null
+  curator_note?: string | null
+  curator_note_html?: string
+}
+
+export interface ExploreFeaturedResponse {
+  bill: ExploreFeaturedBill | null
+  collection: ExploreFeaturedCollection | null
+}

--- a/frontend/features/admin/components/FeaturedAdmin/useFeaturedSlots.test.tsx
+++ b/frontend/features/admin/components/FeaturedAdmin/useFeaturedSlots.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapperWithClient } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      FEATURED_SLOTS: {
+        LIST: '/admin/featured-slots',
+        SET: '/admin/featured-slots',
+        RETIRE: (slotType: string) => `/admin/featured-slots/${slotType}`,
+      },
+    },
+    EXPLORE: {
+      FEATURED: '/explore/featured',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      featuredSlots: () => ['admin', 'featuredSlots'],
+    },
+    explore: {
+      featured: ['explore', 'featured'],
+    },
+  },
+}))
+
+import {
+  useExploreFeatured,
+  useFeaturedSlots,
+  useRetireFeaturedSlot,
+  useSetFeaturedSlot,
+} from './useFeaturedSlots'
+
+function setupClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  return { queryClient, invalidateSpy }
+}
+
+describe('useFeaturedSlots — list query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('GETs /admin/featured-slots and surfaces the response', async () => {
+    mockApiRequest.mockResolvedValueOnce({ slots: [] })
+    const { queryClient } = setupClient()
+
+    const { result } = renderHook(() => useFeaturedSlots(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/admin/featured-slots')
+    expect(result.current.data).toEqual({ slots: [] })
+  })
+})
+
+describe('useExploreFeatured', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('GETs the public /explore/featured endpoint for the active card source', async () => {
+    mockApiRequest.mockResolvedValueOnce({ bill: null, collection: null })
+    const { queryClient } = setupClient()
+
+    const { result } = renderHook(() => useExploreFeatured(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/explore/featured')
+    expect(result.current.data).toEqual({ bill: null, collection: null })
+  })
+})
+
+describe('useSetFeaturedSlot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('POSTs the slot payload and invalidates BOTH list + explore caches', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      body: {
+        id: 5,
+        slot_type: 'bill',
+        entity_id: 101,
+        active_from: '2026-05-24T00:00:00Z',
+        created_by: 1,
+        created_at: '2026-05-24T00:00:00Z',
+        updated_at: '2026-05-24T00:00:00Z',
+      },
+    })
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useSetFeaturedSlot(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        slot_type: 'bill',
+        entity_id: 101,
+        curator_note: 'Sharp bill.',
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/featured-slots',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          slot_type: 'bill',
+          entity_id: 101,
+          curator_note: 'Sharp bill.',
+        }),
+      })
+    )
+    // Both caches must invalidate so the active card + the admin list
+    // refresh; failing to invalidate either leaves the UI desynced.
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['admin', 'featuredSlots'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['explore', 'featured'],
+    })
+  })
+})
+
+describe('useRetireFeaturedSlot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('DELETEs by slot_type path and invalidates both caches', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      slot_type: 'collection',
+      message: 'Featured slot retired',
+    })
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useRetireFeaturedSlot(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync('collection')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/featured-slots/collection',
+      { method: 'DELETE' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['admin', 'featuredSlots'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['explore', 'featured'],
+    })
+  })
+})

--- a/frontend/features/admin/components/FeaturedAdmin/useFeaturedSlots.ts
+++ b/frontend/features/admin/components/FeaturedAdmin/useFeaturedSlots.ts
@@ -1,0 +1,126 @@
+'use client'
+
+/**
+ * TanStack Query hooks for the admin featured-slot endpoints.
+ *
+ * Three hooks mirror the three backend endpoints (PSY-835):
+ *   - useFeaturedSlots — GET /admin/featured-slots (both types in one call)
+ *   - useSetFeaturedSlot — POST /admin/featured-slots (atomic retire + insert)
+ *   - useRetireFeaturedSlot — DELETE /admin/featured-slots/{slot_type}
+ *
+ * Mutations invalidate the list query so both panels re-render on the
+ * next paint. Errors bubble up unchanged so the consuming component can
+ * surface them via the canonical inline-banner primitive
+ * (pattern_mutation_feedback.md).
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type {
+  ExploreFeaturedResponse,
+  FeaturedSlotType,
+  ListFeaturedSlotsResponse,
+  RetireFeaturedSlotResponse,
+  SetFeaturedSlotInput,
+  SetFeaturedSlotResponse,
+} from './types'
+
+/**
+ * Fetch both the Featured Bill + Featured Collection state in one
+ * request. Backend returns one entry per slot type with the active
+ * row (or null) and recent history. Short staleTime (15s) so the
+ * panel reflects mutations quickly without polling.
+ */
+export function useFeaturedSlots(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.admin.featuredSlots(),
+    queryFn: () =>
+      apiRequest<ListFeaturedSlotsResponse>(
+        API_ENDPOINTS.ADMIN.FEATURED_SLOTS.LIST
+      ),
+    enabled: options?.enabled ?? true,
+    staleTime: 15 * 1000,
+  })
+}
+
+/**
+ * Fetch the hydrated active referents (bill + collection) from the
+ * public /explore/featured endpoint. Used by the admin page as the
+ * read source for the "current active" slot cards — the admin
+ * endpoint returns only entity_id, so we delegate name/thumbnail
+ * resolution to the existing public endpoint. Both fields are
+ * nullable when nothing is set or the referent is no longer
+ * publicly visible. Same invalidation key as the admin list so a
+ * Set / Retire mutation refreshes both queries.
+ */
+export function useExploreFeatured(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.explore.featured,
+    queryFn: () =>
+      apiRequest<ExploreFeaturedResponse>(API_ENDPOINTS.EXPLORE.FEATURED),
+    enabled: options?.enabled ?? true,
+    staleTime: 15 * 1000,
+  })
+}
+
+/**
+ * Set a new active pick for a slot type. Backend atomically retires
+ * the previous active row (`active_until = NOW()`) and inserts the new
+ * one inside one transaction, so the unique-active-row invariant
+ * always holds. Invalidates the list query so both panels refresh.
+ */
+export function useSetFeaturedSlot() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: SetFeaturedSlotInput) =>
+      apiRequest<SetFeaturedSlotResponse>(
+        API_ENDPOINTS.ADMIN.FEATURED_SLOTS.SET,
+        {
+          method: 'POST',
+          body: JSON.stringify(input),
+        }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.admin.featuredSlots(),
+      })
+      // Also bust the public /explore/featured cache so the active
+      // card on the admin page (which reads from this endpoint for
+      // hydrated referent details) reflects the change immediately.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.explore.featured,
+      })
+    },
+  })
+}
+
+/**
+ * Retire the current active row for a slot type without replacement.
+ * Idempotent at the API surface — a second DELETE returns 404, which
+ * the consumer can treat as a no-op for UI purposes. The /explore
+ * Featured section collapses for that slot on next render.
+ */
+export function useRetireFeaturedSlot() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (slotType: FeaturedSlotType) =>
+      apiRequest<RetireFeaturedSlotResponse>(
+        API_ENDPOINTS.ADMIN.FEATURED_SLOTS.RETIRE(slotType),
+        {
+          method: 'DELETE',
+        }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.admin.featuredSlots(),
+      })
+      // Also bust the public /explore/featured cache so the active
+      // card on the admin page (which reads from this endpoint for
+      // hydrated referent details) reflects the change immediately.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.explore.featured,
+      })
+    },
+  })
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -195,6 +195,16 @@ export const API_ENDPOINTS = {
       REJECT: (editId: string | number) =>
         `${API_BASE_URL}/admin/pending-edits/${editId}/reject`,
     },
+    // Featured slots — admin-curated /explore editorial picks
+    // (Featured Bill + Featured Collection). PSY-835 backend; PSY-838
+    // admin UI. POST atomically retires the prior active row and
+    // inserts a new one; DELETE retires the current active row.
+    FEATURED_SLOTS: {
+      LIST: `${API_BASE_URL}/admin/featured-slots`,
+      SET: `${API_BASE_URL}/admin/featured-slots`,
+      RETIRE: (slotType: string) =>
+        `${API_BASE_URL}/admin/featured-slots/${slotType}`,
+    },
     ENTITY_REPORTS: {
       LIST: `${API_BASE_URL}/admin/entity-reports`,
       GET: (reportId: string | number) =>
@@ -382,6 +392,16 @@ export const API_ENDPOINTS = {
     POPULAR_ARTISTS: `${API_BASE_URL}/charts/popular-artists`,
     ACTIVE_VENUES: `${API_BASE_URL}/charts/active-venues`,
     HOT_RELEASES: `${API_BASE_URL}/charts/hot-releases`,
+  },
+
+  // /explore landing (PSY-835/836) — public read endpoints. The
+  // FEATURED endpoint returns hydrated referent details (name,
+  // thumbnail, curator note HTML) which the admin /admin/featured
+  // page also uses to render the "current active" slot cards.
+  EXPLORE: {
+    UPCOMING_SHOWS: `${API_BASE_URL}/explore/upcoming-shows`,
+    FEATURED: `${API_BASE_URL}/explore/featured`,
+    SHUFFLE_TARGET: `${API_BASE_URL}/explore/shuffle-target`,
   },
 
   // System endpoints

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -184,6 +184,11 @@ export const queryKeys = {
       ['admin', 'pendingEdits', params] as const,
     entityReports: (params?: Record<string, unknown>) =>
       ['admin', 'entityReports', params] as const,
+    // Featured slots (admin-curated /explore picks). One list query
+    // covers both slot types — list invalidations refresh both
+    // panels after Set / Retire.
+    featuredSlots: (params?: Record<string, unknown>) =>
+      ['admin', 'featuredSlots', params] as const,
   },
 
   // Artist queries (defined in features/artists/api.ts)
@@ -393,6 +398,11 @@ export const queryKeys = {
   // Notification filter queries
   notificationFilters: {
     all: ['notificationFilters'] as const,
+  },
+
+  // /explore landing read endpoints (PSY-835/836)
+  explore: {
+    featured: ['explore', 'featured'] as const,
   },
 
   // System queries


### PR DESCRIPTION
## Summary
- New `/admin/featured` page with two parallel panels (Bill / Collection), each carrying the current active slot card + a "Set new" form.
- Active card is sourced from `/api/explore/featured` (hydrated referent — name, thumbnail, curator-note-rendered-HTML) since the admin list endpoint returns only entity_id. Mutations invalidate both cache keys so admin list + active card stay in sync.
- Reuses existing primitives: `useEntitySearch` for the picker, `MarkdownEditor` for curator notes (same as comment composer), `StatusBanner` + `InlineErrorBanner` for mutation feedback per `pattern_mutation_feedback.md`.
- Wires three hooks: `useFeaturedSlots`, `useSetFeaturedSlot`, `useRetireFeaturedSlot` against PSY-835's admin endpoints.

## Test plan
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:run features/admin` — 11/11 pass (FeaturedAdmin + useFeaturedSlots suites)

## Manual repro
Stack mode: shared. End-to-end verified via agent-browser:

| # | Path | Screenshot |
|---|---|---|
| 1 | admin sets Featured Bill + Featured Collection | `dogfood-output/PSY-838/screenshots/01-both-slots-set.png` |
| 2 | admin retires the Bill | `dogfood-output/PSY-838/screenshots/02-bill-retired.png` |
| 3 | /explore Featured section reflects state after retire (collection-only) | `dogfood-output/PSY-838/screenshots/03-after-retire-reloaded.png` |
| 4 | /explore/featured API response after retire (raw JSON) | `dogfood-output/PSY-838/screenshots/03-explore-featured-api-response.json` |

Verified end-to-end: admin gating (anonymous → redirect), set-new flow for both slot types, retire-current, inline banner feedback, atomic retire+insert (POST overrides prior active row), and consumer-page reflection on next render.

## Scope deviation
The `/code-review` pass surfaced two findings; one fixed in-PR, one filed as a backend follow-up.

**Fixed in-PR (commit `fac83a66`, "code-review pass"):**
- `ActiveBillCard` was rendering `event_date` with `toLocaleDateString` (user's local TZ) instead of the venue timezone, violating the project's "Show times always in venue timezone" convention (`feedback_timezone_display.md`). Switched to `formatShowDate(bill.event_date, bill.venue_state, true)` — the bill payload already carries `venue_state`.

**Deferred to follow-up — [PSY-850](https://linear.app/psychic-homily/issue/PSY-850):**
- The admin entity-search returns shows of any status (pending/rejected/private). Admin can pick one, click Save, the POST returns 200 (PSY-835's `SetActiveSlot` doesn't validate referent status), and the success banner shows — but `/explore/featured` filters by `status='approved'`, so the slot silently no-ops in the consumer. "Phantom save" UX.
- **Why not fix here**: the canonical defense is backend `SetActiveSlot` validating the referent is publicly visible. The frontend filter alternative cascades changes across `ShowSearchItem` + `EntitySearchResult` + `mapShow` + picker (4 files in the shared search primitive) — disproportionate for an admin-UX bug when the backend boundary is the proper layer. PSY-850 closes it cleanly with one backend file + tests.
- **Observed during manual repro** with show id=62 (a pending row that surfaced in the picker).

## Code review
`/code-review` surfaced 2 findings (above): 1 fixed in this PR, 1 filed as PSY-850.

Closes PSY-838