### PR TITLE
PSY-837: /explore landing page + sidebar wiring

### DIFF
--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -1,0 +1,142 @@
+import { Suspense, cache } from 'react'
+import { Metadata } from 'next'
+import * as Sentry from '@sentry/nextjs'
+import { Loader2 } from 'lucide-react'
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { ExplorePage } from '@/features/explore'
+import type {
+  ExploreFeaturedResponse,
+  ExploreUpcomingShowsResponse,
+} from '@/features/explore'
+import { API_BASE_URL } from '@/lib/api-base'
+import { queryKeys, getQueryClient } from '@/lib/queryClient'
+
+export const metadata: Metadata = {
+  title: 'Explore | Psychic Homily',
+  description:
+    'Hand-picked bills, knowledge-graph traversal, and a chronological view of upcoming shows.',
+  alternates: {
+    canonical: 'https://psychichomily.com/explore',
+  },
+  openGraph: {
+    title: 'Explore | Psychic Homily',
+    description:
+      'Hand-picked bills, knowledge-graph traversal, and a chronological view of upcoming shows.',
+    url: '/explore',
+    type: 'website',
+  },
+}
+
+const UPCOMING_LIMIT = 5
+
+// `React.cache()`-wrapped fetches share the request memo so any
+// caller within the same render reuses the result. The /explore
+// endpoints are public; ISR is safe (no per-user content). Featured
+// data changes only when the admin curates, so revalidate every
+// 5 minutes; upcoming shows tick by event_date so a similar window
+// is fine — the section is small and chronological.
+const getFeatured = cache(async (): Promise<ExploreFeaturedResponse | null> => {
+  try {
+    const res = await fetch(`${API_BASE_URL}/explore/featured`, {
+      next: { revalidate: 300 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Explore featured fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'explore-page' },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'explore-page' },
+    })
+  }
+  return null
+})
+
+const getUpcomingShows = cache(
+  async (): Promise<ExploreUpcomingShowsResponse | null> => {
+    try {
+      const res = await fetch(
+        `${API_BASE_URL}/explore/upcoming-shows?limit=${UPCOMING_LIMIT}`,
+        { next: { revalidate: 300 } },
+      )
+      if (res.ok) {
+        return res.json()
+      }
+      if (res.status >= 500) {
+        Sentry.captureMessage(
+          `Explore upcoming-shows fetch error: ${res.status}`,
+          {
+            level: 'error',
+            tags: { service: 'explore-page' },
+          },
+        )
+      }
+    } catch (error) {
+      Sentry.captureException(error, {
+        level: 'error',
+        tags: { service: 'explore-page' },
+      })
+    }
+    return null
+  },
+)
+
+function ExploreLoadingFallback() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+// Next 16's cacheComponents config requires reading either a Request
+// data source (cookies/headers/searchParams) or making an uncached
+// fetch BEFORE any internal Date.now() call (TanStack Query's
+// prefetch helpers call it). Awaiting `searchParams` here is a
+// no-cost way to opt this route into request-time rendering without
+// surrendering ISR on the upstream fetches.
+interface ExploreRouteProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+export default async function ExploreRoute({ searchParams }: ExploreRouteProps) {
+  await searchParams
+
+  const [featured, upcoming] = await Promise.all([
+    getFeatured(),
+    getUpcomingShows(),
+  ])
+
+  // Seed both queries onto ONE shared client so we can hand a single
+  // dehydrated state to the hydration boundary. Missing fetches (a
+  // 500 surfaces as null upstream) simply skip their seed; the client
+  // hook falls back to its own fetch on mount in that path.
+  const queryClient = getQueryClient()
+  if (featured !== null) {
+    await queryClient.prefetchQuery({
+      queryKey: queryKeys.explore.featured,
+      queryFn: () => featured,
+    })
+  }
+  if (upcoming !== null) {
+    await queryClient.prefetchQuery({
+      queryKey: queryKeys.explore.upcomingShows({ limit: UPCOMING_LIMIT }),
+      queryFn: () => upcoming,
+    })
+  }
+  const dehydratedState = dehydrate(queryClient)
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <Suspense fallback={<ExploreLoadingFallback />}>
+        <ExplorePage />
+      </Suspense>
+    </HydrationBoundary>
+  )
+}

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -31,9 +31,9 @@ describe('sidebarGroups', () => {
     expect(sidebarGroups.map(g => g.label)).toEqual(['Discover', 'Community'])
   })
 
