### PR TITLE
PSY-785: standardize api.test.ts base-URL imports across feature modules

### DIFF
--- a/frontend/features/festivals/api.test.ts
+++ b/frontend/features/festivals/api.test.ts
@@ -1,64 +1,61 @@
 import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
 import { festivalEndpoints, festivalQueryKeys } from './api'
-
-// The endpoint builders embed API_BASE_URL, which the vitest config pins to
-// http://localhost:8080 via NEXT_PUBLIC_API_URL.
-const BASE = 'http://localhost:8080'
 
 describe('festivalEndpoints', () => {
   it('exposes static collection endpoints', () => {
-    expect(festivalEndpoints.LIST).toBe(`${BASE}/festivals`)
-    expect(festivalEndpoints.SEARCH).toBe(`${BASE}/festivals/search`)
-    expect(festivalEndpoints.CREATE).toBe(`${BASE}/festivals`)
+    expect(festivalEndpoints.LIST).toBe(`${API_BASE_URL}/festivals`)
+    expect(festivalEndpoints.SEARCH).toBe(`${API_BASE_URL}/festivals/search`)
+    expect(festivalEndpoints.CREATE).toBe(`${API_BASE_URL}/festivals`)
   })
 
   it('builds detail + mutation endpoints from an id or slug', () => {
     expect(festivalEndpoints.GET('form-arcosanti')).toBe(
-      `${BASE}/festivals/form-arcosanti`
+      `${API_BASE_URL}/festivals/form-arcosanti`
     )
-    expect(festivalEndpoints.GET(42)).toBe(`${BASE}/festivals/42`)
-    expect(festivalEndpoints.UPDATE(42)).toBe(`${BASE}/festivals/42`)
-    expect(festivalEndpoints.DELETE(42)).toBe(`${BASE}/festivals/42`)
+    expect(festivalEndpoints.GET(42)).toBe(`${API_BASE_URL}/festivals/42`)
+    expect(festivalEndpoints.UPDATE(42)).toBe(`${API_BASE_URL}/festivals/42`)
+    expect(festivalEndpoints.DELETE(42)).toBe(`${API_BASE_URL}/festivals/42`)
   })
 
   it('builds lineup (artist) endpoints', () => {
-    expect(festivalEndpoints.ARTISTS(1)).toBe(`${BASE}/festivals/1/artists`)
-    expect(festivalEndpoints.ADD_ARTIST(1)).toBe(`${BASE}/festivals/1/artists`)
+    expect(festivalEndpoints.ARTISTS(1)).toBe(`${API_BASE_URL}/festivals/1/artists`)
+    expect(festivalEndpoints.ADD_ARTIST(1)).toBe(`${API_BASE_URL}/festivals/1/artists`)
     expect(festivalEndpoints.UPDATE_ARTIST(1, 7)).toBe(
-      `${BASE}/festivals/1/artists/7`
+      `${API_BASE_URL}/festivals/1/artists/7`
     )
     expect(festivalEndpoints.REMOVE_ARTIST(1, 7)).toBe(
-      `${BASE}/festivals/1/artists/7`
+      `${API_BASE_URL}/festivals/1/artists/7`
     )
   })
 
   it('builds venue endpoints', () => {
-    expect(festivalEndpoints.VENUES(1)).toBe(`${BASE}/festivals/1/venues`)
-    expect(festivalEndpoints.ADD_VENUE(1)).toBe(`${BASE}/festivals/1/venues`)
+    expect(festivalEndpoints.VENUES(1)).toBe(`${API_BASE_URL}/festivals/1/venues`)
+    expect(festivalEndpoints.ADD_VENUE(1)).toBe(`${API_BASE_URL}/festivals/1/venues`)
     expect(festivalEndpoints.REMOVE_VENUE(1, 9)).toBe(
-      `${BASE}/festivals/1/venues/9`
+      `${API_BASE_URL}/festivals/1/venues/9`
     )
   })
 
   it('builds artist-scoped festival endpoints', () => {
     expect(festivalEndpoints.ARTIST_FESTIVALS('radiohead')).toBe(
-      `${BASE}/artists/radiohead/festivals`
+      `${API_BASE_URL}/artists/radiohead/festivals`
     )
     expect(festivalEndpoints.ARTIST_TRAJECTORY('radiohead')).toBe(
-      `${BASE}/artists/radiohead/festival-trajectory`
+      `${API_BASE_URL}/artists/radiohead/festival-trajectory`
     )
   })
 
   it('builds festival-intelligence endpoints', () => {
-    expect(festivalEndpoints.SIMILAR(1)).toBe(`${BASE}/festivals/1/similar`)
+    expect(festivalEndpoints.SIMILAR(1)).toBe(`${API_BASE_URL}/festivals/1/similar`)
     expect(festivalEndpoints.OVERLAP(1, 2)).toBe(
-      `${BASE}/festivals/1/overlap/2`
+      `${API_BASE_URL}/festivals/1/overlap/2`
     )
     expect(festivalEndpoints.BREAKOUTS(1)).toBe(
-      `${BASE}/festivals/1/breakouts`
+      `${API_BASE_URL}/festivals/1/breakouts`
     )
     expect(festivalEndpoints.SERIES_COMPARE('coachella')).toBe(
-      `${BASE}/festivals/series/coachella/compare`
+      `${API_BASE_URL}/festivals/series/coachella/compare`
     )
   })
 })

