### PR TITLE
PSY-846: errcheck phase 1 — testify-suite drops -> require.NoError

### DIFF
--- a/backend/internal/services/admin/artist_report_test.go
+++ b/backend/internal/services/admin/artist_report_test.go
@@ -237,8 +237,10 @@ func (suite *ArtistReportServiceIntegrationTestSuite) TestGetPendingReports_Succ
 	user1 := suite.createTestUser()
 	user2 := suite.createTestUser()
 
-	suite.reportService.CreateReport(user1.ID, artist1.ID, "inaccurate", nil)
-	suite.reportService.CreateReport(user2.ID, artist2.ID, "removal_request", nil)
+	_, err := suite.reportService.CreateReport(user1.ID, artist1.ID, "inaccurate", nil)
+	suite.Require().NoError(err)
+	_, err = suite.reportService.CreateReport(user2.ID, artist2.ID, "removal_request", nil)
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.reportService.GetPendingReports(10, 0)
 
@@ -258,12 +260,14 @@ func (suite *ArtistReportServiceIntegrationTestSuite) TestGetPendingReports_Excl
 	report := suite.createPendingReport(user.ID, artist.ID, "inaccurate")
 
 	// Dismiss the report
-	suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	_, err := suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	suite.Require().NoError(err)
 
 	// Create another pending one
 	artist2 := suite.createTestArtist("Still Pending Artist")
 	user2 := suite.createTestUser()
-	suite.reportService.CreateReport(user2.ID, artist2.ID, "removal_request", nil)
+	_, err = suite.reportService.CreateReport(user2.ID, artist2.ID, "removal_request", nil)
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.reportService.GetPendingReports(10, 0)
 
@@ -278,7 +282,8 @@ func (suite *ArtistReportServiceIntegrationTestSuite) TestGetPendingReports_Pagi
 	for i := 0; i < 5; i++ {
 		artist := suite.createTestArtist(fmt.Sprintf("Paginated Artist %d", i))
 		user := suite.createTestUser()
-		suite.reportService.CreateReport(user.ID, artist.ID, "inaccurate", nil)
+		_, err := suite.reportService.CreateReport(user.ID, artist.ID, "inaccurate", nil)
+		suite.Require().NoError(err)
 	}
 
 	// Page 1
@@ -344,7 +349,8 @@ func (suite *ArtistReportServiceIntegrationTestSuite) TestDismissReport_AlreadyR
 	admin := suite.createTestUser()
 
 	report := suite.createPendingReport(user.ID, artist.ID, "inaccurate")
-	suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	_, err := suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	suite.Require().NoError(err)
 
 	// Try to dismiss again
 	resp, err := suite.reportService.DismissReport(report.ID, admin.ID, nil)
@@ -403,7 +409,8 @@ func (suite *ArtistReportServiceIntegrationTestSuite) TestResolveReport_AlreadyR
 	admin := suite.createTestUser()
 
 	report := suite.createPendingReport(user.ID, artist.ID, "inaccurate")
-	suite.reportService.ResolveReport(report.ID, admin.ID, nil)
+	_, err := suite.reportService.ResolveReport(report.ID, admin.ID, nil)
+	suite.Require().NoError(err)
 
 	resp, err := suite.reportService.ResolveReport(report.ID, admin.ID, nil)
 
@@ -418,7 +425,8 @@ func (suite *ArtistReportServiceIntegrationTestSuite) TestResolveReport_CannotRe
 	admin := suite.createTestUser()
 
 	report := suite.createPendingReport(user.ID, artist.ID, "inaccurate")
-	suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	_, err := suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	suite.Require().NoError(err)
 
 	resp, err := suite.reportService.ResolveReport(report.ID, admin.ID, nil)
 

--- a/backend/internal/services/admin/show_report_test.go
+++ b/backend/internal/services/admin/show_report_test.go
@@ -219,10 +219,12 @@ func (suite *ShowReportServiceIntegrationTestSuite) TestGetPendingReports_Succes
 	user1 := suite.createTestUser()
 	user2 := suite.createTestUser()
 
-	suite.reportService.CreateReport(user1.ID, show.ID, "cancelled", nil)
+	_, err := suite.reportService.CreateReport(user1.ID, show.ID, "cancelled", nil)
+	suite.Require().NoError(err)
 
 	show2 := suite.createApprovedShow("Another Show")
-	suite.reportService.CreateReport(user2.ID, show2.ID, "sold_out", nil)
+	_, err = suite.reportService.CreateReport(user2.ID, show2.ID, "sold_out", nil)
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.reportService.GetPendingReports(10, 0)
 
@@ -242,12 +244,14 @@ func (suite *ShowReportServiceIntegrationTestSuite) TestGetPendingReports_Exclud
 	report := suite.createPendingReport(user.ID, show.ID, "cancelled")
 
 	// Dismiss the report
-	suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	_, err := suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	suite.Require().NoError(err)
 
 	// Create another pending one
 	show2 := suite.createApprovedShow("Still Pending Show")
 	user2 := suite.createTestUser()
-	suite.reportService.CreateReport(user2.ID, show2.ID, "inaccurate", nil)
+	_, err = suite.reportService.CreateReport(user2.ID, show2.ID, "inaccurate", nil)
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.reportService.GetPendingReports(10, 0)
 
@@ -262,7 +266,8 @@ func (suite *ShowReportServiceIntegrationTestSuite) TestGetPendingReports_Pagina
 	for i := 0; i < 5; i++ {
 		show := suite.createApprovedShow(fmt.Sprintf("Paginated Show %d", i))
 		user := suite.createTestUser()
-		suite.reportService.CreateReport(user.ID, show.ID, "cancelled", nil)
+		_, err := suite.reportService.CreateReport(user.ID, show.ID, "cancelled", nil)
+		suite.Require().NoError(err)
 	}
 
 	// Page 1
@@ -320,7 +325,8 @@ func (suite *ShowReportServiceIntegrationTestSuite) TestDismissReport_AlreadyRev
 	admin := suite.createTestUser()
 
 	report := suite.createPendingReport(user.ID, show.ID, "cancelled")
-	suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	_, err := suite.reportService.DismissReport(report.ID, admin.ID, nil)
+	suite.Require().NoError(err)
 
 	// Try to dismiss again
 	resp, err := suite.reportService.DismissReport(report.ID, admin.ID, nil)
@@ -365,7 +371,8 @@ func (suite *ShowReportServiceIntegrationTestSuite) TestResolveReport_AlreadyRev
 	admin := suite.createTestUser()
 
 	report := suite.createPendingReport(user.ID, show.ID, "cancelled")
-	suite.reportService.ResolveReport(report.ID, admin.ID, nil)
+	_, err := suite.reportService.ResolveReport(report.ID, admin.ID, nil)
+	suite.Require().NoError(err)
 
 	resp, err := suite.reportService.ResolveReport(report.ID, admin.ID, nil)
 

--- a/backend/internal/services/catalog/artist_relationship_service_test.go
+++ b/backend/internal/services/catalog/artist_relationship_service_test.go
@@ -146,7 +146,8 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestCreateRelationsh
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelationship_Found() {
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
 	rel, err := suite.svc.GetRelationship(a1, a2, "similar")
 	suite.Require().NoError(err)
@@ -156,7 +157,8 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelationship_
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelationship_ReversedOrder() {
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
 	// Query with reversed order — should still find it
 	rel, err := suite.svc.GetRelationship(a2, a1, "similar")
@@ -175,8 +177,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelatedArtist
 	a2 := suite.createArtist("Related Band 1")
 	a3 := suite.createArtist("Related Band 2")
 
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
-	suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	_, err = suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	suite.Require().NoError(err)
 
 	related, err := suite.svc.GetRelatedArtists(a1, "", 30)
 	suite.Require().NoError(err)
@@ -188,8 +192,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelatedArtist
 	a2 := suite.createArtist("Similar")
 	a3 := suite.createArtist("Shared")
 
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
-	suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	_, err = suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	suite.Require().NoError(err)
 
 	related, err := suite.svc.GetRelatedArtists(a1, "similar", 30)
 	suite.Require().NoError(err)
@@ -200,9 +206,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelatedArtist
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestDeleteRelationship() {
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
-	err := suite.svc.DeleteRelationship(a1, a2, "similar")
+	err = suite.svc.DeleteRelationship(a1, a2, "similar")
 	suite.Assert().NoError(err)
 
 	rel, _ := suite.svc.GetRelationship(a1, a2, "similar")
@@ -222,9 +229,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_Upvote() {
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
 	user := suite.createUser("voter")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
-	err := suite.svc.Vote(a1, a2, "similar", user.ID, true)
+	err = suite.svc.Vote(a1, a2, "similar", user.ID, true)
 	suite.Assert().NoError(err)
 
 	vote, err := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
@@ -237,9 +245,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_Downvote() 
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
 	user := suite.createUser("voter")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
-	err := suite.svc.Vote(a1, a2, "similar", user.ID, false)
+	err = suite.svc.Vote(a1, a2, "similar", user.ID, false)
 	suite.Assert().NoError(err)
 
 	vote, _ := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
@@ -250,10 +259,11 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_ChangeDirec
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
 	user := suite.createUser("voter")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
-	suite.svc.Vote(a1, a2, "similar", user.ID, true)
-	suite.svc.Vote(a1, a2, "similar", user.ID, false) // Change to downvote
+	suite.Require().NoError(suite.svc.Vote(a1, a2, "similar", user.ID, true))
+	suite.Require().NoError(suite.svc.Vote(a1, a2, "similar", user.ID, false)) // Change to downvote
 
 	vote, _ := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
 	suite.Assert().Equal(int16(-1), vote.Direction)
@@ -271,11 +281,12 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_ScoreUpdate
 	a2 := suite.createArtist("Band B")
 	user1 := suite.createUser("voter1")
 	user2 := suite.createUser("voter2")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
 	// Two upvotes
-	suite.svc.Vote(a1, a2, "similar", user1.ID, true)
-	suite.svc.Vote(a1, a2, "similar", user2.ID, true)
+	suite.Require().NoError(suite.svc.Vote(a1, a2, "similar", user1.ID, true))
+	suite.Require().NoError(suite.svc.Vote(a1, a2, "similar", user2.ID, true))
 
 	rel, _ := suite.svc.GetRelationship(a1, a2, "similar")
 	suite.Assert().Greater(rel.Score, float32(0))
@@ -285,10 +296,11 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestRemoveVote() {
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
 	user := suite.createUser("voter")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
-	suite.svc.Vote(a1, a2, "similar", user.ID, true)
-	err := suite.svc.RemoveVote(a1, a2, "similar", user.ID)
+	suite.Require().NoError(suite.svc.Vote(a1, a2, "similar", user.ID, true))
+	err = suite.svc.RemoveVote(a1, a2, "similar", user.ID)
 	suite.Assert().NoError(err)
 
 	vote, _ := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
@@ -299,7 +311,8 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetUserVote_NotV
 	a1 := suite.createArtist("Band A")
 	a2 := suite.createArtist("Band B")
 	user := suite.createUser("voter")
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
 	vote, err := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
 	suite.Assert().NoError(err)
@@ -358,7 +371,8 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestDeriveSharedBill
 	suite.addArtistToShow(show2, a1)
 	suite.addArtistToShow(show2, a2)
 
-	suite.svc.DeriveSharedBills(2)
+	_, err := suite.svc.DeriveSharedBills(2)
+	suite.Require().NoError(err)
 
 	// Add another show and re-derive
 	show3 := suite.createShow("Show 3")
@@ -382,8 +396,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_B
 	a2 := suite.createArtist("Related Band 1")
 	a3 := suite.createArtist("Related Band 2")
 
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
-	suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	_, err = suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	suite.Require().NoError(err)
 
 	graph, err := suite.svc.GetArtistGraph(a1, nil, 0)
 	suite.Require().NoError(err)
@@ -401,8 +417,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_F
 	a2 := suite.createArtist("Similar")
 	a3 := suite.createArtist("Shared")
 
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
-	suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	_, err = suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+	suite.Require().NoError(err)
 
 	// Only similar
 	graph, err := suite.svc.GetArtistGraph(a1, []string{"similar"}, 0)
@@ -418,10 +436,13 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_C
 	a3 := suite.createArtist("Related B")
 
 	// Center connects to both
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
-	suite.svc.CreateRelationship(a1, a3, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	_, err = suite.svc.CreateRelationship(a1, a3, "similar", false)
+	suite.Require().NoError(err)
 	// Cross-connection between related artists
-	suite.svc.CreateRelationship(a2, a3, "shared_bills", true)
+	_, err = suite.svc.CreateRelationship(a2, a3, "shared_bills", true)
+	suite.Require().NoError(err)
 
 	graph, err := suite.svc.GetArtistGraph(a1, nil, 0)
 	suite.Require().NoError(err)
@@ -435,8 +456,9 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_W
 	a2 := suite.createArtist("Related")
 	user := suite.createUser("voter")
 
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
-	suite.svc.Vote(a1, a2, "similar", user.ID, true)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.svc.Vote(a1, a2, "similar", user.ID, true))
 
 	graph, err := suite.svc.GetArtistGraph(a1, nil, user.ID)
 	suite.Require().NoError(err)
@@ -482,7 +504,8 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_U
 	suite.db.Create(futureShow)
 	suite.addArtistToShow(futureShow.ID, a2)
 
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
 
 	graph, err := suite.svc.GetArtistGraph(a1, nil, 0)
 	suite.Require().NoError(err)
@@ -700,8 +723,10 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_F
 
 	// Center ↔ a2 and Center ↔ a3 stored similar relationships so they
 	// surface as related artists.
-	suite.svc.CreateRelationship(a1, a2, "similar", false)
-	suite.svc.CreateRelationship(a1, a3, "similar", false)
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	_, err = suite.svc.CreateRelationship(a1, a3, "similar", false)
+	suite.Require().NoError(err)
 
 	graph, err := suite.svc.GetArtistGraph(a1, nil, 0)
 	suite.Require().NoError(err)

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -287,8 +287,10 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistByName_NotFound() {
 // =============================================================================
 
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_FilterByCity() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "PHX Artist", City: stringPtr("Phoenix")})
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "TUC Artist", City: stringPtr("Tucson")})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "PHX Artist", City: stringPtr("Phoenix")})
+	suite.Require().NoError(err)
+	_, err = suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "TUC Artist", City: stringPtr("Tucson")})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.GetArtists(map[string]interface{}{"city": "Phoenix"})
 
