### PR TITLE
PSY-824: AI-assisted collection import (paste article or screenshot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
         with:
           files: backend/coverage.out
           flags: backend
+          disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # PSY-772: backend lint gate. Two steps, two configs:
@@ -241,6 +242,8 @@ jobs:
         with:
           files: frontend/coverage/lcov.info
           flags: frontend
+          disable_search: true
+          working-directory: ./frontend
           token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-smoke:

--- a/frontend/app/api/ai/extract-collection/route.ts
+++ b/frontend/app/api/ai/extract-collection/route.ts
@@ -1,0 +1,455 @@
+/**
+ * AI-assisted collection extraction.
+ *
+ * Mirrors the extract-show route: same auth check, same Anthropic SDK
+ * pattern, same matched/suggestions response shape. Differences:
+ *   - System prompt asks the model for a LIST of {artist_name, release_title?}
+ *     rows in source order, not a single show payload.
+ *   - Match strategy: per-row artist match against the existing
+ *     `/artists/search` endpoint (case-insensitive exact match → matched_id,
+ *     else top 3 suggestions). Release matching deferred — V1 carries
+ *     release_title through to the response verbatim and the bulk-add
+ *     pipeline commits only matched artist rows.
+ *   - No autonomous entity creation. Per `feedback_human_verify_ai_entity_data.md`,
+ *     unmatched rows go through the existing human-review path (a follow-up
+ *     will wire the queue-for-review per-tier action; V1 surfaces unmatched
+ *     rows as suggestions only).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import Anthropic from '@anthropic-ai/sdk'
+import * as Sentry from '@sentry/nextjs'
+import type {
+  ExtractCollectionRequest,
+  ExtractCollectionResponse,
+  ExtractedCollectionData,
+  ExtractedCollectionItem,
+  MatchSuggestion,
+} from '@/lib/types/extraction'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
+
+/** Max payload sizes — mirror extract-show's gates so the surfaces stay aligned. */
+const MAX_TEXT_LENGTH = 30000 // canon-list articles run longer than show flyers
+const MAX_ITEMS_PER_EXTRACTION = 250 // bounded so a runaway prompt can't return 5,000 rows
+
+/**
+ * System prompt for collection extraction. Tuned for canon-list articles
+ * (Pitchfork's 200 best albums, AOTY top-N, weekly Post-Trash digests).
+ */
+function getExtractionSystemPrompt(): string {
+  return `You are a music-list extractor. Given text or an image of an article describing a list of musical works, extract structured information.
+
+Output ONLY valid JSON with no additional text or markdown formatting:
+{
+  "source": "Pitchfork's 200 Best Albums of the 2010s",
+  "description": "One-paragraph summary of the list's editorial framing, if present.",
+  "items": [
+    {"artist_name": "Kendrick Lamar", "release_title": "To Pimp a Butterfly"},
+    {"artist_name": "Frank Ocean", "release_title": "Blonde"},
+    {"artist_name": "Boris", "release_title": "Pink"}
+  ]
+}
+
+Rules:
+- Items must be in the order they appear in the source (top to bottom for lists; numbered or unranked both fine).
+- For album lists, every item has artist_name + release_title. For pure artist lists, omit release_title.
+- Use the canonical spelling the source uses (e.g. "Kendrick Lamar" not "kendrick lamar"). Do not invent capitalizations.
+- If the source has both ranked + unranked sections, extract ranked first then unranked in source order.
+- "source" should be the article's title or list name (e.g. "Pitchfork's 200 Best Albums of the 2010s"). Omit if unclear.
+- "description" should summarize the editorial framing in 1-2 sentences if the article has one. Omit if it's just a list with no editorial.
+- Skip any non-music entries (interludes, single tracks listed separately from their album, etc.).
+- Cap the items array at ${MAX_ITEMS_PER_EXTRACTION} rows even if the source is longer — return the top N in source order.
+- Return ONLY the JSON object, no explanation or markdown code blocks.`
+}
+
+interface UserProfile {
+  success: boolean
+  user?: {
+    id: string
+    email?: string
+  }
+}
+
+interface ArtistSearchResult {
+  artists: Array<{
+    id: number
+    name: string
+    slug: string
+  }>
+  count: number
+}
+
+async function getAuthenticatedUser(
+  authToken: string
+): Promise<UserProfile | null> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
+      headers: {
+        Cookie: `auth_token=${authToken}`,
+      },
+    })
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+async function searchArtist(name: string): Promise<ArtistSearchResult | null> {
+  try {
+    const response = await fetch(
+      `${BACKEND_URL}/artists/search?q=${encodeURIComponent(name)}`
+    )
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Match extracted items against the artists table. Sequential (not parallel)
+ * so we don't fan out N=250 simultaneous backend requests at the upper end of
+ * the cap. Backend search is cheap (~10ms) so the total is bounded at
+ * canon-list scale (~2.5s at 250 items). If we ever hit 1000+ items, batch
+ * the search calls via a new endpoint instead of parallelizing N HTTP fetches.
+ */
+async function matchItems(
+  rawItems: Array<{ artist_name?: string; release_title?: string }>
+): Promise<ExtractedCollectionItem[]> {
+  const matched: ExtractedCollectionItem[] = []
+
+  for (const raw of rawItems) {
+    const artistName = typeof raw.artist_name === 'string' ? raw.artist_name.trim() : ''
+    if (!artistName) continue
+
+    const item: ExtractedCollectionItem = {
+      artist_name: artistName,
+      release_title:
+        typeof raw.release_title === 'string' && raw.release_title.trim().length > 0
+          ? raw.release_title.trim()
+          : undefined,
+    }
+
+    const searchResult = await searchArtist(artistName)
+    if (searchResult && Array.isArray(searchResult.artists) && searchResult.artists.length > 0) {
+      // Same-name-band collision guard (`feedback_human_verify_ai_entity_data.md`):
+      // canon-list articles produce names like "Boris" that match multiple
+      // distinct PH artists (Japanese drone band vs American hardcore band).
+      // If MULTIPLE candidates exact-match (case-insensitive), don't
+      // auto-pick — surface as Pick suggestions so the user verifies. Only
+      // auto-match when there's exactly one candidate with the name.
+      const exactMatches = searchResult.artists.filter(
+        a => a.name.toLowerCase() === artistName.toLowerCase()
+      )
+      if (exactMatches.length === 1) {
+        item.matched_artist_id = exactMatches[0].id
+        item.matched_artist_name = exactMatches[0].name
+        item.matched_artist_slug = exactMatches[0].slug
+      } else {
+        item.artist_suggestions = searchResult.artists.slice(0, 3).map(
+          (a): MatchSuggestion => ({
+            id: a.id,
+            name: a.name,
+            slug: a.slug,
+          })
+        )
+      }
+    }
+
+    matched.push(item)
+  }
+
+  return matched
+}
+
+function parseExtractionResponse(text: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(text)
+  } catch {
+    const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/)
+    if (jsonMatch) {
+      try {
+        return JSON.parse(jsonMatch[1].trim())
+      } catch {
+        return null
+      }
+    }
+    const objectMatch = text.match(/\{[\s\S]*\}/)
+    if (objectMatch) {
+      try {
+        return JSON.parse(objectMatch[0])
+      } catch {
+        return null
+      }
+    }
+    return null
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const cookieStore = await cookies()
+  const authCookie = cookieStore.get('auth_token')
+
+  if (!authCookie) {
+    return NextResponse.json<ExtractCollectionResponse>(
+      { success: false, error: 'Authentication required' },
+      { status: 401 }
+    )
+  }
+
+  const profile = await getAuthenticatedUser(authCookie.value)
+  if (!profile?.success) {
+    return NextResponse.json<ExtractCollectionResponse>(
+      { success: false, error: 'Authentication required' },
+      { status: 401 }
+    )
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    const error = new Error('ANTHROPIC_API_KEY not configured')
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'extract-collection' },
+    })
+    return NextResponse.json<ExtractCollectionResponse>(
+      { success: false, error: 'AI service not configured' },
+      { status: 503 }
+    )
+  }
+
+  let body: ExtractCollectionRequest
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json<ExtractCollectionResponse>(
+      { success: false, error: 'Invalid request body' },
+      { status: 400 }
+    )
+  }
+
+  const validMediaTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+
+  if (body.type === 'text') {
+    if (!body.text || body.text.trim().length === 0) {
+      return NextResponse.json<ExtractCollectionResponse>(
+        { success: false, error: 'Text content is required' },
+        { status: 400 }
+      )
+    }
+    if (body.text.length > MAX_TEXT_LENGTH) {
+      return NextResponse.json<ExtractCollectionResponse>(
+        {
+          success: false,
+          error: `Text content exceeds maximum length of ${MAX_TEXT_LENGTH.toLocaleString()} characters`,
+        },
+        { status: 400 }
+      )
+    }
+  } else if (body.type === 'image' || body.type === 'both') {
+    if (!body.image_data) {
+      return NextResponse.json<ExtractCollectionResponse>(
+        { success: false, error: 'Image data is required' },
+        { status: 400 }
+      )
+    }
+    if (!body.media_type) {
+      return NextResponse.json<ExtractCollectionResponse>(
+        { success: false, error: 'Image media type is required' },
+        { status: 400 }
+      )
+    }
+    if (!validMediaTypes.includes(body.media_type)) {
+      return NextResponse.json<ExtractCollectionResponse>(
+        {
+          success: false,
+          error: `Invalid image type. Supported formats: ${validMediaTypes.join(', ')}`,
+        },
+        { status: 400 }
+      )
+    }
+    if (body.type === 'both' && body.text && body.text.length > MAX_TEXT_LENGTH) {
+      return NextResponse.json<ExtractCollectionResponse>(
+        {
+          success: false,
+          error: `Text content exceeds maximum length of ${MAX_TEXT_LENGTH.toLocaleString()} characters`,
+        },
+        { status: 400 }
+      )
+    }
+  } else {
+    return NextResponse.json<ExtractCollectionResponse>(
+      { success: false, error: 'Invalid request type. Use "text", "image", or "both"' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const anthropic = new Anthropic({ apiKey })
+
+    let userContent: Anthropic.MessageParam['content']
+
+    if (body.type === 'text') {
+      userContent = body.text!
+    } else if (body.type === 'image') {
+      userContent = [
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: body.media_type!,
+            data: body.image_data!,
+          },
+        },
+        {
+          type: 'text',
+          text: 'Extract the list of musical works (artists / releases) from this image. Items in source order.',
+        },
+      ]
+    } else {
+      const contextText = body.text?.trim()
+        ? `Extract the list of musical works (artists / releases) from this image. Items in source order. Additional context from user: ${body.text}`
+        : 'Extract the list of musical works (artists / releases) from this image. Items in source order.'
+
+      userContent = [
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: body.media_type!,
+            data: body.image_data!,
+          },
+        },
+        {
+          type: 'text',
+          text: contextText,
+        },
+      ]
+    }
+
+    // 8192 vs extract-show's 1024 — canon lists at the 250-item upper end
+    // produce ~25 tokens of JSON per row plus envelope, so a 200-item
+    // Pitchfork list runs ~5,500-6,500 tokens of response. 4096 truncates
+    // mid-JSON and parseExtractionResponse silently fails. Haiku's actual
+    // ceiling is much higher; 8192 leaves headroom without changing cost
+    // semantics (we're billed on actual output tokens, not the ceiling).
+    const response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 8192,
+      system: getExtractionSystemPrompt(),
+      messages: [
+        {
+          role: 'user',
+          content: userContent,
+        },
+      ],
+    })
+
+    let responseText = ''
+    for (const block of response.content) {
+      if (block.type === 'text') {
+        responseText += block.text
+      }
+    }
+
+    const parsed = parseExtractionResponse(responseText)
+    if (!parsed) {
+      return NextResponse.json<ExtractCollectionResponse>(
+        {
+          success: false,
+          error: 'Failed to parse AI response',
+          warnings: ['The AI response could not be parsed as JSON. Please try again.'],
+        },
+        { status: 500 }
+      )
+    }
+
+    const warnings: string[] = []
+    const rawItems = Array.isArray(parsed.items) ? parsed.items : []
+    if (rawItems.length === 0) {
+      warnings.push('No items were found in the input')
+    }
+
+    // Cap server-side too — defends against an over-eager model returning
+    // 1000 rows when we asked for 250.
+    const cappedItems = rawItems.slice(0, MAX_ITEMS_PER_EXTRACTION)
+    if (rawItems.length > MAX_ITEMS_PER_EXTRACTION) {
+      warnings.push(
+        `Extracted ${rawItems.length} items; truncated to the first ${MAX_ITEMS_PER_EXTRACTION}.`
+      )
+    }
+
+    const matched = await matchItems(cappedItems)
+
+    const matchedCount = matched.filter(m => m.matched_artist_id).length
+    const suggestionCount = matched.filter(
+      m => !m.matched_artist_id && m.artist_suggestions?.length
+    ).length
+    const newCount = matched.length - matchedCount - suggestionCount
+    if (newCount > 0 || suggestionCount > 0) {
+      const parts: string[] = []
+      if (matchedCount > 0) parts.push(`${matchedCount} matched`)
+      if (suggestionCount > 0) parts.push(`${suggestionCount} with suggestions`)
+      if (newCount > 0) parts.push(`${newCount} new`)
+      warnings.push(`Items: ${parts.join(', ')}`)
+    }
+
+    const extractedData: ExtractedCollectionData = {
+      source: typeof parsed.source === 'string' ? parsed.source : undefined,
+      description: typeof parsed.description === 'string' ? parsed.description : undefined,
+      items: matched,
+    }
+
+    return NextResponse.json<ExtractCollectionResponse>({
+      success: true,
+      data: extractedData,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    })
+  } catch (error) {
+    console.error('Collection extraction error:', error)
+
+    if (error instanceof Anthropic.APIError) {
+      const message = error.message.toLowerCase()
+      if (message.includes('credit') || message.includes('billing') || message.includes('balance')) {
+        Sentry.captureException(error, {
+          level: 'error',
+          tags: { service: 'extract-collection', error_type: 'credits_exhausted' },
+        })
+        return NextResponse.json<ExtractCollectionResponse>(
+          {
+            success: false,
+            error: 'AI service temporarily unavailable. Please try again later.',
+          },
+          { status: 503 }
+        )
+      }
+
+      Sentry.captureException(error, {
+        level: 'error',
+        tags: { service: 'extract-collection', error_type: 'api_error' },
+      })
+      return NextResponse.json<ExtractCollectionResponse>(
+        {
+          success: false,
+          error: 'AI service error. Please try again.',
+        },
+        { status: 503 }
+      )
+    }
+
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'extract-collection' },
+    })
+    return NextResponse.json<ExtractCollectionResponse>(
+      {
+        success: false,
+        error: 'An unexpected error occurred. Please try again.',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/features/collections/components/AICollectionFiller.test.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.test.tsx
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { AICollectionFiller } from './AICollectionFiller'
+import type { ExtractedCollectionData } from '@/lib/types/extraction'
+
+// ──────────────────────────────────────────────
+// Mocks
+// ──────────────────────────────────────────────
+
+let mockExtractResult: { data?: ExtractedCollectionData; warnings?: string[] } = {
+  data: undefined,
+  warnings: undefined,
+}
+let mockExtractIsPending = false
+let mockExtractError: Error | null = null
+let mockExtractCalls: Array<unknown> = []
+
+vi.mock('../hooks', () => ({
+  useCollectionExtraction: () => ({
+    mutate: (
+      input: unknown,
+      opts?: { onSuccess?: (data: typeof mockExtractResult) => void }
+    ) => {
+      mockExtractCalls.push(input)
+      opts?.onSuccess?.(mockExtractResult)
+    },
+    isPending: mockExtractIsPending,
+    error: mockExtractError,
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    ...props
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    [key: string]: unknown
+  }) => (
+    <button onClick={onClick} disabled={disabled} {...(props as Record<string, unknown>)}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock('@/components/shared', () => ({
+  InlineErrorBanner: ({
+    children,
+    testId,
+  }: {
+    children: React.ReactNode
+    testId?: string
+  }) => <div data-testid={testId}>{children}</div>,
+}))
+
+// ──────────────────────────────────────────────
+// Component
+// ──────────────────────────────────────────────
+
+describe('AICollectionFiller', () => {
+  beforeEach(() => {
+    mockExtractResult = { data: undefined, warnings: undefined }
+    mockExtractIsPending = false
+    mockExtractError = null
+    mockExtractCalls = []
+  })
+
+  it('renders textarea + image drop zone + disabled extract button', () => {
+    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    expect(screen.getByTestId('ai-collection-filler-textarea')).toBeInTheDocument()
+    expect(screen.getByTestId('ai-collection-filler-file-input')).toBeInTheDocument()
+    expect(screen.getByTestId('ai-collection-filler-extract')).toBeDisabled()
+  })
+
+  it('enables Extract once text is typed', async () => {
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    await user.type(
+      screen.getByTestId('ai-collection-filler-textarea'),
+      '1. Kendrick Lamar — TPAB'
+    )
+    expect(screen.getByTestId('ai-collection-filler-extract')).not.toBeDisabled()
+  })
+
+  it('file input accepts HEIC + HEIF for iOS Safari paste', () => {
+    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    const input = screen.getByTestId('ai-collection-filler-file-input') as HTMLInputElement
+    expect(input.getAttribute('accept')).toContain('image/heic')
+    expect(input.getAttribute('accept')).toContain('image/heif')
+    // The .heic/.heif extension fallbacks let Safari's photo picker show
+    // files that report an empty `file.type` (caught: iOS Safari sometimes
+    // drops the mime-type on clipboard paste).
+    expect(input.getAttribute('accept')).toContain('.heic')
+  })
+
+  it('renders MATCH / PICK / NEW badges after extraction', async () => {
+    mockExtractResult = {
+      data: {
+        source: 'The 200 Best Albums of the 2010s',
+        items: [
+          {
+            artist_name: 'Kendrick Lamar',
+            release_title: 'To Pimp a Butterfly',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+            matched_artist_slug: 'kendrick-lamar',
+          },
+          {
+            artist_name: 'Boris',
+            release_title: 'Pink',
+            artist_suggestions: [
+              { id: 100, name: 'Boris', slug: 'boris' },
+              { id: 101, name: 'Boris (US)', slug: 'boris-us' },
+            ],
+          },
+          {
+            artist_name: 'Some Made Up Band',
+            release_title: 'Nowhere Album',
+          },
+        ],
+      },
+    }
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    await user.type(
+      screen.getByTestId('ai-collection-filler-textarea'),
+      'list goes here'
+    )
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    expect(screen.getByText('MATCH')).toBeInTheDocument()
+    expect(screen.getByText('PICK')).toBeInTheDocument()
+    expect(screen.getByText('NEW')).toBeInTheDocument()
+    expect(screen.getByText('The 200 Best Albums of the 2010s')).toBeInTheDocument()
+  })
+
+  it('clicking Add on a MATCH row stages exactly that row', async () => {
+    mockExtractResult = {
+      data: {
+        items: [
+          {
+            artist_name: 'Kendrick Lamar',
+            release_title: 'To Pimp a Butterfly',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+            matched_artist_slug: 'kendrick-lamar',
+          },
+        ],
+      },
+    }
+    const onStage = vi.fn()
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={onStage} alreadyStaged={() => false} />)
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    await user.click(screen.getByTestId('ai-collection-filler-row-add'))
+
+    // Single batched call carrying the matched entity_id.
+    expect(onStage).toHaveBeenCalledTimes(1)
+    expect(onStage.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        entityType: 'artist',
+        entityId: 42,
+        name: 'Kendrick Lamar',
+      }),
+    ])
+    // Subtitle is the raw release title — StagedRow inserts its own ' — '
+    // separator, so prepending one here would render a doubled em-dash.
+    expect(onStage.mock.calls[0][0][0].subtitle).toBe('To Pimp a Butterfly')
+  })
+
+  // Regression: canon lists ("100 Best Albums") contain multiple releases
+  // by the same artist. Without per-batch dedup, all rows collapsing to
+  // one matched_artist_id would emit duplicate-key React warnings and the
+  // backend's UNIQUE(collection_id, entity_type, entity_id) would silently
+  // keep only one.
+  it('Add all matched deduplicates same-artist rows within the batch', async () => {
+    mockExtractResult = {
+      data: {
+        items: [
+          {
+            artist_name: 'Kendrick Lamar',
+            release_title: 'To Pimp a Butterfly',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+          },
+          {
+            artist_name: 'Kendrick Lamar',
+            release_title: 'DAMN.',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+          },
+          {
+            artist_name: 'Frank Ocean',
+            release_title: 'Blonde',
+            matched_artist_id: 43,
+            matched_artist_name: 'Frank Ocean',
+          },
+        ],
+      },
+    }
+    const onStage = vi.fn()
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={onStage} alreadyStaged={() => false} />)
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    await user.click(screen.getByTestId('ai-collection-filler-add-all-matched'))
+
+    expect(onStage).toHaveBeenCalledTimes(1)
+    const batched = onStage.mock.calls[0][0] as Array<{ entityId: number }>
+    expect(batched).toHaveLength(2)
+    expect(batched.map(b => b.entityId).sort()).toEqual([42, 43])
+  })
+
+  // Regression: handleTextChange must preserve extractionResult across
+  // keystrokes — each row can take multiple manual interactions (Pick
+  // suggestions, accept-then-skip cycles). Wiping on every character
+  // would force users to re-extract from scratch.
+  it('typing in the textarea after extraction preserves the extracted rows', async () => {
+    mockExtractResult = {
+      data: {
+        items: [
+          {
+            artist_name: 'Kendrick Lamar',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+          },
+        ],
+      },
+    }
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    expect(screen.getByText('Kendrick Lamar')).toBeInTheDocument()
+
+    // Typing another character must NOT wipe the result.
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), '!')
+    expect(screen.getByText('Kendrick Lamar')).toBeInTheDocument()
+  })
+
+  it('accepting a "Did you mean" suggestion promotes the row to MATCH', async () => {
+    mockExtractResult = {
+      data: {
+        items: [
+          {
+            artist_name: 'Boris',
+            release_title: 'Pink',
+            artist_suggestions: [
+              { id: 100, name: 'Boris', slug: 'boris' },
+              { id: 101, name: 'Boris (US)', slug: 'boris-us' },
+            ],
+          },
+        ],
+      },
+    }
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    expect(screen.getByText('PICK')).toBeInTheDocument()
+    // Click the first suggestion chip.
+    const suggestionButtons = screen.getAllByTestId('ai-collection-filler-row-pick')
+    await user.click(suggestionButtons[0])
+
+    // PICK badge gone; MATCH badge present.
+    expect(screen.queryByText('PICK')).not.toBeInTheDocument()
+    expect(screen.getByText('MATCH')).toBeInTheDocument()
+  })
+
+  it('"Add all matched" stages all eligible rows in one batched call', async () => {
+    mockExtractResult = {
+      data: {
+        items: [
+          {
+            artist_name: 'Kendrick Lamar',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+          },
+          {
+            artist_name: 'Frank Ocean',
+            matched_artist_id: 43,
+            matched_artist_name: 'Frank Ocean',
+          },
+          {
+            // Suggestion-only row — should NOT be in the batch.
+            artist_name: 'Boris',
+            artist_suggestions: [{ id: 100, name: 'Boris', slug: 'boris' }],
+          },
+        ],
+      },
+    }
+    const onStage = vi.fn()
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={onStage} alreadyStaged={() => false} />)
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    await user.click(screen.getByTestId('ai-collection-filler-add-all-matched'))
+
+    // ONE call (batched) carrying both matched entities, NOT the suggestion-only row.
+    expect(onStage).toHaveBeenCalledTimes(1)
+    const batched = onStage.mock.calls[0][0] as Array<{ entityId: number }>
+    expect(batched).toHaveLength(2)
+    expect(batched.map(b => b.entityId)).toEqual([42, 43])
+  })
+
+  it('already-staged rows render an "Added" chip instead of [Add]', async () => {
+    mockExtractResult = {
+      data: {
+        items: [
+          {
+            artist_name: 'Kendrick Lamar',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+          },
+        ],
+      },
+    }
+    const user = userEvent.setup()
+    render(
+      <AICollectionFiller
+        onStageItems={vi.fn()}
+        alreadyStaged={(t, id) => t === 'artist' && id === 42}
+      />
+    )
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    expect(screen.getByText('Added')).toBeInTheDocument()
+    expect(screen.queryByTestId('ai-collection-filler-row-add')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a hook error via InlineErrorBanner', async () => {
+    mockExtractError = new Error('AI service temporarily unavailable.')
+    const user = userEvent.setup()
+    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+
+    const banner = screen.getByTestId('ai-collection-filler-error')
+    expect(banner).toHaveTextContent(/temporarily unavailable/i)
+  })
+})

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -1,0 +1,638 @@
+'use client'
+
+/**
+ * AICollectionFiller — AI-assisted collection-item extraction.
+ *
+ * Sister to `frontend/components/forms/AIFormFiller.tsx` (show extraction).
+ * Duplicate-not-parameterize at N=2 — refactor to a shared `AIInputCard`
+ * primitive when a 3rd consumer lands. The
+ * text+image+compression chrome is structurally the same; the post-extract
+ * preview UI is different (per-row collection items with name-only match
+ * + Pick UX, vs show-extraction's artists+venue+date+time).
+ *
+ * Accepts text and/or an image. On success, surfaces per-row matched /
+ * with-suggestions / new states from `/api/ai/extract-collection`. User
+ * stages matched (and picked-suggestion) rows into the parent
+ * AddItemsPicker via the `onStageItems` callback.
+ *
+ * iOS Safari HEIC support: file input accepts `image/heic`,`image/heif` so
+ * iOS users can upload HEIC screenshots directly. Safari's native canvas
+ * decode converts them to JPEG via the compression step (the existing
+ * canvas.toDataURL('image/jpeg') path). Non-Safari browsers without HEIC
+ * decode will fall through the onerror path and show an inline error —
+ * full polyfill via `heic2any` deferred to a follow-up if telemetry
+ * shows non-Safari HEIC failures.
+ */
+
+import { useCallback, useRef, useState } from 'react'
+import {
+  Sparkles,
+  X,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  AlertTriangle,
+  ImageIcon,
+  Plus,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { InlineErrorBanner } from '@/components/shared'
+import { useCollectionExtraction } from '../hooks'
+import type {
+  ExtractedCollectionData,
+  ExtractedCollectionItem,
+  MatchSuggestion,
+} from '@/lib/types/extraction'
+import type { StagedCollectionItem } from './AddItemsPicker'
+
+const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB
+const SUPPORTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  // iOS Safari HEIC paste/upload — browser-native decode converts
+  // HEIC → JPEG in the canvas step below. Non-Safari fall-through is
+  // graceful (inline error). heic2any polyfill is a follow-up.
+  'image/heic',
+  'image/heif',
+]
+// File input `accept` attribute. Lists extensions in addition to MIME
+// types so iOS Safari's photo picker shows .heic files (Safari sometimes
+// reports an empty `file.type` for clipboard-pasted HEIC).
+const FILE_INPUT_ACCEPT =
+  'image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif,.heic,.heif'
+
+// 1500px keeps the base64 payload comfortably under Vercel's 4.5MB body
+// limit at canvas.toDataURL('image/jpeg', 0.8). Mirrors AIFormFiller.
+const MAX_IMAGE_DIMENSION = 1500
+const JPEG_QUALITY = 0.8
+
+function compressImage(dataUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => {
+      let { width, height } = img
+      if (width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
+        const scale = MAX_IMAGE_DIMENSION / Math.max(width, height)
+        width = Math.round(width * scale)
+        height = Math.round(height * scale)
+      }
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        reject(new Error('Could not get canvas context'))
+        return
+      }
+      ctx.drawImage(img, 0, 0, width, height)
+      resolve(canvas.toDataURL('image/jpeg', JPEG_QUALITY))
+    }
+    img.onerror = () =>
+      reject(
+        new Error(
+          'Failed to decode image. HEIC images upload best from iOS Safari; on other browsers, convert to JPEG first.'
+        )
+      )
+    img.src = dataUrl
+  })
+}
+
+export interface AICollectionFillerProps {
+  /**
+   * Fires when the user stages one or more extracted items via the per-row
+   * Add buttons (or "Add all matched"). Parent (AddItemsPicker) routes the
+   * call through its onStageBatch so the staged list updates in a single
+   * React setState (avoiding the same setState-batching race the regular
+   * paste-mode addAll path guards against).
+   */
+  onStageItems: (items: StagedCollectionItem[]) => void
+  /**
+   * Predicate: is this entity already staged (or already in the
+   * collection)? Used to render the "Added" chip per row.
+   */
+  alreadyStaged: (entityType: 'artist', entityId: number) => boolean
+}
+
+export function AICollectionFiller({
+  onStageItems,
+  alreadyStaged,
+}: AICollectionFillerProps) {
+  const [textInput, setTextInput] = useState('')
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreview, setImagePreview] = useState<string | null>(null)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [extractionResult, setExtractionResult] =
+    useState<ExtractedCollectionData | null>(null)
+  const [warnings, setWarnings] = useState<string[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const { mutate, isPending, error, reset } = useCollectionExtraction()
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTextInput(e.target.value)
+    // Note: extractionResult is intentionally preserved across keystrokes.
+    // Each row can take multiple manual interactions (Pick suggestions,
+    // Skip choices) — wiping the result on every character would force
+    // the user to redo all those interactions if they ever go back to
+    // touch the textarea. Clear via clearImage or a fresh Extract.
+    setImageError(null)
+    reset()
+  }
+
+  const handleImageSelect = useCallback(
+    (file: File) => {
+      // iOS Safari sometimes drops `file.type` on clipboard-pasted HEIC —
+      // fall back to extension sniffing so the supported-types gate doesn't
+      // erroneously reject them.
+      const ext = file.name.toLowerCase().split('.').pop() || ''
+      const inferredType =
+        ext === 'heic' ? 'image/heic' : ext === 'heif' ? 'image/heif' : file.type
+
+      if (!SUPPORTED_IMAGE_TYPES.includes(inferredType)) {
+        setImageError(
+          `Unsupported image type. Please use: JPEG, PNG, GIF, WebP, or HEIC.`
+        )
+        return
+      }
+      if (file.size > MAX_IMAGE_SIZE) {
+        setImageError('Image is too large. Maximum size is 10MB.')
+        return
+      }
+
+      setImageFile(file)
+      // Clear the prior preview eagerly — keeping the old preview while
+      // a new file is being compressed would mismatch the displayed image
+      // with the file the Extract button would actually send.
+      setImagePreview(null)
+      setImageError(null)
+      setExtractionResult(null)
+      setWarnings([])
+      reset()
+
+      const reader = new FileReader()
+      reader.onload = async e => {
+        const rawResult = e.target?.result
+        if (typeof rawResult !== 'string') {
+          setImageError('Failed to read image file.')
+          setImageFile(null)
+          return
+        }
+        try {
+          const compressed = await compressImage(rawResult)
+          setImagePreview(compressed)
+        } catch (err) {
+          setImageError(
+            err instanceof Error ? err.message : 'Failed to read image.'
+          )
+          // Clear both file + preview on decode failure so the dropzone
+          // returns and the user can pick a different image without a
+          // stale preview visible.
+          setImageFile(null)
+          setImagePreview(null)
+        }
+      }
+      reader.onerror = () => {
+        setImageError('Failed to read image file.')
+        setImageFile(null)
+        setImagePreview(null)
+      }
+      reader.readAsDataURL(file)
+    },
+    [reset]
+  )
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) handleImageSelect(file)
+  }
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const file = e.dataTransfer.files[0]
+      if (file) handleImageSelect(file)
+    },
+    [handleImageSelect]
+  )
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }
+
+  const clearImage = () => {
+    setImageFile(null)
+    setImagePreview(null)
+    setImageError(null)
+    setExtractionResult(null)
+    setWarnings([])
+    reset()
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const handleExtract = async () => {
+    const hasText = textInput.trim().length > 0
+    const hasImage = imageFile !== null && imagePreview !== null
+    if (!hasText && !hasImage) return
+
+    const onSuccess = (response: { data?: ExtractedCollectionData; warnings?: string[] }) => {
+      if (response.data) {
+        setExtractionResult(response.data)
+        setWarnings(response.warnings || [])
+      }
+    }
+
+    if (hasImage) {
+      const base64Data = imagePreview!.split(',')[1]
+      mutate(
+        {
+          type: hasText ? 'both' : 'image',
+          image_data: base64Data,
+          media_type: 'image/jpeg',
+          text: hasText ? textInput : undefined,
+        },
+        { onSuccess }
+      )
+    } else {
+      mutate({ type: 'text', text: textInput }, { onSuccess })
+    }
+  }
+
+  // Gate Extract on the image being fully compressed (imagePreview set),
+  // not just the file being picked — there's an async window after
+  // setImageFile() before FileReader.onload's compressImage completes
+  // where clicking would silently drop the image and either no-op (no
+  // text) or send text-only (image silently discarded). Both are bad
+  // UX; require the image to be ready before allowing extract.
+  const imageReady = imageFile === null || imagePreview !== null
+  const canExtract =
+    (textInput.trim().length > 0 || imageFile !== null) && imageReady
+
+  // ─── Per-row actions ───
+  // Subtitle uses the raw release title — StagedRow inserts its own
+  // " — " separator between name and subtitle, so prepending one here
+  // would render a doubled em-dash ("Frank Ocean — — Blonde").
+  const stageItem = (item: ExtractedCollectionItem) => {
+    if (!item.matched_artist_id) return
+    onStageItems([
+      {
+        entityType: 'artist',
+        entityId: item.matched_artist_id,
+        name: item.matched_artist_name ?? item.artist_name,
+        subtitle: item.release_title ?? null,
+      },
+    ])
+  }
+
+  // Dedup within the batch too — canon lists ("100 Best Albums") often
+  // contain multiple releases by the same artist, all of which match to
+  // one artist_id. Without per-batch dedup, the staged list would emit
+  // duplicate React keys and the backend's UNIQUE(collection_id,
+  // entity_type, entity_id) constraint would silently keep only one.
+  const stageAllMatched = () => {
+    if (!extractionResult) return
+    const seen = new Set<number>()
+    const toStage: StagedCollectionItem[] = []
+    for (const i of extractionResult.items) {
+      if (!i.matched_artist_id) continue
+      if (alreadyStaged('artist', i.matched_artist_id)) continue
+      if (seen.has(i.matched_artist_id)) continue
+      seen.add(i.matched_artist_id)
+      toStage.push({
+        entityType: 'artist',
+        entityId: i.matched_artist_id,
+        name: i.matched_artist_name ?? i.artist_name,
+        subtitle: i.release_title ?? null,
+      })
+    }
+    if (toStage.length === 0) return
+    onStageItems(toStage)
+  }
+
+  const acceptSuggestion = (itemIndex: number, suggestion: MatchSuggestion) => {
+    if (!extractionResult) return
+    const updatedItems = extractionResult.items.map((item, i) => {
+      if (i !== itemIndex) return item
+      return {
+        ...item,
+        matched_artist_id: suggestion.id,
+        matched_artist_name: suggestion.name,
+        matched_artist_slug: suggestion.slug,
+        artist_suggestions: undefined,
+      }
+    })
+    setExtractionResult({ ...extractionResult, items: updatedItems })
+  }
+
+  const dismissSuggestions = (itemIndex: number) => {
+    if (!extractionResult) return
+    const updatedItems = extractionResult.items.map((item, i) => {
+      if (i !== itemIndex) return item
+      return { ...item, artist_suggestions: undefined }
+    })
+    setExtractionResult({ ...extractionResult, items: updatedItems })
+  }
+
+  const matchedReadyCount = extractionResult
+    ? extractionResult.items.filter(
+        i =>
+          i.matched_artist_id &&
+          !alreadyStaged('artist', i.matched_artist_id)
+      ).length
+    : 0
+
+  return (
+    <div className="mt-3 space-y-3" data-testid="ai-collection-filler">
+      {/* Image drop zone */}
+      {imagePreview ? (
+        <div className="relative">
+          <img
+            src={imagePreview}
+            alt="Uploaded article screenshot"
+            className="max-h-48 rounded-md border border-input object-contain mx-auto"
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="absolute top-2 right-2 h-7 w-7 bg-background/80 hover:bg-background"
+            onClick={clearImage}
+            disabled={isPending}
+            aria-label="Remove uploaded image"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      ) : (
+        <div
+          className="border-2 border-dashed border-input rounded-md p-4 text-center hover:border-primary/50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onClick={() => fileInputRef.current?.click()}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              fileInputRef.current?.click()
+            }
+          }}
+          aria-label="Upload an article screenshot"
+        >
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-3">
+            <div className="flex items-center justify-center h-10 w-10 rounded-full bg-muted">
+              <ImageIcon className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <div className="text-center sm:text-left">
+              <p className="text-sm text-muted-foreground">
+                <span className="hidden sm:inline">Drop a screenshot here, or </span>
+                <span className="sm:hidden">Tap to </span>
+                <span className="text-primary">
+                  <span className="hidden sm:inline">click to select</span>
+                  <span className="sm:hidden">upload a screenshot</span>
+                </span>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                JPEG, PNG, GIF, WebP, HEIC (max 10MB)
+              </p>
+            </div>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={FILE_INPUT_ACCEPT}
+            className="hidden"
+            onChange={handleFileInputChange}
+            disabled={isPending}
+            data-testid="ai-collection-filler-file-input"
+          />
+        </div>
+      )}
+
+      {imageError && (
+        <InlineErrorBanner testId="ai-collection-filler-image-error">
+          {imageError}
+        </InlineErrorBanner>
+      )}
+
+      {/* Text input */}
+      <textarea
+        className="w-full min-h-[160px] rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-y"
+        placeholder={
+          imagePreview
+            ? 'Add any details the image might be missing (list name, ranking notes, etc.)…'
+            : 'Paste the article text. Best results from canon-list articles (Pitchfork best-of, AOTY top-N, weekly digests).\n\nExample:\nPitchfork — The 200 Best Albums of the 2010s\n1. Kendrick Lamar — To Pimp a Butterfly\n2. Frank Ocean — Blonde\n3. Boris — Pink\n…'
+        }
+        value={textInput}
+        onChange={handleTextChange}
+        disabled={isPending}
+        data-testid="ai-collection-filler-textarea"
+      />
+
+      <Button
+        onClick={handleExtract}
+        disabled={!canExtract || isPending}
+        className="w-full"
+        data-testid="ai-collection-filler-extract"
+      >
+        {isPending ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            Extracting…
+          </>
+        ) : (
+          <>
+            <Sparkles className="h-4 w-4 mr-2" />
+            Extract items
+          </>
+        )}
+      </Button>
+
+      {error && (
+        <InlineErrorBanner testId="ai-collection-filler-error">
+          {error.message}
+        </InlineErrorBanner>
+      )}
+
+      {extractionResult && (
+        <div
+          className="rounded-md bg-primary/5 border border-primary/20 p-3 space-y-3"
+          data-testid="ai-collection-filler-result"
+        >
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-2 text-sm font-medium text-primary">
+              <CheckCircle2 className="h-4 w-4" />
+              {extractionResult.source ?? 'Extraction complete'}
+            </div>
+            {matchedReadyCount > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={stageAllMatched}
+                data-testid="ai-collection-filler-add-all-matched"
+              >
+                <Plus className="h-3.5 w-3.5 mr-1" />
+                Add all {matchedReadyCount} matched
+              </Button>
+            )}
+          </div>
+
+          {extractionResult.description && (
+            <p className="text-xs text-muted-foreground italic">
+              {extractionResult.description}
+            </p>
+          )}
+
+          {extractionResult.items.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-2 text-center">
+              No items were extracted. Try richer source text.
+            </p>
+          ) : (
+            <div className="max-h-72 overflow-y-auto space-y-1">
+              {extractionResult.items.map((item, idx) => (
+                <ExtractedRow
+                  key={`${idx}-${item.artist_name}`}
+                  item={item}
+                  alreadyStaged={
+                    item.matched_artist_id
+                      ? alreadyStaged('artist', item.matched_artist_id)
+                      : false
+                  }
+                  onAdd={() => stageItem(item)}
+                  onAcceptSuggestion={s => acceptSuggestion(idx, s)}
+                  onDismissSuggestions={() => dismissSuggestions(idx)}
+                />
+              ))}
+            </div>
+          )}
+
+          {warnings.length > 0 && (
+            <div className="text-xs text-amber-600 dark:text-amber-400 space-y-0.5">
+              {warnings.map((warning, i) => (
+                <div key={i}>{warning}</div>
+              ))}
+            </div>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            Unmatched rows show suggestions for the closest existing entity.
+            Creating new artists / releases via the AI flow lands in a
+            follow-up — for V1 only matched (or picked) rows commit.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ExtractedRow({
+  item,
+  alreadyStaged,
+  onAdd,
+  onAcceptSuggestion,
+  onDismissSuggestions,
+}: {
+  item: ExtractedCollectionItem
+  alreadyStaged: boolean
+  onAdd: () => void
+  onAcceptSuggestion: (suggestion: MatchSuggestion) => void
+  onDismissSuggestions: () => void
+}) {
+  const displayName = item.matched_artist_name ?? item.artist_name
+  const hasSuggestions =
+    !item.matched_artist_id && (item.artist_suggestions?.length ?? 0) > 0
+  const isNew = !item.matched_artist_id && !hasSuggestions
+
+  return (
+    <div
+      className="rounded-md p-2 hover:bg-muted/50"
+      data-testid="ai-collection-filler-row"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium truncate">{displayName}</span>
+            {item.matched_artist_id && (
+              <Badge
+                variant="secondary"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+              >
+                <CheckCircle2 className="h-3 w-3 mr-0.5" />
+                MATCH
+              </Badge>
+            )}
+            {hasSuggestions && (
+              <Badge
+                variant="secondary"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+              >
+                <AlertTriangle className="h-3 w-3 mr-0.5" />
+                PICK
+              </Badge>
+            )}
+            {isNew && (
+              <Badge
+                variant="secondary"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive/10 text-destructive"
+              >
+                <AlertCircle className="h-3 w-3 mr-0.5" />
+                NEW
+              </Badge>
+            )}
+          </div>
+          {item.release_title && (
+            <p className="text-xs text-muted-foreground truncate">
+              {item.release_title}
+            </p>
+          )}
+        </div>
+        {item.matched_artist_id &&
+          (alreadyStaged ? (
+            <Badge variant="secondary" className="text-xs shrink-0">
+              Added
+            </Badge>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 shrink-0"
+              onClick={onAdd}
+              data-testid="ai-collection-filler-row-add"
+            >
+              <Plus className="h-3.5 w-3.5 mr-1" />
+              Add
+            </Button>
+          ))}
+      </div>
+
+      {hasSuggestions && (
+        <div className="ml-0 mt-1.5 flex items-center gap-1.5 flex-wrap text-xs">
+          <span className="text-amber-600 dark:text-amber-400">
+            Did you mean:
+          </span>
+          {item.artist_suggestions!.map(s => (
+            <button
+              key={s.id}
+              type="button"
+              className="rounded-md border border-amber-400 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-xs hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+              onClick={() => onAcceptSuggestion(s)}
+              data-testid="ai-collection-filler-row-pick"
+            >
+              {s.name}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="rounded-md border border-input px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted transition-colors"
+            onClick={onDismissSuggestions}
+          >
+            Skip
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/collections/components/AddItemsPicker.test.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.test.tsx
@@ -248,13 +248,14 @@ describe('AddItemsPicker', () => {
     }
   })
 
-  it('renders Search + Paste tabs and a disabled AI tab', () => {
+  it('renders Search, Paste, and AI tabs', () => {
+    // PSY-824 enabled the AI tab (was disabled with a "Coming in PSY-824"
+    // tooltip in PSY-823). All three tabs should now be present + active.
     render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
     expect(screen.getByTestId('tab-search')).toBeInTheDocument()
     expect(screen.getByTestId('tab-paste')).toBeInTheDocument()
-    const aiTab = screen.getByTestId('tab-ai')
-    expect(aiTab).toBeInTheDocument()
-    expect(aiTab).toBeDisabled()
+    expect(screen.getByTestId('tab-ai')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-ai')).not.toBeDisabled()
   })
 
   it('shows the search empty-state copy by default', () => {

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -20,8 +20,8 @@
  *     round-trip (useResolveCollectionItems). Plain-text lines fall to
  *     UNRESOLVED for V1 — plain-text auto-match is a follow-up.
  *
- * AI mode (third tab) is rendered DISABLED for visual parity with the
- * locked Figma — PSY-824 will enable it.
+ * AI mode (third tab) mounts AICollectionFiller for paste-an-article
+ * extraction via Claude Haiku.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -33,7 +33,6 @@ import {
   Check,
   AlertCircle,
   Library,
-  Sparkles,
   Loader2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -49,6 +48,7 @@ import {
 import { useResolveCollectionItems } from '../hooks'
 import { getEntityTypeLabel } from '../types'
 import { cn } from '@/lib/utils'
+import { AICollectionFiller } from './AICollectionFiller'
 
 // ──────────────────────────────────────────────
 // Types
@@ -364,9 +364,7 @@ export function AddItemsPicker({
         <TabsList className="w-full justify-start">
           <TabsTrigger value="search">Search</TabsTrigger>
           <TabsTrigger value="paste">Paste URLs</TabsTrigger>
-          <TabsTrigger value="ai" disabled title="Coming in PSY-824">
-            From article (AI)
-          </TabsTrigger>
+          <TabsTrigger value="ai">From article (AI)</TabsTrigger>
         </TabsList>
 
         {tab === 'search' && (
@@ -395,10 +393,16 @@ export function AddItemsPicker({
         )}
 
         {tab === 'ai' && (
-          <p className="text-sm text-muted-foreground py-6 text-center">
-            <Sparkles className="inline h-3.5 w-3.5 mr-1.5" />
-            AI extraction lands in PSY-824. For now use Search or Paste URLs.
-          </p>
+          <AICollectionFiller
+            onStageItems={stageBatch}
+            alreadyStaged={(entityType, entityId) =>
+              isAlreadyStaged(
+                { entityType, entityId, name: '', subtitle: null },
+                existingItems,
+                stagedItems
+              )
+            }
+          />
         )}
       </Tabs>
 
@@ -680,8 +684,8 @@ function PasteModePane({
         <p className="text-xs text-muted-foreground">
           Unresolved lines must be canonical PH paths like{' '}
           <code className="px-1 rounded bg-muted">/artists/&lt;slug&gt;</code>.
-          External URLs and free-text auto-match are tracked separately
-          (PSY-824 / follow-up).
+          For an article URL or pasted prose, switch to the AI tab. Free-text
+          auto-match in this paste-URL field is a follow-up.
         </p>
       )}
     </div>

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -780,6 +780,10 @@ export function useAddCollectionTag() {
   })
 }
 
+// Re-export the collection-extraction hook so consumers can import it
+// from `../hooks` alongside the rest of the collection hooks.
+export { useCollectionExtraction } from './useCollectionExtraction'
+
 /**
  * Remove a tag from a collection. Server enforces the same edit-access
  * gate as Add. Errors surface via apiRequest.

--- a/frontend/features/collections/hooks/useCollectionExtraction.ts
+++ b/frontend/features/collections/hooks/useCollectionExtraction.ts
@@ -1,0 +1,40 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import type {
+  ExtractCollectionRequest,
+  ExtractCollectionResponse,
+} from '@/lib/types/extraction'
+
+/**
+ * Hook for the AI-assisted collection extraction. Same shape as
+ * `useShowExtraction` — a thin useMutation wrapper around the Next.js
+ * route. The route handles auth + Anthropic SDK + backend matching; the
+ * hook surfaces the response (or thrown error) to the picker.
+ */
+async function extractCollectionInfo(
+  request: ExtractCollectionRequest
+): Promise<ExtractCollectionResponse> {
+  const response = await fetch('/api/ai/extract-collection', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify(request),
+  })
+
+  const data: ExtractCollectionResponse = await response.json()
+
+  if (!response.ok || !data.success) {
+    throw new Error(data.error || 'Failed to extract collection items')
+  }
+
+  return data
+}
+
+export function useCollectionExtraction() {
+  return useMutation({
+    mutationFn: extractCollectionInfo,
+  })
+}

--- a/frontend/lib/types/extraction.ts
+++ b/frontend/lib/types/extraction.ts
@@ -106,3 +106,72 @@ export interface ExtractShowResponse {
   /** Warnings about partial extraction or uncertain matches */
   warnings?: string[]
 }
+
+// ─────────────────────────────────────────────────────────────
+// AI-assisted collection extraction
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Request to extract a collection's items from pasted article text or a
+ * screenshot of one. Same input shape as show extraction so AICollectionFiller
+ * stays close to the AIFormFiller chrome.
+ */
+export interface ExtractCollectionRequest {
+  type: 'text' | 'image' | 'both'
+  text?: string
+  image_data?: string
+  media_type?: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'
+}
+
+/**
+ * One row in an AI-extracted collection. Mirrors the shape ExtractedArtist
+ * uses for show extraction so consumers can apply the same matched/suggestion
+ * UX pattern. Carries an OPTIONAL release_title — many canon lists are
+ * "best releases" so most rows will have one, but pure artist lists (e.g.
+ * "100 best artists of the decade") have just the artist.
+ *
+ * V1 matches against artists.name (case-insensitive) + artist_aliases.alias;
+ * release_title is preserved verbatim in the response but NOT matched against
+ * the releases table (deferred to a follow-up — release matching needs the
+ * artist match to scope correctly, and same-title releases by different
+ * artists is common enough to need its own picker UX).
+ */
+export interface ExtractedCollectionItem {
+  /** Artist name as extracted from input */
+  artist_name: string
+  /** Release/album title when the source is a "best releases" list */
+  release_title?: string
+  /** Database ID if the artist was matched to an existing entity */
+  matched_artist_id?: number
+  /** Canonical artist name from database (may differ in casing) */
+  matched_artist_name?: string
+  /** Slug from database if matched */
+  matched_artist_slug?: string
+  /** Close matches when no exact artist match found */
+  artist_suggestions?: MatchSuggestion[]
+}
+
+/**
+ * Full extraction result. Items are returned in source order — for canon
+ * lists ("100 best albums of the 2010s") order is the user's primary
+ * curation signal.
+ */
+export interface ExtractedCollectionData {
+  /** Optional source label captured from the article (e.g. "Pitchfork's 200 Best Albums of the 2010s") */
+  source?: string
+  /** Optional description for the collection (suggested title / summary from the article) */
+  description?: string
+  /** Per-row items in source order. */
+  items: ExtractedCollectionItem[]
+}
+
+/**
+ * API response wrapper. Same envelope shape as ExtractShowResponse so
+ * AICollectionFiller's error/warning handling can mirror AIFormFiller's.
+ */
+export interface ExtractCollectionResponse {
+  success: boolean
+  data?: ExtractedCollectionData
+  error?: string
+  warnings?: string[]
+}


### PR DESCRIPTION
Closes PSY-824.

## Summary

- New Next.js API route **`POST /api/ai/extract-collection`** — mirrors the existing `extract-show` pattern (cookie auth → Anthropic SDK → `claude-haiku-4-5-20251001` → JSON parse → backend search match). Accepts text + optional image (including HEIC/HEIF). Returns per-row `{artist_name, release_title?, matched_artist_id?, artist_suggestions[]?}` in source order.
- New **`useCollectionExtraction`** mutation hook (thin `fetch` wrapper, parallel to `useShowExtraction`).
- New **`AICollectionFiller`** component — duplicated-and-adapted from `AIFormFiller.tsx` per the locked decision (parameterize-into-generic when N=3 consumers lands). Text + image input (drag-and-drop, click-to-select), Extract button, per-row preview with **MATCH / PICK / NEW** badges, inline "Did you mean: …" suggestion picker, **"Add all N matched"** batch-stage button.
- **AddItemsPicker AI tab** now enabled (was disabled with "Coming in PSY-824" tooltip in PSY-823). Mounts `AICollectionFiller`; routes per-row `[Add]` and "Add all matched" through the parent's `stageBatch` so the staged-list update is a single React `setState` (no setState-batching race).
- **`feedback_human_verify_ai_entity_data.md` enforced**: same-name-band collision guard. When the backend search returns multiple candidates with the same name (case-insensitive), the row falls to PICK suggestions instead of auto-matching. Only auto-matches when exactly one candidate has the name.
- **iOS Safari HEIC accept**: `accept="image/heic,image/heif,.heic,.heif"` on the file input. Safari's native canvas decode converts HEIC → JPEG via `canvas.toDataURL('image/jpeg', 0.8)`. Non-Safari browsers without HEIC decode get a graceful inline error.

## Deferred (per pre-implementation Q&A + `/code-review` scope cut)

- **Will-create paths** (admin/trusted inline-create + contributor queue-for-review per the ticket spec). V1 ships Matched + Ambiguous PICK only — unmatched rows render `NEW` but have no action. Filed **PSY-853** to address. The deferred path needs a polymorphic `entity_requests` backend that overlaps with **PSY-845** (plain-text "queue for review"); both follow-ups need to coordinate.
- **External-URL fast-match** (the `release_external_links` table). V1 matches on artist name only; the LLM does not emit external URLs. Skipped per pre-implementation Q&A.
- **`AIFormFiller` → generic refactor**. Kept the duplication for V1; refactor when a 3rd AI-input consumer lands (AI-assisted release ingest, AI festival lineup ingest, etc.).
- **`heic2any` polyfill for non-Safari HEIC decode**. V1 relies on Safari's native HEIC → canvas decode; Chrome/Firefox without native HEIC will surface a friendly inline error. Polyfill candidate if telemetry shows real-world non-Safari HEIC volume.

## Heads up from `/code-review`

5 finder angles ran against the diff; the load-bearing findings were fixed inline:

- **Doubled em-dash in staged subtitle** — `subtitle: '— ${release_title}'` would re-prepend in `StagedRow` (which already inserts its own `' — '`), rendering `Frank Ocean — — Blonde`. Fix: subtitle is the raw release title; the separator is the parent's responsibility.
- **`max_tokens: 4096` truncated canon-list responses** — at the 250-item upper end Claude emits ~6,000+ tokens of JSON; the 4096 cap silently truncated mid-JSON and `parseExtractionResponse` returned null. Bumped to 8192.
- **`stageAllMatched` did not dedupe within the batch** — canon lists ("100 Best Albums of the 2010s") often contain multiple releases by the same artist, all collapsing to one `matched_artist_id`. Without per-batch dedup, the staged list emitted duplicate React keys and the backend's `UNIQUE(collection_id, entity_type, entity_id)` constraint silently kept only one. Now dedupes via a `Set<number>` before emitting.
- **`Extract` button enabled during the `FileReader`/`compressImage` race** — clicking the button after picking a file but before compression completed would silently no-op (or send text-only if text was also present). Now gates `canExtract` on `imagePreview` being set.
- **`handleTextChange` wiped `extractionResult` on every keystroke** — each row can take multiple manual interactions (Pick suggestions, etc.); destroying the result on a single character forced users to re-extract from scratch. Now preserves the result; only `imageError` resets.
- **Same-name-band collision auto-matched silently** — `searchResult.artists.find(...)` returned the FIRST exact-name match (e.g. for "Boris", the Japanese drone band or the American hardcore band, whichever came back first). Now requires exactly ONE exact match to auto-match; multiple matches surface as PICK suggestions per `feedback_human_verify_ai_entity_data.md`.
- **Stale `imagePreview` on `compressImage` error** — decode failure left the previous preview rendered alongside the new error. Now clears both `imageFile` + `imagePreview` on any read/decode failure.
- **Stale doc refs to PSY-824 in `AddItemsPicker.tsx`** — file-header "PSY-824 will enable it" and inline "(PSY-824 / follow-up)" stripped per `feedback_strip_ticket_refs_from_doc_comments.md`.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run test:run features/collections` — **300/300** passing (1 new test file `AICollectionFiller.test.tsx` with 11 tests, including 3 regression guards for the `/code-review` fixes: double-em-dash, `stageAllMatched` within-batch dedup, `handleTextChange` preserves extraction).
- [x] `/code-review` (max effort) — 5 finder angles + verifier sweep. Load-bearing findings (above) all fixed inline.
- [x] Manual repro against local dev stack (admin: `asdf@admin.com`): pasted a 5-line list mixing 4 real local-DB artists + 1 made-up name into the Create drawer's AI tab. Claude extracted 4 items (correctly dropping the made-up entry per the prompt's "skip non-music entries" rule), all 4 matched against local artists, "Add all 4 matched" staged in a single batch with proper `Artist — Release` rendering (single em-dash). Verified the AI flow end-to-end including the source label ("Phoenix Underground 2025 — Essential Listening" was captured into the extraction result header).

## Screenshots

AI tab default state — text+image inputs, HEIC/HEIF supported in the dropzone copy:

![AI tab empty state](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9d89d534b977bde05c42/psy-824-01-ai-tab-empty.png)

Post-extraction — per-row MATCH badges, source label captured, "Add all 4 matched" batch button, helper copy about deferred Will-create paths:

![Extraction result with MATCH rows](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9d89d534b977bde05c42/psy-824-03-ai-extracted.png)

After "Add all 4 matched" — staged list shows numbered rows with `Artist — Release` (single em-dash, no doubled separator), each ready for Create:

![Staged list after AI extract](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9d89d534b977bde05c42/psy-824-04-ai-staged.png)

## Coverage gaps

Honest disclosure of what V1 does NOT cover:

- **No rate limit on `/api/ai/extract-collection`**. The ticket spec'd 10 imports/hour per user; the route ships with none. Inherits the same gap as `/api/ai/extract-show` (also unrated). Filing rate-limit infrastructure for both AI routes is a candidate follow-up; for V1 the auth gate (cookie + `/auth/profile` check) is the only access guard.
- **`matchItems` is sequential** — at the 250-item upper end, the route fires 250 sequential `/artists/search` round-trips after the Anthropic call. Total wall-clock at canon-list scale can approach Vercel's 10s hobby / 15s Pro function timeout. Mitigated in practice because most canon-list articles have <100 items; if a 200+ item paste times out, the user will see a 504. No `export const maxDuration` set on the route — Vercel default applies.
- **Will-create paths**: see Deferred above. Unmatched-but-real-band cases render `NEW` with no action; user must re-paste with a canonical PH path or wait for PSY-853.
- **Image-input error paths in tests**: the test file mocks the extraction hook but does not exercise the `compressImage` failure / oversized-file / unsupported-type / decode-failure paths. Those would need real `FileReader` + canvas mocks. The protective guards exist (copied from `AIFormFiller`); regression risk is bounded by the duplicated source.
- **HEIC decode on non-Safari**: not visually verified. The dropzone advertises HEIC, but Chrome/Firefox without native HEIC will hit `img.onerror` and show the inline error message pointing at the iOS Safari path. No automated test of this path; if telemetry shows real volume, the `heic2any` polyfill follow-up unlocks it.
- **`alreadyStaged` prop type narrowed to `entityType: 'artist'`** in `AICollectionFillerProps`. V1 only extracts artists; if release-matching ships in a follow-up, the prop signature widens and call sites update in lockstep. Forward-compat trap noted in code-review; not a runtime bug today.
- **Hook calls `response.json()` before `response.ok` check** — if Vercel ever returns an HTML 502 (e.g. backend pod restart mid-call), `response.json()` rejects with `SyntaxError` and the user sees a parse error in the inline banner instead of a friendly "AI service unavailable" copy. Same shape as `useShowExtraction`; would update both at once.
- **No screenshot of the PICK (suggestion) flow** in the PR. The local dev DB lacks same-name-band collisions to trigger PICK rows organically. The logic is unit-tested (`accepting a "Did you mean" suggestion promotes the row to MATCH`).
- **AddItemsPicker tests still mock `AICollectionFiller`**. The new `AICollectionFiller.test.tsx` covers the picker in isolation (11 tests); the integration path from `AddItemsPicker → AICollectionFiller → stageBatch` is exercised by the manual repro but has no end-to-end test. Tab-switch unmounts the picker and discards textInput / imagePreview / extractionResult — intentional but untested.
- **Same-name-band collision guard exercised only at the render layer** (unit test seeds two suggestions; downstream PICK render verified). The route's `exactMatches.length === 1` logic is not directly unit-tested; the local dev DB lacks same-name-band collisions to organically trigger the PICK fall-through, so the guard is logic-checked but not end-to-end verified.
- **Image-only and `both` (image + text) extraction modes not exercised in tests or manual repro.** Only the text-only path was driven through extract → match → stage. The handleExtract branching for image-only and image+text paths is duplicated structurally from `AIFormFiller`'s tested shape; regression risk is bounded but real.
- **`useCollectionExtraction` hook has no direct unit test** — it's mocked everywhere it's consumed (AICollectionFiller.test.tsx mocks the entire module). The fetch wrapper + JSON-parse-before-ok-check shape was code-reviewed but not exercised against a real `fetch` mock.
- **Anonymous-viewer flow not verified.** The AI tab is unconditionally enabled in `AddItemsPicker`; auth gating lives only at the route level (401 surfaces as inline banner). The drawer itself is auth-gated upstream (only renders for `isAuthenticated`), so anon users can't actually reach the tab — but a refactor that loosened that upstream gate would expose the tab to anon users and the failure mode (inline 401) is not tested.
