### PR TITLE
PSY-847: errcheck phase 2 — HTTP write/encode via respond.SafeWrite

### DIFF
--- a/backend/internal/api/handlers/auth/unsubscribe_collection_digest.go
+++ b/backend/internal/api/handlers/auth/unsubscribe_collection_digest.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"html"
 	"net/http"
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/respond"
 	"psychic-homily-backend/internal/services/engagement"
 )
 
@@ -65,7 +66,7 @@ func (h *UserPreferencesHandler) UnsubscribeCollectionDigestPageHandler(w http.R
 	)
 
 	if isOneClickPost(r) {
-		writeOneClickUnsubscribed(w)
+		writeOneClickUnsubscribed(r.Context(), w)
 		return
 	}
 
@@ -77,11 +78,11 @@ func (h *UserPreferencesHandler) UnsubscribeCollectionDigestPageHandler(w http.R
 // response: 200 with a minimal JSON body. The body is not strictly required,
 // but Gmail's documented examples include one and it makes manual debugging
 // easier. Shared by every one-click unsubscribe handler.
-func writeOneClickUnsubscribed(w http.ResponseWriter) {
+func writeOneClickUnsubscribed(ctx context.Context, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(map[string]bool{"unsubscribed": true})
+	respond.SafeEncode(ctx, w, map[string]bool{"unsubscribed": true})
 }
 
 // isOneClickPost returns true when the request is a POST with body
@@ -95,22 +96,22 @@ func isOneClickPost(r *http.Request) bool {
 // writeUnsubscribeConfirmation renders the GET success page. Self-contained
 // HTML — no shared template engine — to keep this surface tiny and avoid a
 // new dependency just for one page.
-func writeUnsubscribeConfirmation(w http.ResponseWriter, _ *http.Request) {
+func writeUnsubscribeConfirmation(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, unsubscribeConfirmationHTML)
+	respond.SafeWrite(r.Context(), w, []byte(unsubscribeConfirmationHTML))
 }
 
 // writeScopedUnsubscribeConfirmation renders a GET success page whose body
 // names the specific category the recipient unsubscribed from. The noun is
 // supplied by the handler (e.g. "tier-change emails") and is from a fixed
 // internal allowlist, not user input, so it's safe to interpolate.
-func writeScopedUnsubscribeConfirmation(w http.ResponseWriter, noun string) {
+func writeScopedUnsubscribeConfirmation(ctx context.Context, w http.ResponseWriter, noun string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, scopedUnsubscribeConfirmationTemplate, noun)
+	respond.SafeWrite(ctx, w, []byte(fmt.Sprintf(scopedUnsubscribeConfirmationTemplate, noun)))
 }
 
 // writeUnsubscribeError renders an error page on GET, or a JSON body on POST,
@@ -120,7 +121,7 @@ func writeUnsubscribeError(w http.ResponseWriter, r *http.Request, status int, m
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(status)
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respond.SafeEncode(r.Context(), w, map[string]any{
 			"unsubscribed": false,
 			"error":        message,
 		})
@@ -131,7 +132,7 @@ func writeUnsubscribeError(w http.ResponseWriter, r *http.Request, status int, m
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(status)
 	page := strings.ReplaceAll(unsubscribeErrorTemplate, "{{message}}", html.EscapeString(message))
-	fmt.Fprint(w, page)
+	respond.SafeWrite(r.Context(), w, []byte(page))
 }
 
 // unsubscribeConfirmationHTML is the success page rendered on GET. Keep

--- a/backend/internal/api/handlers/auth/unsubscribe_scoped.go
+++ b/backend/internal/api/handlers/auth/unsubscribe_scoped.go
@@ -85,9 +85,9 @@ func (h *UserPreferencesHandler) handleScopedUnsubscribe(w http.ResponseWriter, 
 	)
 
 	if isOneClickPost(r) {
-		writeOneClickUnsubscribed(w)
+		writeOneClickUnsubscribed(r.Context(), w)
 		return
 	}
 
-	writeScopedUnsubscribeConfirmation(w, cfg.noun)
+	writeScopedUnsubscribeConfirmation(r.Context(), w, cfg.noun)
 }

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -15,6 +15,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/respond"
 	"psychic-homily-backend/internal/services/contracts"
 	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
@@ -1397,7 +1398,7 @@ func (h *ShowHandler) ExportShowHandler(ctx context.Context, req *ExportShowRequ
 		Body: func(ctx huma.Context) {
 			ctx.SetHeader("Content-Type", "text/markdown; charset=utf-8")
 			ctx.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
-			ctx.BodyWriter().Write(content)
+			respond.SafeWrite(ctx.Context(), ctx.BodyWriter(), content)
 		},
 	}, nil
 }

--- a/backend/internal/api/handlers/engagement/calendar.go
+++ b/backend/internal/api/handlers/engagement/calendar.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/respond"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -66,7 +67,7 @@ func (h *CalendarHandler) GetCalendarFeedHandler(w http.ResponseWriter, r *http.
 	w.Header().Set("Content-Disposition", "inline; filename=\"psychic-homily.ics\"")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.WriteHeader(http.StatusOK)
-	w.Write(icsData)
+	respond.SafeWrite(r.Context(), w, icsData)
 }
 
 // --- Token CRUD endpoints (Huma, protected) ---

--- a/backend/internal/api/handlers/notification/notification_filter_test.go
+++ b/backend/internal/api/handlers/notification/notification_filter_test.go
@@ -517,6 +517,7 @@ func TestInt64ArrayToSlice(t *testing.T) {
 // create a circular dependency in test setup).
 func computeTestFilterSig(filterID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "unsubscribe:filter:%d", filterID)
+	// hash.Hash.Write never returns an error; the drop is intentional.
+	_, _ = fmt.Fprintf(mac, "unsubscribe:filter:%d", filterID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/api/handlers/shared/safe_write.go
+++ b/backend/internal/api/handlers/shared/safe_write.go
@@ -1,0 +1,43 @@
+package shared
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"psychic-homily-backend/internal/logger"
+)
+
+// SafeWrite writes data to w. Logs at debug level on failure but does not
+// return any error.
+//
+// Use this on HTTP response write paths where the request is already over
+// and the caller has no meaningful action to take on a write failure
+// (client disconnect, network timeout, full buffer). Centralizing the
+// drop here also gives us one place to hang future observability hooks
+// (e.g. a client-disconnect rate metric) without touching every handler.
+//
+// Do NOT use SafeWrite for writes to non-HTTP io.Writers (hash.Hash,
+// bytes.Buffer, files) — those have their own error semantics and a
+// debug log polluted with hash-write entries is noise. Use an explicit
+//
+//	_, _ = ...
+//
+// drop with a brief comment in those cases.
+func SafeWrite(ctx context.Context, w io.Writer, data []byte) {
+	if _, err := w.Write(data); err != nil {
+		logger.FromContext(ctx).Debug("response write failed", "err", err)
+	}
+}
+
+// SafeEncode JSON-encodes v to w. Logs at debug level on failure but does
+// not return any error — same rationale as SafeWrite. Used for the
+//
+//	json.NewEncoder(w).Encode(v)
+//
+// drop pattern that errcheck flags on HTTP response paths.
+func SafeEncode(ctx context.Context, w io.Writer, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		logger.FromContext(ctx).Debug("response encode failed", "err", err)
+	}
+}

--- a/backend/internal/api/handlers/shared/safe_write_test.go
+++ b/backend/internal/api/handlers/shared/safe_write_test.go
@@ -1,0 +1,65 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// failingWriter returns the configured error on every Write call. Used to
+// exercise the failure branch where the helpers swallow the write error.
+type failingWriter struct {
+	err error
+}
+
+func (f *failingWriter) Write(_ []byte) (int, error) {
+	return 0, f.err
+}
+
+func TestSafeWrite_WritesPayload(t *testing.T) {
+	rr := httptest.NewRecorder()
+	SafeWrite(context.Background(), rr, []byte("hello"))
+	if got := rr.Body.String(); got != "hello" {
+		t.Errorf("SafeWrite body = %q, want %q", got, "hello")
+	}
+}
+
+func TestSafeWrite_SwallowsWriteError(t *testing.T) {
+	// Helper must not panic or propagate when the underlying writer
+	// errors. This is the entire reason the helper exists.
+	fw := &failingWriter{err: errors.New("broken pipe")}
+	SafeWrite(context.Background(), fw, []byte("payload"))
+}
+
+func TestSafeEncode_EncodesJSON(t *testing.T) {
+	var buf bytes.Buffer
+	SafeEncode(context.Background(), &buf, map[string]int{"a": 1})
+
+	got := strings.TrimSpace(buf.String())
+	want := `{"a":1}`
+	if got != want {
+		t.Errorf("SafeEncode body = %q, want %q", got, want)
+	}
+}
+
+func TestSafeEncode_SwallowsEncodeError(t *testing.T) {
+	// Underlying writer error surfaces through json.Encoder.Encode as
+	// the same error; the helper must swallow it.
+	fw := &failingWriter{err: errors.New("broken pipe")}
+	SafeEncode(context.Background(), fw, map[string]int{"a": 1})
+}
+
+func TestSafeEncode_AppendsNewline(t *testing.T) {
+	// json.NewEncoder.Encode terminates each value with a newline. We
+	// preserve that behavior — some callers (notably one-click
+	// unsubscribe responses) have always emitted the trailing newline
+	// and changing it would shift the wire format.
+	var buf bytes.Buffer
+	SafeEncode(context.Background(), &buf, map[string]bool{"ok": true})
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Errorf("SafeEncode output %q missing trailing newline", buf.String())
+	}
+}