@@ -298,9 +300,12 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_FilterByCity() {
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_MultiCityFilter() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "PHX Band", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Mesa Band", City: stringPtr("Mesa"), State: stringPtr("AZ")})
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "LA Band", City: stringPtr("Los Angeles"), State: stringPtr("CA")})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "PHX Band", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
+	suite.Require().NoError(err)
+	_, err = suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Mesa Band", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+	suite.Require().NoError(err)
+	_, err = suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "LA Band", City: stringPtr("Los Angeles"), State: stringPtr("CA")})
+	suite.Require().NoError(err)
 
 	cities := []map[string]string{
 		{"city": "Phoenix", "state": "AZ"},
@@ -316,8 +321,10 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_MultiCityFilter()
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_FilterByState() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "AZ Artist", State: stringPtr("AZ")})
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "CA Artist", State: stringPtr("CA")})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "AZ Artist", State: stringPtr("AZ")})
+	suite.Require().NoError(err)
+	_, err = suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "CA Artist", State: stringPtr("CA")})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.GetArtists(map[string]interface{}{"state": "CA"})
 
@@ -327,8 +334,10 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_FilterByState() {
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_FilterByName() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Crescent Band"})
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Valley Group"})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Crescent Band"})
+	suite.Require().NoError(err)
+	_, err = suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Valley Group"})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.GetArtists(map[string]interface{}{"name": "crescent"})
 
@@ -457,7 +466,8 @@ func (suite *ArtistServiceIntegrationTestSuite) TestDeleteArtist_HasShows_Fails(
 // =============================================================================
 
 func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_EmptyQuery() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Some Artist"})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Some Artist"})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.SearchArtists("")
 
@@ -466,8 +476,10 @@ func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_EmptyQuery() {
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_ShortQuery_PrefixMatch() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Valley Heat"})
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Crescent Moon"})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Valley Heat"})
+	suite.Require().NoError(err)
+	_, err = suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Crescent Moon"})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.SearchArtists("Va")
 
@@ -477,8 +489,10 @@ func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_ShortQuery_Pre
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_LongQuery_TrigramMatch() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Radiohead"})
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "The Rebel Lounge Band"})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Radiohead"})
+	suite.Require().NoError(err)
+	_, err = suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "The Rebel Lounge Band"})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.SearchArtists("Radiohead")
 
@@ -488,7 +502,8 @@ func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_LongQuery_Trig
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_NoMatch() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Real Artist"})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Real Artist"})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.SearchArtists("zzzznonexistent")
 
@@ -717,7 +732,8 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_ExcludesArti
 	suite.createApprovedShowWithArtist(pastArtist.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, -7))
 
 	// Artist with city but no shows at all should not appear
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "No Show Artist", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "No Show Artist", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+	suite.Require().NoError(err)
 
 	resp, err := suite.artistService.GetArtistCities()
 
@@ -837,10 +853,11 @@ func (suite *ArtistServiceIntegrationTestSuite) TestAddArtistAlias_DuplicateAlia
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestAddArtistAlias_ConflictsWithArtistName_Fails() {
-	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Existing Band"})
+	_, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Existing Band"})
+	suite.Require().NoError(err)
 	artist2, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Another Band"})
 
-	_, err := suite.artistService.AddArtistAlias(artist2.ID, "Existing Band")
+	_, err = suite.artistService.AddArtistAlias(artist2.ID, "Existing Band")
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "conflicts with existing artist name")
 }
@@ -883,8 +900,10 @@ func (suite *ArtistServiceIntegrationTestSuite) TestRemoveArtistAlias_NotFound()
 
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistAliases_Success() {
 	artist, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "List Aliases Artist"})
-	suite.artistService.AddArtistAlias(artist.ID, "Alias B")
-	suite.artistService.AddArtistAlias(artist.ID, "Alias A")
+	_, err := suite.artistService.AddArtistAlias(artist.ID, "Alias B")
+	suite.Require().NoError(err)
+	_, err = suite.artistService.AddArtistAlias(artist.ID, "Alias A")
+	suite.Require().NoError(err)
 
 	aliases, err := suite.artistService.GetArtistAliases(artist.ID)
 
@@ -1009,7 +1028,8 @@ func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_TransfersAliase
 	mergeFrom, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Alias Merge"})
 
 	// Add existing alias to mergeFrom
-	suite.artistService.AddArtistAlias(mergeFrom.ID, "Old Alias")
+	_, err := suite.artistService.AddArtistAlias(mergeFrom.ID, "Old Alias")
+	suite.Require().NoError(err)
 
 	result, err := suite.artistService.MergeArtists(canonical.ID, mergeFrom.ID)
 

--- a/backend/internal/services/catalog/festival_test.go
+++ b/backend/internal/services/catalog/festival_test.go
@@ -267,14 +267,16 @@ func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByStat
 	// Create a confirmed festival
 	city := "Phoenix"
 	state := "AZ"
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	_, err := suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "Confirmed Fest", SeriesSlug: "cf", EditionYear: 2026,
 		City: &city, State: &state, StartDate: "2026-03-01", EndDate: "2026-03-03", Status: "confirmed",
 	})
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "Announced Fest", SeriesSlug: "af", EditionYear: 2026,
 		StartDate: "2026-04-01", EndDate: "2026-04-03",
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"status": "confirmed"})
 
@@ -284,12 +286,14 @@ func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByStat
 }
 
 func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByYear() {
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	_, err := suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "2025 Fest", SeriesSlug: "f25", EditionYear: 2025, StartDate: "2025-06-01", EndDate: "2025-06-03",
 	})
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "2026 Fest", SeriesSlug: "f26", EditionYear: 2026, StartDate: "2026-06-01", EndDate: "2026-06-03",
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"year": 2026})
 
@@ -301,12 +305,14 @@ func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByYear
 func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByCity() {
 	city1 := "Phoenix"
 	city2 := "Chicago"
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	_, err := suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "PHX Fest", SeriesSlug: "phx", EditionYear: 2026, City: &city1, StartDate: "2026-03-01", EndDate: "2026-03-03",
 	})
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "CHI Fest", SeriesSlug: "chi", EditionYear: 2026, City: &city2, StartDate: "2026-07-01", EndDate: "2026-07-03",
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"city": "Phoenix"})
 
@@ -316,15 +322,18 @@ func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByCity
 }
 
 func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterBySeriesSlug() {
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	_, err := suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "M3F 2025", SeriesSlug: "m3f", EditionYear: 2025, StartDate: "2025-03-01", EndDate: "2025-03-03",
 	})
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "M3F 2026", SeriesSlug: "m3f", EditionYear: 2026, StartDate: "2026-03-01", EndDate: "2026-03-03",
 	})
-	suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.CreateFestival(&contracts.CreateFestivalRequest{
 		Name: "Other Fest", SeriesSlug: "other", EditionYear: 2026, StartDate: "2026-06-01", EndDate: "2026-06-03",
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"series_slug": "m3f"})
 
@@ -416,16 +425,18 @@ func (suite *FestivalServiceIntegrationTestSuite) TestDeleteFestival_CascadesJun
 	artist := suite.createTestArtistForFestival("Cascade Artist")
 	venue := suite.createTestVenue("Cascade Venue", "Phoenix", "AZ")
 
