### PR TITLE
PSY-848: errcheck phase 3 — json.Unmarshal drops -> require.NoError

### DIFF
--- a/backend/internal/api/middleware/jwt_test.go
+++ b/backend/internal/api/middleware/jwt_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/stretchr/testify/require"
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/logger"
@@ -152,7 +153,7 @@ func TestJWTMiddleware_InvalidAuthHeaderFormat(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_MISSING" {
 		t.Errorf("ErrorCode = %q, want TOKEN_MISSING", body.ErrorCode)
 	}
@@ -174,7 +175,7 @@ func TestJWTMiddleware_InvalidToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID", body.ErrorCode)
 	}
@@ -196,7 +197,7 @@ func TestJWTMiddleware_InvalidTokenFromCookie(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID", body.ErrorCode)
 	}
@@ -234,7 +235,7 @@ func TestJWTMiddleware_ExpiredToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_EXPIRED" {
 		t.Errorf("ErrorCode = %q, want TOKEN_EXPIRED", body.ErrorCode)
 	}
@@ -256,7 +257,7 @@ func TestJWTMiddleware_BearerTokenPreferredOverCookie(t *testing.T) {
 
 	// Should get TOKEN_INVALID (from header token), not TOKEN_MISSING
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID (header token should be used)", body.ErrorCode)
 	}
@@ -347,7 +348,7 @@ func TestWriteHumaJWTError_NilSessionConfig(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.RequestID != "" {
 		t.Errorf("RequestID = %q, want empty", body.RequestID)
 	}
@@ -372,7 +373,7 @@ func TestHumaJWTMiddleware_NoToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_MISSING" {
 		t.Errorf("ErrorCode = %q, want TOKEN_MISSING", body.ErrorCode)
 	}
@@ -396,7 +397,7 @@ func TestHumaJWTMiddleware_InvalidBearerToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID", body.ErrorCode)
 	}
@@ -434,7 +435,7 @@ func TestHumaJWTMiddleware_ExpiredToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_EXPIRED" {
 		t.Errorf("ErrorCode = %q, want TOKEN_EXPIRED", body.ErrorCode)
 	}
@@ -469,7 +470,7 @@ func TestHumaJWTMiddleware_ValidJWT_FailsDBLookup(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID (DB user lookup failure)", body.ErrorCode)
 	}
@@ -504,7 +505,7 @@ func TestHumaJWTMiddleware_CookieFallback(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	// Should get TOKEN_INVALID (not TOKEN_MISSING — cookie was found)
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID (cookie extracted, DB failed)", body.ErrorCode)
@@ -529,7 +530,7 @@ func TestHumaJWTMiddleware_InvalidAPIToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID", body.ErrorCode)
 	}
@@ -554,7 +555,7 @@ func TestHumaJWTMiddleware_InvalidAuthHeaderFormat(t *testing.T) {
 
 	// No Bearer prefix extracted → falls through to cookie check → no cookie → TOKEN_MISSING
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_MISSING" {
 		t.Errorf("ErrorCode = %q, want TOKEN_MISSING", body.ErrorCode)
 	}
@@ -609,7 +610,7 @@ func TestHumaJWTMiddleware_RequestIDFromContext(t *testing.T) {
 	})
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	// The request ID should be propagated to the error response
 	if body.RequestID != "ctx-req-id-123" {
 		t.Errorf("RequestID = %q, want ctx-req-id-123", body.RequestID)
@@ -635,7 +636,7 @@ func TestLenientHumaJWTMiddleware_NoToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_MISSING" {
 		t.Errorf("ErrorCode = %q, want TOKEN_MISSING", body.ErrorCode)
 	}
@@ -659,7 +660,7 @@ func TestLenientHumaJWTMiddleware_InvalidToken(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID", body.ErrorCode)
 	}
@@ -692,7 +693,7 @@ func TestLenientHumaJWTMiddleware_ValidToken_FailsDBLookup(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID (DB lookup failed)", body.ErrorCode)
 	}