--- a/backend/internal/api/middleware/jwt.go
+++ b/backend/internal/api/middleware/jwt.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	autherrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/respond"
 	adminsvc "psychic-homily-backend/internal/services/admin"
 	"psychic-homily-backend/internal/services/auth"
 )
@@ -68,7 +68,7 @@ func JWTMiddleware(jwtService *auth.JWTService) func(http.Handler) http.Handler 
 				logger.AuthWarn(ctx, "jwt_token_missing",
 					"path", r.URL.Path,
 				)
-				writeJWTError(w, requestID, autherrors.CodeTokenMissing, "Authentication required", http.StatusUnauthorized)
+				writeJWTError(ctx, w, requestID, autherrors.CodeTokenMissing, "Authentication required", http.StatusUnauthorized)
 				return
 			}
 
@@ -92,7 +92,7 @@ func JWTMiddleware(jwtService *auth.JWTService) func(http.Handler) http.Handler 
 					"error", err.Error(),
 					"error_code", errorCode,
 				)
-				writeJWTError(w, requestID, errorCode, message, http.StatusUnauthorized)
+				writeJWTError(ctx, w, requestID, errorCode, message, http.StatusUnauthorized)
 				return
 			}
 
@@ -378,10 +378,10 @@ func GetUserFromContext(ctx context.Context) *authm.User {
 }
 
 // writeJWTError writes a JSON error response for JWT authentication failures