-	suite.festivalService.AddFestivalArtist(created.ID, &contracts.AddFestivalArtistRequest{
+	_, err := suite.festivalService.AddFestivalArtist(created.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID:    artist.ID,
 		BillingTier: "headliner",
 	})
-	suite.festivalService.AddFestivalVenue(created.ID, &contracts.AddFestivalVenueRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalVenue(created.ID, &contracts.AddFestivalVenueRequest{
 		VenueID:   venue.ID,
 		IsPrimary: true,
 	})
+	suite.Require().NoError(err)
 
-	err := suite.festivalService.DeleteFestival(created.ID)
+	err = suite.festivalService.DeleteFestival(created.ID)
 	suite.Require().NoError(err)
 
 	// Verify junction records cleaned up
@@ -521,15 +532,18 @@ func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalArtists_Ordered
 	local := suite.createTestArtistForFestival("Local Opener")
 
 	// Add in reverse order to test ordering
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
+	_, err := suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: local.ID, BillingTier: "local", Position: 0,
 	})
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: headliner.ID, BillingTier: "headliner", Position: 0,
 	})
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: undercard.ID, BillingTier: "undercard", Position: 0,
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.festivalService.GetFestivalArtists(festival.ID, nil)
 
@@ -545,12 +559,14 @@ func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalArtists_FilterB
 	day1Artist := suite.createTestArtistForFestival("Day 1 Artist")
 	day2Artist := suite.createTestArtistForFestival("Day 2 Artist")
 
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
+	_, err := suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: day1Artist.ID, BillingTier: "headliner", DayDate: strPtrFestival("2026-03-06"),
 	})
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: day2Artist.ID, BillingTier: "headliner", DayDate: strPtrFestival("2026-03-07"),
 	})
+	suite.Require().NoError(err)
 
 	dayFilter := "2026-03-07"
 	resp, err := suite.festivalService.GetFestivalArtists(festival.ID, &dayFilter)
@@ -564,10 +580,11 @@ func (suite *FestivalServiceIntegrationTestSuite) TestUpdateFestivalArtist_Succe
 	festival := suite.createBasicFestival("Update Artist Festival")
 	artist := suite.createTestArtistForFestival("Promoted Band")
 
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
+	_, err := suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID:    artist.ID,
 		BillingTier: "undercard",
 	})
+	suite.Require().NoError(err)
 
 	newTier := "headliner"
 	newStage := "Main Stage"
@@ -596,11 +613,12 @@ func (suite *FestivalServiceIntegrationTestSuite) TestRemoveFestivalArtist_Succe
 	festival := suite.createBasicFestival("Remove Artist Festival")
 	artist := suite.createTestArtistForFestival("Removed Band")
 
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
+	_, err := suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: artist.ID,
 	})
+	suite.Require().NoError(err)
 
-	err := suite.festivalService.RemoveFestivalArtist(festival.ID, artist.ID)
+	err = suite.festivalService.RemoveFestivalArtist(festival.ID, artist.ID)
 
 	suite.Require().NoError(err)
 
@@ -677,9 +695,10 @@ func (suite *FestivalServiceIntegrationTestSuite) TestRemoveFestivalVenue_Succes
 	festival := suite.createBasicFestival("Remove Venue Festival")
 	venue := suite.createTestVenue("Removable Venue", "Phoenix", "AZ")
 
-	suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{VenueID: venue.ID})
+	_, err := suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{VenueID: venue.ID})
+	suite.Require().NoError(err)
 
-	err := suite.festivalService.RemoveFestivalVenue(festival.ID, venue.ID)
+	err = suite.festivalService.RemoveFestivalVenue(festival.ID, venue.ID)
 
 	suite.Require().NoError(err)
 
@@ -701,12 +720,14 @@ func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalVenues_PrimaryF
 	venue1 := suite.createTestVenue("Secondary Venue", "Phoenix", "AZ")
 	venue2 := suite.createTestVenue("Primary Venue", "Phoenix", "AZ")
 
-	suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{
+	_, err := suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{
 		VenueID: venue1.ID, IsPrimary: false,
 	})
-	suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{
 		VenueID: venue2.ID, IsPrimary: true,
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.festivalService.GetFestivalVenues(festival.ID)
 
@@ -727,12 +748,14 @@ func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalsForArtist_Succ
 	fest2 := suite.createBasicFestival("Festival Two")
 	suite.createBasicFestival("Festival Three") // not associated
 
-	suite.festivalService.AddFestivalArtist(fest1.ID, &contracts.AddFestivalArtistRequest{
+	_, err := suite.festivalService.AddFestivalArtist(fest1.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: artist.ID, BillingTier: "headliner",
 	})
-	suite.festivalService.AddFestivalArtist(fest2.ID, &contracts.AddFestivalArtistRequest{
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalArtist(fest2.ID, &contracts.AddFestivalArtistRequest{
 		ArtistID: artist.ID, BillingTier: "undercard",
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.festivalService.GetFestivalsForArtist(artist.ID)
 
@@ -777,9 +800,12 @@ func (suite *FestivalServiceIntegrationTestSuite) TestFestival_ArtistAndVenueCou
 	artist2 := suite.createTestArtistForFestival("Count Artist 2")
 	venue := suite.createTestVenue("Count Venue", "Phoenix", "AZ")
 
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{ArtistID: artist1.ID})
-	suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{ArtistID: artist2.ID})
-	suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{VenueID: venue.ID})
+	_, err := suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{ArtistID: artist1.ID})
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalArtist(festival.ID, &contracts.AddFestivalArtistRequest{ArtistID: artist2.ID})
+	suite.Require().NoError(err)
+	_, err = suite.festivalService.AddFestivalVenue(festival.ID, &contracts.AddFestivalVenueRequest{VenueID: venue.ID})
+	suite.Require().NoError(err)
 
 	// Test detail response counts
 	detail, err := suite.festivalService.GetFestival(festival.ID)

--- a/backend/internal/services/catalog/label_test.go
+++ b/backend/internal/services/catalog/label_test.go
@@ -221,9 +221,12 @@ func (suite *LabelServiceIntegrationTestSuite) TestGetLabelBySlug_NotFound() {
 // =============================================================================
 
 func (suite *LabelServiceIntegrationTestSuite) TestListLabels_All() {
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Alpha Records"})
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Beta Records"})
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Charlie Records"})
+	_, err := suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Alpha Records"})
+	suite.Require().NoError(err)
+	_, err = suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Beta Records"})
+	suite.Require().NoError(err)
+	_, err = suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Charlie Records"})
+	suite.Require().NoError(err)
 
 	resp, err := suite.labelService.ListLabels(map[string]interface{}{})
 
@@ -236,8 +239,10 @@ func (suite *LabelServiceIntegrationTestSuite) TestListLabels_All() {
 }
 
 func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByStatus() {
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Active Label", Status: "active"})
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Defunct Label", Status: "defunct"})
+	_, err := suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Active Label", Status: "active"})
+	suite.Require().NoError(err)
+	_, err = suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Defunct Label", Status: "defunct"})
+	suite.Require().NoError(err)
 
 	resp, err := suite.labelService.ListLabels(map[string]interface{}{"status": "defunct"})
 
@@ -249,8 +254,10 @@ func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByStatus() {
 func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByCity() {
 	city1 := "Seattle"
 	city2 := "Portland"
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Seattle Label", City: &city1})
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Portland Label", City: &city2})
+	_, err := suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Seattle Label", City: &city1})
+	suite.Require().NoError(err)
+	_, err = suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "Portland Label", City: &city2})
+	suite.Require().NoError(err)
 
 	resp, err := suite.labelService.ListLabels(map[string]interface{}{"city": "Seattle"})
 
@@ -262,8 +269,10 @@ func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByCity() {
 func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByState() {
 	state1 := "WA"
 	state2 := "OR"
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "WA Label", State: &state1})
-	suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "OR Label", State: &state2})
+	_, err := suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "WA Label", State: &state1})
+	suite.Require().NoError(err)
+	_, err = suite.labelService.CreateLabel(&contracts.CreateLabelRequest{Name: "OR Label", State: &state2})
+	suite.Require().NoError(err)
 
 	resp, err := suite.labelService.ListLabels(map[string]interface{}{"state": "WA"})
 

--- a/backend/internal/services/catalog/release_test.go
+++ b/backend/internal/services/catalog/release_test.go
@@ -236,9 +236,12 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestGetReleaseBySlug_NotFound()
 // =============================================================================
 
 func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_All() {
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Album A", ReleaseYear: intPtr(2020)})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Album B", ReleaseYear: intPtr(2023)})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Album C", ReleaseYear: intPtr(2021)})
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Album A", ReleaseYear: intPtr(2020)})
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Album B", ReleaseYear: intPtr(2023)})
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Album C", ReleaseYear: intPtr(2021)})
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{})
 
@@ -252,9 +255,12 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_All() {
 }
 
 func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_FilterByType() {
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "LP Release", ReleaseType: "lp"})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "EP Release", ReleaseType: "ep"})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Single Release", ReleaseType: "single"})
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "LP Release", ReleaseType: "lp"})
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "EP Release", ReleaseType: "ep"})
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Single Release", ReleaseType: "single"})
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{ReleaseType: "ep"})
 
@@ -265,8 +271,10 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_FilterByType()
 }
 
 func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_FilterByYear() {
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Old Album", ReleaseYear: intPtr(2020)})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "New Album", ReleaseYear: intPtr(2024)})
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "Old Album", ReleaseYear: intPtr(2020)})
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{Title: "New Album", ReleaseYear: intPtr(2024)})
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{Year: 2024})
 
@@ -280,14 +288,16 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_FilterByArtist
 	artist1 := suite.createTestArtist("Artist One")
 	artist2 := suite.createTestArtist("Artist Two")
 
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title:   "Artist One Album",
 		Artists: []contracts.CreateReleaseArtistEntry{{ArtistID: artist1.ID, Role: "main"}},
 	})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title:   "Artist Two Album",
 		Artists: []contracts.CreateReleaseArtistEntry{{ArtistID: artist2.ID, Role: "main"}},
 	})
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{ArtistID: artist1.ID})
 
@@ -301,13 +311,14 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistCount() 
 	artist1 := suite.createTestArtist("Count Artist 1")
 	artist2 := suite.createTestArtist("Count Artist 2")
 
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title: "Multi Artist Album",
 		Artists: []contracts.CreateReleaseArtistEntry{
 			{ArtistID: artist1.ID, Role: "main"},
 			{ArtistID: artist2.ID, Role: "featured"},
 		},
 	})
+	suite.Require().NoError(err)
 
 	resp, _, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{})
 
@@ -320,13 +331,14 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistNames() 
 	artist1 := suite.createTestArtist("Alvvays")
 	artist2 := suite.createTestArtist("Snail Mail")
 
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title: "Split EP",
 		Artists: []contracts.CreateReleaseArtistEntry{
 			{ArtistID: artist1.ID, Role: "main"},
 			{ArtistID: artist2.ID, Role: "main"},
 		},
 	})
+	suite.Require().NoError(err)
 
 	resp, _, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{})
 
@@ -341,9 +353,10 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistNames() 
 
 func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistsEmptySlice() {
 	// Release with no artists should have empty artists slice (not nil)
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title: "No Artist Album",
 	})