-  it('Discover contains Shows, Festivals, Artists, Venues, Releases, Labels, Tags, Collections, Radio', () => {
+  it('Discover contains Shows, Festivals, Artists, Venues, Explore, Releases, Labels, Tags, Scenes, Collections, Charts, Radio', () => {
     const discover = sidebarGroups.find(g => g.label === 'Discover')!
-    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Tags', 'Scenes', 'Collections', 'Charts', 'Radio'])
+    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Explore', 'Releases', 'Labels', 'Tags', 'Scenes', 'Collections', 'Charts', 'Radio'])
   })
 
   it('Community contains Contribute, Requests, Blog, DJ Sets, Substack, Submit a Show, My Submissions', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, UserCircle, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink, Globe, TrendingUp, Bell, HeartHandshake, Trophy, Radio, Music,
+  ExternalLink, Globe, TrendingUp, Bell, HeartHandshake, Trophy, Radio, Music, Compass,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -34,6 +34,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { href: '/festivals', label: 'Festivals', icon: Tent },
       { href: '/artists', label: 'Artists', icon: Mic2 },
       { href: '/venues', label: 'Venues', icon: MapPin },
+      { href: '/explore', label: 'Explore', icon: Compass },
       { href: '/releases', label: 'Releases', icon: Disc3 },
       { href: '/labels', label: 'Labels', icon: Tag },
       { href: '/tags', label: 'Tags', icon: Tags },

--- a/frontend/features/explore/components/ExplorePage.test.tsx
+++ b/frontend/features/explore/components/ExplorePage.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ExplorePage } from './ExplorePage'
+import type { ExploreFeaturedResponse } from '../types'
+
+const mockUseExploreFeatured = vi.fn<() => {
+  data: ExploreFeaturedResponse | undefined
+}>(() => ({ data: undefined }))
+
+vi.mock('../hooks', () => ({
+  useExploreFeatured: () => mockUseExploreFeatured(),
+}))
+
+// Stub the heavy children so we can assert layout assembly without their
+// internals.
+vi.mock('./UpcomingShowsList', () => ({
+  UpcomingShowsList: () => <div data-testid="upcoming-shows-list" />,
+}))
+vi.mock('./FeaturedBillCard', () => ({
+  FeaturedBillCard: ({ bill }: { bill: { title: string } }) => (
+    <div data-testid="featured-bill-card">{bill.title}</div>
+  ),
+}))
+vi.mock('./FeaturedCollectionCard', () => ({
+  FeaturedCollectionCard: ({
+    collection,
+  }: {
+    collection: { title: string }
+  }) => <div data-testid="featured-collection-card">{collection.title}</div>,
+}))
+vi.mock('./InlineGraph', () => ({
+  InlineGraph: () => <div data-testid="inline-graph" />,
+}))
+vi.mock('./ShuffleCta', () => ({
+  ShuffleCta: () => <div data-testid="shuffle-cta" />,
+}))
+
+const sampleFeatured: ExploreFeaturedResponse = {
+  bill: {
+    id: 1,
+    slug: 'bill-slug',
+    title: 'Big Bill',
+    event_date: '2026-06-15T03:00:00Z',
+    headliner_name: 'Cool Band',
+    venue_name: 'The Trunk Space',
+    venue_city: 'Phoenix',
+    venue_state: 'AZ',
+  },
+  collection: {
+    id: 2,
+    slug: 'arizona-noise',
+    title: 'Arizona Noise',
+  },
+}
+
+beforeEach(() => {
+  mockUseExploreFeatured.mockReset()
+})
+
+describe('ExplorePage', () => {
+  it('renders the heading + upcoming shows + shuffle CTA when featured slots are empty', () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: { bill: null, collection: null },
+    })
+    render(<ExplorePage />)
+    expect(
+      screen.getByRole('heading', { level: 1, name: /explore/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('upcoming-shows-list')).toBeInTheDocument()
+    expect(screen.getByTestId('shuffle-cta')).toBeInTheDocument()
+    // Featured + graph + collection sections collapse when null.
+    expect(screen.queryByTestId('featured-bill-card')).toBeNull()
+    expect(screen.queryByTestId('inline-graph')).toBeNull()
+    expect(screen.queryByTestId('featured-collection-card')).toBeNull()
+  })
+
+  it('renders the bill + graph + collection sections when featured returns both', () => {
+    mockUseExploreFeatured.mockReturnValue({ data: sampleFeatured })
+    render(<ExplorePage />)
+    expect(screen.getByTestId('featured-bill-card')).toHaveTextContent(
+      'Big Bill',
+    )
+    expect(screen.getByTestId('inline-graph')).toBeInTheDocument()
+    expect(screen.getByTestId('featured-collection-card')).toHaveTextContent(
+      'Arizona Noise',
+    )
+  })
+
+  it('renders the bill + graph but no collection when only the bill is set', () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: { bill: sampleFeatured.bill, collection: null },
+    })
+    render(<ExplorePage />)
+    expect(screen.getByTestId('featured-bill-card')).toBeInTheDocument()
+    expect(screen.getByTestId('inline-graph')).toBeInTheDocument()
+    expect(screen.queryByTestId('featured-collection-card')).toBeNull()
+  })
+
+  it('renders the collection but no bill/graph when only the collection is set', () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: { bill: null, collection: sampleFeatured.collection },
+    })
+    render(<ExplorePage />)
+    expect(screen.queryByTestId('featured-bill-card')).toBeNull()
+    expect(screen.queryByTestId('inline-graph')).toBeNull()
+    expect(screen.getByTestId('featured-collection-card')).toBeInTheDocument()
+  })
+})