-func writeJWTError(w http.ResponseWriter, requestID, errorCode, message string, statusCode int) {
+func writeJWTError(ctx context.Context, w http.ResponseWriter, requestID, errorCode, message string, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(JWTErrorResponse{
+	respond.SafeEncode(ctx, w, JWTErrorResponse{
 		Success:   false,
 		Message:   message,
 		ErrorCode: errorCode,
@@ -399,12 +399,10 @@ func writeHumaJWTError(ctx huma.Context, requestID, errorCode, message string, s
 		ctx.SetHeader("Set-Cookie", clearCookie.String())
 	}
 
-	resp := JWTErrorResponse{
+	respond.SafeEncode(ctx.Context(), ctx.BodyWriter(), JWTErrorResponse{
 		Success:   false,
 		Message:   message,
 		ErrorCode: errorCode,
 		RequestID: requestID,
-	}
-	data, _ := json.Marshal(resp)
-	ctx.BodyWriter().Write(data)
+	})
 }

--- a/backend/internal/api/middleware/jwt_test.go
+++ b/backend/internal/api/middleware/jwt_test.go
@@ -57,7 +57,7 @@ func TestGetUserFromContext_WrongType(t *testing.T) {
 func TestWriteJWTError(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	writeJWTError(rr, "req-123", "TOKEN_MISSING", "Authentication required", http.StatusUnauthorized)
+	writeJWTError(context.Background(), rr, "req-123", "TOKEN_MISSING", "Authentication required", http.StatusUnauthorized)
 
 	if rr.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
@@ -89,7 +89,7 @@ func TestWriteJWTError(t *testing.T) {
 func TestWriteJWTError_EmptyRequestID(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	writeJWTError(rr, "", "TOKEN_INVALID", "Invalid token", http.StatusUnauthorized)
+	writeJWTError(context.Background(), rr, "", "TOKEN_INVALID", "Invalid token", http.StatusUnauthorized)
 
 	var body JWTErrorResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {

--- a/backend/internal/api/middleware/ratelimit.go
+++ b/backend/internal/api/middleware/ratelimit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/httprate"
 
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/respond"
 	"psychic-homily-backend/internal/services/auth"
 )
 
@@ -177,5 +178,5 @@ func RateLimitExceededHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Retry-After", "60")
 	w.WriteHeader(http.StatusTooManyRequests)
-	w.Write([]byte(`{"success":false,"error":"too_many_requests","message":"Rate limit exceeded. Please try again in 60 seconds."}`))
+	respond.SafeWrite(r.Context(), w, []byte(`{"success":false,"error":"too_many_requests","message":"Rate limit exceeded. Please try again in 60 seconds."}`))
 }

--- a/backend/internal/api/routes/shared.go
+++ b/backend/internal/api/routes/shared.go
@@ -11,6 +11,7 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/respond"
 	"psychic-homily-backend/internal/services"
 )
 
@@ -65,5 +66,5 @@ func rateLimitHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Retry-After", "60")
 	w.WriteHeader(http.StatusTooManyRequests)
-	w.Write([]byte(`{"success":false,"error":"too_many_requests","message":"Rate limit exceeded. Please try again in 60 seconds."}`))
+	respond.SafeWrite(r.Context(), w, []byte(`{"success":false,"error":"too_many_requests","message":"Rate limit exceeded. Please try again in 60 seconds."}`))
 }

--- a/backend/internal/api/routes/system.go
+++ b/backend/internal/api/routes/system.go
@@ -1,12 +1,12 @@
 package routes
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
 
 	systemh "psychic-homily-backend/internal/api/handlers/system"
+	"psychic-homily-backend/internal/respond"
 )
 
 // setupSystemRoutes configures system/infrastructure endpoints
@@ -18,6 +18,6 @@ func setupSystemRoutes(rc RouteContext) {
 	api := rc.API
 	rc.Router.Get("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(api.OpenAPI())
+		respond.SafeEncode(r.Context(), w, api.OpenAPI())
 	})
 }

--- a/backend/internal/respond/safe_write.go
+++ b/backend/internal/respond/safe_write.go
@@ -1,4 +1,20 @@
-package shared
+// Package respond centralizes HTTP response-write helpers.
+//
+// The helpers swallow write errors (logged at debug level) rather than
+// propagating them, because by the time we're writing the response body
+// the request is already over and the caller has no meaningful action
+// to take on a write failure (client disconnect, network timeout, full
+// buffer).
+//
+// This is a leaf-level package (no dependencies on api/middleware or
+// handler sub-packages) so it can be imported from middleware and from
+// every handler sub-package without forming an import cycle. The
+// original intent — keeping the helpers next to other handler shared
+// code in api/handlers/shared — couldn't hold because middleware
+// transitively imports api/handlers/shared/testhelpers, which would
+// cycle back through shared if shared depended on middleware-callable
+// helpers like SafeEncode.
+package respond
 
 import (
 	"context"
@@ -12,10 +28,10 @@ import (
 // return any error.
 //
 // Use this on HTTP response write paths where the request is already over
-// and the caller has no meaningful action to take on a write failure
-// (client disconnect, network timeout, full buffer). Centralizing the
-// drop here also gives us one place to hang future observability hooks
-// (e.g. a client-disconnect rate metric) without touching every handler.
+// and the caller has no meaningful action to take on a write failure.
+// Centralizing the drop here also gives us one place to hang future
+// observability hooks (e.g. a client-disconnect rate metric) without
+// touching every handler.
 //
 // Do NOT use SafeWrite for writes to non-HTTP io.Writers (hash.Hash,
 // bytes.Buffer, files) — those have their own error semantics and a

--- a/backend/internal/respond/safe_write_test.go
+++ b/backend/internal/respond/safe_write_test.go
@@ -1,4 +1,4 @@
-package shared
+package respond
 
 import (
 	"bytes"

--- a/backend/internal/services/auth/apple_test.go
+++ b/backend/internal/services/auth/apple_test.go
@@ -105,7 +105,7 @@ func TestValidateIdentityToken(t *testing.T) {
 		eBase64 := base64.RawURLEncoding.EncodeToString(eBytes)
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"` + kid + `","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))
+		_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"` + kid + `","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))
 	}))
 	defer mockServer.Close()
 
@@ -207,7 +207,7 @@ func TestAppleKeyFetching(t *testing.T) {
 			nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes())
 			eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
 			eBase64 := base64.RawURLEncoding.EncodeToString(eBytes)
-			w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"cached-kid","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))
+			_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"cached-kid","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))
 		}))
 		defer mockServer.Close()
 
@@ -234,7 +234,7 @@ func TestAppleKeyFetching(t *testing.T) {
 			nBase64 := base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes())
 			eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
 			eBase64 := base64.RawURLEncoding.EncodeToString(eBytes)
-			w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"known-kid","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))
+			_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"known-kid","use":"sig","alg":"RS256","n":"` + nBase64 + `","e":"` + eBase64 + `"}]}`))
 		}))
 		defer mockServer.Close()
 

--- a/backend/internal/services/catalog/radio_provider_nts_test.go
+++ b/backend/internal/services/catalog/radio_provider_nts_test.go
@@ -122,7 +122,7 @@ const ntsEmptyEpisodesJSON = `{"results": []}`
 func TestNTS_DiscoverShows_ParsesAllFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsShowsPage1JSON)
+		_, _ = fmt.Fprint(w, ntsShowsPage1JSON)
 	}))
 	defer server.Close()
 
@@ -175,10 +175,10 @@ func TestNTS_DiscoverShows_Pagination(t *testing.T) {
 				}
 			}
 			data, _ := json.Marshal(ntsShowsResponse{Results: results})
-			w.Write(data)
+			_, _ = w.Write(data)
 		} else {
 			// Second page: return fewer results (signals end of pagination)
-			fmt.Fprint(w, ntsShowsPage2JSON)
+			_, _ = fmt.Fprint(w, ntsShowsPage2JSON)
 		}
 	}))
 	defer server.Close()
@@ -195,7 +195,7 @@ func TestNTS_DiscoverShows_Pagination(t *testing.T) {
 func TestNTS_DiscoverShows_Empty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEmptyShowsJSON)
+		_, _ = fmt.Fprint(w, ntsEmptyShowsJSON)
 	}))
 	defer server.Close()
 
@@ -214,7 +214,7 @@ func TestNTS_DiscoverShows_Empty(t *testing.T) {
 func TestNTS_FetchNewEpisodes_AllFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEpisodesJSON)
+		_, _ = fmt.Fprint(w, ntsEpisodesJSON)
 	}))
 	defer server.Close()
 
@@ -242,7 +242,7 @@ func TestNTS_FetchNewEpisodes_AllFields(t *testing.T) {
 func TestNTS_FetchNewEpisodes_DateFiltering(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEpisodesJSON)
+		_, _ = fmt.Fprint(w, ntsEpisodesJSON)
 	}))
 	defer server.Close()
 
@@ -276,10 +276,10 @@ func TestNTS_FetchNewEpisodes_StopsAtOldEpisodes(t *testing.T) {
 				}
 			}
 			data, _ := json.Marshal(ntsEpisodesResponse{Results: results})
-			w.Write(data)
+			_, _ = w.Write(data)
 		} else {
 			// Second page has old episodes
-			fmt.Fprint(w, ntsEpisodeOlderJSON)
+			_, _ = fmt.Fprint(w, ntsEpisodeOlderJSON)
 		}
 	}))
 	defer server.Close()
@@ -297,7 +297,7 @@ func TestNTS_FetchNewEpisodes_StopsAtOldEpisodes(t *testing.T) {
 func TestNTS_FetchNewEpisodes_Empty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEmptyEpisodesJSON)
+		_, _ = fmt.Fprint(w, ntsEmptyEpisodesJSON)
 	}))
 	defer server.Close()
 
@@ -320,7 +320,7 @@ func TestNTS_FetchPlaylist_WithTracklist(t *testing.T) {
 		// data and every import was coming back empty because of it.
 		assert.Equal(t, "/v2/shows/huerco-s/episodes/march-2026/tracklist", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsTracklistJSON)
+		_, _ = fmt.Fprint(w, ntsTracklistJSON)
 	}))
 	defer server.Close()
 
@@ -368,7 +368,7 @@ func TestNTS_FetchPlaylist_EmptyTracklist(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v2/shows/scratcha-dva/episodes/march-2026-mix/tracklist", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEmptyTracklistJSON)
+		_, _ = fmt.Fprint(w, ntsEmptyTracklistJSON)
 	}))
 	defer server.Close()
 
@@ -387,7 +387,7 @@ func TestNTS_FetchPlaylist_EmptyTracklist(t *testing.T) {
 func TestNTS_FetchPlaylist_TracklistNotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, `{"detail": "Not found."}`)
+		_, _ = fmt.Fprint(w, `{"detail": "Not found."}`)
 	}))
 	defer server.Close()
 
@@ -431,7 +431,7 @@ func TestNTS_FetchPlaylist_SkipsEmptyArtist(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, tracklistJSON)
+		_, _ = fmt.Fprint(w, tracklistJSON)
 	}))
 	defer server.Close()
 
@@ -456,7 +456,7 @@ func TestNTS_FetchPlaylist_SkipsEmptyArtist(t *testing.T) {
 func TestNTS_MixcloudArchiveURL_Preserved(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEpisodesJSON)
+		_, _ = fmt.Fprint(w, ntsEpisodesJSON)
 	}))
 	defer server.Close()
 
@@ -482,7 +482,7 @@ func TestNTS_RateLimiting(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEmptyShowsJSON)
+		_, _ = fmt.Fprint(w, ntsEmptyShowsJSON)
 	}))
 	defer server.Close()
 
@@ -515,7 +515,7 @@ func TestNTS_RateLimiting(t *testing.T) {
 func TestNTS_HTTPError_DiscoverShows(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, "Internal Server Error")
+		_, _ = fmt.Fprint(w, "Internal Server Error")
 	}))
 	defer server.Close()
 
@@ -530,7 +530,7 @@ func TestNTS_HTTPError_DiscoverShows(t *testing.T) {
 func TestNTS_HTTPError_FetchNewEpisodes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, "Not Found")
+		_, _ = fmt.Fprint(w, "Not Found")
 	}))
 	defer server.Close()
 
@@ -545,7 +545,7 @@ func TestNTS_HTTPError_FetchNewEpisodes(t *testing.T) {
 func TestNTS_HTTPError_FetchPlaylist(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprint(w, "Service Unavailable")
+		_, _ = fmt.Fprint(w, "Service Unavailable")
 	}))
 	defer server.Close()
 
@@ -560,7 +560,7 @@ func TestNTS_HTTPError_FetchPlaylist(t *testing.T) {
 func TestNTS_MalformedJSON_DiscoverShows(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "this is not json")
+		_, _ = fmt.Fprint(w, "this is not json")
 	}))
 	defer server.Close()
 
@@ -575,7 +575,7 @@ func TestNTS_MalformedJSON_DiscoverShows(t *testing.T) {
 func TestNTS_MalformedJSON_FetchPlaylist(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "{invalid json")
+		_, _ = fmt.Fprint(w, "{invalid json")
 	}))
 	defer server.Close()
 
@@ -620,7 +620,7 @@ func TestNTS_UserAgent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedUA = r.Header.Get("User-Agent")
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEmptyShowsJSON)
+		_, _ = fmt.Fprint(w, ntsEmptyShowsJSON)
 	}))
 	defer server.Close()
 
@@ -839,7 +839,7 @@ func TestNTS_FetchNewEpisodes_DateFiltering_OffsetFormat(t *testing.T) {
 	]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, body)
+		_, _ = fmt.Fprint(w, body)
 	}))
 	defer server.Close()
 

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -167,7 +167,7 @@ func TestKEXPProvider_DiscoverShows(t *testing.T) {
 	// array. The shows handler must come BEFORE the programs handler so the
 	// most-specific path matches first in net/http's mux.
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
 			"count": 3,
 			"results": []map[string]interface{}{
@@ -199,7 +199,7 @@ func TestKEXPProvider_DiscoverShows(t *testing.T) {
 	// Mock programs endpoint — note: the real API does NOT return
 	// host_ids/host_names on programs, so the test omits those fields.
 	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
 			"count": 2,
 			"results": []map[string]interface{}{
@@ -254,7 +254,7 @@ func TestKEXPProvider_DiscoverShows_Pagination(t *testing.T) {
 	// PSY-509: empty broadcast slice — exercise the warn-log "empty map"
 	// branch alongside paginated programs.
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 0, "results": []interface{}{},
 		})
 	})
@@ -263,7 +263,7 @@ func TestKEXPProvider_DiscoverShows_Pagination(t *testing.T) {
 	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		if callCount == 1 {
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"next":  fmt.Sprintf("%s/v2/programs/?offset=1", server.URL),
 				"count": 2,
 				"results": []map[string]interface{}{
@@ -271,7 +271,7 @@ func TestKEXPProvider_DiscoverShows_Pagination(t *testing.T) {
 				},
 			})
 		} else {
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"next":  nil,
 				"count": 2,
 				"results": []map[string]interface{}{
@@ -310,7 +310,7 @@ func TestKEXPProvider_DiscoverShows_Pagination(t *testing.T) {
 func TestKEXPProvider_FetchNewEpisodes(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
 			"count": 1,
 			"results": []map[string]interface{}{
@@ -358,7 +358,7 @@ func TestKEXPProvider_FetchNewEpisodes_FiltersByProgram(t *testing.T) {
 	// episodes imported for every KEXP program).
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 3,
 			"results": []map[string]interface{}{
 				{"id": 1, "program": 42, "program_name": "Wanted", "start_time": "2026-01-15T06:00:00-08:00"},
@@ -388,7 +388,7 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 	// Show detail endpoint -- returns start_time AND end_time so the provider
 	// should use the actual broadcast window (4 hours) instead of the fallback.
 	mux.HandleFunc("/v2/shows/5678/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"id":           5678,
 			"program":      42,
 			"program_name": "The Morning Show",
@@ -398,7 +398,7 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 	})
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
 		playsRequestQuery = r.URL.RawQuery
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
 			"count": 3,
 			"results": []map[string]interface{}{
@@ -486,14 +486,14 @@ func TestKEXPProvider_FetchPlaylist_NoEndTimeFallback(t *testing.T) {
 	// Show detail endpoint -- no end_time, so provider should fall back to
 	// kexpPlaylistWindowFallback (5 hours).
 	mux.HandleFunc("/v2/shows/7777/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"id":         7777,
 			"start_time": "2026-01-15T14:00:00Z",
 		})
 	})
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
 		playsRequestQuery = r.URL.RawQuery
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
 			"count": 1,
 			"results": []map[string]interface{}{
@@ -528,13 +528,13 @@ func TestKEXPProvider_FetchPlaylist_NoEndTimeFallback(t *testing.T) {
 func TestKEXPProvider_FetchPlaylist_OnlyTrackPlays(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/shows/1234/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"id":         1234,
 			"start_time": "2026-01-15T06:00:00Z",
 		})
 	})
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
 			"count": 3,
 			"results": []map[string]interface{}{
@@ -561,13 +561,13 @@ func TestKEXPProvider_FetchPlaylist_OnlyTrackPlays(t *testing.T) {
 func TestKEXPProvider_FetchPlaylist_EmptyPlays(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/shows/9999/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"id":         9999,
 			"start_time": "2026-01-15T06:00:00Z",
 		})
 	})
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":    nil,
 			"count":   0,
 			"results": []map[string]interface{}{},
@@ -590,7 +590,7 @@ func TestKEXPProvider_FetchPlaylist_ShowNotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/shows/404/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"detail":"Not found."}`))
+		_, _ = w.Write([]byte(`{"detail":"Not found."}`))
 	})
 
 	server := httptest.NewServer(mux)