+	suite.Require().NoError(err)
 
 	resp, _, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{})
 
@@ -373,9 +386,10 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_LabelInfo() {
 }
 
 func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_NoLabel() {
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title: "Unlabeled Album",
 	})
+	suite.Require().NoError(err)
 
 	resp, _, err := suite.releaseService.ListReleases(contracts.ReleaseListFilters{})
 
@@ -388,10 +402,11 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_NoLabel() {
 func (suite *ReleaseServiceIntegrationTestSuite) TestSearchReleases_ArtistNames() {
 	artist := suite.createTestArtist("Radiohead")
 
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title:   "OK Computer",
 		Artists: []contracts.CreateReleaseArtistEntry{{ArtistID: artist.ID, Role: "main"}},
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.releaseService.SearchReleases("OK Computer")
 
@@ -518,20 +533,23 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestGetReleasesForArtist_Succes
 	artist := suite.createTestArtist("Discography Artist")
 	otherArtist := suite.createTestArtist("Other Artist")
 
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	_, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title:       "Album A",
 		ReleaseYear: intPtr(2020),
 		Artists:     []contracts.CreateReleaseArtistEntry{{ArtistID: artist.ID, Role: "main"}},
 	})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title:       "Album B",
 		ReleaseYear: intPtr(2023),
 		Artists:     []contracts.CreateReleaseArtistEntry{{ArtistID: artist.ID, Role: "main"}},
 	})
-	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
 		Title:   "Other Album",
 		Artists: []contracts.CreateReleaseArtistEntry{{ArtistID: otherArtist.ID, Role: "main"}},
 	})
+	suite.Require().NoError(err)
 
 	resp, err := suite.releaseService.GetReleasesForArtist(artist.ID)
 

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -259,7 +259,8 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_FilterByParent() {
 	parent := suite.createTag("rock", "genre")
 	suite.createTag("post-punk", "genre")
 	// Make post-rock a child of rock
-	suite.tagService.CreateTag("post-rock", nil, &parent.ID, "genre", false, nil)
+	_, err := suite.tagService.CreateTag("post-rock", nil, &parent.ID, "genre", false, nil)
+	suite.Require().NoError(err)
 
 	tags, total, err := suite.tagService.ListTags("", "", &parent.ID, "name", 50, 0, "")
 	suite.Require().NoError(err)
@@ -541,8 +542,10 @@ func (suite *TagServiceIntegrationTestSuite) TestListEntityTags() {
 	tag2 := suite.createTag("lo-fi", "other")
 	artistID := suite.createArtist("Indie Lo-Fi Band")
 
-	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID, "")
-	suite.tagService.AddTagToEntity(tag2.ID, "", "artist", artistID, user.ID, "")
+	_, err := suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
+	_, err = suite.tagService.AddTagToEntity(tag2.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
 
 	tags, err := suite.tagService.ListEntityTags("artist", artistID, 0)
 	suite.Require().NoError(err)
@@ -554,8 +557,9 @@ func (suite *TagServiceIntegrationTestSuite) TestListEntityTags_WithUserVote() {
 	tag := suite.createTag("punk", "genre")
 	artistID := suite.createArtist("Punk Band")
 
-	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
-	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true))
 
 	tags, err := suite.tagService.ListEntityTags("artist", artistID, user.ID)
 	suite.Require().NoError(err)
@@ -630,9 +634,10 @@ func (suite *TagServiceIntegrationTestSuite) TestVoteOnTag_Upvote() {
 	tag := suite.createTag("synth", "genre")
 	artistID := suite.createArtist("Synth Band")
 
-	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
 
-	err := suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+	err = suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
 	suite.Assert().NoError(err)
 }
 
@@ -641,11 +646,12 @@ func (suite *TagServiceIntegrationTestSuite) TestVoteOnTag_ChangeVote() {
 	tag := suite.createTag("grunge", "genre")
 	artistID := suite.createArtist("Grunge Band")
 
-	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
-	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true))
 
 	// Change to downvote
-	err := suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, false)
+	err = suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, false)
 	suite.Assert().NoError(err)
 
 	// Verify vote changed
@@ -671,10 +677,11 @@ func (suite *TagServiceIntegrationTestSuite) TestRemoveTagVote() {
 	tag := suite.createTag("noise", "genre")
 	artistID := suite.createArtist("Noise Band")
 
-	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
-	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true))
 
-	err := suite.tagService.RemoveTagVote(tag.ID, "artist", artistID, user.ID)
+	err = suite.tagService.RemoveTagVote(tag.ID, "artist", artistID, user.ID)
 	suite.Assert().NoError(err)
 
 	// Verify vote removed
@@ -698,9 +705,10 @@ func (suite *TagServiceIntegrationTestSuite) TestCreateAlias_Success() {
 
 func (suite *TagServiceIntegrationTestSuite) TestCreateAlias_Duplicate() {
 	tag := suite.createTag("hip-hop", "genre")
-	suite.tagService.CreateAlias(tag.ID, "hiphop")
+	_, err := suite.tagService.CreateAlias(tag.ID, "hiphop")
+	suite.Require().NoError(err)
 
-	_, err := suite.tagService.CreateAlias(tag.ID, "HipHop")
+	_, err = suite.tagService.CreateAlias(tag.ID, "HipHop")
 	suite.Assert().Error(err)
 	var tagErr *apperrors.TagError
 	suite.Assert().ErrorAs(err, &tagErr)
@@ -736,8 +744,10 @@ func (suite *TagServiceIntegrationTestSuite) TestDeleteAlias() {
 
 func (suite *TagServiceIntegrationTestSuite) TestListAliases() {
 	tag := suite.createTag("post-punk", "genre")
-	suite.tagService.CreateAlias(tag.ID, "post punk")
-	suite.tagService.CreateAlias(tag.ID, "postpunk")
+	_, err := suite.tagService.CreateAlias(tag.ID, "post punk")
+	suite.Require().NoError(err)
+	_, err = suite.tagService.CreateAlias(tag.ID, "postpunk")
+	suite.Require().NoError(err)
 
 	aliases, err := suite.tagService.ListAliases(tag.ID)
 	suite.Require().NoError(err)
@@ -746,7 +756,8 @@ func (suite *TagServiceIntegrationTestSuite) TestListAliases() {
 
 func (suite *TagServiceIntegrationTestSuite) TestResolveAlias_Found() {
 	tag := suite.createTag("post-punk", "genre")
-	suite.tagService.CreateAlias(tag.ID, "post punk")
+	_, err := suite.tagService.CreateAlias(tag.ID, "post punk")
+	suite.Require().NoError(err)
 
 	resolved, err := suite.tagService.ResolveAlias("Post Punk")
 	suite.Require().NoError(err)
@@ -896,7 +907,8 @@ func (suite *TagServiceIntegrationTestSuite) TestGetTrendingTags() {
 	artistID := suite.createArtist("Multi-Genre")
 
 	// Apply tags to entities to increase usage count
-	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID, "")
+	_, err := suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
 	// tag2 not applied, so usage_count stays 0
 
 	_ = tag2
@@ -913,9 +925,11 @@ func (suite *TagServiceIntegrationTestSuite) TestGetTrendingTags_FilterByCategor
 	tag2 := suite.createTag("1990s", "other")
 	artistID := suite.createArtist("Band")
 
-	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID, "")
+	_, err := suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID, "")
+	suite.Require().NoError(err)
 	artist2 := suite.createArtist("Band2")
-	suite.tagService.AddTagToEntity(tag2.ID, "", "artist", artist2, user.ID, "")
+	_, err = suite.tagService.AddTagToEntity(tag2.ID, "", "artist", artist2, user.ID, "")
+	suite.Require().NoError(err)
 
 	tags, err := suite.tagService.GetTrendingTags(10, "other")
 	suite.Require().NoError(err)
@@ -930,9 +944,10 @@ func (suite *TagServiceIntegrationTestSuite) TestPruneDownvotedTags() {
 	artistID := suite.createArtist("Some Band")
 
 	// Apply tag and get downvoted
-	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user1.ID, "")
-	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user1.ID, false)
-	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user2.ID, false)
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user1.ID, "")
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user1.ID, false))
+	suite.Require().NoError(suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user2.ID, false))
 
 	pruned, err := suite.tagService.PruneDownvotedTags()
 	suite.Require().NoError(err)
@@ -949,9 +964,10 @@ func (suite *TagServiceIntegrationTestSuite) TestPruneDownvotedTags_OfficialImmu
 	tag, _ := suite.tagService.CreateTag("official-tag", nil, nil, "genre", true, nil)
 	artistID := suite.createArtist("Some Official Band")
 
-	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user1.ID, "")
-	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user1.ID, false)
-	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user2.ID, false)
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user1.ID, "")
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user1.ID, false))
+	suite.Require().NoError(suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user2.ID, false))
 
 	pruned, err := suite.tagService.PruneDownvotedTags()
 	suite.Require().NoError(err)
@@ -1582,8 +1598,10 @@ func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_ReturnsCanonical
 func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_SearchByAlias() {
 	tagA := suite.createTag("post-punk", "genre")
 	tagB := suite.createTag("hip-hop", "genre")
-	suite.tagService.CreateAlias(tagA.ID, "postpunk")
-	suite.tagService.CreateAlias(tagB.ID, "hiphop")
+	_, err := suite.tagService.CreateAlias(tagA.ID, "postpunk")
+	suite.Require().NoError(err)
+	_, err = suite.tagService.CreateAlias(tagB.ID, "hiphop")
+	suite.Require().NoError(err)
 
 	items, total, err := suite.tagService.ListAllAliases("post", 50, 0)
 	suite.Require().NoError(err)
@@ -1595,8 +1613,10 @@ func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_SearchByAlias() 
 func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_SearchByCanonicalName() {
 	tagA := suite.createTag("post-punk", "genre")
 	tagB := suite.createTag("hip-hop", "genre")
-	suite.tagService.CreateAlias(tagA.ID, "xyz")
-	suite.tagService.CreateAlias(tagB.ID, "abc")
+	_, err := suite.tagService.CreateAlias(tagA.ID, "xyz")
+	suite.Require().NoError(err)
+	_, err = suite.tagService.CreateAlias(tagB.ID, "abc")
+	suite.Require().NoError(err)
 
 	items, total, err := suite.tagService.ListAllAliases("hip", 50, 0)
 	suite.Require().NoError(err)
@@ -1683,7 +1703,8 @@ func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_DuplicateInBa
 
 func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_AliasAlreadyExists() {
 	tagA := suite.createTag("drum-and-bass", "genre")
-	suite.tagService.CreateAlias(tagA.ID, "dnb")
+	_, err := suite.tagService.CreateAlias(tagA.ID, "dnb")
+	suite.Require().NoError(err)
 
 	items := []contracts.BulkAliasImportItem{
 		{Alias: "dnb", Canonical: "drum-and-bass"},

--- a/backend/internal/services/catalog/venue_test.go
+++ b/backend/internal/services/catalog/venue_test.go
@@ -267,8 +267,10 @@ func (suite *VenueServiceIntegrationTestSuite) TestGetVenueBySlug_NotFound() {
 // =============================================================================
 
 func (suite *VenueServiceIntegrationTestSuite) TestGetVenues_FilterByCity() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "PHX Venue", City: "Phoenix", State: "AZ"}, true)
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "TUC Venue", City: "Tucson", State: "AZ"}, true)
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "PHX Venue", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
+	_, err = suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "TUC Venue", City: "Tucson", State: "AZ"}, true)
+	suite.Require().NoError(err)
 
 	resp, err := suite.venueService.GetVenues(map[string]interface{}{"city": "Phoenix"})
 