--- a/frontend/features/explore/components/ExplorePage.tsx
+++ b/frontend/features/explore/components/ExplorePage.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+/**
+ * ExplorePage (PSY-837)
+ *
+ * Client component that composes the /explore landing sections in the
+ * order locked in the brief (`docs/open-questions/explore-landing.md`):
+ *
+ *   1. Page heading
+ *   2. Upcoming Shows (chronological)
+ *   3. Featured (admin-curated bill) — collapses if null
+ *   4. Inline graph — lazy-mounts via IntersectionObserver, anchored
+ *      to the featured bill's headliner
+ *   5. Featured Collection — collapses if null
+ *   6. "Drop me somewhere" shuffle CTA
+ *
+ * Reads from the SSR-prefetched TanStack Query cache — both Upcoming
+ * Shows and Featured are seeded by `app/explore/page.tsx` so the first
+ * paint is synchronous, no spinner. The shuffle endpoint is fetched on
+ * demand (button click). The graph is fully client-side and only
+ * mounts once scrolled into view.
+ */
+
+import Link from 'next/link'
+import { useExploreFeatured } from '../hooks'
+import { UpcomingShowsList } from './UpcomingShowsList'
+import { FeaturedBillCard } from './FeaturedBillCard'
+import { FeaturedCollectionCard } from './FeaturedCollectionCard'
+import { InlineGraph } from './InlineGraph'
+import { ShuffleCta } from './ShuffleCta'
+
+export function ExplorePage() {
+  const { data: featured } = useExploreFeatured()
+  const bill = featured?.bill ?? null
+  const collection = featured?.collection ?? null
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <div className="w-full max-w-6xl px-4 py-8 md:px-8">
+        {/* 1. Heading */}
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight">Explore</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Hand-picked bills, the artists they connect to, and a chronological
+            view of everything coming up.
+          </p>
+        </header>
+
+        {/* 2. Upcoming Shows */}
+        <section className="mb-14">
+          <div className="flex justify-between items-center mb-5">
+            <h2 className="text-2xl font-bold tracking-tight">Upcoming Shows</h2>
+            <Link
+              href="/shows"
+              className="text-sm text-muted-foreground hover:text-primary transition-colors hover:underline underline-offset-4"
+            >
+              View all shows →
+            </Link>
+          </div>
+          <UpcomingShowsList limit={5} />
+        </section>
+
+        {/* 3. Featured Bill (collapses when null) */}
+        {bill && (
+          <section className="mb-14">
+            <div className="flex justify-between items-center mb-5">
+              <h2 className="text-2xl font-bold tracking-tight">Featured</h2>
+            </div>
+            <FeaturedBillCard bill={bill} />
+          </section>
+        )}
+
+        {/* 4. Inline knowledge graph anchored to the featured bill */}
+        {bill && (
+          <section className="mb-14">
+            <div className="flex justify-between items-center mb-5">
+              <h2 className="text-2xl font-bold tracking-tight">
+                Explore the lineup
+              </h2>
+            </div>
+            <InlineGraph
+              billSlug={bill.slug}
+              billTitle={bill.title}
+              billHref={`/shows/${bill.slug || bill.id}`}
+            />
+          </section>
+        )}
+
+        {/* 5. Featured Collection (collapses when null) */}
+        {collection && (
+          <section className="mb-14">
+            <div className="flex justify-between items-center mb-5">
+              <h2 className="text-2xl font-bold tracking-tight">
+                Featured Collection
+              </h2>
+              <Link
+                href="/collections"
+                className="text-sm text-muted-foreground hover:text-primary transition-colors hover:underline underline-offset-4"
+              >
+                View all collections →
+              </Link>
+            </div>
+            <FeaturedCollectionCard collection={collection} />
+          </section>
+        )}
+
+        {/* 6. Shuffle CTA */}
+        <section className="mb-14">
+          <div className="mb-3">
+            <h2 className="text-2xl font-bold tracking-tight">Surprise me</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Drop into a random artist's page from the next or last 90 days
+              of shows.
+            </p>
+          </div>
+          <ShuffleCta />
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/frontend/features/explore/components/FeaturedBillCard.test.tsx
+++ b/frontend/features/explore/components/FeaturedBillCard.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FeaturedBillCard } from './FeaturedBillCard'
+import type { ExploreFeaturedBill } from '../types'
+
+const baseBill: ExploreFeaturedBill = {
+  id: 42,
+  slug: 'featured-bill',
+  title: 'Big Show',
+  event_date: '2026-06-15T03:00:00Z',
+  headliner_name: 'Cool Band',
+  venue_name: 'The Trunk Space',
+  venue_city: 'Phoenix',
+  venue_state: 'AZ',
+  curator_note_html: '<p>Why this bill matters.</p>',
+}
+
+describe('FeaturedBillCard', () => {
+  it('renders the headliner, venue line, and a view-show link', () => {
+    render(<FeaturedBillCard bill={baseBill} />)
+    expect(screen.getByText('Cool Band')).toBeInTheDocument()
+    // venue line
+    expect(screen.getByText(/The Trunk Space/)).toBeInTheDocument()
+    // view-show CTA points to the show detail page
+    const cta = screen.getByRole('link', { name: /view show/i })
+    expect(cta).toHaveAttribute('href', '/shows/featured-bill')
+  })
+
+  it('renders the curator note as sanitized HTML', () => {
+    const { container } = render(<FeaturedBillCard bill={baseBill} />)
+    expect(container.querySelector('p')?.textContent).toBe(
+      'Why this bill matters.',
+    )
+  })
+
+  it('omits the curator note block when no HTML is provided', () => {
+    const { container } = render(
+      <FeaturedBillCard bill={{ ...baseBill, curator_note_html: undefined }} />,
+    )
+    expect(container.querySelector('p')).toBeNull()
+  })
+
+  it('renders the thumbnail when image_url is set', () => {
+    render(
+      <FeaturedBillCard bill={{ ...baseBill, image_url: '/big.jpg' }} />,
+    )
+    const img = screen.getByRole('img', { name: 'Big Show' })
+    expect(img).toBeInTheDocument()
+  })
+
+  it('omits the thumbnail when image_url is absent', () => {
+    render(<FeaturedBillCard bill={baseBill} />)
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+})

--- a/frontend/features/explore/components/FeaturedBillCard.tsx
+++ b/frontend/features/explore/components/FeaturedBillCard.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+/**
+ * FeaturedBillCard (PSY-837)
+ *
+ * Hero card for the admin-curated featured bill slot. Renders a 160px
+ * thumb (when an image_url is present), a venue/date eyebrow, the
+ * headline (artists / show title), the curator's note (rendered HTML
+ * from the markdown source — sanitized server-side by goldmark +
+ * bluemonday), and a "View show →" link.
+ *
+ * The parent collapses the section entirely when `bill` is null —
+ * this component assumes a non-null prop.
+ */
+
+import Link from 'next/link'
+import Image from 'next/image'
+import type { ExploreFeaturedBill } from '../types'
+import { formatShowDate } from '@/lib/utils/formatters'
+
+interface FeaturedBillCardProps {
+  bill: ExploreFeaturedBill
+}
+
+export function FeaturedBillCard({ bill }: FeaturedBillCardProps) {
+  const detailsHref = `/shows/${bill.slug || bill.id}`
+  const dateLine = formatShowDate(bill.event_date, bill.venue_state)
+  const venueLine = [bill.venue_name, bill.venue_city, bill.venue_state]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <article className="bg-card/50 border border-border/50 rounded-xl p-6 hover:border-border transition-colors">
+      <div className="flex flex-col sm:flex-row gap-5">
+        {bill.image_url && (
+          <Link
+            href={detailsHref}
+            className="shrink-0 block overflow-hidden rounded-lg"
+            aria-label={bill.title}
+          >
+            <Image
+              src={bill.image_url}
+              alt={bill.title}
+              width={160}
+              height={160}
+              className="h-40 w-40 object-cover"
+            />
+          </Link>
+        )}
+
+        <div className="flex-1 min-w-0">
+          <div className="text-xs uppercase tracking-wider text-muted-foreground">
+            {dateLine}
+            {venueLine && (
+              <>
+                <span className="px-1.5">·</span>
+                <span className="normal-case tracking-normal">{venueLine}</span>
+              </>
+            )}
+          </div>
+
+          <h3 className="mt-1.5 text-xl font-semibold leading-tight tracking-tight">
+            <Link
+              href={detailsHref}
+              className="hover:text-primary transition-colors"
+            >
+              {bill.headliner_name || bill.title}
+            </Link>
+          </h3>
+
+          {bill.curator_note_html && (
+            <div
+              className="mt-3 text-sm leading-relaxed text-foreground/85 prose prose-sm max-w-none dark:prose-invert"
+              dangerouslySetInnerHTML={{ __html: bill.curator_note_html }}
+            />
+          )}
+
+          <Link
+            href={detailsHref}
+            className="inline-block mt-4 px-4 py-2 text-sm bg-muted/50 border border-border/50 rounded-lg hover:bg-muted hover:border-border transition-colors"
+          >
+            View show →
+          </Link>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/features/explore/components/FeaturedBillCard.tsx
+++ b/frontend/features/explore/components/FeaturedBillCard.tsx
@@ -44,6 +44,7 @@ export function FeaturedBillCard({ bill }: FeaturedBillCardProps) {
               width={160}
               height={160}
               className="h-40 w-40 object-cover"
+              unoptimized
             />
           </Link>
         )}

--- a/frontend/features/explore/components/FeaturedCollectionCard.test.tsx
+++ b/frontend/features/explore/components/FeaturedCollectionCard.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FeaturedCollectionCard } from './FeaturedCollectionCard'
+import type { ExploreFeaturedCollection } from '../types'
+
+const baseCollection: ExploreFeaturedCollection = {
+  id: 7,
+  slug: 'arizona-noise',
+  title: 'Arizona Noise Roundup',
+  curator_note_html: '<p>Sound from the desert.</p>',
+}
+
+describe('FeaturedCollectionCard', () => {
+  it('renders the title and a view-collection link', () => {
+    render(<FeaturedCollectionCard collection={baseCollection} />)
+    expect(screen.getByText('Arizona Noise Roundup')).toBeInTheDocument()
+    const cta = screen.getByRole('link', { name: /view collection/i })
+    expect(cta).toHaveAttribute('href', '/collections/arizona-noise')
+  })
+
+  it('renders the curator note as sanitized HTML', () => {
+    const { container } = render(
+      <FeaturedCollectionCard collection={baseCollection} />,
+    )
+    expect(container.querySelector('p')?.textContent).toBe(
+      'Sound from the desert.',
+    )
+  })
+
+  it('renders the cover image when cover_image_url is set', () => {
+    render(
+      <FeaturedCollectionCard
+        collection={{ ...baseCollection, cover_image_url: '/cover.jpg' }}
+      />,
+    )
+    expect(
+      screen.getByRole('img', { name: 'Arizona Noise Roundup' }),
+    ).toBeInTheDocument()
+  })
+
+  it('omits the cover image when cover_image_url is absent', () => {
+    render(<FeaturedCollectionCard collection={baseCollection} />)
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+})

--- a/frontend/features/explore/components/FeaturedCollectionCard.tsx
+++ b/frontend/features/explore/components/FeaturedCollectionCard.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+/**
+ * FeaturedCollectionCard (PSY-837)
+ *
+ * Mirror of FeaturedBillCard for the collection slot. Renders a 160px
+ * cover image when present, the collection title, the curator's note
+ * (sanitized HTML), and a "View collection →" link.
+ *
+ * Parent collapses the section when `collection` is null.
+ */
+
+import Link from 'next/link'
+import Image from 'next/image'
+import type { ExploreFeaturedCollection } from '../types'
+
+interface FeaturedCollectionCardProps {
+  collection: ExploreFeaturedCollection
+}
+
+export function FeaturedCollectionCard({ collection }: FeaturedCollectionCardProps) {
+  const detailsHref = `/collections/${collection.slug || collection.id}`
+
+  return (
+    <article className="bg-card/50 border border-border/50 rounded-xl p-6 hover:border-border transition-colors">
+      <div className="flex flex-col sm:flex-row gap-5">
+        {collection.cover_image_url && (
+          <Link
+            href={detailsHref}
+            className="shrink-0 block overflow-hidden rounded-lg"
+            aria-label={collection.title}
+          >
+            <Image
+              src={collection.cover_image_url}
+              alt={collection.title}
+              width={160}
+              height={160}
+              className="h-40 w-40 object-cover"
+            />
+          </Link>
+        )}
+
+        <div className="flex-1 min-w-0">
+          <div className="text-xs uppercase tracking-wider text-muted-foreground">
+            Collection
+          </div>
+
+          <h3 className="mt-1.5 text-xl font-semibold leading-tight tracking-tight">
+            <Link
+              href={detailsHref}
+              className="hover:text-primary transition-colors"
+            >
+              {collection.title}
+            </Link>
+          </h3>
+
+          {collection.curator_note_html && (
+            <div
+              className="mt-3 text-sm leading-relaxed text-foreground/85 prose prose-sm max-w-none dark:prose-invert"
+              dangerouslySetInnerHTML={{ __html: collection.curator_note_html }}
+            />
+          )}
+
+          <Link
+            href={detailsHref}
+            className="inline-block mt-4 px-4 py-2 text-sm bg-muted/50 border border-border/50 rounded-lg hover:bg-muted hover:border-border transition-colors"
+          >
+            View collection →
+          </Link>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/features/explore/components/FeaturedCollectionCard.tsx
+++ b/frontend/features/explore/components/FeaturedCollectionCard.tsx
@@ -36,6 +36,7 @@ export function FeaturedCollectionCard({ collection }: FeaturedCollectionCardPro
               width={160}
               height={160}
               className="h-40 w-40 object-cover"
+              unoptimized
             />
           </Link>
         )}

--- a/frontend/features/explore/components/InlineGraph.test.tsx
+++ b/frontend/features/explore/components/InlineGraph.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { InlineGraph } from './InlineGraph'
+
+// Stub the heavy ForceGraphView so tests don't pull in d3-force / canvas.
+vi.mock('@/components/graph/ForceGraphView', () => ({
+  ForceGraphView: ({ ariaLabel }: { ariaLabel: string }) => (
+    <div role="img" aria-label={ariaLabel} data-testid="force-graph">
+      graph
+    </div>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockUseShow = vi.fn()
+vi.mock('@/features/shows', () => ({
+  useShow: (slug: string) => mockUseShow(slug),
+}))
+
+const mockUseArtistGraph = vi.fn()
+vi.mock('@/features/artists/hooks/useArtistGraph', () => ({
+  useArtistGraph: (opts: unknown) => mockUseArtistGraph(opts),
+}))
+
+// The test/setup.ts file installs a no-op IntersectionObserver. Override
+// it with one that records the callback so the test can fire visibility
+// events on demand.
+type ObserverInstance = {
+  callback: IntersectionObserverCallback
+  observed: Element[]
+}
+const observers: ObserverInstance[] = []
+
+class FiringIntersectionObserver implements IntersectionObserver {
+  readonly root = null
+  readonly rootMargin = ''
+  readonly thresholds = []
+  private callback: IntersectionObserverCallback
+  private observed: Element[] = []
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback
+    observers.push({ callback, observed: this.observed })
+  }
+  observe(target: Element) {
+    this.observed.push(target)
+  }
+  unobserve() {}
+  disconnect() {
+    this.observed.length = 0
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+
+function fireAllVisible() {
+  for (const obs of observers) {
+    const entries: IntersectionObserverEntry[] = obs.observed.map(target => ({
+      isIntersecting: true,
+      target,
+      time: 0,
+      boundingClientRect: {} as DOMRectReadOnly,
+      intersectionRatio: 1,
+      intersectionRect: {} as DOMRectReadOnly,
+      rootBounds: null,
+    }))
+    obs.callback(entries, {} as IntersectionObserver)
+  }
+}
+
+// setup.ts installs a no-op IntersectionObserver via
+// `Object.defineProperty(window, ..., { writable: true })` — assignable
+// but NOT configurable, so we mutate via assignment and restore the
+// same way in afterEach.
+let originalObserver: typeof IntersectionObserver | undefined
+
+beforeEach(() => {
+  observers.length = 0
+  originalObserver = window.IntersectionObserver
+  ;(window as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    FiringIntersectionObserver
+  mockUseShow.mockReset()
+  mockUseArtistGraph.mockReset()
+})
+
+afterEach(() => {
+  if (originalObserver) {
+    ;(window as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+      originalObserver
+  }
+})
+
+describe('InlineGraph', () => {
+  it('renders a skeleton placeholder before IntersectionObserver fires', () => {
+    mockUseShow.mockReturnValue({ data: undefined })
+    mockUseArtistGraph.mockReturnValue({ data: undefined, isLoading: false })
+
+    const { container } = render(
+      <InlineGraph
+        billSlug="featured-bill"
+        billTitle="Big Show"
+        billHref="/shows/featured-bill"
+      />,
+    )
+
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+    expect(screen.queryByTestId('force-graph')).toBeNull()
+  })
+
+  it('passes the headliner artist id to the graph hook once mounted', () => {
+    mockUseShow.mockReturnValue({
+      data: {
+        artists: [
+          { id: 11, is_headliner: false },
+          { id: 22, is_headliner: true },
+        ],
+      },
+    })
+    mockUseArtistGraph.mockReturnValue({
+      data: { center: { id: 22 }, nodes: [], links: [] },
+      isLoading: false,
+    })
+
+    render(
+      <InlineGraph
+        billSlug="featured-bill"
+        billTitle="Big Show"
+        billHref="/shows/featured-bill"
+      />,
+    )
+
+    act(() => {
+      fireAllVisible()
+    })
+
+    const calls = mockUseArtistGraph.mock.calls
+    const lastCall = calls[calls.length - 1][0] as {
+      artistId: number
+      enabled: boolean
+    }
+    expect(lastCall.artistId).toBe(22)
+    expect(lastCall.enabled).toBe(true)
+  })
+})

--- a/frontend/features/explore/components/InlineGraph.tsx
+++ b/frontend/features/explore/components/InlineGraph.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+/**
+ * InlineGraph (PSY-837)
+ *
+ * Lazy-mounted force graph anchored to the featured bill's headliner.
+ * The brief calls for the graph initial nodes to come from the bill's
+ * lineup; the /explore/featured response only exposes the bill slug +
+ * headliner name (not artist IDs), so we resolve the lineup by
+ * fetching the show detail when the section scrolls into view, then
+ * pass the headliner's artist ID to the existing artist-relationship
+ * graph (PSY-365 ForceGraphView via PSY-361 useArtistGraph).
+ *
+ * Lazy-mount strategy:
+ *   1. Render a skeleton placeholder at the natural graph height to
+ *      prevent CLS.
+ *   2. IntersectionObserver with rootMargin '200px' so the data fetch
+ *      kicks off shortly before the placeholder scrolls into view.
+ *   3. Only once mounted do we call `useShow` / `useArtistGraph`.
+ *
+ * Mobile gate (<640px) collapses the graph to a static teaser per
+ * PSY-511; canvas touch handling isn't usable at small widths.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ForceGraphView } from '@/components/graph/ForceGraphView'
+import type { GraphNode } from '@/components/graph/ForceGraphView'
+import { useShow } from '@/features/shows'
+import { useArtistGraph } from '@/features/artists/hooks/useArtistGraph'
+
+const GRAPH_BREAKPOINT_PX = 640
+const GRAPH_HEIGHT_PX = 480
+const INTERSECTION_ROOT_MARGIN = '200px'
+
+interface InlineGraphProps {
+  /** Featured bill slug — drives the show-detail fetch for lineup. */
+  billSlug: string
+  /** Featured bill title — for the canvas aria-label. */
+  billTitle: string
+  /** Featured bill href — for the mobile teaser fallback link. */
+  billHref: string
+}
+
+export function InlineGraph({ billSlug, billTitle, billHref }: InlineGraphProps) {
+  const router = useRouter()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isMounted, setIsMounted] = useState(false)
+  const [containerWidth, setContainerWidth] = useState<number | null>(null)
+
+  // Lazy-mount via IntersectionObserver. Pre-mount with a 200px root
+  // margin so the data is in flight before the placeholder is fully
+  // on-screen; once mounted, we never tear down (the user has shown
+  // intent by scrolling here).
+  useEffect(() => {
+    if (isMounted) return
+    const node = containerRef.current
+    if (!node || typeof IntersectionObserver === 'undefined') {
+      // SSR / very old browsers — fall back to immediate mount.
+      setIsMounted(true)
+      return
+    }
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setIsMounted(true)
+            observer.disconnect()
+            return
+          }
+        }
+      },
+      { rootMargin: INTERSECTION_ROOT_MARGIN },
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [isMounted])
+
+  // Width measurement only kicks in after mount. Same callback-ref +
+  // ResizeObserver pattern as CollectionGraph / SceneGraph.
+  const measureRefCallback = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return
+    setContainerWidth(node.getBoundingClientRect().width)
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width)
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const { data: showData } = useShow(isMounted ? billSlug : '')
+  const headlinerId = showData?.artists.find(a => a.is_headliner)?.id
+    ?? showData?.artists[0]?.id
+    ?? 0
+
+  const { data: graphData, isLoading: graphLoading } = useArtistGraph({
+    artistId: headlinerId,
+    enabled: isMounted && headlinerId > 0,
+  })
+
+  const handleNodeClick = useCallback(
+    (node: GraphNode) => {
+      router.push(`/artists/${node.slug}`)
+    },
+    [router],
+  )
+
+  const graphAvailable =
+    containerWidth !== null && containerWidth >= GRAPH_BREAKPOINT_PX
+
+  // Static teaser for <640px viewports per PSY-511.
+  const teaser = (
+    <div className="aspect-[16/9] w-full rounded-lg border border-border/50 bg-muted/20 flex flex-col items-center justify-center text-center p-6 gap-3">
+      <p className="text-sm text-muted-foreground max-w-xs">
+        The interactive knowledge graph is best on a tablet or larger
+        screen.
+      </p>
+      <Link
+        href={billHref}
+        className="text-sm text-primary hover:underline underline-offset-4"
+      >
+        View the bill instead →
+      </Link>
+    </div>
+  )
+
+  // Skeleton placeholder — reserves the graph's natural height so the
+  // section below doesn't shift when the canvas mounts (CLS budget).
+  const skeleton = (
+    <div
+      className="aspect-[16/9] w-full rounded-lg border border-border/50 bg-muted/10 animate-pulse"
+      style={{ minHeight: GRAPH_HEIGHT_PX }}
+      aria-hidden="true"
+    />
+  )
+
+  return (
+    <div ref={containerRef} className="w-full">
+      <div ref={measureRefCallback} className="w-full">
+        {!isMounted && skeleton}
+
+        {isMounted && containerWidth !== null && !graphAvailable && teaser}
+
+        {isMounted && graphAvailable && (
+          <>
+            {graphLoading && skeleton}
+            {graphData && graphData.nodes.length > 0 && (
+              <ForceGraphView
+                nodes={graphData.nodes}
+                links={graphData.links}
+                clusters={[]}
+                containerWidth={containerWidth}
+                height={GRAPH_HEIGHT_PX}
+                ariaLabel={`Knowledge graph anchored to ${billTitle}: ${graphData.nodes.length} artists.`}
+                onNodeClick={handleNodeClick}
+              />
+            )}
+            {!graphLoading && (!graphData || graphData.nodes.length === 0) && (
+              <div className="aspect-[16/9] w-full rounded-lg border border-border/50 bg-muted/10 flex items-center justify-center text-sm text-muted-foreground">
+                Not enough related artists to render the graph yet.
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/features/explore/components/ShuffleCta.test.tsx
+++ b/frontend/features/explore/components/ShuffleCta.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ShuffleCta } from './ShuffleCta'
+import type { ExploreShuffleTargetResponse } from '../types'
+
+const mockRouterPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+type RefetchResult = { data: ExploreShuffleTargetResponse | undefined }
+const mockRefetch = vi.fn<() => Promise<RefetchResult>>()
+const mockHookState = {
+  isFetching: false,
+}
+vi.mock('../hooks', () => ({
+  useShuffleTarget: () => ({
+    refetch: mockRefetch,
+    isFetching: mockHookState.isFetching,
+  }),
+}))
+
+beforeEach(() => {
+  mockRouterPush.mockReset()
+  mockRefetch.mockReset()
+  mockHookState.isFetching = false
+})
+
+describe('ShuffleCta', () => {
+  it('renders the button label', () => {
+    render(<ShuffleCta />)
+    expect(
+      screen.getByRole('button', { name: /drop me somewhere/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('navigates to the resolved artist page on click', async () => {
+    mockRefetch.mockResolvedValue({
+      data: {
+        artist_id: 7,
+        artist_slug: 'cool-band',
+        artist_name: 'Cool Band',
+      },
+    })
+    render(<ShuffleCta />)
+
+    fireEvent.click(screen.getByRole('button', { name: /drop me somewhere/i }))
+
+    await waitFor(() =>
+      expect(mockRouterPush).toHaveBeenCalledWith('/artists/cool-band'),
+    )
+  })
+
+  it('shows an inline message when no shuffle target is returned', async () => {
+    mockRefetch.mockResolvedValue({
+      data: {
+        artist_id: null,
+        artist_slug: null,
+        artist_name: null,
+      },
+    })
+    render(<ShuffleCta />)
+
+    fireEvent.click(screen.getByRole('button', { name: /drop me somewhere/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/no artists/i),
+    )
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error message when the refetch throws', async () => {
+    mockRefetch.mockRejectedValue(new Error('boom'))
+    render(<ShuffleCta />)
+
+    fireEvent.click(screen.getByRole('button', { name: /drop me somewhere/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/could not pick/i),
+    )
+  })
+})

--- a/frontend/features/explore/components/ShuffleCta.tsx
+++ b/frontend/features/explore/components/ShuffleCta.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+/**
+ * ShuffleCta (PSY-837)
+ *
+ * "Drop me somewhere" outline button. Each click pulls a fresh random
+ * artist from the ±90-day show pool (`useShuffleTarget` is disabled on
+ * mount; we `refetch()` per click so each press is a new pick), then
+ * router-pushes to that artist's detail page.
+ *
+ * When the database has no qualifying artists, the endpoint returns
+ * all-null fields with HTTP 200 — we surface a brief inline message
+ * rather than navigate. No toast library (per
+ * `pattern_mutation_feedback.md`).
+ */
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useShuffleTarget } from '../hooks'
+
+export function ShuffleCta() {
+  const router = useRouter()
+  const { refetch, isFetching } = useShuffleTarget()
+  const [error, setError] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    setError(null)
+    try {
+      const result = await refetch()
+      const target = result.data
+      if (target?.artist_slug) {
+        router.push(`/artists/${target.artist_slug}`)
+        return
+      }
+      setError('No artists available to shuffle to right now.')
+    } catch {
+      setError('Could not pick a shuffle target — try again in a moment.')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isFetching}
+        className="inline-flex items-center px-4 py-2 text-sm rounded-lg border border-border/60 hover:bg-muted/50 hover:border-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isFetching ? 'Picking…' : 'Drop me somewhere →'}
+      </button>
+      {error && (
+        <p className="text-sm text-muted-foreground" role="status">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/explore/components/UpcomingShowsList.test.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { UpcomingShowsList } from './UpcomingShowsList'
+import type { ExploreUpcomingShowsResponse } from '../types'
+
+type MockHookResult = {
+  data: ExploreUpcomingShowsResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+const mockUseExploreUpcomingShows = vi.fn<() => MockHookResult>(() => ({
+  data: undefined,
+  isLoading: false,
+  error: null,
+}))
+
+vi.mock('../hooks', () => ({
+  useExploreUpcomingShows: () => mockUseExploreUpcomingShows(),
+}))
+
+const sampleResponse: ExploreUpcomingShowsResponse = {
+  shows: [
+    {
+      id: 1,
+      slug: 'show-one',
+      title: 'Show One',
+      event_date: '2026-06-15T03:00:00Z',
+      headliner_name: 'Headliner A',
+      venue_name: 'The Trunk Space',
+      venue_city: 'Phoenix',
+      venue_state: 'AZ',
+    },
+    {
+      id: 2,
+      slug: 'show-two',
+      title: 'Show Two',
+      event_date: '2026-06-16T03:00:00Z',
+      headliner_name: 'Headliner B',
+      venue_name: 'Crescent Ballroom',
+      venue_city: 'Phoenix',
+      venue_state: 'AZ',
+    },
+  ],
+  total: 2,
+  limit: 5,
+  offset: 0,
+}
+
+describe('UpcomingShowsList', () => {
+  beforeEach(() => {
+    mockUseExploreUpcomingShows.mockReset()
+  })
+
+  it('renders a loading spinner while fetching', () => {
+    mockUseExploreUpcomingShows.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+    const { container } = render(<UpcomingShowsList />)
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('renders an error message when the hook fails', () => {
+    mockUseExploreUpcomingShows.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    })
+    render(<UpcomingShowsList />)
+    expect(screen.getByText(/unable to load shows/i)).toBeInTheDocument()
+  })
+
+  it('renders the empty state when no shows come back', () => {
+    mockUseExploreUpcomingShows.mockReturnValue({
+      data: { shows: [], total: 0, limit: 5, offset: 0 },
+      isLoading: false,
+      error: null,
+    })
+    render(<UpcomingShowsList />)
+    expect(screen.getByText(/no upcoming shows/i)).toBeInTheDocument()
+  })
+
+  it('renders one row per show with a link to the show detail page', () => {
+    mockUseExploreUpcomingShows.mockReturnValue({
+      data: sampleResponse,
+      isLoading: false,
+      error: null,
+    })
+    render(<UpcomingShowsList />)
+
+    const linkOne = screen.getByRole('link', { name: 'Show One' })
+    expect(linkOne).toHaveAttribute('href', '/shows/show-one')
+    expect(linkOne).toHaveTextContent('Headliner A')
+
+    const linkTwo = screen.getByRole('link', { name: 'Show Two' })
+    expect(linkTwo).toHaveAttribute('href', '/shows/show-two')
+    expect(linkTwo).toHaveTextContent('Headliner B')
+  })
+})

--- a/frontend/features/explore/components/UpcomingShowsList.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+/**
+ * UpcomingShowsList (PSY-837)
+ *
+ * Vertical list of upcoming-show rows for the /explore landing. Matches
+ * the homepage's compact-density show row pattern (date · artists ·
+ * venue) without the homepage's filters / save / attendance affordances
+ * — /explore is a discovery surface, not a saved-list manager.
+ *
+ * Reads from `useExploreUpcomingShows` which is seeded by the page-
+ * level SSR prefetch, so this renders synchronously from cache on
+ * first paint.
+ */
+
+import Link from 'next/link'
+import { useExploreUpcomingShows } from '../hooks'
+import { formatShowDateBadge } from '@/lib/utils/showDateBadge'
+
+interface UpcomingShowsListProps {
+  limit?: number
+}
+
+export function UpcomingShowsList({ limit = 5 }: UpcomingShowsListProps) {
+  const { data, isLoading, error } = useExploreUpcomingShows({ limit })
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-foreground"></div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        <p>Unable to load shows.</p>
+      </div>
+    )
+  }
+
+  if (!data || data.shows.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        <p>No upcoming shows at this time.</p>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="flex flex-col divide-y divide-border/40 rounded-lg border border-border/50 bg-card/30">
+      {data.shows.map(show => {
+        const state = show.state ?? show.venue_state ?? null
+        const cityLabel = show.city ?? show.venue_city ?? ''
+        const dateBadge = formatShowDateBadge(show.event_date, state)
+        const detailsHref = `/shows/${show.slug || show.id}`
+
+        return (
+          <li key={show.id}>
+            <Link
+              href={detailsHref}
+              className="flex items-center gap-3 px-3 py-2.5 hover:bg-muted/40 transition-colors"
+              aria-label={show.title}
+            >
+              <span className="text-xs text-muted-foreground shrink-0 w-20 tabular-nums">
+                {dateBadge.dayOfWeek} {dateBadge.monthDay}
+              </span>
+              <span className="font-medium text-sm flex-1 truncate">
+                {show.headliner_name || show.title}
+              </span>
+              <span className="text-xs text-muted-foreground shrink-0 hidden sm:inline truncate max-w-[40%]">
+                {show.venue_name}
+                {(cityLabel || state) && (
+                  <span className="text-muted-foreground/70">
+                    {' '}&middot; {[cityLabel, state].filter(Boolean).join(', ')}
+                  </span>
+                )}
+              </span>
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/frontend/features/explore/components/index.ts
+++ b/frontend/features/explore/components/index.ts
@@ -1,0 +1,6 @@
+export { ExplorePage } from './ExplorePage'
+export { UpcomingShowsList } from './UpcomingShowsList'
+export { FeaturedBillCard } from './FeaturedBillCard'
+export { FeaturedCollectionCard } from './FeaturedCollectionCard'
+export { InlineGraph } from './InlineGraph'
+export { ShuffleCta } from './ShuffleCta'

--- a/frontend/features/explore/hooks/index.ts
+++ b/frontend/features/explore/hooks/index.ts
@@ -1,0 +1,5 @@
+export {
+  useExploreUpcomingShows,
+  useExploreFeatured,
+  useShuffleTarget,
+} from './useExplore'

--- a/frontend/features/explore/hooks/useExplore.ts
+++ b/frontend/features/explore/hooks/useExplore.ts
@@ -1,0 +1,89 @@
+'use client'
+
+/**
+ * Explore feature hooks (PSY-837)
+ *
+ * TanStack Query hooks for the three /explore read endpoints. Two are
+ * page-load reads (upcoming shows, featured slots) — the route's server
+ * component prefetches and seeds the cache via `prefetchEntity` so
+ * these hooks resolve from the seeded cache and the client never
+ * refetches on first paint.
+ *
+ * The shuffle-target endpoint is interaction-driven (button click);
+ * it's wrapped in `useShuffleTarget` (manually triggered via the
+ * returned `refetch`) rather than running on mount.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type {
+  ExploreFeaturedResponse,
+  ExploreShuffleTargetResponse,
+  ExploreUpcomingShowsResponse,
+} from '../types'
+
+interface UseExploreUpcomingShowsOptions {
+  limit?: number
+  offset?: number
+}
+
+/**
+ * Upcoming shows for the /explore landing — chronological
+ * (event_date ASC, id ASC), deterministic pagination, no algorithmic
+ * ranking. Default limit matches the page section design (5 rows).
+ */
+export function useExploreUpcomingShows(
+  options: UseExploreUpcomingShowsOptions = {},
+) {
+  const { limit, offset } = options
+  const params = new URLSearchParams()
+  if (limit != null) params.set('limit', String(limit))
+  if (offset != null) params.set('offset', String(offset))
+  const queryString = params.toString()
+  const endpoint = queryString
+    ? `${API_ENDPOINTS.EXPLORE.UPCOMING_SHOWS}?${queryString}`
+    : API_ENDPOINTS.EXPLORE.UPCOMING_SHOWS
+
+  return useQuery({
+    queryKey: queryKeys.explore.upcomingShows({ limit, offset }),
+    queryFn: () =>
+      apiRequest<ExploreUpcomingShowsResponse>(endpoint, { method: 'GET' }),
+    staleTime: 60 * 1000,
+  })
+}
+
+/**
+ * Admin-curated Featured Bill + Featured Collection. Both fields can
+ * independently be null — the consumer collapses the matching section.
+ */
+export function useExploreFeatured() {
+  return useQuery({
+    queryKey: queryKeys.explore.featured,
+    queryFn: () =>
+      apiRequest<ExploreFeaturedResponse>(API_ENDPOINTS.EXPLORE.FEATURED, {
+        method: 'GET',
+      }),
+    staleTime: 60 * 1000,
+  })
+}
+
+/**
+ * Random artist from the ±90-day show pool. Disabled on mount — the
+ * shuffle CTA calls `refetch()` then navigates with the returned slug
+ * so each click pulls a fresh pick rather than reusing a cached one.
+ */
+export function useShuffleTarget() {
+  return useQuery({
+    queryKey: queryKeys.explore.shuffleTarget,
+    queryFn: () =>
+      apiRequest<ExploreShuffleTargetResponse>(
+        API_ENDPOINTS.EXPLORE.SHUFFLE_TARGET,
+        { method: 'GET' },
+      ),
+    enabled: false,
+    // staleTime: 0 — every click should hit the backend for a fresh pick.
+    staleTime: 0,
+    gcTime: 0,
+  })
+}

--- a/frontend/features/explore/index.ts
+++ b/frontend/features/explore/index.ts
@@ -1,0 +1,25 @@
+// Public API for the explore feature module.
+
+export type {
+  ExploreUpcomingShowItem,
+  ExploreUpcomingShowsResponse,
+  ExploreFeaturedBill,
+  ExploreFeaturedCollection,
+  ExploreFeaturedResponse,
+  ExploreShuffleTargetResponse,
+} from './types'
+
+export {
+  useExploreUpcomingShows,
+  useExploreFeatured,
+  useShuffleTarget,
+} from './hooks'
+
+export {
+  ExplorePage,
+  UpcomingShowsList,
+  FeaturedBillCard,
+  FeaturedCollectionCard,
+  InlineGraph,
+  ShuffleCta,
+} from './components'

--- a/frontend/features/explore/types.ts
+++ b/frontend/features/explore/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Wire-shape types for the /explore landing read endpoints.
+ * Mirrors `backend/internal/services/contracts/explore.go`.
+ *
+ * Backend uses Huma — the JSON wire payload is the value of the Go-side
+ * `Body` field; there is NO `body` envelope key. These types describe
+ * the flat shape clients receive directly.
+ */
+
+// ──────────────────────────────────────────────
+// GET /explore/upcoming-shows
+// ──────────────────────────────────────────────
+
+/**
+ * Single row on the Upcoming Shows list. Headliner is denormalized for
+ * tile rendering; richer bill detail lives on the show-detail page.
+ */
+export interface ExploreUpcomingShowItem {
+  id: number
+  slug: string
+  title: string
+  event_date: string
+  /** Show's headliner name (set_type='headliner' or first artist by position). */
+  headliner_name: string
+  /** First associated venue's name/city/state. */
+  venue_name: string
+  venue_city: string
+  venue_state: string
+  /** Show-level city/state overrides (rare — backend prefers venue values). */
+  city?: string | null
+  state?: string | null
+}
+
+export interface ExploreUpcomingShowsResponse {
+  shows: ExploreUpcomingShowItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+// ──────────────────────────────────────────────
+// GET /explore/featured
+// ──────────────────────────────────────────────
+
+/**
+ * Featured Bill referent. `curator_note_html` is the pre-rendered HTML
+ * (goldmark + bluemonday sanitized) — render with
+ * `dangerouslySetInnerHTML` directly; the renderer is the canonical
+ * sanitizer shared with comments + collections.
+ */
+export interface ExploreFeaturedBill {
+  id: number
+  slug: string
+  title: string
+  event_date: string
+  headliner_name: string
+  venue_name: string
+  venue_city: string
+  venue_state: string
+  image_url?: string | null
+  curator_note?: string | null
+  curator_note_html?: string
+}
+
+export interface ExploreFeaturedCollection {
+  id: number
+  slug: string
+  title: string
+  description?: string
+  description_html?: string
+  cover_image_url?: string | null
+  curator_note?: string | null
+  curator_note_html?: string
+}
+
+/**
+ * Both fields are nullable. When both are null the entire Featured
+ * section collapses; each can be null independently (admin can curate
+ * just one slot type).
+ */
+export interface ExploreFeaturedResponse {
+  bill: ExploreFeaturedBill | null
+  collection: ExploreFeaturedCollection | null
+}
+
+// ──────────────────────────────────────────────
+// GET /explore/shuffle-target
+// ──────────────────────────────────────────────
+
+/**
+ * Random artist drawn from the ±90-day show pool. All fields are
+ * nullable: a cold-start database with no qualifying artists returns
+ * an all-null response with HTTP 200 (graceful empty state).
+ */
+export interface ExploreShuffleTargetResponse {
+  artist_id: number | null
+  artist_slug: string | null
+  artist_name: string | null
+}

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -406,9 +406,14 @@ export const queryKeys = {
     all: ['notificationFilters'] as const,
   },
 
-  // /explore landing read endpoints (PSY-835/836)
+  // /explore landing read endpoints (PSY-835/836/837)
   explore: {
     featured: ['explore', 'featured'] as const,
+    upcomingShows: (params?: { limit?: number; offset?: number }) =>
+      params && Object.values(params).some(v => v != null)
+        ? (['explore', 'upcomingShows', params] as const)
+        : (['explore', 'upcomingShows'] as const),
+    shuffleTarget: ['explore', 'shuffleTarget'] as const,
   },
 
   // System queries


### PR DESCRIPTION
## Summary
- Adds `app/explore/page.tsx` with SSR hydration (prefetch /explore/featured + /explore/upcoming-shows on the server, dehydrate into a HydrationBoundary so client hooks resolve from seed)
- New `features/explore` module: types, hooks (`useExploreUpcomingShows`, `useExploreFeatured`, `useShuffleTarget`), and 6 components (`ExplorePage`, `UpcomingShowsList`, `FeaturedBillCard`, `FeaturedCollectionCard`, `InlineGraph`, `ShuffleCta`)
- Sidebar Discover group gains an `Explore` entry (Compass icon) between Venues and Releases; existing active-state logic in Sidebar.tsx + TopBar mobile sheet handles highlighting on /explore with no extra wiring
- Inline knowledge graph lazy-mounts via IntersectionObserver (200px root-margin) and reuses `ForceGraphView` (PSY-365) anchored to the featured bill's headliner; below 640px collapses to a static teaser per PSY-511
- Featured Bill / Featured Collection sections collapse silently when the admin hasn't curated those slots
- Shuffle CTA hits `/explore/shuffle-target` on each click and router-pushes to the returned artist's page

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/explore` — 23 tests across 6 files all green (covers each sub-component's render contract, null-collapse for Featured slots, IntersectionObserver lazy-mount, shuffle redirect + empty-pool + error paths)
- [x] `bun run test:run components/layout/Sidebar` — 27 tests pass (updated discover-group ordering assertion)

## Manual repro
Dispatch stack mode `isolated` (auto-selected because the worktree includes seed-data changes). Backend wire shapes verified directly via curl:
- `GET /explore/featured` returns flat `{bill, collection}` (NOT `{body: ...}`) — types modelled accordingly
- `GET /explore/upcoming-shows?limit=5` returns flat `{shows, total, limit, offset}`
- `GET /explore/shuffle-target` returns flat `{artist_id, artist_slug, artist_name}`

Screenshots:
- Desktop empty (no admin curation): `dogfood-output/PSY-837/screenshots/01-explore-desktop-anonymous.png`
- Desktop scrolled (graph teaser when headliner has no relationships): `dogfood-output/PSY-837/screenshots/01b-explore-desktop-anonymous-scrolled.png`
- Desktop further scrolled (Featured Collection + Surprise Me): `dogfood-output/PSY-837/screenshots/01c-explore-desktop-anonymous-scrolled2.png`
- Mobile 375px: `dogfood-output/PSY-837/screenshots/02-explore-mobile.png`
- Mobile graph collapsed to static teaser: `dogfood-output/PSY-837/screenshots/02b-explore-mobile-graph-teaser.png`
- Shuffle CTA redirected to /artists/the-format: `dogfood-output/PSY-837/screenshots/03-shuffle-target-redirect.png`
- Sidebar with Explore highlighted on /explore: `dogfood-output/PSY-837/screenshots/04-sidebar-active.png`

Verified: section order matches the brief (Upcoming Shows → Featured Bill → Inline graph → Featured Collection → Surprise Me), null-collapse for empty Featured/Featured Collection works, mobile graph teaser fires under 640px with "View the bill instead" link, sidebar active-state highlights Explore on /explore, shuffle redirects to a real artist page.

## Code review
`/code-review` flagged the missing `unoptimized` prop on `<Image>` in FeaturedBillCard + FeaturedCollectionCard — without it, `next.config.ts`'s absent `images.remotePatterns` allowlist would runtime-reject arbitrary user-provided image URLs. Fixed in-PR (`PSY-837: code-review pass`) to mirror the existing FeaturedAdmin pattern. No follow-up tickets filed.

Closes PSY-837