### PR TITLE
PSY-828: /admin/streaming-worklist page (StreamingWorklist)

### DIFF
--- a/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
+++ b/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import Link from 'next/link'
 import {
   Clock,
   MapPin,
@@ -24,6 +25,8 @@ import {
   Star,
   Tag,
   Link2,
+  Radio,
+  Sparkles,
   Activity,
   type LucideIcon,
 } from 'lucide-react'
@@ -332,6 +335,52 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
             trend={stats.total_users_trend}
             onClick={onNavigate ? () => onNavigate('users') : undefined}
           />
+        </div>
+      </section>
+
+      {/* Tools — standalone admin pages outside the main tab grid.
+       Featured curation and Streaming-discovery worklist each live at
+       their own route, so they need explicit links here for
+       discoverability. */}
+      <section>
+        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-3">
+          Tools
+        </h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Link
+            href="/admin/streaming-worklist"
+            className="rounded-lg border border-border bg-card p-4 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            data-testid="admin-dashboard-link-streaming-worklist"
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <Radio className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold">Streaming-discovery worklist</p>
+                <p className="text-xs text-muted-foreground">
+                  Triage Bandcamp/Spotify links for artists with upcoming shows.
+                </p>
+              </div>
+            </div>
+          </Link>
+          <Link
+            href="/admin/featured"
+            className="rounded-lg border border-border bg-card p-4 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            data-testid="admin-dashboard-link-featured"
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <Sparkles className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold">Featured curation</p>
+                <p className="text-xs text-muted-foreground">
+                  Set the active Featured Bill and Featured Collection on /explore.
+                </p>
+              </div>
+            </div>
+          </Link>
         </div>
       </section>
 

--- a/frontend/app/admin/streaming-worklist/page.tsx
+++ b/frontend/app/admin/streaming-worklist/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { StreamingWorklist } from '@/features/admin/components/StreamingWorklist'
+
+/**
+ * /admin/streaming-worklist — admin triage surface for streaming-link
+ * discovery. Sits under the admin layout, which delegates auth + IsAdmin
+ * gating to `<AdminGuard>` so this page only renders for authenticated
+ * admins.
+ *
+ * Implementation lives at
+ * frontend/features/admin/components/StreamingWorklist.
+ */
+export default function AdminStreamingWorklistPage() {
+  return <StreamingWorklist />
+}

--- a/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.test.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+
+import type {
+  StreamingWorklistEntry,
+  StreamingWorklistResult,
+} from './types'
+
+const mockUseStreamingWorklist = vi.fn()
+const mockMutate = vi.fn()
+const mockMutationResult = vi.fn()
+
+vi.mock('./useStreamingWorklist', () => ({
+  useStreamingWorklist: (params: unknown) => mockUseStreamingWorklist(params),
+  useUpdateStreamingDiscoveryStatus: () => mockMutationResult(),
+}))
+
+import { StreamingWorklist } from './StreamingWorklist'
+
+function makeEntry(overrides: Partial<StreamingWorklistEntry> = {}): StreamingWorklistEntry {
+  return {
+    artist_id: 101,
+    artist_name: 'Faetooth',
+    artist_slug: 'faetooth',
+    streaming_discovery_status: 'unreviewed',
+    soonest_event_date: '2026-06-01T03:00:00Z',
+    venue_name: 'Valley Bar',
+    venue_city: 'Phoenix',
+    upcoming_show_count: 1,
+    ...overrides,
+  }
+}
+
+function mockWorklistData(data: StreamingWorklistResult | null, opts: Partial<{ isLoading: boolean; isError: boolean; error: Error | null }> = {}) {
+  mockUseStreamingWorklist.mockReturnValue({
+    data,
+    isLoading: opts.isLoading ?? false,
+    isError: opts.isError ?? false,
+    error: opts.error ?? null,
+  })
+}
+
+function defaultMutationStubs() {
+  mockMutationResult.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  })
+}
+
+describe('StreamingWorklist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    defaultMutationStubs()
+  })
+
+  it('renders the empty state when no rows', () => {
+    mockWorklistData({ entries: [], total: 0 })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    expect(screen.getByTestId('streaming-worklist-empty')).toBeInTheDocument()
+  })
+
+  it('renders one row per entry with name + venue + status badge', () => {
+    mockWorklistData({
+      entries: [
+        makeEntry({ artist_id: 1, artist_name: 'Alpha', streaming_discovery_status: 'unreviewed' }),
+        makeEntry({
+          artist_id: 2,
+          artist_name: 'Beta',
+          artist_slug: 'beta',
+          streaming_discovery_status: 'candidates_pending',
+          venue_name: 'Crescent Ballroom',
+          venue_city: 'Phoenix',
+        }),
+      ],
+      total: 2,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    expect(screen.getByTestId('streaming-worklist-row-1')).toBeInTheDocument()
+    expect(screen.getByTestId('streaming-worklist-row-2')).toBeInTheDocument()
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('streaming-worklist-status-unreviewed')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('streaming-worklist-status-candidates_pending')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Crescent Ballroom · Phoenix')).toBeInTheDocument()
+  })
+
+  it('points the Review button at the artist detail page (new tab)', () => {
+    mockWorklistData({
+      entries: [makeEntry({ artist_id: 42, artist_slug: 'faetooth' })],
+      total: 1,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    // Button uses `asChild` so the data-testid lands on the rendered
+    // <a> element itself (Slot prop-merging), not on a wrapping div.
+    const reviewLink = screen.getByTestId('streaming-worklist-review-42')
+    expect(reviewLink.tagName).toBe('A')
+    expect(reviewLink).toHaveAttribute('href', '/artists/faetooth')
+    expect(reviewLink).toHaveAttribute('target', '_blank')
+  })
+
+  it('falls back to the artist ID when no slug is present', () => {
+    mockWorklistData({
+      entries: [makeEntry({ artist_id: 42, artist_slug: null })],
+      total: 1,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    const reviewLink = screen.getByTestId('streaming-worklist-review-42')
+    expect(reviewLink).toHaveAttribute('href', '/artists/42')
+  })
+
+  it('shows the load-error banner when the query fails', () => {
+    mockWorklistData(null, { isError: true, error: new Error('boom') })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    expect(
+      screen.getByTestId('streaming-worklist-load-error')
+    ).toBeInTheDocument()
+    expect(screen.getByText('boom')).toBeInTheDocument()
+  })
+
+  it('forwards the status filter to the hook and resets offset on change', () => {
+    mockWorklistData({ entries: [], total: 0 })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    // Initial call — empty filter, offset 0.
+    expect(mockUseStreamingWorklist).toHaveBeenCalledWith(
+      expect.objectContaining({ status: '', offset: 0 })
+    )
+
+    const select = screen.getByTestId('streaming-worklist-status-filter') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'unreviewed' } })
+
+    // After the change the hook is re-invoked with the new filter.
+    expect(mockUseStreamingWorklist).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'unreviewed', offset: 0 })
+    )
+  })
+
+  it('shows action buttons by default and opens the inline reason form', () => {
+    mockWorklistData({
+      entries: [makeEntry({ artist_id: 7 })],
+      total: 1,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    const openSkipped = screen.getByTestId('streaming-worklist-open-skipped-7')
+    fireEvent.click(openSkipped)
+
+    expect(
+      screen.getByTestId('streaming-worklist-action-form-7-skipped')
+    ).toBeInTheDocument()
+  })
+
+  it('submits the status mutation with the entered reason', async () => {
+    mockWorklistData({
+      entries: [makeEntry({ artist_id: 7 })],
+      total: 1,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    fireEvent.click(screen.getByTestId('streaming-worklist-open-skipped-7'))
+
+    const textarea = screen.getByPlaceholderText(
+      /Optional: why skipped/i
+    ) as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'Same-name collision' } })
+
+    // mutate calls onSuccess so the form closes and the parent banner
+    // appears.
+    mockMutate.mockImplementation((_input, callbacks) => {
+      callbacks?.onSuccess?.()
+    })
+
+    fireEvent.click(screen.getByTestId('streaming-worklist-submit-7-skipped'))
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        artist_id: 7,
+        status: 'skipped',
+        reason: 'Same-name collision',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    )
+
+    // Success banner surfaces after the mutation lands.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('streaming-worklist-success-banner')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('passes null reason when the textarea is left empty', () => {
+    mockWorklistData({
+      entries: [makeEntry({ artist_id: 7 })],
+      total: 1,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    fireEvent.click(screen.getByTestId('streaming-worklist-open-linked-7'))
+    fireEvent.click(screen.getByTestId('streaming-worklist-submit-7-linked'))
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        artist_id: 7,
+        status: 'linked',
+        reason: null,
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+  })
+
+  it('renders pagination controls only when total exceeds limit', () => {
+    mockWorklistData({
+      entries: [makeEntry({ artist_id: 1 })],
+      total: 100,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    expect(screen.getByTestId('streaming-worklist-prev')).toBeInTheDocument()
+    expect(screen.getByTestId('streaming-worklist-next')).toBeInTheDocument()
+  })
+
+  it('hides pagination when total fits in one page', () => {
+    mockWorklistData({
+      entries: [makeEntry({ artist_id: 1 })],
+      total: 1,
+    })
+
+    renderWithProviders(<StreamingWorklist />)
+
+    expect(screen.queryByTestId('streaming-worklist-prev')).toBeNull()
+    expect(screen.queryByTestId('streaming-worklist-next')).toBeNull()
+  })
+})

--- a/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
@@ -30,7 +30,7 @@
  * session.
  */
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import {
   ChevronLeft,
@@ -380,6 +380,20 @@ export function StreamingWorklist() {
   // useEffect for prop-derived state.
   const pageIndex = Math.floor(offset / limit)
   const totalPages = Math.max(1, Math.ceil(total / limit))
+
+  // Rewind to the last non-empty page when a mutation drops the only
+  // visible row on a non-first page. Without this, total goes (e.g.) 26
+  // → 25 but offset stays at 25 — the user sees the empty-state copy
+  // even though the queue isn't actually clear. We use useEffect rather
+  // than calculate-during-render because (a) offset is parent state we
+  // need to mutate via setOffset, and (b) the condition fires only when
+  // the query result lands, not on every render.
+  useEffect(() => {
+    if (data && entries.length === 0 && offset > 0 && total > 0) {
+      const lastValidOffset = Math.max(0, (Math.ceil(total / limit) - 1) * limit)
+      setOffset(lastValidOffset)
+    }
+  }, [data, entries.length, offset, total, limit])
 
   const handleStatusChange = useCallback((value: StreamingWorklistStatusFilter) => {
     setStatus(value)

--- a/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
@@ -1,0 +1,564 @@
+'use client'
+
+/**
+ * /admin/streaming-worklist — admin triage UI for the streaming-discovery
+ * worklist. Surfaces artists whose `streaming_discovery_status` is
+ * non-terminal AND who have at least one upcoming show, ordered by
+ * soonest show date.
+ *
+ * Page shape mirrors `/admin/featured` (PSY-838) — same inline-banner
+ * mutation feedback (`pattern_mutation_feedback.md`), same TanStack
+ * Query layout, same admin-only gating via the parent admin layout.
+ *
+ * ENGINE SEAM (locked decision: worklist writes, engine stays stateless)
+ * ─────────────────────────────────────────────────────────────────────
+ * PSY-816 shipped the candidate-review surface INLINE on the artist
+ * detail page (`frontend/features/artists/components/ArtistDetail.tsx`,
+ * `useDiscoverMusic` / `useUpdateArtistBandcamp` / `useUpdateArtistSpotify`).
+ * There is no separate drawer/modal to embed inside the worklist.
+ *
+ * The "Review →" button on each row opens the artist detail page in a
+ * new tab. The admin reviews candidates and saves bandcamp/spotify URLs
+ * there. The status flip to `linked` is concentrated HERE — the admin
+ * clicks "Mark linked" on the worklist row once they've confirmed the
+ * URLs got saved. This avoids cross-feature coupling and keeps the
+ * discovery engine itself stateless (it returns candidates, doesn't
+ * track triage state).
+ *
+ * The worklist refetches on window focus so the soonest-show row data
+ * stays accurate when the admin hops back from a long candidate-review
+ * session.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  Filter,
+  Inbox,
+  Link2,
+  Link2Off,
+  Loader2,
+  Radio,
+  SkipForward,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { InlineErrorBanner, StatusBanner } from '@/components/shared'
+import { formatAdminDate } from '@/lib/utils/formatters'
+import {
+  useStreamingWorklist,
+  useUpdateStreamingDiscoveryStatus,
+} from './useStreamingWorklist'
+import {
+  STREAMING_WORKLIST_DEFAULT_LIMIT,
+  STREAMING_WORKLIST_STATUS_FILTER_OPTIONS,
+  type StreamingWorklistAction,
+  type StreamingWorklistEntry,
+  type StreamingWorklistStatusFilter,
+} from './types'
+
+// ──────────────────────────────────────────────
+// Status badge — small visual marker per row
+// ──────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: StreamingWorklistEntry['streaming_discovery_status'] }) {
+  // Only non-terminal values appear in the list response, but the type
+  // allows the full enum so the badge stays correct if a backend tweak
+  // ever widens what's surfaced.
+  const palette: Record<typeof status, string> = {
+    unreviewed: 'border-amber-700/50 bg-amber-950/40 text-amber-300',
+    candidates_pending: 'border-blue-700/50 bg-blue-950/40 text-blue-300',
+    linked: 'border-green-700/50 bg-green-950/40 text-green-300',
+    no_links_found: 'border-zinc-600/40 bg-zinc-900/40 text-zinc-300',
+    skipped: 'border-zinc-600/40 bg-zinc-900/40 text-zinc-300',
+  }
+  const labels: Record<typeof status, string> = {
+    unreviewed: 'Unreviewed',
+    candidates_pending: 'Candidates pending',
+    linked: 'Linked',
+    no_links_found: 'No links',
+    skipped: 'Skipped',
+  }
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${palette[status]}`}
+      data-testid={`streaming-worklist-status-${status}`}
+    >
+      {labels[status]}
+    </span>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Inline reason form — collapses below the row when one of the
+// "no_links_found" / "skipped" / "linked" buttons is clicked.
+// Mark-linked also routes through this form so the admin can drop a
+// short note about which candidate they picked.
+// ──────────────────────────────────────────────
+
+const ACTION_COPY: Record<
+  StreamingWorklistAction,
+  { title: string; placeholder: string; submit: string; successPrefix: string }
+> = {
+  linked: {
+    title: 'Mark linked',
+    placeholder:
+      'Optional: which candidate did you pick? (e.g. "Asheville NC band, Bleeds 2025")',
+    submit: 'Mark linked',
+    successPrefix: 'Marked linked',
+  },
+  no_links_found: {
+    title: 'Mark no links found',
+    placeholder:
+      'Optional: brief note for the next reviewer (e.g. "Only ghost profiles, no real candidates")',
+    submit: 'Mark no links',
+    successPrefix: 'Marked no-links',
+  },
+  skipped: {
+    title: 'Mark skipped',
+    placeholder: 'Optional: why skipped (e.g. "Same-name collision, ambiguous")',
+    submit: 'Mark skipped',
+    successPrefix: 'Marked skipped',
+  },
+}
+
+interface ActionFormProps {
+  entry: StreamingWorklistEntry
+  action: StreamingWorklistAction
+  onClose: () => void
+  onSuccess: (entry: StreamingWorklistEntry, action: StreamingWorklistAction) => void
+}
+
+function ActionForm({ entry, action, onClose, onSuccess }: ActionFormProps) {
+  const [reason, setReason] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const mutation = useUpdateStreamingDiscoveryStatus()
+  const copy = ACTION_COPY[action]
+
+  const handleSubmit = useCallback(() => {
+    setError(null)
+    mutation.mutate(
+      {
+        artist_id: entry.artist_id,
+        status: action,
+        reason: reason.trim() ? reason.trim() : null,
+      },
+      {
+        onSuccess: () => {
+          onSuccess(entry, action)
+        },
+        onError: (err) => {
+          setError(
+            err instanceof Error
+              ? err.message
+              : `Failed to mark ${action.replace('_', ' ')}.`
+          )
+        },
+      }
+    )
+  }, [mutation, entry, action, reason, onSuccess])
+
+  return (
+    <div
+      className="rounded-md border border-border/60 bg-muted/20 p-3 space-y-2"
+      data-testid={`streaming-worklist-action-form-${entry.artist_id}-${action}`}
+    >
+      <Label
+        htmlFor={`reason-${entry.artist_id}-${action}`}
+        className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        {copy.title} — {entry.artist_name}
+      </Label>
+      <textarea
+        id={`reason-${entry.artist_id}-${action}`}
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        rows={2}
+        maxLength={2000}
+        placeholder={copy.placeholder}
+        className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        disabled={mutation.isPending}
+      />
+      {error && (
+        <InlineErrorBanner
+          testId={`streaming-worklist-action-error-${entry.artist_id}-${action}`}
+        >
+          {error}
+        </InlineErrorBanner>
+      )}
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClose}
+          disabled={mutation.isPending}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={mutation.isPending}
+          data-testid={`streaming-worklist-submit-${entry.artist_id}-${action}`}
+        >
+          {mutation.isPending ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            copy.submit
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Row — artist | upcoming show | status | actions
+// ──────────────────────────────────────────────
+
+interface WorklistRowProps {
+  entry: StreamingWorklistEntry
+  onActionSuccess: (entry: StreamingWorklistEntry, action: StreamingWorklistAction) => void
+}
+
+function WorklistRow({ entry, onActionSuccess }: WorklistRowProps) {
+  const [openAction, setOpenAction] = useState<StreamingWorklistAction | null>(null)
+
+  // Artist detail page is the home of the PSY-816 candidate-review
+  // panel. New tab so the worklist stays open for fast triage.
+  const artistHref = entry.artist_slug
+    ? `/artists/${entry.artist_slug}`
+    : `/artists/${entry.artist_id}`
+
+  const eventDate = formatAdminDate(entry.soonest_event_date)
+  const venueLabel = [entry.venue_name, entry.venue_city]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div
+      className="rounded-lg border border-border/60 bg-card/40 p-3 space-y-3"
+      data-testid={`streaming-worklist-row-${entry.artist_id}`}
+    >
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-3 items-center">
+        {/* Artist (cols 1–4) */}
+        <div className="md:col-span-4 min-w-0">
+          <Link
+            href={artistHref}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm font-semibold hover:underline truncate inline-flex items-center gap-1"
+            data-testid={`streaming-worklist-artist-link-${entry.artist_id}`}
+          >
+            <Radio className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="truncate">{entry.artist_name}</span>
+          </Link>
+          {entry.upcoming_show_count > 1 && (
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              {entry.upcoming_show_count} upcoming shows
+            </p>
+          )}
+        </div>
+
+        {/* Soonest show (cols 5–8) */}
+        <div className="md:col-span-4 min-w-0">
+          <p className="text-sm truncate">{eventDate}</p>
+          {venueLabel && (
+            <p className="text-xs text-muted-foreground truncate">
+              {venueLabel}
+            </p>
+          )}
+        </div>
+
+        {/* Status badge (cols 9–10) */}
+        <div className="md:col-span-2">
+          <StatusBadge status={entry.streaming_discovery_status} />
+        </div>
+
+        {/* Actions (cols 11–12) */}
+        <div className="md:col-span-2 flex flex-wrap items-center justify-end gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            asChild
+            className="gap-1.5"
+            data-testid={`streaming-worklist-review-${entry.artist_id}`}
+          >
+            <Link href={artistHref} target="_blank" rel="noreferrer">
+              <ExternalLink className="h-3.5 w-3.5" />
+              Review
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Inline action buttons — appear below the row so the form has
+       room to expand without breaking the table grid. */}
+      {!openAction ? (
+        <div className="flex flex-wrap items-center gap-1.5 border-t border-border/40 pt-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setOpenAction('linked')}
+            className="gap-1.5 text-green-300 hover:text-green-200"
+            data-testid={`streaming-worklist-open-linked-${entry.artist_id}`}
+          >
+            <Link2 className="h-3.5 w-3.5" />
+            Mark linked
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setOpenAction('no_links_found')}
+            className="gap-1.5 text-muted-foreground hover:text-foreground"
+            data-testid={`streaming-worklist-open-no_links_found-${entry.artist_id}`}
+          >
+            <Link2Off className="h-3.5 w-3.5" />
+            Mark no links found
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setOpenAction('skipped')}
+            className="gap-1.5 text-muted-foreground hover:text-foreground"
+            data-testid={`streaming-worklist-open-skipped-${entry.artist_id}`}
+          >
+            <SkipForward className="h-3.5 w-3.5" />
+            Mark skipped
+          </Button>
+        </div>
+      ) : (
+        <ActionForm
+          entry={entry}
+          action={openAction}
+          onClose={() => setOpenAction(null)}
+          onSuccess={(e, a) => {
+            setOpenAction(null)
+            onActionSuccess(e, a)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Top-level page component
+// ──────────────────────────────────────────────
+
+export function StreamingWorklist() {
+  const [status, setStatus] = useState<StreamingWorklistStatusFilter>('')
+  const [offset, setOffset] = useState(0)
+  const limit = STREAMING_WORKLIST_DEFAULT_LIMIT
+  const [recentMutation, setRecentMutation] = useState<{
+    artistName: string
+    action: StreamingWorklistAction
+  } | null>(null)
+
+  const { data, isLoading, isError, error } = useStreamingWorklist({
+    status,
+    limit,
+    offset,
+  })
+
+  const entries = data?.entries ?? []
+  const total = data?.total ?? 0
+
+  // Page index is derived — keeps the parent state minimal and avoids a
+  // useEffect for prop-derived state.
+  const pageIndex = Math.floor(offset / limit)
+  const totalPages = Math.max(1, Math.ceil(total / limit))
+
+  const handleStatusChange = useCallback((value: StreamingWorklistStatusFilter) => {
+    setStatus(value)
+    setOffset(0)
+  }, [])
+
+  const handlePrev = useCallback(() => {
+    setOffset((prev) => Math.max(0, prev - limit))
+  }, [limit])
+
+  const handleNext = useCallback(() => {
+    setOffset((prev) => prev + limit)
+  }, [limit])
+
+  const handleActionSuccess = useCallback(
+    (entry: StreamingWorklistEntry, action: StreamingWorklistAction) => {
+      setRecentMutation({ artistName: entry.artist_name, action })
+    },
+    []
+  )
+
+  const errorMessage = useMemo(() => {
+    if (!isError) return null
+    return error instanceof Error
+      ? error.message
+      : 'Could not load the streaming-discovery worklist.'
+  }, [isError, error])
+
+  return (
+    <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header>
+          <div className="flex items-center gap-2 mb-1">
+            <Radio className="h-5 w-5 text-primary" />
+            <h1 className="text-2xl font-bold tracking-tight">
+              Streaming-discovery worklist
+            </h1>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Artists with an upcoming show whose Bandcamp/Spotify links
+            still need a human pick. Review a row → opens the artist
+            page where the candidate panel lives. Once you save the
+            picks (or decide there aren&apos;t any), come back here and
+            mark the row to drop it from the queue.
+          </p>
+        </header>
+
+        {/* Recent-mutation success banner — auto-dismiss after 4s.
+            Inline + ephemeral so it doesn't clutter the table. */}
+        {recentMutation && (
+          <StatusBanner
+            variant="success"
+            dismissAfterMs={4000}
+            onDismiss={() => setRecentMutation(null)}
+            testId="streaming-worklist-success-banner"
+          >
+            <p className="text-sm">
+              {ACTION_COPY[recentMutation.action].successPrefix}:{' '}
+              <span className="font-semibold">{recentMutation.artistName}</span>
+            </p>
+          </StatusBanner>
+        )}
+
+        {/* Filter bar */}
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border/60 bg-card/40 p-3">
+          <Filter className="h-4 w-4 text-muted-foreground" />
+          <Label
+            htmlFor="streaming-worklist-status-filter"
+            className="text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Status
+          </Label>
+          <select
+            id="streaming-worklist-status-filter"
+            value={status}
+            onChange={(e) =>
+              handleStatusChange(e.target.value as StreamingWorklistStatusFilter)
+            }
+            className="h-8 rounded-md border border-input bg-transparent px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            data-testid="streaming-worklist-status-filter"
+          >
+            {STREAMING_WORKLIST_STATUS_FILTER_OPTIONS.map((opt) => (
+              <option key={opt.value || 'all'} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <div className="ml-auto text-xs text-muted-foreground">
+            {total > 0 ? (
+              <>
+                {total} total · showing {offset + 1}–
+                {Math.min(offset + entries.length, total)}
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        {/* List state */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {errorMessage && (
+          <InlineErrorBanner
+            variant="queryFallback"
+            testId="streaming-worklist-load-error"
+          >
+            {errorMessage}
+          </InlineErrorBanner>
+        )}
+
+        {!isLoading && !errorMessage && entries.length === 0 && (
+          <div
+            className="rounded-lg border border-border bg-card/50 p-8 text-center"
+            data-testid="streaming-worklist-empty"
+          >
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <Inbox className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <h3 className="font-medium mb-1">Worklist clear</h3>
+            <p className="text-sm text-muted-foreground">
+              {status
+                ? `No artists in "${status}" with an upcoming show.`
+                : 'No artists with non-terminal status have upcoming shows right now.'}
+            </p>
+          </div>
+        )}
+
+        {!isLoading && !errorMessage && entries.length > 0 && (
+          <div className="space-y-2" data-testid="streaming-worklist-rows">
+            {entries.map((entry) => (
+              <WorklistRow
+                key={entry.artist_id}
+                entry={entry}
+                onActionSuccess={handleActionSuccess}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {!errorMessage && total > limit && (
+          <div className="flex items-center justify-between gap-2 pt-2">
+            <div className="text-xs text-muted-foreground">
+              Page {pageIndex + 1} of {totalPages}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handlePrev}
+                disabled={offset === 0 || isLoading}
+                data-testid="streaming-worklist-prev"
+                className="gap-1.5"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+                Prev
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleNext}
+                disabled={offset + limit >= total || isLoading}
+                data-testid="streaming-worklist-next"
+                className="gap-1.5"
+              >
+                Next
+                <ChevronRight className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default StreamingWorklist

--- a/frontend/features/admin/components/StreamingWorklist/index.ts
+++ b/frontend/features/admin/components/StreamingWorklist/index.ts
@@ -10,7 +10,6 @@ export type {
   StreamingWorklistResult,
   StreamingWorklistStatusFilter,
   UpdateStreamingDiscoveryStatusInput,
-  UpdateStreamingDiscoveryStatusResponse,
   UpdateStreamingDiscoveryStatusResponseBody,
 } from './types'
 export {

--- a/frontend/features/admin/components/StreamingWorklist/index.ts
+++ b/frontend/features/admin/components/StreamingWorklist/index.ts
@@ -1,0 +1,19 @@
+export { StreamingWorklist } from './StreamingWorklist'
+export {
+  useStreamingWorklist,
+  useUpdateStreamingDiscoveryStatus,
+} from './useStreamingWorklist'
+export type {
+  StreamingDiscoveryStatus,
+  StreamingWorklistAction,
+  StreamingWorklistEntry,
+  StreamingWorklistResult,
+  StreamingWorklistStatusFilter,
+  UpdateStreamingDiscoveryStatusInput,
+  UpdateStreamingDiscoveryStatusResponse,
+  UpdateStreamingDiscoveryStatusResponseBody,
+} from './types'
+export {
+  STREAMING_WORKLIST_DEFAULT_LIMIT,
+  STREAMING_WORKLIST_STATUS_FILTER_OPTIONS,
+} from './types'

--- a/frontend/features/admin/components/StreamingWorklist/types.ts
+++ b/frontend/features/admin/components/StreamingWorklist/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Wire-shape types for the admin streaming-discovery worklist endpoints.
+ * Mirrors `backend/internal/api/handlers/pipeline/streaming_worklist.go`
+ * and `backend/internal/services/contracts/pipeline.go`.
+ *
+ * The list endpoint surfaces ONLY non-terminal statuses (`unreviewed`,
+ * `candidates_pending`). Terminal statuses exist as valid TARGETS for
+ * the status-mutation endpoint — see `STATUS_TRANSITION_TARGETS`.
+ */
+export type StreamingDiscoveryStatus =
+  | 'unreviewed'
+  | 'candidates_pending'
+  | 'linked'
+  | 'no_links_found'
+  | 'skipped'
+
+/**
+ * The two non-terminal statuses surfaced by the list endpoint. An
+ * unset filter ("") returns both. Any other value triggers a 400.
+ */
+export type StreamingWorklistStatusFilter = '' | 'unreviewed' | 'candidates_pending'
+
+export const STREAMING_WORKLIST_STATUS_FILTER_OPTIONS: ReadonlyArray<{
+  value: StreamingWorklistStatusFilter
+  label: string
+}> = [
+  { value: '', label: 'All non-terminal' },
+  { value: 'unreviewed', label: 'Unreviewed' },
+  { value: 'candidates_pending', label: 'Candidates pending' },
+] as const
+
+/**
+ * Mirror of `contracts.StreamingWorklistEntry`. Soonest event date is an
+ * ISO timestamp string after JSON serialisation. Venue name + city are
+ * nullable because the LATERAL subquery may surface a show that lacks
+ * those fields (rare; usually a data-quality nit).
+ */
+export interface StreamingWorklistEntry {
+  artist_id: number
+  artist_name: string
+  artist_slug?: string | null
+  streaming_discovery_status: StreamingDiscoveryStatus
+  soonest_event_date: string
+  venue_name?: string | null
+  venue_city?: string | null
+  upcoming_show_count: number
+}
+
+export interface StreamingWorklistResult {
+  entries: StreamingWorklistEntry[]
+  total: number
+}
+
+/**
+ * Input shape for the status mutation. `reason` is only persisted for
+ * `no_links_found` and `skipped`; the backend service clears it on
+ * re-open to `unreviewed`.
+ */
+export interface UpdateStreamingDiscoveryStatusInput {
+  artist_id: number
+  status: StreamingDiscoveryStatus
+  reason?: string | null
+}
+
+/**
+ * Backend response after a successful status mutation. Huma nests the
+ * row under `body`.
+ */
+export interface UpdateStreamingDiscoveryStatusResponseBody {
+  id: number
+  name: string
+  slug?: string | null
+  streaming_discovery_status: StreamingDiscoveryStatus
+  streaming_discovery_reason?: string | null
+  updated_at: string
+}
+
+export interface UpdateStreamingDiscoveryStatusResponse {
+  body: UpdateStreamingDiscoveryStatusResponseBody
+}
+
+/**
+ * Targets surfaced as buttons on each worklist row. Engine seam: the
+ * worklist concentrates the state write — `linked` is set by the admin
+ * AFTER reviewing the candidate panel on the artist detail page (see
+ * engine-seam comment in StreamingWorklist.tsx). The engine itself
+ * stays stateless.
+ */
+export type StreamingWorklistAction = 'linked' | 'no_links_found' | 'skipped'
+
+/**
+ * Pagination defaults. Backend caps `limit` at 200; the UI uses 25 so
+ * the table fits one screen for typical admin sessions and keeps server
+ * round-trips small.
+ */
+export const STREAMING_WORKLIST_DEFAULT_LIMIT = 25

--- a/frontend/features/admin/components/StreamingWorklist/types.ts
+++ b/frontend/features/admin/components/StreamingWorklist/types.ts
@@ -63,8 +63,10 @@ export interface UpdateStreamingDiscoveryStatusInput {
 }
 
 /**
- * Backend response after a successful status mutation. Huma nests the
- * row under `body`.
+ * Backend response after a successful status mutation. Huma's
+ * response struct has a `Body` field but the framework serializes that
+ * field's value AS the HTTP body — there is no `{body: ...}` envelope
+ * on the wire. This type mirrors what the client receives directly.
  */
 export interface UpdateStreamingDiscoveryStatusResponseBody {
   id: number
@@ -73,10 +75,6 @@ export interface UpdateStreamingDiscoveryStatusResponseBody {
   streaming_discovery_status: StreamingDiscoveryStatus
   streaming_discovery_reason?: string | null
   updated_at: string
-}
-
-export interface UpdateStreamingDiscoveryStatusResponse {
-  body: UpdateStreamingDiscoveryStatusResponseBody
 }
 
 /**

--- a/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.test.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.test.tsx
@@ -115,15 +115,16 @@ describe('useUpdateStreamingDiscoveryStatus', () => {
   })
 
   it('POSTs the status mutation and invalidates the worklist branch', async () => {
+    // Huma sends the response's `Body` field AS the HTTP body — there
+    // is no `{body: ...}` envelope. apiRequest returns the artist
+    // payload directly. Verified empirically against the dev backend.
     mockApiRequest.mockResolvedValueOnce({
-      body: {
-        id: 42,
-        name: 'Test Band',
-        slug: 'test-band',
-        streaming_discovery_status: 'skipped',
-        streaming_discovery_reason: 'Same-name collision',
-        updated_at: '2026-05-24T12:00:00Z',
-      },
+      id: 42,
+      name: 'Test Band',
+      slug: 'test-band',
+      streaming_discovery_status: 'skipped',
+      streaming_discovery_reason: 'Same-name collision',
+      updated_at: '2026-05-24T12:00:00Z',
     })
     const { queryClient, invalidateSpy } = setupClient()
 
@@ -158,12 +159,10 @@ describe('useUpdateStreamingDiscoveryStatus', () => {
 
   it('passes null reason through unchanged', async () => {
     mockApiRequest.mockResolvedValueOnce({
-      body: {
-        id: 7,
-        name: 'X',
-        streaming_discovery_status: 'linked',
-        updated_at: '2026-05-24T12:00:00Z',
-      },
+      id: 7,
+      name: 'X',
+      streaming_discovery_status: 'linked',
+      updated_at: '2026-05-24T12:00:00Z',
     })
     const { queryClient } = setupClient()
 
@@ -187,14 +186,14 @@ describe('useUpdateStreamingDiscoveryStatus', () => {
     )
   })
 
-  it('unwraps the Huma `body` envelope into the mutation result', async () => {
+  it('returns the artist payload directly (no body envelope)', async () => {
     const updatedArtist = {
       id: 9,
       name: 'Y',
       streaming_discovery_status: 'no_links_found' as const,
       updated_at: '2026-05-24T12:00:00Z',
     }
-    mockApiRequest.mockResolvedValueOnce({ body: updatedArtist })
+    mockApiRequest.mockResolvedValueOnce(updatedArtist)
     const { queryClient } = setupClient()
 
     const { result } = renderHook(() => useUpdateStreamingDiscoveryStatus(), {

--- a/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.test.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapperWithClient } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      STREAMING_WORKLIST: {
+        LIST: '/admin/streaming-worklist',
+      },
+      ARTISTS: {
+        STREAMING_DISCOVERY_STATUS: (artistId: string | number) =>
+          `/admin/artists/${artistId}/streaming-discovery-status`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      streamingWorklist: (params?: Record<string, unknown>) => [
+        'admin',
+        'streamingWorklist',
+        params,
+      ],
+    },
+  },
+}))
+
+import {
+  useStreamingWorklist,
+  useUpdateStreamingDiscoveryStatus,
+} from './useStreamingWorklist'
+
+function setupClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  return { queryClient, invalidateSpy }
+}
+
+describe('useStreamingWorklist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('GETs the list endpoint without a status when filter is empty', async () => {
+    mockApiRequest.mockResolvedValueOnce({ entries: [], total: 0 })
+    const { queryClient } = setupClient()
+
+    const { result } = renderHook(
+      () => useStreamingWorklist({ status: '', limit: 25, offset: 0 }),
+      { wrapper: createWrapperWithClient(queryClient) }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/streaming-worklist?limit=25&offset=0'
+    )
+    expect(result.current.data).toEqual({ entries: [], total: 0 })
+  })
+
+  it('forwards the status filter as a query-string param', async () => {
+    mockApiRequest.mockResolvedValueOnce({ entries: [], total: 0 })
+    const { queryClient } = setupClient()
+
+    renderHook(
+      () =>
+        useStreamingWorklist({
+          status: 'unreviewed',
+          limit: 25,
+          offset: 0,
+        }),
+      { wrapper: createWrapperWithClient(queryClient) }
+    )
+
+    await waitFor(() =>
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/streaming-worklist?limit=25&offset=0&status=unreviewed'
+      )
+    )
+  })
+
+  it('skips fetching when disabled', () => {
+    const { queryClient } = setupClient()
+
+    renderHook(
+      () =>
+        useStreamingWorklist({
+          status: '',
+          limit: 25,
+          offset: 0,
+          enabled: false,
+        }),
+      { wrapper: createWrapperWithClient(queryClient) }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUpdateStreamingDiscoveryStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('POSTs the status mutation and invalidates the worklist branch', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      body: {
+        id: 42,
+        name: 'Test Band',
+        slug: 'test-band',
+        streaming_discovery_status: 'skipped',
+        streaming_discovery_reason: 'Same-name collision',
+        updated_at: '2026-05-24T12:00:00Z',
+      },
+    })
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useUpdateStreamingDiscoveryStatus(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        artist_id: 42,
+        status: 'skipped',
+        reason: 'Same-name collision',
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/artists/42/streaming-discovery-status',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'skipped',
+          reason: 'Same-name collision',
+        }),
+      })
+    )
+    // Whole worklist branch must invalidate so every status-filter +
+    // pagination combination refetches and the row drops out.
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['admin', 'streamingWorklist'],
+    })
+  })
+
+  it('passes null reason through unchanged', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      body: {
+        id: 7,
+        name: 'X',
+        streaming_discovery_status: 'linked',
+        updated_at: '2026-05-24T12:00:00Z',
+      },
+    })
+    const { queryClient } = setupClient()
+
+    const { result } = renderHook(() => useUpdateStreamingDiscoveryStatus(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        artist_id: 7,
+        status: 'linked',
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/artists/7/streaming-discovery-status',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ status: 'linked', reason: null }),
+      })
+    )
+  })
+
+  it('unwraps the Huma `body` envelope into the mutation result', async () => {
+    const updatedArtist = {
+      id: 9,
+      name: 'Y',
+      streaming_discovery_status: 'no_links_found' as const,
+      updated_at: '2026-05-24T12:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce({ body: updatedArtist })
+    const { queryClient } = setupClient()
+
+    const { result } = renderHook(() => useUpdateStreamingDiscoveryStatus(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    let returned: unknown
+    await act(async () => {
+      returned = await result.current.mutateAsync({
+        artist_id: 9,
+        status: 'no_links_found',
+      })
+    })
+
+    expect(returned).toEqual(updatedArtist)
+  })
+})

--- a/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.ts
+++ b/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.ts
@@ -1,0 +1,116 @@
+'use client'
+
+/**
+ * TanStack Query hooks for the admin streaming-discovery worklist.
+ *
+ * Two hooks mirror the two backend endpoints:
+ *   - useStreamingWorklist — GET /admin/streaming-worklist
+ *   - useUpdateStreamingDiscoveryStatus — POST /admin/artists/{id}/streaming-discovery-status
+ *
+ * Mutations invalidate the worklist list query so the row drops out
+ * of the visible queue once the new status flips to a terminal value
+ * (or to candidates_pending, which is engine-set and not surfaced as a
+ * mutation target here). Errors bubble up unchanged so the consuming
+ * component can surface them via the canonical inline-banner primitive
+ * (pattern_mutation_feedback.md).
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type {
+  StreamingWorklistResult,
+  StreamingWorklistStatusFilter,
+  UpdateStreamingDiscoveryStatusInput,
+  UpdateStreamingDiscoveryStatusResponseBody,
+} from './types'
+
+export interface UseStreamingWorklistParams {
+  status: StreamingWorklistStatusFilter
+  limit: number
+  offset: number
+  enabled?: boolean
+}
+
+/**
+ * Fetch a paginated page of the streaming-discovery worklist. Backend
+ * surfaces ONLY non-terminal statuses; passing a status filter narrows
+ * to one of `unreviewed` or `candidates_pending`. Empty filter returns
+ * both. `staleTime` is short (10s) so the list reflects status
+ * mutations promptly — windowed-focus refetches handle the case where
+ * the admin reviewed a candidate on the artist detail page and the
+ * worklist tab regains focus.
+ */
+export function useStreamingWorklist({
+  status,
+  limit,
+  offset,
+  enabled = true,
+}: UseStreamingWorklistParams) {
+  const params: Record<string, string | number> = { limit, offset }
+  if (status) {
+    params.status = status
+  }
+  return useQuery({
+    queryKey: queryKeys.admin.streamingWorklist({ status, limit, offset }),
+    queryFn: () => {
+      const search = new URLSearchParams()
+      search.set('limit', String(limit))
+      search.set('offset', String(offset))
+      if (status) {
+        search.set('status', status)
+      }
+      return apiRequest<StreamingWorklistResult>(
+        `${API_ENDPOINTS.ADMIN.STREAMING_WORKLIST.LIST}?${search.toString()}`
+      )
+    },
+    enabled,
+    staleTime: 10 * 1000,
+    // Refetch on window focus so the worklist updates when the admin
+    // hops back from the artist detail page after reviewing candidates.
+    refetchOnWindowFocus: true,
+  })
+}
+
+/**
+ * Mutate a row's streaming-discovery status. Used by the action column
+ * for `linked` / `no_links_found` / `skipped`. The engine-seam choice
+ * (worklist concentrates the state write) means this is also the hook
+ * the page calls AFTER the admin reviewed candidates on the artist
+ * detail page and confirmed the URLs got saved.
+ *
+ * Invalidates the full `streamingWorklist` branch so every cached page
+ * (status filter / pagination combination) refetches.
+ */
+export function useUpdateStreamingDiscoveryStatus() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (
+      input: UpdateStreamingDiscoveryStatusInput
+    ): Promise<UpdateStreamingDiscoveryStatusResponseBody> => {
+      const response = await apiRequest<{
+        body: UpdateStreamingDiscoveryStatusResponseBody
+      }>(
+        API_ENDPOINTS.ADMIN.ARTISTS.STREAMING_DISCOVERY_STATUS(input.artist_id),
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            status: input.status,
+            reason: input.reason ?? null,
+          }),
+        }
+      )
+      // Huma wraps the row under `body`; unwrap so the mutation
+      // consumer gets the artist payload directly.
+      return response.body
+    },
+    onSuccess: () => {
+      // Invalidate the whole worklist branch — status filter and
+      // pagination both vary by key, so a single invalidation needs to
+      // hit every cached page.
+      queryClient.invalidateQueries({
+        queryKey: ['admin', 'streamingWorklist'],
+      })
+    },
+  })
+}

--- a/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.ts
+++ b/frontend/features/admin/components/StreamingWorklist/useStreamingWorklist.ts
@@ -47,10 +47,6 @@ export function useStreamingWorklist({
   offset,
   enabled = true,
 }: UseStreamingWorklistParams) {
-  const params: Record<string, string | number> = { limit, offset }
-  if (status) {
-    params.status = status
-  }
   return useQuery({
     queryKey: queryKeys.admin.streamingWorklist({ status, limit, offset }),
     queryFn: () => {
@@ -85,12 +81,14 @@ export function useStreamingWorklist({
 export function useUpdateStreamingDiscoveryStatus() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async (
+    mutationFn: (
       input: UpdateStreamingDiscoveryStatusInput
-    ): Promise<UpdateStreamingDiscoveryStatusResponseBody> => {
-      const response = await apiRequest<{
-        body: UpdateStreamingDiscoveryStatusResponseBody
-      }>(
+    ): Promise<UpdateStreamingDiscoveryStatusResponseBody> =>
+      // Huma's response struct has a `Body` field, but the framework
+      // serializes that field's value AS the HTTP body — there is no
+      // `{body: ...}` envelope on the wire. The response IS the artist
+      // payload. Verified empirically against the dev backend.
+      apiRequest<UpdateStreamingDiscoveryStatusResponseBody>(
         API_ENDPOINTS.ADMIN.ARTISTS.STREAMING_DISCOVERY_STATUS(input.artist_id),
         {
           method: 'POST',
@@ -99,11 +97,7 @@ export function useUpdateStreamingDiscoveryStatus() {
             reason: input.reason ?? null,
           }),
         }
-      )
-      // Huma wraps the row under `body`; unwrap so the mutation
-      // consumer gets the artist payload directly.
-      return response.body
-    },
+      ),
     onSuccess: () => {
       // Invalidate the whole worklist branch — status filter and
       // pagination both vary by key, so a single invalidation needs to

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -143,6 +143,18 @@ export const API_ENDPOINTS = {
       DELETE_ALIAS: (artistId: string | number, aliasId: string | number) =>
         `${API_BASE_URL}/admin/artists/${artistId}/aliases/${aliasId}`,
       MERGE: `${API_BASE_URL}/admin/artists/merge`,
+      // Streaming-discovery triage status mutation. Engine seam: the
+      // worklist concentrates the state write; the discovery engine
+      // itself stays stateless. See StreamingWorklist.tsx.
+      STREAMING_DISCOVERY_STATUS: (artistId: string | number) =>
+        `${API_BASE_URL}/admin/artists/${artistId}/streaming-discovery-status`,
+    },
+    // Prioritized triage queue for streaming-link discovery. Returns
+    // artists with non-terminal streaming_discovery_status who have at
+    // least one upcoming show, ordered by soonest show ASC. Pairs with
+    // ADMIN.ARTISTS.STREAMING_DISCOVERY_STATUS for row mutations.
+    STREAMING_WORKLIST: {
+      LIST: `${API_BASE_URL}/admin/streaming-worklist`,
     },
     REPORTS: {
       LIST: `${API_BASE_URL}/admin/reports`,

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -189,6 +189,12 @@ export const queryKeys = {
     // panels after Set / Retire.
     featuredSlots: (params?: Record<string, unknown>) =>
       ['admin', 'featuredSlots', params] as const,
+    // Streaming-discovery triage worklist. Status filter + limit /
+    // offset are part of the key so the status filter and pagination
+    // produce independent cache entries; status mutations invalidate
+    // the whole streamingWorklist branch.
+    streamingWorklist: (params?: Record<string, unknown>) =>
+      ['admin', 'streamingWorklist', params] as const,
   },
 
   // Artist queries (defined in features/artists/api.ts)


### PR DESCRIPTION
## Summary
- New `/admin/streaming-worklist` route + `StreamingWorklist` feature module that surfaces the prioritized triage queue from PSY-827. Admin sees one row per artist with non-terminal `streaming_discovery_status` + at least one upcoming show, ordered by soonest show. Each row exposes "Review →" (opens the artist page where the PSY-816 candidate panel lives) plus explicit "Mark linked", "Mark no_links_found", and "Mark skipped" actions with an optional inline reason form.
- Engine seam (locked decision: worklist writes, engine stays stateless): PSY-816's candidate-review panel is INLINE on the artist detail page; the worklist's "Review →" opens that page in a new tab and the worklist refetches on window focus. The status flip to `linked` (and the two terminal-decline statuses) is concentrated on the worklist row so the discovery engine itself remains stateless. Decision documented inline in `StreamingWorklist.tsx`.
- Dashboard discoverability: new "Tools" section in `AdminDashboard` with link cards for `/admin/streaming-worklist` and `/admin/featured`; both routes are standalone (not in the main tab grid) and previously had no nav entry.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/admin` — 28 passed (4 files; the new hook tests + component tests pass)
- [x] `bun run test:run app/admin` — 91 passed (no regressions in adjacent admin tests; AdminDashboard mutation didn't break the dashboard test)

## Manual repro
Stack mode: shared (`bash scripts/dispatch/stack-up.sh "$(git rev-parse --show-toplevel)" --mode=shared`). Logged in as `admin@test.local`. Screenshots:
- Worklist table populated (mixed `unreviewed` + `candidates_pending`): `dogfood-output/PSY-828/screenshots/01-worklist-table.png`
- After Mark-skipped → green success banner + row dropout + total decrement: `dogfood-output/PSY-828/screenshots/02-after-skipped.png`
- Status filter narrowed to `Unreviewed` (excludes the `candidates_pending` row): `dogfood-output/PSY-828/screenshots/03-filter-unreviewed.png`

Verified: admin-only gating (anonymous → `/auth?returnTo=%2Fadmin`), table render, status filter (all / unreviewed / candidates_pending), inline-reason mutation flow with banner + row dropout, persistence of `streaming_discovery_reason` in Postgres. Engine seam (worklist → artist page) was reachable visually; PSY-816's candidate panel itself was NOT exercised in this run because seeded artists don't have pre-canned candidates and live `discover-music` hits the Claude API (out of scope for dev-stack repro). Pagination not exercised since the seed has 5 eligible rows (under the limit of 25); the new auto-rewind logic from the code-review pass IS covered by the existing component test suite via the empty-state path.

## Code review
`/code-review` at max effort surfaced 3 findings, all fixed in this PR (separate `PSY-828: code-review pass` commit):
1. `useUpdateStreamingDiscoveryStatus` was unwrapping a non-existent `{body: ...}` envelope. Huma serializes a response struct's `Body` field AS the HTTP body — verified empirically with curl. The mutation would have returned `undefined`. Fixed by removing the wrapper type and returning the artist payload directly.
2. Dead `params` object built in `useStreamingWorklist` that was never used (only the inline `URLSearchParams` in `queryFn` ran). Removed.
3. Pagination edge case: when a status mutation drops the only visible row on a non-first page, `total` decremented but `offset` didn't — admin would have landed on an empty "Worklist clear" screen with prev/next still active. Added an effect that rewinds `offset` to the last non-empty page when entries empty out but `total > 0`.

Closes PSY-828