@@ -278,8 +280,10 @@ func (suite *VenueServiceIntegrationTestSuite) TestGetVenues_FilterByCity() {
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestGetVenues_FilterByState() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "AZ Venue", City: "Phoenix", State: "AZ"}, true)
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "CA Venue", City: "Los Angeles", State: "CA"}, true)
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "AZ Venue", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
+	_, err = suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "CA Venue", City: "Los Angeles", State: "CA"}, true)
+	suite.Require().NoError(err)
 
 	resp, err := suite.venueService.GetVenues(map[string]interface{}{"state": "CA"})
 
@@ -289,8 +293,10 @@ func (suite *VenueServiceIntegrationTestSuite) TestGetVenues_FilterByState() {
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestGetVenues_FilterByName() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Crescent Ballroom", City: "Phoenix", State: "AZ"}, true)
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Valley Bar", City: "Phoenix", State: "AZ"}, true)
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Crescent Ballroom", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
+	_, err = suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Valley Bar", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
 
 	resp, err := suite.venueService.GetVenues(map[string]interface{}{"name": "crescent"})
 
@@ -332,11 +338,12 @@ func (suite *VenueServiceIntegrationTestSuite) TestUpdateVenue_NotFound() {
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestUpdateVenue_DuplicateNameCity_Fails() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{
 		Name:  "Existing Venue",
 		City:  "Phoenix",
 		State: "AZ",
 	}, true)
+	suite.Require().NoError(err)
 	other, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{
 		Name:  "Other Venue",
 		City:  "Phoenix",
@@ -418,7 +425,8 @@ func (suite *VenueServiceIntegrationTestSuite) TestDeleteVenue_HasShows_Fails() 
 // =============================================================================
 
 func (suite *VenueServiceIntegrationTestSuite) TestSearchVenues_EmptyQuery() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Some Venue", City: "Phoenix", State: "AZ"}, true)
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Some Venue", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
 
 	resp, err := suite.venueService.SearchVenues("")
 
@@ -427,8 +435,10 @@ func (suite *VenueServiceIntegrationTestSuite) TestSearchVenues_EmptyQuery() {
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestSearchVenues_ShortQuery_PrefixMatch() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Valley Bar", City: "Phoenix", State: "AZ"}, true)
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Crescent Ballroom", City: "Phoenix", State: "AZ"}, true)
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Valley Bar", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
+	_, err = suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Crescent Ballroom", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
 
 	resp, err := suite.venueService.SearchVenues("Va")
 
@@ -438,8 +448,10 @@ func (suite *VenueServiceIntegrationTestSuite) TestSearchVenues_ShortQuery_Prefi
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestSearchVenues_LongQuery_TrigramMatch() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Crescent Ballroom", City: "Phoenix", State: "AZ"}, true)
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "The Rebel Lounge", City: "Phoenix", State: "AZ"}, true)
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Crescent Ballroom", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
+	_, err = suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "The Rebel Lounge", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
 
 	resp, err := suite.venueService.SearchVenues("Crescent")
 
@@ -449,7 +461,8 @@ func (suite *VenueServiceIntegrationTestSuite) TestSearchVenues_LongQuery_Trigra
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestSearchVenues_NoMatch() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Real Venue", City: "Phoenix", State: "AZ"}, true)
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{Name: "Real Venue", City: "Phoenix", State: "AZ"}, true)
+	suite.Require().NoError(err)
 
 	resp, err := suite.venueService.SearchVenues("zzzznonexistent")
 
@@ -474,11 +487,12 @@ func (suite *VenueServiceIntegrationTestSuite) TestFindOrCreateVenue_CreatesNew(
 
 func (suite *VenueServiceIntegrationTestSuite) TestFindOrCreateVenue_FindsExisting() {
 	// Create a venue first
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{
 		Name:  "Existing Place",
 		City:  "Phoenix",
 		State: "AZ",
 	}, true)
+	suite.Require().NoError(err)
 
 	venue, created, err := suite.venueService.FindOrCreateVenue("Existing Place", "Phoenix", "AZ", nil, nil, nil, false)
 
@@ -488,11 +502,12 @@ func (suite *VenueServiceIntegrationTestSuite) TestFindOrCreateVenue_FindsExisti
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestFindOrCreateVenue_CaseInsensitive() {
-	suite.venueService.CreateVenue(&contracts.CreateVenueRequest{
+	_, err := suite.venueService.CreateVenue(&contracts.CreateVenueRequest{
 		Name:  "The Venue",
 		City:  "Phoenix",
 		State: "AZ",
 	}, true)
+	suite.Require().NoError(err)
 
 	venue, created, err := suite.venueService.FindOrCreateVenue("the venue", "phoenix", "AZ", nil, nil, nil, false)
 

--- a/backend/internal/services/community/collection_test.go
+++ b/backend/internal/services/community/collection_test.go
@@ -420,7 +420,8 @@ func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_PublicOn
 	suite.createPublicCollection(user, "Public One")
 
 	privateReq := &contracts.CreateCollectionRequest{Title: "Private One", IsPublic: false}
-	suite.collectionService.CreateCollection(user.ID, privateReq)
+	_, err := suite.collectionService.CreateCollection(user.ID, privateReq)
+	suite.Require().NoError(err)
 
 	resp, total, err := suite.collectionService.ListCollections(contracts.CollectionFilters{PublicOnly: true}, 20, 0)
 
@@ -773,7 +774,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterBy
 	coll := suite.createBasicCollection(user, "Featured Collection")
 	suite.createBasicCollection(user, "Normal Collection")
 
-	suite.collectionService.SetFeatured(coll.Slug, true)
+	suite.Require().NoError(suite.collectionService.SetFeatured(coll.Slug, true))
 
 	resp, total, err := suite.collectionService.ListCollections(contracts.CollectionFilters{Featured: true}, 20, 0)
 
@@ -1103,12 +1104,13 @@ func (suite *CollectionServiceIntegrationTestSuite) TestDeleteCollection_Cascade
 	created := suite.createBasicCollection(user, "Cascade Delete")
 
 	artist := suite.createTestArtist("Cascade Artist")
-	suite.collectionService.AddItem(created.Slug, user.ID, &contracts.AddCollectionItemRequest{
+	_, err := suite.collectionService.AddItem(created.Slug, user.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityArtist,
 		EntityID:   artist.ID,
 	})
+	suite.Require().NoError(err)
 
-	err := suite.collectionService.DeleteCollection(created.Slug, user.ID, false)
+	err = suite.collectionService.DeleteCollection(created.Slug, user.ID, false)
 	suite.Require().NoError(err)
 
 	// Verify items and subscribers are cleaned up
@@ -1549,7 +1551,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestUnsubscribe_Success() {
 	subscriber := suite.createTestUser("Unsubscriber")
 	coll := suite.createPublicCollection(creator, "Unsub Collection")
 
-	suite.collectionService.Subscribe(coll.Slug, subscriber.ID)
+	suite.Require().NoError(suite.collectionService.Subscribe(coll.Slug, subscriber.ID))
 
 	err := suite.collectionService.Unsubscribe(coll.Slug, subscriber.ID)
 	suite.Require().NoError(err)
@@ -1612,15 +1614,18 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetStats_Success() {
 	a2 := suite.createTestArtist("Stats Artist 2")
 	v1 := suite.createTestVenueForCollection("Stats Venue")
 
-	suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
+	_, err := suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityArtist, EntityID: a1.ID,
 	})
-	suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
+	suite.Require().NoError(err)
+	_, err = suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityArtist, EntityID: a2.ID,
 	})
-	suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
+	suite.Require().NoError(err)
+	_, err = suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityVenue, EntityID: v1.ID,
 	})
+	suite.Require().NoError(err)
 
 	stats, err := suite.collectionService.GetStats(coll.Slug)
 
@@ -1673,7 +1678,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Inclu
 
 	// Public so the non-creator subscriber can subscribe.
 	coll := suite.createPublicCollection(creator, "Subscribed Collection")
-	suite.collectionService.Subscribe(coll.Slug, subscriber.ID)
+	suite.Require().NoError(suite.collectionService.Subscribe(coll.Slug, subscriber.ID))
 
 	// Subscriber's own collection
 	suite.createBasicCollection(subscriber, "Own Collection")
@@ -1897,7 +1902,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestSetFeatured_Unfeature() 
 	user := suite.createTestUser("UnfeatureCreator")
 	coll := suite.createBasicCollection(user, "Unfeature Me")
 
-	suite.collectionService.SetFeatured(coll.Slug, true)
+	suite.Require().NoError(suite.collectionService.SetFeatured(coll.Slug, true))
 
 	err := suite.collectionService.SetFeatured(coll.Slug, false)
 	suite.Require().NoError(err)
@@ -1926,12 +1931,14 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetBySlug_ItemEntityName
 	artist := suite.createTestArtist("Resolved Artist")
 	venue := suite.createTestVenueForCollection("Resolved Venue")
 
-	suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
+	_, err := suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityArtist, EntityID: artist.ID,
 	})
-	suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
+	suite.Require().NoError(err)
+	_, err = suite.collectionService.AddItem(coll.Slug, user.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityVenue, EntityID: venue.ID,
 	})
+	suite.Require().NoError(err)
 
 	detail, err := suite.collectionService.GetBySlug(coll.Slug, user.ID)
 	suite.Require().NoError(err)
@@ -1954,15 +1961,18 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetBySlug_ContributorCou
 	a2 := suite.createTestArtist("Contrib Artist 2")
 	a3 := suite.createTestArtist("Contrib Artist 3")
 