@@ -609,7 +609,7 @@ func TestKEXPProvider_FetchPlaylist_Pagination(t *testing.T) {
 	playsCallCount := 0
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/shows/5678/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"id":         5678,
 			"start_time": "2026-01-15T06:00:00Z",
 		})
@@ -619,7 +619,7 @@ func TestKEXPProvider_FetchPlaylist_Pagination(t *testing.T) {
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
 		playsCallCount++
 		if playsCallCount == 1 {
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"next":  fmt.Sprintf("%s/v2/plays/?cursor=page2", server.URL),
 				"count": 3,
 				"results": []map[string]interface{}{
@@ -640,7 +640,7 @@ func TestKEXPProvider_FetchPlaylist_Pagination(t *testing.T) {
 				},
 			})
 		} else {
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"next":  nil,
 				"count": 3,
 				"results": []map[string]interface{}{
@@ -682,14 +682,14 @@ func TestKEXPProvider_HTTPError(t *testing.T) {
 	// PSY-509: shows endpoint (used to build the host map) succeeds —
 	// host-map failures are non-fatal so we must isolate the programs error.
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 0, "results": []interface{}{},
 		})
 	})
 	// Programs returns 500
 	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("internal error"))
+		_, _ = w.Write([]byte("internal error"))
 	})
 
 	server := httptest.NewServer(mux)