--- a/frontend/features/radio/api.test.ts
+++ b/frontend/features/radio/api.test.ts
@@ -1,70 +1,66 @@
 import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
 import { radioEndpoints, radioQueryKeys } from './api'
-
-// API_BASE_URL resolves to 'http://localhost:8080' under vitest
-// (NEXT_PUBLIC_API_URL set in vitest.config.mts), so endpoint strings
-// below are asserted against that fully-resolved base.
-const BASE = 'http://localhost:8080'
 
 describe('radioEndpoints', () => {
   it('STATIONS is the collection URL', () => {
-    expect(radioEndpoints.STATIONS).toBe(`${BASE}/radio-stations`)
+    expect(radioEndpoints.STATIONS).toBe(`${API_BASE_URL}/radio-stations`)
   })
 
   it('STATION(slug) appends the slug', () => {
-    expect(radioEndpoints.STATION('kexp')).toBe(`${BASE}/radio-stations/kexp`)
+    expect(radioEndpoints.STATION('kexp')).toBe(`${API_BASE_URL}/radio-stations/kexp`)
   })
 
   it('SHOWS is the collection URL', () => {
-    expect(radioEndpoints.SHOWS).toBe(`${BASE}/radio-shows`)
+    expect(radioEndpoints.SHOWS).toBe(`${API_BASE_URL}/radio-shows`)
   })
 
   it('SHOW(slug) appends the slug', () => {
-    expect(radioEndpoints.SHOW('wfmu-drummer')).toBe(`${BASE}/radio-shows/wfmu-drummer`)
+    expect(radioEndpoints.SHOW('wfmu-drummer')).toBe(`${API_BASE_URL}/radio-shows/wfmu-drummer`)
   })
 
   it('SHOW_EPISODES(slug) nests under the show', () => {
     expect(radioEndpoints.SHOW_EPISODES('wfmu-drummer')).toBe(
-      `${BASE}/radio-shows/wfmu-drummer/episodes`
+      `${API_BASE_URL}/radio-shows/wfmu-drummer/episodes`
     )
   })
 
   it('SHOW_EPISODE_BY_DATE(slug, date) nests the date segment', () => {
     expect(radioEndpoints.SHOW_EPISODE_BY_DATE('wfmu-drummer', '2026-05-01')).toBe(
-      `${BASE}/radio-shows/wfmu-drummer/episodes/2026-05-01`
+      `${API_BASE_URL}/radio-shows/wfmu-drummer/episodes/2026-05-01`
     )
   })
 
   it('SHOW_TOP_ARTISTS(slug) nests under the show', () => {
     expect(radioEndpoints.SHOW_TOP_ARTISTS('wfmu-drummer')).toBe(
-      `${BASE}/radio-shows/wfmu-drummer/top-artists`
+      `${API_BASE_URL}/radio-shows/wfmu-drummer/top-artists`
     )
   })
 
   it('SHOW_TOP_LABELS(slug) nests under the show', () => {
     expect(radioEndpoints.SHOW_TOP_LABELS('wfmu-drummer')).toBe(
-      `${BASE}/radio-shows/wfmu-drummer/top-labels`
+      `${API_BASE_URL}/radio-shows/wfmu-drummer/top-labels`
     )
   })
 
   it('ARTIST_RADIO_PLAYS(slug) nests under the artist', () => {
     expect(radioEndpoints.ARTIST_RADIO_PLAYS('gatecreeper')).toBe(
-      `${BASE}/artists/gatecreeper/radio-plays`
+      `${API_BASE_URL}/artists/gatecreeper/radio-plays`
     )
   })
 
   it('RELEASE_RADIO_PLAYS(slug) nests under the release', () => {
     expect(radioEndpoints.RELEASE_RADIO_PLAYS('an-unkindness')).toBe(
-      `${BASE}/releases/an-unkindness/radio-plays`
+      `${API_BASE_URL}/releases/an-unkindness/radio-plays`
     )
   })
 
   it('NEW_RELEASES is the aggregation URL', () => {
-    expect(radioEndpoints.NEW_RELEASES).toBe(`${BASE}/radio/new-releases`)
+    expect(radioEndpoints.NEW_RELEASES).toBe(`${API_BASE_URL}/radio/new-releases`)
   })
 
   it('STATS is the aggregation URL', () => {
-    expect(radioEndpoints.STATS).toBe(`${BASE}/radio/stats`)
+    expect(radioEndpoints.STATS).toBe(`${API_BASE_URL}/radio/stats`)
   })
 })
 