-	suite.collectionService.AddItem(coll.Slug, creator.ID, &contracts.AddCollectionItemRequest{
+	_, err := suite.collectionService.AddItem(coll.Slug, creator.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityArtist, EntityID: a1.ID,
 	})
-	suite.collectionService.AddItem(coll.Slug, collab1.ID, &contracts.AddCollectionItemRequest{
+	suite.Require().NoError(err)
+	_, err = suite.collectionService.AddItem(coll.Slug, collab1.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityArtist, EntityID: a2.ID,
 	})
-	suite.collectionService.AddItem(coll.Slug, collab2.ID, &contracts.AddCollectionItemRequest{
+	suite.Require().NoError(err)
+	_, err = suite.collectionService.AddItem(coll.Slug, collab2.ID, &contracts.AddCollectionItemRequest{
 		EntityType: communitym.CollectionEntityArtist, EntityID: a3.ID,
 	})
+	suite.Require().NoError(err)
 
 	detail, err := suite.collectionService.GetBySlug(coll.Slug, creator.ID)
 	suite.Require().NoError(err)

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -415,7 +415,7 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendance_Going(
 	user := suite.createTestUser()
 	show := suite.createApprovedShow("Get Going Show", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "going"))
 
 	status, err := suite.attendanceService.GetUserAttendance(user.ID, show.ID)
 	suite.Require().NoError(err)
@@ -426,7 +426,7 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendance_Intere
 	user := suite.createTestUser()
 	show := suite.createApprovedShow("Get Interested Show", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, show.ID, "interested")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "interested"))
 
 	status, err := suite.attendanceService.GetUserAttendance(user.ID, show.ID)
 	suite.Require().NoError(err)
@@ -452,9 +452,9 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetAttendanceCounts_Mult
 	user3 := suite.createTestUser()
 	show := suite.createApprovedShow("Count Show", user1.ID)
 
-	suite.attendanceService.SetAttendance(user1.ID, show.ID, "going")
-	suite.attendanceService.SetAttendance(user2.ID, show.ID, "going")
-	suite.attendanceService.SetAttendance(user3.ID, show.ID, "interested")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user1.ID, show.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user2.ID, show.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user3.ID, show.ID, "interested"))
 
 	counts, err := suite.attendanceService.GetAttendanceCounts(show.ID)
 	suite.Require().NoError(err)
@@ -484,9 +484,9 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetBatchAttendanceCounts
 	show2 := suite.createApprovedShow("Batch Show 2", user1.ID)
 	show3 := suite.createApprovedShow("Batch Show 3", user1.ID)
 
-	suite.attendanceService.SetAttendance(user1.ID, show1.ID, "going")
-	suite.attendanceService.SetAttendance(user2.ID, show1.ID, "interested")
-	suite.attendanceService.SetAttendance(user1.ID, show2.ID, "interested")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user1.ID, show1.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user2.ID, show1.ID, "interested"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user1.ID, show2.ID, "interested"))
 
 	result, err := suite.attendanceService.GetBatchAttendanceCounts([]uint{show1.ID, show2.ID, show3.ID})
 	suite.Require().NoError(err)
@@ -516,8 +516,8 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetBatchUserAttendance_M
 	show2 := suite.createApprovedShow("Batch User Show 2", user.ID)
 	show3 := suite.createApprovedShow("Batch User Show 3", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
-	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show1.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested"))
 
 	result, err := suite.attendanceService.GetBatchUserAttendance(user.ID, []uint{show1.ID, show2.ID, show3.ID})
 	suite.Require().NoError(err)
@@ -545,8 +545,8 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_Al
 	show1, _ := suite.createShowWithVenue("Attending Show 1", user.ID)
 	show2, _ := suite.createShowWithVenue("Attending Show 2", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
-	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show1.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested"))
 
 	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
 	suite.Require().NoError(err)
@@ -559,8 +559,8 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_Fi
 	show1, _ := suite.createShowWithVenue("Going Only Show", user.ID)
 	show2, _ := suite.createShowWithVenue("Interested Only Show", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
-	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show1.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested"))
 
 	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "going", 10, 0)
 	suite.Require().NoError(err)
@@ -574,8 +574,8 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_Fi
 	show1, _ := suite.createShowWithVenue("Going Show for Filter", user.ID)
 	show2, _ := suite.createShowWithVenue("Interested Show for Filter", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
-	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show1.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested"))
 
 	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "interested", 10, 0)
 	suite.Require().NoError(err)
@@ -589,8 +589,8 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_On
 	upcomingShow, _ := suite.createShowWithVenue("Upcoming Show", user.ID)
 	pastShow := suite.createPastShow("Past Show", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, upcomingShow.ID, "going")
-	suite.attendanceService.SetAttendance(user.ID, pastShow.ID, "going")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, upcomingShow.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, pastShow.ID, "going"))
 
 	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
 	suite.Require().NoError(err)
@@ -613,8 +613,8 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_On
 	}
 	suite.db.Create(pendingShow)
 
-	suite.attendanceService.SetAttendance(user.ID, approvedShow.ID, "going")
-	suite.attendanceService.SetAttendance(user.ID, pendingShow.ID, "going")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, approvedShow.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, pendingShow.ID, "going"))
 
 	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
 	suite.Require().NoError(err)
@@ -627,7 +627,7 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_Pa
 	user := suite.createTestUser()
 	for i := 0; i < 5; i++ {
 		show, _ := suite.createShowWithVenue(fmt.Sprintf("Paginated Show %d", i), user.ID)
-		suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+		suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "going"))
 	}
 
 	shows1, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 2, 0)
@@ -650,7 +650,7 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_In
 	user := suite.createTestUser()
 	show, venue := suite.createShowWithVenue("Venue Info Show", user.ID)
 
-	suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "going"))
 
 	shows, _, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
 	suite.Require().NoError(err)

--- a/backend/internal/services/engagement/bookmark_test.go
+++ b/backend/internal/services/engagement/bookmark_test.go
@@ -141,7 +141,7 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestCreateBookmark_DifferentEn
 func (suite *BookmarkServiceIntegrationTestSuite) TestDeleteBookmark_Success() {
 	user := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
 
 	err := suite.bookmarkService.DeleteBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
 
@@ -171,7 +171,7 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestDeleteBookmark_NotFound() 
 func (suite *BookmarkServiceIntegrationTestSuite) TestIsBookmarked_True() {
 	user := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
 
 	result, err := suite.bookmarkService.IsBookmarked(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
 
@@ -191,7 +191,7 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestIsBookmarked_False() {
 func (suite *BookmarkServiceIntegrationTestSuite) TestIsBookmarked_WrongAction() {
 	user := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
 
 	result, err := suite.bookmarkService.IsBookmarked(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionGoing)
 
@@ -206,8 +206,8 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestIsBookmarked_WrongAction()
 func (suite *BookmarkServiceIntegrationTestSuite) TestGetBookmarkedEntityIDs_Success() {
 	user := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 3, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 3, engagementm.BookmarkActionSave))
 
 	result, err := suite.bookmarkService.GetBookmarkedEntityIDs(user.ID, engagementm.BookmarkEntityShow, engagementm.BookmarkActionSave, []uint{1, 2, 3})
 
@@ -233,9 +233,9 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestGetBookmarkedEntityIDs_Emp
 func (suite *BookmarkServiceIntegrationTestSuite) TestGetUserBookmarks_Success() {
 	user := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
 	time.Sleep(10 * time.Millisecond)
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionSave))
 
 	bookmarks, total, err := suite.bookmarkService.GetUserBookmarks(user.ID, engagementm.BookmarkEntityShow, engagementm.BookmarkActionSave, 10, 0)
 
@@ -261,7 +261,7 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestGetUserBookmarks_Paginatio
 	user := suite.createTestUser()
 
 	for i := uint(1); i <= 5; i++ {
-		suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, i, engagementm.BookmarkActionSave)
+		suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, i, engagementm.BookmarkActionSave))
 		time.Sleep(5 * time.Millisecond)
 	}
 
@@ -286,8 +286,8 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestGetUserBookmarks_OnlyOwnBo
 	user1 := suite.createTestUser()
 	user2 := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user1.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
-	suite.bookmarkService.CreateBookmark(user2.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user1.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user2.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionSave))
 
 	bookmarks, total, err := suite.bookmarkService.GetUserBookmarks(user1.ID, engagementm.BookmarkEntityShow, engagementm.BookmarkActionSave, 10, 0)
 
@@ -301,9 +301,9 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestGetUserBookmarks_FiltersBy
 	user := suite.createTestUser()
 
 	// Create different types of bookmarks
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityVenue, 1, engagementm.BookmarkActionFollow)
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionGoing)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityVenue, 1, engagementm.BookmarkActionFollow))
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionGoing))
 
 	// Should only return show saves
 	bookmarks, total, err := suite.bookmarkService.GetUserBookmarks(user.ID, engagementm.BookmarkEntityShow, engagementm.BookmarkActionSave, 10, 0)
@@ -323,9 +323,9 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestGetUserBookmarks_FiltersBy
 func (suite *BookmarkServiceIntegrationTestSuite) TestGetUserBookmarksByEntityType_Success() {
 	user := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityVenue, 1, engagementm.BookmarkActionFollow)
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityVenue, 2, engagementm.BookmarkActionFollow)
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave) // Different type
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityVenue, 1, engagementm.BookmarkActionFollow))
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityVenue, 2, engagementm.BookmarkActionFollow))
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)) // Different type
 
 	bookmarks, err := suite.bookmarkService.GetUserBookmarksByEntityType(user.ID, engagementm.BookmarkEntityVenue, engagementm.BookmarkActionFollow)
 
@@ -340,8 +340,8 @@ func (suite *BookmarkServiceIntegrationTestSuite) TestGetUserBookmarksByEntityTy
 func (suite *BookmarkServiceIntegrationTestSuite) TestCountUserBookmarks_Success() {
 	user := suite.createTestUser()
 
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave)
-	suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionSave)
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 1, engagementm.BookmarkActionSave))
+	suite.Require().NoError(suite.bookmarkService.CreateBookmark(user.ID, engagementm.BookmarkEntityShow, 2, engagementm.BookmarkActionSave))
 
 	count, err := suite.bookmarkService.CountUserBookmarks(user.ID, engagementm.BookmarkEntityShow, engagementm.BookmarkActionSave)
 

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -961,7 +961,7 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_HiddenNotVisib
 		EntityID:   artistID,
 		Body:       "Will be hidden",
 	})
-	suite.commentService.DeleteComment(user.ID, comment.ID, false)
+	suite.Require().NoError(suite.commentService.DeleteComment(user.ID, comment.ID, false))
 
 	// List should not include hidden comments by default
 	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{})
@@ -1090,12 +1090,14 @@ func (suite *CommentServiceIntegrationTestSuite) TestUpdateComment_EditHistoryAp
 		Body:       "Version 1",
 	})
 
-	suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
+	_, err := suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
 		Body: "Version 2",
 	})
-	suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
+	suite.Require().NoError(err)
+	_, err = suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
 		Body: "Version 3",
 	})
+	suite.Require().NoError(err)
 
 	// Check edit history
 	var edits []engagementm.CommentEdit
@@ -1502,7 +1504,7 @@ func (suite *CommentServiceIntegrationTestSuite) TestRestoreComment_Success() {
 		EntityID:   artistID,
 		Body:       "Hide then restore",
 	})
-	suite.commentService.HideComment(admin.ID, comment.ID, "temp hide")
+	suite.Require().NoError(suite.commentService.HideComment(admin.ID, comment.ID, "temp hide"))
 
 	err := suite.commentService.RestoreComment(admin.ID, comment.ID)
 	suite.Require().NoError(err)

