### PR TITLE
PSY-851: fix E2E auth-hydration race in follow-and-attendance smoke spec

### DIFF
--- a/frontend/e2e/pages/follow-and-attendance.spec.ts
+++ b/frontend/e2e/pages/follow-and-attendance.spec.ts
@@ -1,9 +1,23 @@
+import { type Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
 import {
   resetTestFixtures,
   lookupWorkerUserId,
 } from '../fixtures/test-fixtures-reset'
 import { USER_COUNT, userAuthFileForWorker } from '../global-setup'
+
+// Auth-gated buttons (FollowButton, AttendanceButton) redirect to /auth
+// when useAuthContext returns isAuthenticated=false at click time. The
+// buttons render regardless of auth state (only tooltip copy differs),
+// so visibility checks don't gate against the SSR-pre-hydration → client
+// propagation race window. The sidebar's "Library" link is rendered only
+// when isAuthenticated=true (Sidebar.tsx), so waiting on it is a reliable
+// signal that auth has propagated before we click an auth-gated button.
+async function waitForAuthHydrated(page: Page) {
+  await expect(
+    page.getByRole('link', { name: 'Library' })
+  ).toBeVisible({ timeout: 10_000 })
+}
 
 // PSY-457: backfill E2E coverage for follow + going/interested flows.
 // PSY-430: pin to reserved artist + show seeded by setup-db.sh so parallel
@@ -53,6 +67,8 @@ test.describe('Follow and attendance', () => {
         name: RESERVED_ARTIST_NAME,
       })
     ).toBeVisible({ timeout: 10_000 })
+
+    await waitForAuthHydrated(authenticatedPage)
 
     // FollowButton on the artist detail page renders as a BracketLink
     // (variant="bracket" since PSY-641). The bracket variant uses the
@@ -107,6 +123,8 @@ test.describe('Follow and attendance', () => {
       })
     ).toBeVisible({ timeout: 10_000 })
 
+    await waitForAuthHydrated(authenticatedPage)
+
     // Clicking the [Following] bracket link while isFollowing=true triggers
     // unfollow. Bracket variant has no hover-to-Unfollow state, so the
     // accessible name stays "Following" until the click resolves.
@@ -140,6 +158,8 @@ test.describe('Follow and attendance', () => {
         .getByRole('navigation', { name: 'Breadcrumb' })
         .getByText(RESERVED_SHOW_TITLE)
     ).toBeVisible({ timeout: 10_000 })
+
+    await waitForAuthHydrated(authenticatedPage)
 
     // Going button initial state: no count suffix on a fresh reserved show
     // (accessible name = "Going").
@@ -185,6 +205,8 @@ test.describe('Follow and attendance', () => {
         .getByRole('navigation', { name: 'Breadcrumb' })
         .getByText(RESERVED_SHOW_TITLE)
     ).toBeVisible({ timeout: 10_000 })
+
+    await waitForAuthHydrated(authenticatedPage)
 
     await Promise.all([
       authenticatedPage.waitForResponse(


### PR DESCRIPTION
## Summary
- Test-only fix for the `follow-and-attendance.spec.ts` smoke flake first observed on [PR #811](https://github.com/mtrifilo/psychic-homily-web/pull/811).
- Adds `waitForAuthHydrated(page)` helper that waits for the sidebar's auth-only "Library" link before each auth-gated click block (4 sites: initial action + cleanup in each of the 2 tests).

## Why
`AttendanceButton.tsx:51-55` (and `FollowButton` with the same shape) redirect to `/auth` when `useAuthContext()` returns `isAuthenticated=false` at click time:

```ts
if (!isAuthenticated) {
  router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)
  return
}
```

The buttons render regardless of auth state (only tooltip copy differs — "Mark as going" vs "Sign in to RSVP"), so the test's existing `expect(button).toBeVisible()` check passes BEFORE the auth context has resolved on the client. PSY-841 added SSR auth pre-hydration via `<AuthHydrator>` + `<Suspense>`, but a residual window between DOM-paint and `useAuthContext` propagation remains. Under that window, the click handler reads `isAuthenticated: false` and pushes to `/auth` instead of POSTing → `waitForResponse` never matches → 10s timeout (failure observed twice — both retries).

The sidebar's "Library" link only renders when `isAuthenticated=true` (`Sidebar.tsx`), making it a reliable signal that auth has propagated.

## Scope
- `frontend/e2e/pages/follow-and-attendance.spec.ts` — added `Page` type import, `waitForAuthHydrated` helper, and 4 call sites. 22 inserts, 0 deletes. No production code touched.

## Out of scope (potential follow-ups)
- Promoting `waitForAuthHydrated` to a shared `fixtures/` helper if other E2E specs hit the same race.
- Component-level fix (`AttendanceButton` / `FollowButton`): disable until `useAuthContext` returns `loading=false`, or show a loading state. Semantically cleaner but larger change.

## Test plan
- [x] `bun run typecheck` — passed
- [x] `/code-review` — N/A: low-effort review explicitly skips test/spec files per the loaded skill; diff is 100% in `frontend/e2e/pages/follow-and-attendance.spec.ts` (test file). Self-reviewed: helper signature correct, all 4 sites placed after navigation/visibility check + before `Promise.all(waitForResponse + click)`, sidebar Library link is the right auth-gated selector.

## Manual repro
**Cannot directly reproduce the flake locally** — same caveat as PSY-781's `EntityTagList` flake fix. The race is timing-sensitive under CI parallel load; local single-spec runs pass 100% in isolation. Structural fix per the root-cause mechanism documented in the commit body.

Recommend: 3 consecutive CI Smoke runs to confirm no flake before merge. If the same shape recurs, escalate to a component-level fix per the "Out of scope" section above.

## Note for the merge
This PR was opened with `CLAUDE_SKIP_SIMPLIFY_CHECK=1` because the session's harness loaded the legacy `/simplify` hook at session start (pre-PSY-844 rename merge). Future sessions started against current main pick up the renamed `/code-review` hook automatically.

Closes PSY-851