@@ -716,11 +716,11 @@ func TestKEXPProvider_DiscoverShows_HostMapNonFatal(t *testing.T) {
 	// /v2/shows/ returns 500 — host map fetch fails.
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("upstream broken"))
+		_, _ = w.Write([]byte("upstream broken"))
 	})
 	// Programs endpoint healthy.
 	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 1,
 			"results": []map[string]interface{}{
 				{"id": 99, "name": "Show With No Host Yet"},
@@ -753,7 +753,7 @@ func TestKEXPProvider_DiscoverShows_HostMappingIntegration(t *testing.T) {
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
 		// Results are returned in -start_time order, matching how the
 		// real API responds when ordering=-start_time is requested.
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 6,
 			"results": []map[string]interface{}{
 				// Most recent: program 100 hosted by two co-DJs.
@@ -804,7 +804,7 @@ func TestKEXPProvider_DiscoverShows_HostMappingIntegration(t *testing.T) {
 	})
 
 	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 5,
 			"results": []map[string]interface{}{
 				{"id": 100, "name": "El Sonido"},
@@ -1119,7 +1119,7 @@ func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
 
 	// Mock programs
 	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 1,
 			"results": []map[string]interface{}{
 				{"id": 42, "name": "The Morning Show"},
@@ -1137,7 +1137,7 @@ func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
 		// Detail-by-ID: /v2/shows/100/ used by FetchPlaylist.
 		if r.URL.Path == "/v2/shows/100/" {
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":           100,
 				"program":      42,
 				"program_name": "The Morning Show",
@@ -1153,7 +1153,7 @@ func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
 		// PSY-813: the real /v2/shows/ list response does NOT include
 		// `end_time` or `archive_url` — only the detail endpoint above does.
 		// Omitting them here keeps the fixture aligned with production behavior.
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 1,
 			"results": []map[string]interface{}{
 				{
@@ -1169,7 +1169,7 @@ func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
 
 	// Mock plays
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 2,
 			"results": []map[string]interface{}{
 				{

--- a/backend/internal/services/catalog/radio_provider_wfmu_test.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu_test.go
@@ -596,7 +596,7 @@ func TestWFMU_DiscoverShows_Integration(t *testing.T) {
 		switch r.URL.Path {
 		case "/playlists/":
 			w.Header().Set("Content-Type", "text/html")
-			fmt.Fprint(w, wfmuDJIndexHTML)
+			_, _ = fmt.Fprint(w, wfmuDJIndexHTML)
 		default:
 			http.NotFound(w, r)
 		}
@@ -632,7 +632,7 @@ func TestWFMU_FetchNewEpisodes_Integration(t *testing.T) {
 		case "/playlists/BT":
 			archiveHits++
 			w.Header().Set("Content-Type", "text/html")
-			w.Write(archiveBody)
+			_, _ = w.Write(archiveBody)
 		default:
 			http.NotFound(w, r)
 		}
@@ -660,7 +660,7 @@ func TestWFMU_FetchPlaylist_Integration(t *testing.T) {
 		switch r.URL.Path {
 		case "/playlists/shows/162145":
 			w.Header().Set("Content-Type", "text/html")
-			fmt.Fprint(w, wfmuPlaylistPageHTML)
+			_, _ = fmt.Fprint(w, wfmuPlaylistPageHTML)
 		default:
 			http.NotFound(w, r)
 		}
@@ -689,7 +689,7 @@ func TestWFMU_FetchPlaylist_Integration(t *testing.T) {
 func TestWFMU_HTTPError_DiscoverShows(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, "Internal Server Error")
+		_, _ = fmt.Fprint(w, "Internal Server Error")
 	}))
 	defer server.Close()
 
@@ -707,7 +707,7 @@ func TestWFMU_HTTPError_FetchNewEpisodes_404(t *testing.T) {
 	// fetch over a stale/typo'd show code doesn't trip the circuit breaker.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, "Not Found")
+		_, _ = fmt.Fprint(w, "Not Found")
 	}))
 	defer server.Close()
 
@@ -722,7 +722,7 @@ func TestWFMU_HTTPError_FetchNewEpisodes_404(t *testing.T) {
 func TestWFMU_HTTPError_FetchNewEpisodes_5xx(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, "Internal Server Error")
+		_, _ = fmt.Fprint(w, "Internal Server Error")
 	}))
 	defer server.Close()
 
@@ -737,7 +737,7 @@ func TestWFMU_HTTPError_FetchNewEpisodes_5xx(t *testing.T) {
 func TestWFMU_HTTPError_FetchPlaylist(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprint(w, "Service Unavailable")
+		_, _ = fmt.Fprint(w, "Service Unavailable")
 	}))
 	defer server.Close()
 
@@ -759,9 +759,9 @@ func TestWFMU_RateLimiting(t *testing.T) {
 		requestCount++
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/playlists/"):
-			fmt.Fprint(w, wfmuDJIndexHTML)
+			_, _ = fmt.Fprint(w, wfmuDJIndexHTML)
 		default:
-			fmt.Fprint(w, wfmuEmptyPlaylistHTML)
+			_, _ = fmt.Fprint(w, wfmuEmptyPlaylistHTML)
 		}
 	}))
 	defer server.Close()
@@ -812,7 +812,7 @@ func TestWFMU_UserAgent(t *testing.T) {
 	var capturedUA string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedUA = r.Header.Get("User-Agent")
-		fmt.Fprint(w, wfmuEmptyPlaylistHTML)
+		_, _ = fmt.Fprint(w, wfmuEmptyPlaylistHTML)
 	}))
 	defer server.Close()
 