--- a/backend/internal/services/engagement/favorite_venue_test.go
+++ b/backend/internal/services/engagement/favorite_venue_test.go
@@ -165,7 +165,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestUnfavoriteVenue_Succe
 	user := suite.createTestUser()
 	venue := suite.createTestVenue("Unfavorite Me", "Phoenix", "AZ")
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	err := suite.favoriteVenueService.UnfavoriteVenue(user.ID, venue.ID)
 
@@ -197,9 +197,9 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUserFavoriteVenues
 	venue1 := suite.createTestVenue("Fav Venue 1", "Phoenix", "AZ")
 	venue2 := suite.createTestVenue("Fav Venue 2", "Tempe", "AZ")
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue1.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue1.ID))
 	time.Sleep(10 * time.Millisecond)
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue2.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue2.ID))
 
 	resp, total, err := suite.favoriteVenueService.GetUserFavoriteVenues(user.ID, 10, 0)
 
@@ -233,7 +233,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUserFavoriteVenues
 	// Create 1 past show (should not count)
 	suite.createApprovedShowAtVenue("Past Show", venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, -7))
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	resp, _, err := suite.favoriteVenueService.GetUserFavoriteVenues(user.ID, 10, 0)
 
@@ -246,7 +246,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUserFavoriteVenues
 	user := suite.createTestUser()
 	for i := 0; i < 5; i++ {
 		venue := suite.createTestVenue(fmt.Sprintf("Paginated Venue %d", i), "Phoenix", "AZ")
-		suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+		suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 		time.Sleep(5 * time.Millisecond)
 	}
 
@@ -272,8 +272,8 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUserFavoriteVenues
 	venue1 := suite.createTestVenue("User1 Venue", "Phoenix", "AZ")
 	venue2 := suite.createTestVenue("User2 Venue", "Tempe", "AZ")
 
-	suite.favoriteVenueService.FavoriteVenue(user1.ID, venue1.ID)
-	suite.favoriteVenueService.FavoriteVenue(user2.ID, venue2.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user1.ID, venue1.ID))
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user2.ID, venue2.ID))
 
 	resp, total, err := suite.favoriteVenueService.GetUserFavoriteVenues(user1.ID, 10, 0)
 
@@ -291,7 +291,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestIsVenueFavorited_True
 	user := suite.createTestUser()
 	venue := suite.createTestVenue("Fav Check", "Phoenix", "AZ")
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	fav, err := suite.favoriteVenueService.IsVenueFavorited(user.ID, venue.ID)
 
@@ -320,7 +320,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUpcomingShowsFromF
 	suite.createApprovedShowAtVenue("Future Show", venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
 	suite.createApprovedShowAtVenue("Past Show", venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, -7))
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	resp, total, err := suite.favoriteVenueService.GetUpcomingShowsFromFavorites(user.ID, "UTC", 10, 0)
 
@@ -335,7 +335,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUpcomingShowsFromF
 	venue := suite.createTestVenue("Venue Info Venue", "Phoenix", "AZ")
 
 	suite.createApprovedShowAtVenue("Venue Show", venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	resp, _, err := suite.favoriteVenueService.GetUpcomingShowsFromFavorites(user.ID, "UTC", 10, 0)
 
@@ -350,7 +350,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUpcomingShowsFromF
 	venue := suite.createTestVenue("Artist Venue", "Phoenix", "AZ")
 
 	suite.createShowWithArtistAtVenue("Artist Show", venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7), "Cool Band")
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	resp, _, err := suite.favoriteVenueService.GetUpcomingShowsFromFavorites(user.ID, "UTC", 10, 0)
 
@@ -389,7 +389,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUpcomingShowsFromF
 	suite.db.Create(pendingShow)
 	suite.db.Create(&catalogm.ShowVenue{ShowID: pendingShow.ID, VenueID: venue.ID})
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	resp, total, err := suite.favoriteVenueService.GetUpcomingShowsFromFavorites(user.ID, "UTC", 10, 0)
 
@@ -407,8 +407,8 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUpcomingShowsFromF
 	suite.createApprovedShowAtVenue("Show at V1", venue1.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
 	suite.createApprovedShowAtVenue("Show at V2", venue2.ID, user.ID, time.Now().UTC().AddDate(0, 0, 14))
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue1.ID)
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue2.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue1.ID))
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue2.ID))
 
 	resp, total, err := suite.favoriteVenueService.GetUpcomingShowsFromFavorites(user.ID, "UTC", 10, 0)
 
@@ -432,7 +432,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetUpcomingShowsFromF
 		)
 	}
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue.ID))
 
 	resp1, total, err := suite.favoriteVenueService.GetUpcomingShowsFromFavorites(user.ID, "UTC", 2, 0)
 	suite.Require().NoError(err)
@@ -456,8 +456,8 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) TestGetFavoriteVenueIDs_S
 	venue2 := suite.createTestVenue("Batch Venue 2", "Tempe", "AZ")
 	venue3 := suite.createTestVenue("Batch Venue 3", "Mesa", "AZ")
 
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue1.ID)
-	suite.favoriteVenueService.FavoriteVenue(user.ID, venue3.ID)
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue1.ID))
+	suite.Require().NoError(suite.favoriteVenueService.FavoriteVenue(user.ID, venue3.ID))
 
 	result, err := suite.favoriteVenueService.GetFavoriteVenueIDs(user.ID, []uint{venue1.ID, venue2.ID, venue3.ID})
 

--- a/backend/internal/services/engagement/follow_test.go
+++ b/backend/internal/services/engagement/follow_test.go
@@ -331,7 +331,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestUnfollow_Success() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Unfollow Artist")
 
-	suite.followService.Follow(user.ID, "artist", artistID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artistID))
 
 	err := suite.followService.Unfollow(user.ID, "artist", artistID)
 	suite.Require().NoError(err)
@@ -361,7 +361,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestIsFollowing_True() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Following Artist")
 
-	suite.followService.Follow(user.ID, "artist", artistID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artistID))
 
 	result, err := suite.followService.IsFollowing(user.ID, "artist", artistID)
 	suite.Require().NoError(err)
@@ -387,9 +387,9 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetFollowerCount_MultipleFol
 	user3 := suite.createTestUser()
 	artistID := suite.createTestArtist("Popular Artist")
 
-	suite.followService.Follow(user1.ID, "artist", artistID)
-	suite.followService.Follow(user2.ID, "artist", artistID)
-	suite.followService.Follow(user3.ID, "artist", artistID)
+	suite.Require().NoError(suite.followService.Follow(user1.ID, "artist", artistID))
+	suite.Require().NoError(suite.followService.Follow(user2.ID, "artist", artistID))
+	suite.Require().NoError(suite.followService.Follow(user3.ID, "artist", artistID))
 
 	count, err := suite.followService.GetFollowerCount("artist", artistID)
 	suite.Require().NoError(err)
@@ -415,9 +415,9 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetBatchFollowerCounts_Multi
 	artist2ID := suite.createTestArtist("Batch Artist 2")
 	artist3ID := suite.createTestArtist("Batch Artist 3")
 
-	suite.followService.Follow(user1.ID, "artist", artist1ID)
-	suite.followService.Follow(user2.ID, "artist", artist1ID)
-	suite.followService.Follow(user1.ID, "artist", artist2ID)
+	suite.Require().NoError(suite.followService.Follow(user1.ID, "artist", artist1ID))
+	suite.Require().NoError(suite.followService.Follow(user2.ID, "artist", artist1ID))
+	suite.Require().NoError(suite.followService.Follow(user1.ID, "artist", artist2ID))
 
 	result, err := suite.followService.GetBatchFollowerCounts("artist", []uint{artist1ID, artist2ID, artist3ID})
 	suite.Require().NoError(err)
@@ -443,8 +443,8 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetBatchUserFollowing_MixedF
 	artist2ID := suite.createTestArtist("Batch User Artist 2")
 	artist3ID := suite.createTestArtist("Batch User Artist 3")
 
-	suite.followService.Follow(user.ID, "artist", artist1ID)
-	suite.followService.Follow(user.ID, "artist", artist3ID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artist1ID))
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artist3ID))
 
 	result, err := suite.followService.GetBatchUserFollowing(user.ID, "artist", []uint{artist1ID, artist2ID, artist3ID})
 	suite.Require().NoError(err)
@@ -472,9 +472,9 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_ByType() {
 	artist2ID := suite.createTestArtist("Following Artist 2")
 	venueID := suite.createTestVenue("Following Venue")
 
-	suite.followService.Follow(user.ID, "artist", artist1ID)
-	suite.followService.Follow(user.ID, "artist", artist2ID)
-	suite.followService.Follow(user.ID, "venue", venueID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artist1ID))
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artist2ID))
+	suite.Require().NoError(suite.followService.Follow(user.ID, "venue", venueID))
 
 	// Filter by artist
 	following, total, err := suite.followService.GetUserFollowing(user.ID, "artist", 10, 0)
@@ -492,9 +492,9 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_AllTypes() 
 	venueID := suite.createTestVenue("All Types Venue")
 	labelID := suite.createTestLabel("All Types Label")
 
-	suite.followService.Follow(user.ID, "artist", artistID)
-	suite.followService.Follow(user.ID, "venue", venueID)
-	suite.followService.Follow(user.ID, "label", labelID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artistID))
+	suite.Require().NoError(suite.followService.Follow(user.ID, "venue", venueID))
+	suite.Require().NoError(suite.followService.Follow(user.ID, "label", labelID))
 
 	following, total, err := suite.followService.GetUserFollowing(user.ID, "", 10, 0)
 	suite.Require().NoError(err)
@@ -506,7 +506,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_Pagination(
 	user := suite.createTestUser()
 	for i := 0; i < 5; i++ {
 		artistID := suite.createTestArtist(fmt.Sprintf("Paginated Artist %d", i))
-		suite.followService.Follow(user.ID, "artist", artistID)
+		suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artistID))
 	}
 
 	// First page
@@ -534,10 +534,10 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_OrderByFoll
 	artist1ID := suite.createTestArtist("First Followed")
 	artist2ID := suite.createTestArtist("Second Followed")
 
-	suite.followService.Follow(user.ID, "artist", artist1ID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artist1ID))
 	// Small delay to ensure different timestamps
 	time.Sleep(10 * time.Millisecond)
-	suite.followService.Follow(user.ID, "artist", artist2ID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artist2ID))
 
 	following, _, err := suite.followService.GetUserFollowing(user.ID, "artist", 10, 0)
 	suite.Require().NoError(err)
@@ -552,7 +552,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_IncludesNam
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Named Artist")
 
-	suite.followService.Follow(user.ID, "artist", artistID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artistID))
 
 	following, _, err := suite.followService.GetUserFollowing(user.ID, "artist", 10, 0)
 	suite.Require().NoError(err)
@@ -578,7 +578,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetFollowers_ReturnsUserInfo
 	user := suite.createTestUserWithUsername("follower-user")
 	artistID := suite.createTestArtist("Followed Artist")
 
