### PR TITLE
PSY-780: consolidate formatTimeAgo + location helpers

### DIFF
--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -5,6 +5,8 @@
  * from backend/internal/services/artist.go
  */
 
+import { formatLocation } from '@/lib/formatLocation'
+
 export interface ArtistSocial {
   instagram: string | null
   facebook: string | null
@@ -116,30 +118,14 @@ export interface ArtistSearchResponse {
 /**
  * Get a formatted location string for an artist (PSY-558 display rule).
  *
- * Country is included unless state is set AND country is "USA"/"US" — local
- * audiences read "Phoenix, AZ" as US-implicit, so adding "USA" is noise.
- * International artists ("Melbourne, Australia", "London, England, UK",
- * "Tokyo, Japan") always render the country since the state cue alone is
- * not enough to locate them.
- *
- * Comparison is case-insensitive and trimmed; either spelling ("USA"/"US")
- * triggers the suppression. Parameter is structurally typed (city/state/country
- * only) so callers with a narrower row shape — e.g. the ArtistSidebar prop —
- * can pass directly without a cast.
+ * Thin wrapper around the shared `formatLocation` helper — see
+ * `lib/formatLocation.ts` for the full rule. Kept as a named export so
+ * artist call sites and tests don't need to import from `lib/` directly
+ * and the structural type is conveniently labeled "artist" at the call site.
  */
 export const getArtistLocation = (
   artist: { city?: string | null; state?: string | null; country?: string | null },
-): string => {
-  const parts = [artist.city, artist.state].filter(Boolean) as string[]
-  const country = artist.country?.trim() ?? ''
-  const stateSet = !!artist.state
-  const countryIsUS =
-    country.toUpperCase() === 'USA' || country.toUpperCase() === 'US'
-  if (country && !(stateSet && countryIsUS)) {
-    parts.push(country)
-  }
-  return parts.length > 0 ? parts.join(', ') : 'Location Unknown'
-}
+): string => formatLocation(artist)
 
 /**
  * Venue info in artist show response

--- a/frontend/features/notifications/types.test.ts
+++ b/frontend/features/notifications/types.test.ts
@@ -94,54 +94,22 @@ describe('formatTimeAgo', () => {
     return formatTimeAgo(new Date(NOW.getTime() - ms).toISOString())
   }
 
+  // Smoke test — full behavior is covered in lib/formatTimeAgo.test.ts. The
+  // notifications module re-exports the shared helper (PSY-780); these cases
+  // pin the integration so a future divergence is caught here too.
   it('returns "just now" under a minute', () => {
     expect(ago(30 * SECOND)).toBe('just now')
-  })
-
-  it('singularizes one minute', () => {
-    expect(ago(MINUTE)).toBe('1 minute ago')
-  })
-
-  it('pluralizes minutes', () => {
-    expect(ago(5 * MINUTE)).toBe('5 minutes ago')
-  })
-
-  it('singularizes one hour', () => {
-    expect(ago(HOUR)).toBe('1 hour ago')
-  })
-
-  it('pluralizes hours', () => {
-    expect(ago(3 * HOUR)).toBe('3 hours ago')
-  })
-
-  it('singularizes one day', () => {
-    expect(ago(DAY)).toBe('1 day ago')
-  })
-
-  it('pluralizes days', () => {
-    expect(ago(3 * DAY)).toBe('3 days ago')
-  })
-
-  it('singularizes one week', () => {
-    expect(ago(WEEK)).toBe('1 week ago')
   })
 
   it('pluralizes weeks', () => {
     expect(ago(3 * WEEK)).toBe('3 weeks ago')
   })
 
-  it('falls back to an absolute date at five weeks (no month branch)', () => {
-    // This formatter has no "months ago" branch — once diffWeeks reaches 5 it
-    // drops straight to a localized absolute date. Compare against the same
-    // toLocaleDateString call so the assertion is timezone-independent.
-    const old = new Date(NOW.getTime() - 5 * WEEK)
-    expect(ago(5 * WEEK)).toBe(
-      old.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-      })
-    )
+  it('rolls over to months at 35 days (PSY-780 consolidation)', () => {
+    // Previously the notifications copy dropped to an absolute date at 5 weeks;
+    // the consolidated helper renders "1 month ago" at 35 days, matching the
+    // requests-feature behavior.
+    expect(ago(35 * DAY)).toBe('1 month ago')
   })
 })
 

--- a/frontend/features/notifications/types.ts
+++ b/frontend/features/notifications/types.ts
@@ -1,5 +1,7 @@
 // Notification filter types — aligned with backend contracts/notification_filter.go response types.
 
+import { formatTimeAgo as sharedFormatTimeAgo } from '@/lib/formatTimeAgo'
+
 /** City criteria for notification filter */
 export interface FilterCity {
   city: string
@@ -119,32 +121,14 @@ export interface UpdateFilterInput {
 export const NOTIFY_ENTITY_TYPES = ['artist', 'venue', 'label', 'tag'] as const
 export type NotifyEntityType = (typeof NOTIFY_ENTITY_TYPES)[number]
 
-/** Helper: format relative time for last_matched_at */
-export function formatTimeAgo(dateString: string): string {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffSeconds = Math.floor(diffMs / 1000)
-  const diffMinutes = Math.floor(diffSeconds / 60)
-  const diffHours = Math.floor(diffMinutes / 60)
-  const diffDays = Math.floor(diffHours / 24)
-  const diffWeeks = Math.floor(diffDays / 7)
-
-  if (diffSeconds < 60) return 'just now'
-  if (diffMinutes === 1) return '1 minute ago'
-  if (diffMinutes < 60) return `${diffMinutes} minutes ago`
-  if (diffHours === 1) return '1 hour ago'
-  if (diffHours < 24) return `${diffHours} hours ago`
-  if (diffDays === 1) return '1 day ago'
-  if (diffDays < 7) return `${diffDays} days ago`
-  if (diffWeeks === 1) return '1 week ago'
-  if (diffWeeks < 5) return `${diffWeeks} weeks ago`
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
-}
+/**
+ * Helper: format relative time for last_matched_at.
+ *
+ * Re-exports the canonical `formatTimeAgo` (PSY-780). Prior copy was missing
+ * the month branch, so anything older than 5 weeks dropped straight to an
+ * absolute date — the divergence was accidental, not a deliberate UX choice.
+ */
+export const formatTimeAgo = sharedFormatTimeAgo
 
 /** Helper: build a human-readable summary of filter criteria */
 export function getFilterSummary(filter: NotificationFilter): string {

--- a/frontend/features/requests/types.test.ts
+++ b/frontend/features/requests/types.test.ts
@@ -155,55 +155,28 @@ describe('formatTimeAgo', () => {
   const DAY = 24 * HOUR
   const WEEK = 7 * DAY
 
+  // Smoke test — full behavior is covered in lib/formatTimeAgo.test.ts. The
+  // requests module re-exports the shared helper (PSY-780); these cases pin
+  // the months-aware path that previously lived only in this file.
   it('returns "just now" under a minute', () => {
     expect(ago(30 * SECOND)).toBe('just now')
-  })
-
-  it('singularizes one minute', () => {
-    expect(ago(MINUTE)).toBe('1 minute ago')
-  })
-
-  it('pluralizes minutes', () => {
-    expect(ago(5 * MINUTE)).toBe('5 minutes ago')
-  })
-
-  it('singularizes one hour', () => {
-    expect(ago(HOUR)).toBe('1 hour ago')
-  })
-
-  it('pluralizes hours', () => {
-    expect(ago(3 * HOUR)).toBe('3 hours ago')
-  })
-
-  it('singularizes one day', () => {
-    expect(ago(DAY)).toBe('1 day ago')
-  })
-
-  it('pluralizes days', () => {
-    expect(ago(3 * DAY)).toBe('3 days ago')
-  })
-
-  it('singularizes one week', () => {
-    expect(ago(WEEK)).toBe('1 week ago')
   })
 
   it('pluralizes weeks', () => {
     expect(ago(3 * WEEK)).toBe('3 weeks ago')
   })
 
-  it('singularizes one month', () => {
+  it('singularizes one month at 35 days', () => {
     // The month branch is only reachable once the week count reaches 5
     // (diffWeeks < 5 short-circuits first), so 35 days is the floor for
     // "1 month ago" rather than 31.
     expect(ago(35 * DAY)).toBe('1 month ago')
   })
 
-  it('pluralizes months', () => {
-    expect(ago(90 * DAY)).toBe('3 months ago')
-  })
-
   it('falls back to an absolute date past a year', () => {
-    // ~13 months ago — beyond the relative window, so it returns formatDate().
-    expect(ago(400 * DAY)).toBe(formatDate(new Date(NOW.getTime() - 400 * DAY).toISOString()))
+    // ~13 months ago — beyond the relative window, so it matches formatDate().
+    expect(ago(400 * DAY)).toBe(
+      formatDate(new Date(NOW.getTime() - 400 * DAY).toISOString())
+    )
   })
 })

--- a/frontend/features/requests/types.ts
+++ b/frontend/features/requests/types.ts
@@ -1,5 +1,7 @@
 // Request types — aligned with backend contracts/request.go response types.
 
+import { formatTimeAgo as sharedFormatTimeAgo } from '@/lib/formatTimeAgo'
+
 export const REQUEST_ENTITY_TYPES = [
   'artist',
   'release',
@@ -131,31 +133,15 @@ export function getStatusColor(status: string): string {
   }
 }
 
-/** Helper: format a date string as relative time (e.g., "3 hours ago") */
-export function formatTimeAgo(dateString: string): string {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffSeconds = Math.floor(diffMs / 1000)
-  const diffMinutes = Math.floor(diffSeconds / 60)
-  const diffHours = Math.floor(diffMinutes / 60)
-  const diffDays = Math.floor(diffHours / 24)
-  const diffWeeks = Math.floor(diffDays / 7)
-  const diffMonths = Math.floor(diffDays / 30)
-
-  if (diffSeconds < 60) return 'just now'
-  if (diffMinutes === 1) return '1 minute ago'
-  if (diffMinutes < 60) return `${diffMinutes} minutes ago`
-  if (diffHours === 1) return '1 hour ago'
-  if (diffHours < 24) return `${diffHours} hours ago`
-  if (diffDays === 1) return '1 day ago'
-  if (diffDays < 7) return `${diffDays} days ago`
-  if (diffWeeks === 1) return '1 week ago'
-  if (diffWeeks < 5) return `${diffWeeks} weeks ago`
-  if (diffMonths === 1) return '1 month ago'
-  if (diffMonths < 12) return `${diffMonths} months ago`
-  return formatDate(dateString)
-}
+/**
+ * Helper: format a date string as relative time (e.g., "3 hours ago").
+ *
+ * Re-exports the canonical `formatTimeAgo` (PSY-780) — the months-aware
+ * implementation that previously lived only in this file. Past ~12 months
+ * the shared helper falls back to the same `month: short, day, year`
+ * format as `formatDate`, so the visible output for callers is unchanged.
+ */
+export const formatTimeAgo = sharedFormatTimeAgo
 
 /** Helper: format a date string as "Jan 5, 2026" */
 export function formatDate(dateString: string): string {

--- a/frontend/features/venues/types.test.ts
+++ b/frontend/features/venues/types.test.ts
@@ -27,9 +27,20 @@ describe('getVenueLocation', () => {
     )
   })
 
-  it('still renders the separator when a part is an empty string', () => {
-    // The helper is a plain template join with no null/empty guard; an empty
-    // state leaves a trailing ", " so callers can spot missing data.
-    expect(getVenueLocation(venue({ state: '' }))).toBe('Phoenix, ')
+  it('drops the separator when state is empty (PSY-780 fix)', () => {
+    // Previously the helper rendered "Phoenix, " (trailing comma + space) for
+    // venues with a missing state. Now delegates to the shared formatLocation
+    // helper, which filters empty parts before joining.
+    expect(getVenueLocation(venue({ state: '' }))).toBe('Phoenix')
+  })
+
+  it('renders only the state when city is empty', () => {
+    expect(getVenueLocation(venue({ city: '', state: 'AZ' }))).toBe('AZ')
+  })
+
+  it('returns "Location Unknown" when both city and state are empty', () => {
+    expect(getVenueLocation(venue({ city: '', state: '' }))).toBe(
+      'Location Unknown'
+    )
   })
 })

--- a/frontend/features/venues/types.ts
+++ b/frontend/features/venues/types.ts
@@ -102,12 +102,12 @@ export interface VenueCitiesResponse {
  *
  * Delegates to the shared `formatLocation` helper (PSY-780) so empty/missing
  * state no longer leaves a trailing ", " in the UI. The `Venue` model does
- * not (yet) carry a country field, so the PSY-558 country-suppression rule
- * is a no-op here — but the helper accepts it structurally, so adding
- * `country` to `Venue` later requires no change to this call site.
+ * not currently carry a `country` field, so the PSY-558 country-suppression
+ * rule is a no-op here today. `Venue` is passed directly (structural typing)
+ * so when `country` is added to the model the field will flow through this
+ * helper without further changes here.
  */
-export const getVenueLocation = (venue: Venue): string =>
-  formatLocation({ city: venue.city, state: venue.state })
+export const getVenueLocation = (venue: Venue): string => formatLocation(venue)
 
 // ============================================================================
 // Venue Editing Types

--- a/frontend/features/venues/types.ts
+++ b/frontend/features/venues/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ArtistResponse } from '@/features/shows'
+import { formatLocation } from '@/lib/formatLocation'
 
 export interface Venue {
   id: number
@@ -97,11 +98,16 @@ export interface VenueCitiesResponse {
 }
 
 /**
- * Get a formatted location string for a venue
+ * Get a formatted location string for a venue.
+ *
+ * Delegates to the shared `formatLocation` helper (PSY-780) so empty/missing
+ * state no longer leaves a trailing ", " in the UI. The `Venue` model does
+ * not (yet) carry a country field, so the PSY-558 country-suppression rule
+ * is a no-op here — but the helper accepts it structurally, so adding
+ * `country` to `Venue` later requires no change to this call site.
  */
-export const getVenueLocation = (venue: Venue): string => {
-  return `${venue.city}, ${venue.state}`
-}
+export const getVenueLocation = (venue: Venue): string =>
+  formatLocation({ city: venue.city, state: venue.state })
 
 // ============================================================================
 // Venue Editing Types

--- a/frontend/lib/ensureUTC.ts
+++ b/frontend/lib/ensureUTC.ts
@@ -1,0 +1,22 @@
+/**
+ * Ensures a date string is treated as UTC.
+ *
+ * The backend formats timestamps with a literal "Z" suffix (e.g.
+ * "2026-03-30T10:00:00Z"), which `new Date()` correctly interprets
+ * as UTC.  However, if a timestamp ever arrives without a timezone
+ * indicator, `new Date()` treats it as *local* time, which introduces
+ * an offset equal to the user's UTC difference (e.g. 7 hours in
+ * Arizona / MST).
+ *
+ * This helper appends "Z" when the string lacks any timezone suffix
+ * so the value is always parsed as UTC. Originally introduced as a
+ * private helper for `formatRelativeTime` (PSY-255); extracted (PSY-780)
+ * so the same rule applies to every relative-time formatter in the app.
+ */
+export function ensureUTC(dateStr: string): Date {
+  // Already has a timezone indicator: ends with "Z", or has a +/-HH:MM / +/-HHMM offset
+  if (/Z$|[+-]\d{2}:\d{2}$|[+-]\d{4}$/.test(dateStr)) {
+    return new Date(dateStr)
+  }
+  return new Date(dateStr + 'Z')
+}

--- a/frontend/lib/formatLocation.test.ts
+++ b/frontend/lib/formatLocation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { formatLocation } from './formatLocation'
+
+describe('formatLocation (canonical PSY-780, PSY-558 rule)', () => {
+  // Trailing-comma guards — the original `getVenueLocation` bug that motivated
+  // PSY-780. Each variant of "one or more parts missing" should drop the
+  // empty piece rather than rendering a stray separator.
+  describe('trailing-separator guards', () => {
+    it('returns "city" when state and country are absent', () => {
+      expect(formatLocation({ city: 'Phoenix' })).toBe('Phoenix')
+    })
+
+    it('returns "state" when city and country are absent', () => {
+      expect(formatLocation({ state: 'AZ' })).toBe('AZ')
+    })
+
+    it('drops empty-string state', () => {
+      expect(formatLocation({ city: 'Phoenix', state: '' })).toBe('Phoenix')
+    })
+
+    it('drops whitespace-only city', () => {
+      expect(formatLocation({ city: '  ', state: 'AZ' })).toBe('AZ')
+    })
+
+    it('returns "Location Unknown" when every part is missing', () => {
+      expect(formatLocation({})).toBe('Location Unknown')
+    })
+
+    it('returns "Location Unknown" when every part is null', () => {
+      expect(
+        formatLocation({ city: null, state: null, country: null })
+      ).toBe('Location Unknown')
+    })
+
+    it('returns "Location Unknown" when every part is empty/whitespace', () => {
+      expect(formatLocation({ city: '', state: '   ', country: '' })).toBe(
+        'Location Unknown'
+      )
+    })
+  })
+
+  // PSY-558 country-suppression rule. "Phoenix, AZ" reads as US-implicit to
+  // local users; "Phoenix, AZ, USA" is noise. International artists always
+  // render the country since the state cue alone isn't a sufficient locator.
+  describe('PSY-558 country-suppression rule', () => {
+    it('suppresses "USA" for a domestic city + state', () => {
+      expect(
+        formatLocation({ city: 'Phoenix', state: 'AZ', country: 'USA' })
+      ).toBe('Phoenix, AZ')
+    })
+
+    it('suppresses "US" for a domestic city + state', () => {
+      expect(
+        formatLocation({ city: 'Austin', state: 'TX', country: 'US' })
+      ).toBe('Austin, TX')
+    })
+
+    it('treats US suppression as case-insensitive', () => {
+      expect(
+        formatLocation({ city: 'Phoenix', state: 'AZ', country: 'usa' })
+      ).toBe('Phoenix, AZ')
+      expect(
+        formatLocation({ city: 'Austin', state: 'TX', country: 'us' })
+      ).toBe('Austin, TX')
+    })
+
+    it('trims whitespace around the country before comparing', () => {
+      expect(
+        formatLocation({ city: 'Austin', state: 'TX', country: '  USA  ' })
+      ).toBe('Austin, TX')
+    })
+
+    it('renders non-US country with city + state', () => {
+      expect(
+        formatLocation({
+          city: 'Melbourne',
+          state: 'Victoria',
+          country: 'Australia',
+        })
+      ).toBe('Melbourne, Victoria, Australia')
+    })
+
+    it('renders non-US country with city only', () => {
+      expect(
+        formatLocation({ city: 'Melbourne', country: 'Australia' })
+      ).toBe('Melbourne, Australia')
+    })
+
+    it('renders "USA" when state is missing (suppression needs both)', () => {
+      // No state ⇒ country carries the locator load and must render.
+      expect(formatLocation({ city: 'Phoenix', country: 'USA' })).toBe(
+        'Phoenix, USA'
+      )
+    })
+
+    it('renders country alone when city + state are absent', () => {
+      expect(formatLocation({ country: 'Japan' })).toBe('Japan')
+    })
+  })
+})

--- a/frontend/lib/formatLocation.ts
+++ b/frontend/lib/formatLocation.ts
@@ -1,0 +1,43 @@
+/**
+ * Format a city/state/country triple as a display location string.
+ *
+ * PSY-558 display rule (locked):
+ *  - Falsy parts (null, undefined, empty/whitespace strings) are dropped so
+ *    callers never render trailing separators like "Phoenix, ".
+ *  - Country is included UNLESS state is set AND country is "USA"/"US" —
+ *    local readers parse "Phoenix, AZ" as US-implicit, so adding "USA"
+ *    is noise. International artists ("Melbourne, Australia",
+ *    "London, England, UK", "Tokyo, Japan") always render the country.
+ *  - Country comparison is case-insensitive + trimmed; either spelling
+ *    ("USA" / "US") triggers the suppression.
+ *  - When every part is missing, returns "Location Unknown" as a stable
+ *    placeholder rather than an empty string.
+ *
+ * Consolidated PSY-780: previously the canonical PSY-558 implementation
+ * lived only in `features/artists/types.ts getArtistLocation`. The venue
+ * counterpart was a bare `${city}, ${state}` template that left a trailing
+ * comma when `state` was empty. Both call sites now delegate here so the
+ * rule is enforced uniformly.
+ */
+export function formatLocation(loc: {
+  city?: string | null
+  state?: string | null
+  country?: string | null
+}): string {
+  const city = nonEmpty(loc.city)
+  const state = nonEmpty(loc.state)
+  const country = nonEmpty(loc.country)
+  const parts = [city, state].filter(Boolean) as string[]
+  const countryIsUS =
+    country?.toUpperCase() === 'USA' || country?.toUpperCase() === 'US'
+  if (country && !(state && countryIsUS)) {
+    parts.push(country)
+  }
+  return parts.length > 0 ? parts.join(', ') : 'Location Unknown'
+}
+
+function nonEmpty(value: string | null | undefined): string | undefined {
+  if (value == null) return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}

--- a/frontend/lib/formatRelativeTime.ts
+++ b/frontend/lib/formatRelativeTime.ts
@@ -1,29 +1,12 @@
-/**
- * Ensures a date string is treated as UTC.
- *
- * The backend formats timestamps with a literal "Z" suffix (e.g.
- * "2026-03-30T10:00:00Z"), which `new Date()` correctly interprets
- * as UTC.  However, if a timestamp ever arrives without a timezone
- * indicator, `new Date()` treats it as *local* time, which introduces
- * an offset equal to the user's UTC difference (e.g. 7 hours in
- * Arizona / MST).
- *
- * This helper appends "Z" when the string lacks any timezone suffix
- * so the value is always parsed as UTC.
- */
-function ensureUTC(dateStr: string): Date {
-  // Already has a timezone indicator: ends with "Z", or has a +/-HH:MM / +/-HHMM offset
-  if (/Z$|[+-]\d{2}:\d{2}$|[+-]\d{4}$/.test(dateStr)) {
-    return new Date(dateStr)
-  }
-  return new Date(dateStr + 'Z')
-}
+import { ensureUTC } from './ensureUTC'
 
 /**
  * Format a UTC timestamp string into a human-friendly relative time.
  *
  * Handles both short-form ("2m ago") and long-form ("2 minutes ago")
- * output via the `short` option (default: false).
+ * output via the `short` option (default: false). The long form jumps
+ * from "N days ago" straight to an absolute date past 30 days — callers
+ * that want weeks/months granularity should use `formatTimeAgo` instead.
  */
 export function formatRelativeTime(
   dateStr: string,

--- a/frontend/lib/formatTimeAgo.test.ts
+++ b/frontend/lib/formatTimeAgo.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { formatTimeAgo } from './formatTimeAgo'
+
+describe('formatTimeAgo (canonical PSY-780)', () => {
+  // formatTimeAgo compares against Date.now(); pin the clock so the relative
+  // strings are deterministic regardless of when the suite runs.
+  const NOW = new Date('2026-05-19T12:00:00Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const SECOND = 1000
+  const MINUTE = 60 * SECOND
+  const HOUR = 60 * MINUTE
+  const DAY = 24 * HOUR
+  const WEEK = 7 * DAY
+
+  function ago(ms: number): string {
+    return formatTimeAgo(new Date(NOW.getTime() - ms).toISOString())
+  }
+
+  it('returns "just now" under a minute', () => {
+    expect(ago(30 * SECOND)).toBe('just now')
+  })
+
+  it('singularizes one minute', () => {
+    expect(ago(MINUTE)).toBe('1 minute ago')
+  })
+
+  it('pluralizes minutes', () => {
+    expect(ago(5 * MINUTE)).toBe('5 minutes ago')
+  })
+
+  it('singularizes one hour', () => {
+    expect(ago(HOUR)).toBe('1 hour ago')
+  })
+
+  it('pluralizes hours', () => {
+    expect(ago(3 * HOUR)).toBe('3 hours ago')
+  })
+
+  it('singularizes one day', () => {
+    expect(ago(DAY)).toBe('1 day ago')
+  })
+
+  it('pluralizes days', () => {
+    expect(ago(3 * DAY)).toBe('3 days ago')
+  })
+
+  it('singularizes one week', () => {
+    expect(ago(WEEK)).toBe('1 week ago')
+  })
+
+  it('pluralizes weeks', () => {
+    expect(ago(3 * WEEK)).toBe('3 weeks ago')
+  })
+
+  it('singularizes one month at 35 days', () => {
+    // Week branch caps at < 5 weeks (35 days), so the months branch kicks in
+    // at exactly 5 weeks rather than at 30 days.
+    expect(ago(35 * DAY)).toBe('1 month ago')
+  })
+
+  it('pluralizes months', () => {
+    expect(ago(90 * DAY)).toBe('3 months ago')
+  })
+
+  it('falls back to a localized absolute date past 12 months', () => {
+    const old = new Date(NOW.getTime() - 400 * DAY)
+    expect(ago(400 * DAY)).toBe(
+      old.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    )
+  })
+
+  // PSY-780: the previous duplicates parsed `new Date(dateString)` directly,
+  // which treats a timezone-less timestamp as LOCAL time. The consolidated
+  // helper routes through `ensureUTC`, matching the PSY-255 fix in
+  // `formatRelativeTime`.
+  it('treats timestamps without Z suffix as UTC (PSY-255 parity)', () => {
+    expect(formatTimeAgo('2026-05-19T11:59:45')).toBe('just now')
+  })
+
+  it('handles timestamps with +00:00 offset', () => {
+    expect(formatTimeAgo('2026-05-19T11:59:45+00:00')).toBe('just now')
+  })
+})

--- a/frontend/lib/formatTimeAgo.ts
+++ b/frontend/lib/formatTimeAgo.ts
@@ -1,0 +1,48 @@
+import { ensureUTC } from './ensureUTC'
+
+/**
+ * Format a UTC timestamp string as a long-form relative time descriptor.
+ *
+ * Granularity goes: just now → minutes → hours → days → weeks → months →
+ * absolute date (past ~12 months). The week branch caps at 5 weeks before
+ * handing off to months, so "1 month ago" appears starting at 35 days.
+ *
+ * Sibling of `formatRelativeTime`:
+ *  - `formatRelativeTime` (default) skips weeks/months and jumps from days
+ *    straight to an absolute date past 30 days — fine for compact bylines.
+ *  - `formatTimeAgo` is the right pick when you want the richer
+ *    weeks/months phrasing (e.g. notification feeds, request lists).
+ *
+ * Consolidated PSY-780: previously duplicated in `features/notifications/types.ts`
+ * (no month branch) and `features/requests/types.ts` (with months). The drift
+ * was accidental — every surface that wants relative time should get the same
+ * weeks/months breakdown.
+ */
+export function formatTimeAgo(dateString: string): string {
+  const date = ensureUTC(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+  const diffWeeks = Math.floor(diffDays / 7)
+  const diffMonths = Math.floor(diffDays / 30)
+
+  if (diffSeconds < 60) return 'just now'
+  if (diffMinutes === 1) return '1 minute ago'
+  if (diffMinutes < 60) return `${diffMinutes} minutes ago`
+  if (diffHours === 1) return '1 hour ago'
+  if (diffHours < 24) return `${diffHours} hours ago`
+  if (diffDays === 1) return '1 day ago'
+  if (diffDays < 7) return `${diffDays} days ago`
+  if (diffWeeks === 1) return '1 week ago'
+  if (diffWeeks < 5) return `${diffWeeks} weeks ago`
+  if (diffMonths === 1) return '1 month ago'
+  if (diffMonths < 12) return `${diffMonths} months ago`
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}


### PR DESCRIPTION
## Summary

Two duplicated utility helpers had drifted across feature modules. This PR collapses each into a single canonical implementation under `frontend/lib/` and updates the call sites to delegate.

- **`formatTimeAgo`** — was duplicated in `features/notifications/types.ts` (no month branch — jumped to absolute date at 5 weeks) and `features/requests/types.ts` (with months). Now lives in `lib/formatTimeAgo.ts`; both feature modules re-export the canonical helper.
- **`formatLocation`** — `getArtistLocation` (canonical PSY-558) and `getVenueLocation` (bare template join that left a trailing `", "` when state was empty) now both delegate to a new `lib/formatLocation.ts`. The trailing-comma bug is gone; PSY-558 country rule applies uniformly.
- **`ensureUTC`** — extracted from `lib/formatRelativeTime.ts` to `lib/ensureUTC.ts` so the same UTC-parsing rule lives in one place across every relative-time formatter (consolidated helper now gets it for free, fixing the PSY-255 timezone bug for these surfaces too).

## Decisions

- **`formatTimeAgo` divergence resolved as accidental drift** (per ticket default). Both surfaces now render the richer ladder (… → weeks → months → absolute date). Notifications previously dropped to an absolute date at 5 weeks; it now renders `"1 month ago"` at 35 days. Documented in the lib doc-comment + the notifications smoke test.
- **`formatLocation` carries the PSY-558 country-suppression rule** (USA/US case-insensitive, trimmed). `getArtistLocation` is now a thin wrapper (kept as a named export so artist call sites stay self-documenting). `getVenueLocation` passes the `Venue` structurally so a future `country` field on `Venue` propagates through with no further changes.
- **`ensureUTC` extracted, not duplicated.** The PSY-255 fix had only protected `formatRelativeTime`; now `formatTimeAgo` benefits as well (the prior duplicates parsed `new Date(dateString)` directly).
- **Did not consolidate `formatTimeAgo` into `formatRelativeTime`** even though they're similar. They serve different surfaces: `formatRelativeTime` is the compact byline formatter (no weeks/months); `formatTimeAgo` is the richer descriptor (weeks, months). Collapsing would have silently changed many caller's output and ballooned scope.

## Test plan

- [x] `cd frontend && bun run test:run features/notifications features/requests features/artists features/venues lib` — 1397/1397 pass
- [x] `cd frontend && bun run test:run components/forms` — 109/109 pass (ArtistInput / VenueInput mocks unaffected)
- [x] `cd frontend && bun run typecheck` — clean
- [x] `/code-review` run — one finding (misleading comment + explicit-shape pass to `formatLocation`); fixed in commit 2

## Manual repro

Unit-test additions cover the consolidated cases — the test names ARE the manual repro:

- `lib/formatLocation.test.ts` — 15 tests
  - trailing-separator guards: empty/whitespace city, empty state, all-empty → `"Location Unknown"`
  - PSY-558 rule: domestic suppression, case-insensitivity, international preservation
- `lib/formatTimeAgo.test.ts` — 14 tests
  - full ladder including the 35-day month boundary
  - PSY-255 UTC parity (timestamps without Z are treated as UTC)
- `features/venues/types.test.ts` — replaced the test asserting the trailing-comma bug with one asserting it's now `"Phoenix"` (no trailing separator), plus two new edge cases.
- `features/notifications/types.test.ts` — replaced the test asserting "no month branch" with one asserting the consolidated `"1 month ago"` at 35 days.

Closes PSY-780