### PR TITLE
PSY-852: fix Codecov frontend coverage upload + flag pollution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
         with:
           files: backend/coverage.out
           flags: backend
+          disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # PSY-772: backend lint gate. Two steps, two configs:
@@ -241,6 +242,8 @@ jobs:
         with:
           files: frontend/coverage/lcov.info
           flags: frontend
+          disable_search: true
+          working-directory: ./frontend
           token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-smoke:


### PR DESCRIPTION
## Summary

- Codecov dashboard was showing only `backend/` in the file tree because the frontend `lcov.info` uses paths relative to `frontend/` (e.g. `SF:app/global-error.tsx`) and `codecov-action@v5` couldn't match them to repo files without a `working-directory` prefix.
- Both upload steps were also auto-discovering every `*.out` in the workspace (the `files:` param doesn't restrict — it adds), tagging 8 backend coverage files with the `frontend` flag and vice versa.
- Adds `disable_search: true` to both upload steps and `working-directory: ./frontend` to the frontend step. Three additive lines.

## Test plan

- [ ] After merge, a CI run on `main` shows `Found 1 coverage files to report` in both upload step logs (not 8–9)
- [ ] Codecov file tree at app.codecov.io/gh/mtrifilo/psychic-homily-web shows both `backend/` and `frontend/` directories
- [ ] `frontend` flag in Codecov reports frontend-only line counts
- [ ] `backend` flag in Codecov reports backend-only line counts

Closes PSY-852

🤖 Generated with [Claude Code](https://claude.com/claude-code)