@@ -1175,7 +1175,7 @@ func TestWFMU_FetchNewEpisodes_ArchiveFallback_Integration(t *testing.T) {
 		case "/playlists/BT":
 			archiveHits++
 			w.Header().Set("Content-Type", "text/html")
-			w.Write(archiveBody)
+			_, _ = w.Write(archiveBody)
 		default:
 			http.NotFound(w, r)
 		}
@@ -1207,7 +1207,7 @@ func TestWFMU_FetchNewEpisodes_ArchiveFallback_ZeroSince(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/playlists/BT" {
 			archiveHits++
-			w.Write(archiveBody)
+			_, _ = w.Write(archiveBody)
 			return
 		}
 		http.NotFound(w, r)
@@ -1228,7 +1228,7 @@ func TestWFMU_FetchNewEpisodes_ArchiveFallback_404(t *testing.T) {
 	// Unknown show codes should return empty, not error.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, "Not Found")
+		_, _ = fmt.Fprint(w, "Not Found")
 	}))
 	defer server.Close()
 

--- a/backend/internal/services/engagement/collection_digest.go
+++ b/backend/internal/services/engagement/collection_digest.go
@@ -547,6 +547,7 @@ func VerifyCollectionDigestUnsubscribeSignature(userID uint, signature, secret s
 // one notification type can't be replayed against another.
 func ComputeCollectionDigestUnsubscribeSignature(userID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "unsubscribe:collection-digest:%d", userID)
+	// hash.Hash.Write never returns an error; the drop is intentional.
+	_, _ = fmt.Fprintf(mac, "unsubscribe:collection-digest:%d", userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/comment_notification.go
+++ b/backend/internal/services/engagement/comment_notification.go
@@ -581,7 +581,8 @@ func VerifyCommentSubscriptionUnsubscribeSignature(userID uint, entityType strin
 // as long as the JWT secret doesn't rotate.
 func ComputeCommentSubscriptionUnsubscribeSignature(userID uint, entityType string, entityID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "unsubscribe:comment-subscription:%d:%s:%d", userID, entityType, entityID)
+	// hash.Hash.Write never returns an error; the drop is intentional.
+	_, _ = fmt.Fprintf(mac, "unsubscribe:comment-subscription:%d:%s:%d", userID, entityType, entityID)
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
@@ -603,6 +604,7 @@ func VerifyMentionUnsubscribeSignature(userID uint, signature, secret string) bo
 // ComputeMentionUnsubscribeSignature hashes userID under secret.
 func ComputeMentionUnsubscribeSignature(userID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "unsubscribe:mention:%d", userID)
+	// hash.Hash.Write never returns an error; the drop is intentional.
+	_, _ = fmt.Fprintf(mac, "unsubscribe:mention:%d", userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/reminder.go
+++ b/backend/internal/services/engagement/reminder.go
@@ -220,6 +220,7 @@ func VerifyUnsubscribeSignature(userID uint, signature, secret string) bool {
 // ComputeUnsubscribeSignature computes HMAC-SHA256 of the user ID
 func ComputeUnsubscribeSignature(userID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "unsubscribe:show-reminders:%d", userID)
+	// hash.Hash.Write never returns an error; the drop is intentional.
+	_, _ = fmt.Fprintf(mac, "unsubscribe:show-reminders:%d", userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/unsubscribe_scope.go
+++ b/backend/internal/services/engagement/unsubscribe_scope.go
@@ -24,7 +24,8 @@ const (
 // tier-change and edit-review categories.
 func ComputeScopedUnsubscribeSignature(userID uint, scope, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "unsubscribe:%s:%d", scope, userID)
+	// hash.Hash.Write never returns an error; the drop is intentional.
+	_, _ = fmt.Fprintf(mac, "unsubscribe:%s:%d", scope, userID)
 	return hex.EncodeToString(mac.Sum(nil))
 }
 

--- a/backend/internal/services/notification/email_test.go
+++ b/backend/internal/services/notification/email_test.go
@@ -36,7 +36,7 @@ func setupEmailTest(t *testing.T) (*EmailService, chan capturedEmail, *httptest.
 		json.NewDecoder(r.Body).Decode(&req)
 		requests <- req
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"id": "test-email-id"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "test-email-id"})
 	}))
 	t.Cleanup(server.Close)
 
@@ -56,7 +56,7 @@ func setupEmailTestError(t *testing.T) *EmailService {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"message": "internal error"}`))
+		_, _ = w.Write([]byte(`{"message": "internal error"}`))
 	}))
 	t.Cleanup(server.Close)
 

--- a/backend/internal/services/notification/filter_service.go
+++ b/backend/internal/services/notification/filter_service.go
@@ -969,7 +969,8 @@ func VerifyFilterUnsubscribeSignature(filterID uint, signature, secret string) b
 // ComputeFilterUnsubscribeSignature computes HMAC-SHA256 of the filter ID.
 func ComputeFilterUnsubscribeSignature(filterID uint, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "unsubscribe:filter:%d", filterID)
+	// hash.Hash.Write never returns an error; the drop is intentional.
+	_, _ = fmt.Fprintf(mac, "unsubscribe:filter:%d", filterID)
 	return hex.EncodeToString(mac.Sum(nil))
 }
 

--- a/backend/internal/services/pipeline/extraction_calendar_test.go
+++ b/backend/internal/services/pipeline/extraction_calendar_test.go
@@ -514,7 +514,7 @@ func TestExtractCalendarPage(t *testing.T) {
 			assert.Equal(t, "claude-haiku-4-5-20251001", reqBody.Model)
 
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -556,7 +556,7 @@ func TestExtractCalendarPage(t *testing.T) {
 			assert.Len(t, reqBody.Messages, 1)
 
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -590,7 +590,7 @@ func TestExtractCalendarPage(t *testing.T) {
 	t.Run("api_returns_empty_array", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -622,7 +622,7 @@ func TestExtractCalendarPage(t *testing.T) {
 	t.Run("api_returns_unparseable_response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -652,7 +652,7 @@ func TestExtractCalendarPage(t *testing.T) {
 	t.Run("api_error_returns_friendly_message", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("internal error"))
+			_, _ = w.Write([]byte("internal error"))
 		}))
 		defer server.Close()
 
@@ -675,7 +675,7 @@ func TestExtractCalendarPage(t *testing.T) {
 	t.Run("billing_error_returns_friendly_message", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusPaymentRequired)
-			w.Write([]byte("Your credit balance is too low"))
+			_, _ = w.Write([]byte("Your credit balance is too low"))
 		}))
 		defer server.Close()
 
@@ -698,7 +698,7 @@ func TestExtractCalendarPage(t *testing.T) {
 	t.Run("events_with_missing_dates_produces_warning", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -739,7 +739,7 @@ func TestExtractCalendarPage(t *testing.T) {
 	t.Run("events_with_missing_artists_produces_warning", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -781,7 +781,7 @@ func TestExtractCalendarPage(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedBody, _ = io.ReadAll(r.Body)
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`

--- a/backend/internal/services/pipeline/extraction_test.go
+++ b/backend/internal/services/pipeline/extraction_test.go
@@ -364,7 +364,7 @@ func TestExtractShowValidation(t *testing.T) {
 	}
 	validationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("test server"))
+		_, _ = w.Write([]byte("test server"))
 	}))
 	defer validationServer.Close()
 	svc := &ExtractionService{config: cfg, httpClient: validationServer.Client(), anthropicBaseURL: validationServer.URL}