@@ -734,7 +735,7 @@ func TestLenientHumaJWTMiddleware_ExpiredWithinGrace_FailsDBLookup(t *testing.T)
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	// Token passes grace check but DB fails → TOKEN_INVALID
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID (grace OK, DB failed)", body.ErrorCode)
@@ -773,7 +774,7 @@ func TestLenientHumaJWTMiddleware_ExpiredBeyondGrace(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	if body.ErrorCode != "TOKEN_EXPIRED" {
 		t.Errorf("ErrorCode = %q, want TOKEN_EXPIRED", body.ErrorCode)
 	}
@@ -806,7 +807,7 @@ func TestLenientHumaJWTMiddleware_CookieFallback(t *testing.T) {
 	}
 
 	var body JWTErrorResponse
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	// Cookie was found and parsed, but DB lookup fails
 	if body.ErrorCode != "TOKEN_INVALID" {
 		t.Errorf("ErrorCode = %q, want TOKEN_INVALID (cookie extracted, DB failed)", body.ErrorCode)

--- a/backend/internal/services/pipeline/extraction_calendar_test.go
+++ b/backend/internal/services/pipeline/extraction_calendar_test.go
@@ -506,7 +506,7 @@ func TestExtractCalendarPage(t *testing.T) {
 			// Verify the request is well-formed
 			body, _ := io.ReadAll(r.Body)
 			var reqBody anthropicRequest
-			json.Unmarshal(body, &reqBody)
+			require.NoError(t, json.Unmarshal(body, &reqBody))
 
 			// Verify calendar-specific settings
 			assert.Equal(t, 4096, reqBody.MaxTokens)
@@ -550,7 +550,7 @@ func TestExtractCalendarPage(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, _ := io.ReadAll(r.Body)
 			var reqBody anthropicRequest
-			json.Unmarshal(body, &reqBody)
+			require.NoError(t, json.Unmarshal(body, &reqBody))
 
 			// Verify message content includes image block
 			assert.Len(t, reqBody.Messages, 1)


### PR DESCRIPTION
## Summary
- Wrap 22 dropped `json.Unmarshal` error returns in test files with `require.NoError(t, ...)` so silent decode failures surface loudly instead of asserting against zero-valued response bodies.
- All 22 sites are in `_test.go` files; the spike's prediction that the subset would be mostly tests held — there were zero production sites needing per-site investigation.

Phase 3 of 4 in the PSY-833 errcheck graduation series. errcheck STAYS advisory after this PR; graduation in Phase 4 (PSY-849).

## Re-baseline
- `json.Unmarshal` subset before: 22. After: 0.
- Full errcheck before (this branch base = `origin/main` @ e1587a2c, which has Phase 1 merged but Phase 2 not yet merged): 205. After: 183. Delta: −22 (exact).

(Ticket cited "post-Phase-2 = 81 total" but PSY-847 (Phase 2) hasn't merged to main yet, so the actual pre-count on this branch is 205. The 22-site json.Unmarshal subset matches the spike estimate either way.)

## Per-site disposition

| file:line | location | disposition | rationale |
|---|---|---|---|
| `internal/api/middleware/jwt_test.go:155,177,199,237,259,350,375,399,437,472,507,532,557,612,638,662,695,737,776,809` (20 sites) | test | `require.NoError(t, json.Unmarshal(...))` wrap | unmarshal of `JWTErrorResponse` from `httptest.ResponseRecorder` body; silent decode failure would assert against zero-valued struct. File had no testify import; added it (matches sibling non-suite tests like `pipeline/fetcher_test.go`, `explore/explore_test.go`). |
| `internal/services/pipeline/extraction_calendar_test.go:509,553` (2 sites) | test | `require.NoError(t, json.Unmarshal(...))` wrap | unmarshal of captured Anthropic request body inside `httptest.NewServer` handler closure; `t` already captured from enclosing test scope. File already imports `require`. |

Net: 22 test wraps, 0 production checks, 0 explicit `_=` annotations.

## Bugs surfaced
None — all 22 sites were in test files. No production code was changed.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./...` — all packages passed (incl. `internal/api/middleware` and `internal/services/pipeline` which contain the changed test files)
- [x] `cd backend && ~/go/bin/golangci-lint run --no-config --enable-only=errcheck --max-issues-per-linter=0 --max-same-issues=0 ./...` — `json.Unmarshal` subset → 0
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues (no NEW gated linter regression)

## Manual repro
Pre: 22 `json.Unmarshal` drops + 205 total errcheck. Post: 0 `json.Unmarshal` + 183 total errcheck. Bugs surfaced: 0. mode=none (backend test-code only, no dev stack needed).

## Code review
Three-lens review (reuse / quality / efficiency) on the diff. All three converged on "no issues" — the change is the minimal mechanical wrap matching the PSY-846 precedent. The file `jwt_test.go` still uses `t.Errorf`/`t.Fatalf` for its other assertions (mixed with the new `require.NoError`); a wholesale migration to testify is explicitly out of scope for an errcheck-graduation phase.

Closes PSY-848