### PR TITLE
PSY-842: wrap 2xx JSON parse failures in ApiError

### DIFF
--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -499,26 +499,41 @@ describe('API Module', () => {
       )
     })
 
-    // Documents current behavior: success-path JSON.parse failures propagate
-    // as SyntaxError, unlike the error path which falls back to a generic
-    // message. Tracked separately for graceful handling.
-    it('propagates JSON parse errors on 200 success responses', async () => {
+    // PSY-842: success-path JSON parse failures are wrapped in the same
+    // ApiError envelope as the error path so callers get status/requestId/
+    // endpoint context instead of a bare SyntaxError leaking JSON.parse
+    // internals to the UI.
+    it('wraps JSON parse errors on 2xx responses in an ApiError', async () => {
       const parseError = new SyntaxError(
         'Unexpected token < in JSON at position 0'
       )
+      const headers = new Headers()
+      headers.set('X-Request-ID', 'req-parse-2xx')
       const mockResponse = {
         ok: true,
         status: 200,
+        statusText: 'OK',
         json: () => Promise.reject(parseError),
-        headers: new Headers(),
+        headers,
       }
       vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response)
 
       const { apiRequest } = await import('./api')
 
-      await expect(apiRequest('/test')).rejects.toThrow(
-        'Unexpected token < in JSON at position 0'
-      )
+      try {
+        await apiRequest('/test')
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect(error).not.toBeInstanceOf(SyntaxError)
+        expect((error as { status: number }).status).toBe(200)
+        expect((error as { statusText: string }).statusText).toBe('OK')
+        expect((error as { requestId: string }).requestId).toBe('req-parse-2xx')
+        expect((error as Error).message).toContain('Invalid JSON')
+        expect((error as Error).message).toContain('/test')
+        // Original parse error preserved as details for debuggability.
+        expect((error as { details: unknown }).details).toBe(parseError)
+      }
     })
   })
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -582,8 +582,36 @@ export const apiRequest = async <T = unknown>(
     return undefined as T
   }
 
-  // Parse successful response
-  const data = (await response.json()) as T
+  // Parse successful response. A 2xx with a non-JSON body (misconfigured
+  // proxy returning HTML, gateway page, truncated stream, etc.) must
+  // surface as an ApiError so callers get the same structured envelope as
+  // the error path — bare SyntaxError leaks `JSON.parse` internals to the
+  // UI with no status/requestId/endpoint context.
+  let data: T
+  try {
+    data = (await response.json()) as T
+  } catch (parseError) {
+    const parseMessage =
+      parseError instanceof Error ? parseError.message : String(parseError)
+    const message = `Invalid JSON in successful response from ${endpointPath} (HTTP ${response.status}): ${parseMessage}`
+
+    authLogger.error(
+      'API response parse failed',
+      parseError instanceof Error ? parseError : new Error(parseMessage),
+      {
+        endpoint: endpointPath,
+        status: response.status,
+      },
+      requestId
+    )
+
+    const apiError: ApiError = new Error(message)
+    apiError.status = response.status
+    apiError.statusText = response.statusText
+    apiError.requestId = requestId
+    apiError.details = parseError
+    throw apiError
+  }
 
   // Inject request ID from header if not in response body (if data is an object)
   if (requestId && data && typeof data === 'object') {


### PR DESCRIPTION
## Summary
- Wrap `apiRequest`'s success-path `response.json()` parse in the same `ApiError` shape as the error path. A 2xx response with a non-JSON body (misconfigured proxy returning HTML, gateway error page, truncated stream) used to surface a raw `SyntaxError` — no `status`, no `requestId`, no endpoint context. Now callers get a typed `ApiError` with the actual 2xx status, the response's request ID, and an endpoint-aware message.
- Original `SyntaxError` preserved as `ApiError.details` for debuggability.
- Failure routed through `authLogger.error` to match observability on the error path.
- The existing test `propagates JSON parse errors on 200 success responses` (added in PSY-709 to document the unwanted behavior) flipped to assert the new graceful shape.

## Why
204 No Content path already short-circuits before `response.json()` runs, so empty 204 responses were not affected. But every other 2xx with a malformed body was a bare-SyntaxError-throw — useless for callers + Sentry. The error path at `api.ts:468` already catches parse failures and falls back to a generic message; this PR brings the success path to parity.

## Scope
- `frontend/lib/api.ts` — try/catch around `await response.json()` on the success branch; ApiError build with status / statusText / requestId / details / endpoint-aware message; `authLogger.error` call mirroring the error path.
- `frontend/lib/api.test.ts` — existing 200-non-JSON test flipped to assert the new shape (ApiError, status 200, message includes "Invalid JSON in successful response").

## Test plan
- [x] `bun run test:run lib/api` — passed (38/38: 33 in api.test.ts + 5 in api-base.test.ts)
- [x] `bun run typecheck` — clean
- [x] `/code-review` — clean (0 findings; max-effort 5-angle review confirmed implementation correctly mirrors the error-path pattern, test correctly asserts the new shape, no callers break)
- [x] **Local verification before push** (per the local-test-before-push convention): tests run in the agent's worktree before push. Orchestrator re-verified after stall-takeover for the push step.

## Manual repro
Unit-test additions. Manual repro = the flipped test:
- `propagates JSON parse errors on 200 success responses` now asserts the thrown error has `status === 200`, message includes `"Invalid JSON in successful response from /test (HTTP 200)"`, and the original SyntaxError is preserved as `details`.

## Note for the merge
Agent stalled after committing + running /code-review; orchestrator took over the push + PR step per psy-dispatch's stall-takeover carveout. Tests re-verified locally before push to confirm no drift since commit.

Closes PSY-842