@@ -506,7 +506,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -526,7 +526,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("multiple_content_blocks", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -547,7 +547,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("empty_content", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
@@ -565,7 +565,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("non_text_blocks_ignored", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"content":[{"type":"tool_use","text":"ignored"},{"type":"text","text":"kept"}]}`))
+			_, _ = w.Write([]byte(`{"content":[{"type":"tool_use","text":"ignored"},{"type":"text","text":"kept"}]}`))
 		})
 		defer server.Close()
 
@@ -578,7 +578,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("non_200_status", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusTooManyRequests)
-			w.Write([]byte("rate limited"))
+			_, _ = w.Write([]byte("rate limited"))
 		})
 		defer server.Close()
 
@@ -592,7 +592,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("api_error_response", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"error":{"type":"overloaded_error","message":"Overloaded"}}`))
+			_, _ = w.Write([]byte(`{"error":{"type":"overloaded_error","message":"Overloaded"}}`))
 		})
 		defer server.Close()
 
@@ -606,7 +606,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("credit_billing_error", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("Your credit balance is too low"))
+			_, _ = w.Write([]byte("Your credit balance is too low"))
 		})
 		defer server.Close()
 
@@ -620,7 +620,7 @@ func TestCallAnthropic(t *testing.T) {
 	t.Run("invalid_response_json", func(t *testing.T) {
 		svc, server := newTestExtractionService(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("not json"))
+			_, _ = w.Write([]byte("not json"))
 		})
 		defer server.Close()
 
@@ -638,7 +638,7 @@ func TestCallAnthropic(t *testing.T) {
 			capturedHeaders = r.Header.Clone()
 			capturedBody, _ = io.ReadAll(r.Body)
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(anthropicResponse{
+			_ = json.NewEncoder(w).Encode(anthropicResponse{
 				Content: []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`

--- a/backend/internal/services/pipeline/fetcher_chromedp_test.go
+++ b/backend/internal/services/pipeline/fetcher_chromedp_test.go
@@ -105,7 +105,7 @@ func TestFetchDynamic_Basic(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 
@@ -144,7 +144,7 @@ func TestFetchDynamic_StaticPage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 
@@ -175,7 +175,7 @@ func TestFetchScreenshot_Basic(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 
@@ -220,7 +220,7 @@ func TestDetectRenderMethod_Static(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 
@@ -254,7 +254,7 @@ func TestDetectRenderMethod_NeedsDynamic(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 
@@ -351,7 +351,7 @@ func TestWorkerPoolSemaphore(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`<!DOCTYPE html><html><body><div class="event">Event</div></body></html>`))
+		_, _ = w.Write([]byte(`<!DOCTYPE html><html><body><div class="event">Event</div></body></html>`))
 	}))
 	defer server.Close()
 
@@ -452,7 +452,7 @@ func TestDetectRenderMethod_WithoutInit(t *testing.T) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
 		// Very small page with no event markers
-		w.Write([]byte("<html><body>Hello</body></html>"))
+		_, _ = w.Write([]byte("<html><body>Hello</body></html>"))
 	}))
 	defer server.Close()
 
@@ -483,7 +483,7 @@ func TestFetchDynamic_ContentHash(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 
@@ -523,7 +523,7 @@ func TestFetchDynamic_LargePage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 
@@ -546,7 +546,7 @@ func TestFetchDynamic_NoEventSelector(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(page))
+		_, _ = w.Write([]byte(page))
 	}))
 	defer server.Close()
 

--- a/backend/internal/services/pipeline/fetcher_test.go
+++ b/backend/internal/services/pipeline/fetcher_test.go
@@ -15,7 +15,7 @@ func TestFetch_200_Changed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(body))
+		_, _ = w.Write([]byte(body))
 	}))
 	defer server.Close()
 
@@ -36,7 +36,7 @@ func TestFetch_200_Unchanged(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(body))
+		_, _ = w.Write([]byte(body))
 	}))
 	defer server.Close()
 
@@ -56,7 +56,7 @@ func TestFetch_200_HashMismatch(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(body))
+		_, _ = w.Write([]byte(body))
 	}))
 	defer server.Close()
 
@@ -77,7 +77,7 @@ func TestFetch_304_NotModified(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("body"))
+		_, _ = w.Write([]byte("body"))
 	}))
 	defer server.Close()
 
@@ -97,7 +97,7 @@ func TestFetch_ETag_Sent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedETag = r.Header.Get("If-None-Match")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("body"))
+		_, _ = w.Write([]byte("body"))
 	}))
 	defer server.Close()
 
@@ -114,7 +114,7 @@ func TestFetch_ETag_NotSent_WhenEmpty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedETag = r.Header.Get("If-None-Match")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("body"))
+		_, _ = w.Write([]byte("body"))
 	}))
 	defer server.Close()
 
@@ -268,7 +268,7 @@ func TestFetch_UserAgent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedUA = r.Header.Get("User-Agent")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("body"))
+		_, _ = w.Write([]byte("body"))
 	}))
 	defer server.Close()
 
@@ -283,7 +283,7 @@ func TestFetch_ContentType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"events":[]}`))
+		_, _ = w.Write([]byte(`{"events":[]}`))
 	}))
 	defer server.Close()
 
@@ -302,7 +302,7 @@ func TestFetch_200_WithETag(t *testing.T) {
 		w.Header().Set("ETag", responseETag)
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(body))
+		_, _ = w.Write([]byte(body))
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Summary
- Add `backend/internal/respond/safe_write.go` with `SafeWrite(ctx, w, data)` + `SafeEncode(ctx, w, v)` helpers. Both log at debug level on failure (client disconnect, network timeout, full buffer) and do not propagate the error — response is already over.
- Switch 125 HTTP-handler write/encode drops to the helpers across 24+ handler/middleware/test-helper files.
- Helper landed in `internal/respond/` (not `api/handlers/shared/` per original spec) — moving up the dependency tree avoids an import cycle through `handlers/shared/testhelpers`. Doc on the package explains why.

Phase 2 of 4 in the PSY-833 errcheck graduation series. errcheck STAYS advisory after this PR; graduation in Phase 4 (PSY-849).

## Re-baseline
HTTP-write subset cleared: 125 sites.
Full errcheck before (post-Phase-1): 206. After: 81.
Remaining 81 sites for Phases 3-4: `json.Unmarshal` drops (~22, Phase 3), bcrypt timing-mitigation (2, Phase 4 annotate), `resp.Body.Close` (~11, Phase 4), `os.Unsetenv` (~7, Phase 4), DB ops (gorm `.Count`/`.Find`), file I/O, long-tail (~39, Phase 4).

## Helper design
Decision: Option A (centralized helper). Rationale: 125 sites is enough boilerplate that a helper amortizes; future observability hooks (e.g. client-disconnect rate metric) live in one place.

Logger API: `logger.FromContext(ctx)` from `internal/logger/`. Called only on the error branch — happy path is `io.Writer.Write` + error compare, identical cost to the prior `_, _ = w.Write(...)` shape.

Helper doc explicitly warns NOT to use for non-HTTP `io.Writer`s (`hash.Hash`, `bytes.Buffer`, files) — those have their own error semantics and a debug log polluted with hash-write entries would be noise. Per that guidance, HMAC sites in `services/engagement/*.go` + `services/notification/filter_service.go` use `_, _ = fmt.Fprintf(mac, ...)` with a `// hash.Hash.Write never returns an error` comment.

CLI `fmt.Fprint(os.Stdout/Stderr, ...)` sites are unaffected — none existed under `backend/cmd/` to over-switch.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./...` — passed (full suite)
- [x] `cd backend && ~/go/bin/golangci-lint run --no-config --enable-only=errcheck --max-issues-per-linter=0 --max-same-issues=0 ./...` — count dropped 206 → 81 (-125)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues (no NEW gated regression)

## Manual repro
Backend HTTP-handler change; no dev stack needed (mode=none).
Pre: 125 HTTP-write/encode drops, 206 total errcheck. Post: 0 HTTP-write/encode drops, 81 total errcheck.

Sample diff (representative SafeEncode swap from a handler):

\`\`\`diff
-    json.NewEncoder(w).Encode(response)
+    respond.SafeEncode(ctx, w, response)
\`\`\`

## Code review
Three parallel reviewers (reuse / quality / efficiency) — all returned no blocking issues. Two minor non-blocking observations from quality:
- Helper package doc is verbose (~11 lines on import-cycle backstory). Kept as-is: the cycle history has genuine value for future readers considering moving the package back.
- One test (`TestSafeEncode_AppendsNewline`) borders on stdlib testing. Kept as-is: pins wire format.

Reuse reviewer noted a non-blocking observation: `RateLimitExceededHandler` (`middleware/ratelimit.go:165`) and `rateLimitHandler` (`routes/shared.go:43`) are near-duplicates — but they were duplicates BEFORE this PR. Worth a separate consolidation ticket if desired; not widening scope here.

Closes PSY-847