--- a/frontend/features/releases/api.test.ts
+++ b/frontend/features/releases/api.test.ts
@@ -1,46 +1,41 @@
-import { describe, it, expect, vi } from 'vitest'
-
-// Pin API_BASE_URL so endpoint assertions are deterministic regardless of env.
-vi.mock('@/lib/api-base', () => ({
-  API_BASE_URL: 'http://api.test',
-}))
-
+import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
 import { releaseEndpoints, releaseQueryKeys } from './api'
 
 describe('releaseEndpoints', () => {
   it('builds static collection endpoints', () => {
-    expect(releaseEndpoints.LIST).toBe('http://api.test/releases')
-    expect(releaseEndpoints.SEARCH).toBe('http://api.test/releases/search')
-    expect(releaseEndpoints.CREATE).toBe('http://api.test/releases')
+    expect(releaseEndpoints.LIST).toBe(`${API_BASE_URL}/releases`)
+    expect(releaseEndpoints.SEARCH).toBe(`${API_BASE_URL}/releases/search`)
+    expect(releaseEndpoints.CREATE).toBe(`${API_BASE_URL}/releases`)
   })
 
   it('builds a detail endpoint from a slug', () => {
     expect(releaseEndpoints.GET('ok-computer')).toBe(
-      'http://api.test/releases/ok-computer'
+      `${API_BASE_URL}/releases/ok-computer`
     )
   })
 
   it('builds a detail endpoint from a numeric id', () => {
-    expect(releaseEndpoints.GET(42)).toBe('http://api.test/releases/42')
+    expect(releaseEndpoints.GET(42)).toBe(`${API_BASE_URL}/releases/42`)
   })
 
   it('builds update and delete endpoints by id', () => {
-    expect(releaseEndpoints.UPDATE(7)).toBe('http://api.test/releases/7')
-    expect(releaseEndpoints.DELETE(7)).toBe('http://api.test/releases/7')
+    expect(releaseEndpoints.UPDATE(7)).toBe(`${API_BASE_URL}/releases/7`)
+    expect(releaseEndpoints.DELETE(7)).toBe(`${API_BASE_URL}/releases/7`)
   })
 
   it('builds nested link endpoints', () => {
     expect(releaseEndpoints.ADD_LINK(7)).toBe(
-      'http://api.test/releases/7/links'
+      `${API_BASE_URL}/releases/7/links`
     )
     expect(releaseEndpoints.REMOVE_LINK(7, 99)).toBe(
-      'http://api.test/releases/7/links/99'
+      `${API_BASE_URL}/releases/7/links/99`
     )
   })
 
   it('builds the artist-releases endpoint', () => {
     expect(releaseEndpoints.ARTIST_RELEASES('radiohead')).toBe(
-      'http://api.test/artists/radiohead/releases'
+      `${API_BASE_URL}/artists/radiohead/releases`
     )
   })
 })


### PR DESCRIPTION
## Summary
- Convert 3 remaining `features/*/api.test.ts` files off legacy base-URL styles onto the PSY-706 import standard so the whole suite reads identically
- `festivals/api.test.ts`: hardcoded `const BASE` → `import { API_BASE_URL }`
- `radio/api.test.ts`: hardcoded `const BASE` → `import { API_BASE_URL }`
- `releases/api.test.ts`: `vi.mock('@/lib/api-base')` → `import { API_BASE_URL }`
- 5 already-conforming files (artists, comments, labels, shows, venues) unchanged

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run features` — passed (224 files, 2700 tests, 29.4s)
- [x] `/code-review` — no findings (3-file pure literal substitution; nothing for the 5-angle review to surface)

## Manual repro
`test:run features` full suite — all 8 `api.test.ts` files pass with the standardized import style. Zero production code touched; purely test-internal scaffolding cleanup. Endpoint builders embed `API_BASE_URL`, which vitest pins to `http://localhost:8080` via `NEXT_PUBLIC_API_URL`, so assertion behaviour is identical pre/post-change.

## Code review
No changes — `/code-review` ran 5 angles (line scan, removed-behavior audit, cross-file tracer, language pitfalls, wrapper correctness), found 0 candidates. Diff is mechanical literal substitution.

## Orchestrator-takeover disclosure
Dispatched agent committed the implementation + ran `/code-review` cleanly, then stalled before push. Orchestrator (this session) verified diff scope matches ticket (3 files, +46/-58 lines), re-ran `bun run typecheck` and `bun run test:run features` from the worktree, both green, then pushed and opened this PR. Same pattern as PSY-842 (May 2026) — non-MCP post-/code-review stall.

Closes PSY-785