-	suite.followService.Follow(user.ID, "artist", artistID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artistID))
 
 	followers, total, err := suite.followService.GetFollowers("artist", artistID, 10, 0)
 	suite.Require().NoError(err)
@@ -593,7 +593,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetFollowers_Pagination() {
 	artistID := suite.createTestArtist("Paginated Followers Artist")
 	for i := 0; i < 5; i++ {
 		user := suite.createTestUser()
-		suite.followService.Follow(user.ID, "artist", artistID)
+		suite.Require().NoError(suite.followService.Follow(user.ID, "artist", artistID))
 	}
 
 	page1, total, err := suite.followService.GetFollowers("artist", artistID, 2, 0)
@@ -623,7 +623,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_VenueNameSl
 	user := suite.createTestUser()
 	venueID := suite.createTestVenue("The Rebel Lounge")
 
-	suite.followService.Follow(user.ID, "venue", venueID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "venue", venueID))
 
 	following, total, err := suite.followService.GetUserFollowing(user.ID, "venue", 10, 0)
 	suite.Require().NoError(err)
@@ -638,7 +638,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_FestivalNam
 	user := suite.createTestUser()
 	festivalID := suite.createTestFestival("summer-fest")
 
-	suite.followService.Follow(user.ID, "festival", festivalID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "festival", festivalID))
 
 	following, total, err := suite.followService.GetUserFollowing(user.ID, "festival", 10, 0)
 	suite.Require().NoError(err)
@@ -653,7 +653,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetUserFollowing_LabelNameSl
 	user := suite.createTestUser()
 	labelID := suite.createTestLabel("Sub Pop")
 
-	suite.followService.Follow(user.ID, "label", labelID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "label", labelID))
 
 	following, total, err := suite.followService.GetUserFollowing(user.ID, "label", 10, 0)
 	suite.Require().NoError(err)
@@ -669,8 +669,8 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetFollowers_VenueEntityType
 	user2 := suite.createTestUserWithUsername("venue-follower-2")
 	venueID := suite.createTestVenue("Crescent Ballroom")
 
-	suite.followService.Follow(user1.ID, "venue", venueID)
-	suite.followService.Follow(user2.ID, "venue", venueID)
+	suite.Require().NoError(suite.followService.Follow(user1.ID, "venue", venueID))
+	suite.Require().NoError(suite.followService.Follow(user2.ID, "venue", venueID))
 
 	followers, total, err := suite.followService.GetFollowers("venue", venueID, 10, 0)
 	suite.Require().NoError(err)
@@ -682,7 +682,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetFollowers_FestivalEntityT
 	user := suite.createTestUserWithUsername("fest-follower")
 	festivalID := suite.createTestFestival("m3f-fest")
 
-	suite.followService.Follow(user.ID, "festival", festivalID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "festival", festivalID))
 
 	followers, total, err := suite.followService.GetFollowers("festival", festivalID, 10, 0)
 	suite.Require().NoError(err)
@@ -696,7 +696,7 @@ func (suite *FollowServiceIntegrationTestSuite) TestGetBatchFollowerCounts_Venue
 	venue1ID := suite.createTestVenue("Batch Venue 1")
 	venue2ID := suite.createTestVenue("Batch Venue 2")
 
-	suite.followService.Follow(user.ID, "venue", venue1ID)
+	suite.Require().NoError(suite.followService.Follow(user.ID, "venue", venue1ID))
 
 	result, err := suite.followService.GetBatchFollowerCounts("venue", []uint{venue1ID, venue2ID})
 	suite.Require().NoError(err)

--- a/backend/internal/services/engagement/saved_show_test.go
+++ b/backend/internal/services/engagement/saved_show_test.go
@@ -161,7 +161,7 @@ func (suite *SavedShowServiceIntegrationTestSuite) TestUnsaveShow_Success() {
 	user := suite.createTestUser()
 	show := suite.createApprovedShow("Unsave Me", user.ID)
 
-	suite.savedShowService.SaveShow(user.ID, show.ID)
+	suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show.ID))
 
 	err := suite.savedShowService.UnsaveShow(user.ID, show.ID)
 
@@ -194,9 +194,9 @@ func (suite *SavedShowServiceIntegrationTestSuite) TestGetUserSavedShows_Success
 	show1, _, _ := suite.createShowWithVenueAndArtist("Saved Show 1", user.ID)
 	show2, _, _ := suite.createShowWithVenueAndArtist("Saved Show 2", user.ID)
 
-	suite.savedShowService.SaveShow(user.ID, show1.ID)
+	suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show1.ID))
 	time.Sleep(10 * time.Millisecond) // ensure different saved_at
-	suite.savedShowService.SaveShow(user.ID, show2.ID)
+	suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show2.ID))
 
 	resp, total, err := suite.savedShowService.GetUserSavedShows(user.ID, 10, 0)
 
@@ -223,7 +223,7 @@ func (suite *SavedShowServiceIntegrationTestSuite) TestGetUserSavedShows_Include
 	user := suite.createTestUser()
 	show, venue, artist := suite.createShowWithVenueAndArtist("Full Show", user.ID)
 
-	suite.savedShowService.SaveShow(user.ID, show.ID)
+	suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show.ID))
 
 	resp, _, err := suite.savedShowService.GetUserSavedShows(user.ID, 10, 0)
 
@@ -239,7 +239,7 @@ func (suite *SavedShowServiceIntegrationTestSuite) TestGetUserSavedShows_Paginat
 	user := suite.createTestUser()
 	for i := 0; i < 5; i++ {
 		show := suite.createApprovedShow(fmt.Sprintf("Paginated Show %d", i), user.ID)
-		suite.savedShowService.SaveShow(user.ID, show.ID)
+		suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show.ID))
 		time.Sleep(5 * time.Millisecond)
 	}
 
@@ -269,8 +269,8 @@ func (suite *SavedShowServiceIntegrationTestSuite) TestGetUserSavedShows_OnlyOwn
 	show1 := suite.createApprovedShow("User1 Show", user1.ID)
 	show2 := suite.createApprovedShow("User2 Show", user2.ID)
 
-	suite.savedShowService.SaveShow(user1.ID, show1.ID)
-	suite.savedShowService.SaveShow(user2.ID, show2.ID)
+	suite.Require().NoError(suite.savedShowService.SaveShow(user1.ID, show1.ID))
+	suite.Require().NoError(suite.savedShowService.SaveShow(user2.ID, show2.ID))
 
 	resp, total, err := suite.savedShowService.GetUserSavedShows(user1.ID, 10, 0)
 
@@ -288,7 +288,7 @@ func (suite *SavedShowServiceIntegrationTestSuite) TestIsShowSaved_True() {
 	user := suite.createTestUser()
 	show := suite.createApprovedShow("Saved Check", user.ID)
 
-	suite.savedShowService.SaveShow(user.ID, show.ID)
+	suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show.ID))
 
 	saved, err := suite.savedShowService.IsShowSaved(user.ID, show.ID)
 
@@ -316,8 +316,8 @@ func (suite *SavedShowServiceIntegrationTestSuite) TestGetSavedShowIDs_Success()
 	show2 := suite.createApprovedShow("Batch Show 2", user.ID)
 	show3 := suite.createApprovedShow("Batch Show 3", user.ID)
 
-	suite.savedShowService.SaveShow(user.ID, show1.ID)
-	suite.savedShowService.SaveShow(user.ID, show3.ID)
+	suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show1.ID))
+	suite.Require().NoError(suite.savedShowService.SaveShow(user.ID, show3.ID))
 
 	result, err := suite.savedShowService.GetSavedShowIDs(user.ID, []uint{show1.ID, show2.ID, show3.ID})
 


### PR DESCRIPTION
## Summary
- Convert 276 testify-suite bare-error-return drops in backend test files into `require.NoError` wraps so silent setup failures surface loudly instead of passing partially-built state into assertions.
- Production code untouched. errcheck remains advisory in `backend/.golangci-advisory.yml`.

Phase 1 of 4 in the PSY-833 errcheck graduation series. errcheck STAYS advisory after this PR; graduation in Phase 4 (PSY-849).

## Re-baseline
Suite-X drop subset before: 276. After: 0.
Full errcheck before: 482. After: 206 (remaining for Phases 2-4).

## Per-file changes
| file | drops converted | tests now failing | bugs surfaced |
|---|---:|---:|---:|
| catalog/artist_relationship_service_test.go | 31 | 0 | 0 |
| engagement/follow_test.go | 29 | 0 | 0 |
| catalog/tag_service_test.go | 28 | 0 | 0 |
| catalog/festival_test.go | 26 | 0 | 0 |
| engagement/attendance_test.go | 22 | 0 | 0 |
| catalog/artist_test.go | 20 | 0 | 0 |
| engagement/bookmark_test.go | 18 | 0 | 0 |
| catalog/release_test.go | 18 | 0 | 0 |
| engagement/favorite_venue_test.go | 17 | 0 | 0 |
| catalog/venue_test.go | 15 | 0 | 0 |
| community/collection_test.go | 14 | 0 | 0 |
| engagement/saved_show_test.go | 10 | 0 | 0 |
| catalog/label_test.go | 9 | 0 | 0 |
| admin/artist_report_test.go | 8 | 0 | 0 |
| admin/show_report_test.go | 7 | 0 | 0 |
| engagement/comment_service_test.go | 4 | 0 | 0 |

## Bugs surfaced (real test infra issues fixed, not papered over)
No bugs surfaced — all 276 wraps were trivial NoError. The underlying service calls have been quietly succeeding in setup; the goal here is simply to surface any future regression that flips that.

## Codemod shape
- Error-only returns (`Follow`, `Vote`, `Subscribe`, etc.) → inline `suite.Require().NoError(suite.X.Y(...))`.
- `(*X, error)` returns (`CreateRelationship`, `AddTagToEntity`, `CreateFestival`, etc.) → two-statement `_, err := suite.X.Y(...); suite.Require().NoError(err)`. Subsequent siblings within the same function use `_, err =` to avoid `:=` redeclaration.
- Local style preserved: every affected suite already used `suite.Require().NoError(err)` rather than `require.NoError(suite.T(), err)`.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./...` — passed (all 35+ packages)
- [x] `cd backend && ~/go/bin/golangci-lint run --no-config --enable-only=errcheck --max-issues-per-linter=0 --max-same-issues=0 ./...` — suite-X subset count dropped from 276 to 0; full errcheck count dropped from 482 to 206
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues (no new gated linter regression)

## Manual repro
Backend test-code change; no dev stack needed. Pre: 276 suite-X drops + 482 total errcheck. Post: 0 suite-X + 206 total. Bugs surfaced: 0.

## Simplify
Reviewed three concerns (reuse / quality / efficiency); mechanical test-only wraps introduce no new helpers, conditionals, or hot-path work. Mixed inline-vs-two-statement style across the same file is intentional — signals the underlying signature (error-only vs `(*X, error)`).

Closes PSY-846