### PR TITLE
PSY-716: strengthen settings panel tests + add reply-permission test

### DIFF
--- a/frontend/components/settings/SettingsPanel.test.tsx
+++ b/frontend/components/settings/SettingsPanel.test.tsx
@@ -466,7 +466,9 @@ describe('SettingsPanel', () => {
     const exportPayload = { profile: { email: 'user@example.com' } }
     mockExportMutateAsync.mockResolvedValueOnce(exportPayload)
 
-    // Capture URL.createObjectURL + revokeObjectURL.
+    // Capture URL.createObjectURL + revokeObjectURL. Wrap in try/finally so
+    // a failing assertion can't poison subsequent tests in this file with a
+    // broken URL.createObjectURL stub.
     const createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
     const revokeObjectURL = vi.fn()
     const originalCreateObjectURL = URL.createObjectURL
@@ -474,19 +476,21 @@ describe('SettingsPanel', () => {
     URL.createObjectURL = createObjectURL
     URL.revokeObjectURL = revokeObjectURL
 
-    const user = userEvent.setup()
-    renderWithProviders(<SettingsPanel />)
+    try {
+      const user = userEvent.setup()
+      renderWithProviders(<SettingsPanel />)
 
-    await user.click(screen.getByRole('button', { name: /Export My Data/ }))
+      await user.click(screen.getByRole('button', { name: /Export My Data/ }))
 
-    expect(mockExportMutateAsync).toHaveBeenCalled()
-    await waitFor(() => {
-      expect(createObjectURL).toHaveBeenCalled()
-      expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url')
-    })
-
-    URL.createObjectURL = originalCreateObjectURL
-    URL.revokeObjectURL = originalRevokeObjectURL
+      expect(mockExportMutateAsync).toHaveBeenCalled()
+      await waitFor(() => {
+        expect(createObjectURL).toHaveBeenCalled()
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url')
+      })
+    } finally {
+      URL.createObjectURL = originalCreateObjectURL
+      URL.revokeObjectURL = originalRevokeObjectURL
+    }
   })
 
   it('renders the issued CLI token and a Copy button after generation succeeds', async () => {
@@ -558,14 +562,18 @@ describe('SettingsPanel', () => {
     writeTextSpy.mockRestore()
   })
 
-  it('opens delete account dialog AND closes it via onOpenChange(false)', async () => {
+  it('opens delete account dialog when Delete Account button is clicked (verifies open state propagates)', async () => {
     const user = userEvent.setup()
     renderWithProviders(<SettingsPanel />)
 
-    // Dialog mock surfaces when open=true (per the vi.mock above).
+    // Dialog mock only mounts when open=true (per the vi.mock above), so its
+    // presence verifies the open-state wiring on the trigger button.
+    expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument()
+
     await user.click(
       screen.getByRole('button', { name: /Delete Account/ })
     )
+
     expect(screen.getByTestId('delete-dialog')).toBeInTheDocument()
   })
 

--- a/frontend/components/settings/SettingsPanel.test.tsx
+++ b/frontend/components/settings/SettingsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
 import { SettingsPanel } from './SettingsPanel'
@@ -432,5 +432,162 @@ describe('SettingsPanel', () => {
     renderWithProviders(<SettingsPanel />)
 
     expect(screen.getByText('Token generation failed')).toBeInTheDocument()
+  })
+
+  it('shows "Verification email sent!" success UI after Send Verification Email is clicked', async () => {
+    mockSendVerificationMutateAsync.mockResolvedValueOnce(undefined)
+    // After awaitable resolves, the hook is in success state.
+    mockSendVerificationState = {
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPanel />)
+
+    await user.click(
+      screen.getByRole('button', { name: /Send Verification Email/ })
+    )
+
+    expect(mockSendVerificationMutateAsync).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(
+        screen.getByText('Verification email sent! Check your inbox.')
+      ).toBeInTheDocument()
+    })
+    // After success, the send button is replaced by the success message.
+    expect(
+      screen.queryByRole('button', { name: /Send Verification Email/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('triggers data-export download flow when Export My Data is clicked', async () => {
+    const exportPayload = { profile: { email: 'user@example.com' } }
+    mockExportMutateAsync.mockResolvedValueOnce(exportPayload)
+
+    // Capture URL.createObjectURL + revokeObjectURL.
+    const createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
+    const revokeObjectURL = vi.fn()
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    URL.createObjectURL = createObjectURL
+    URL.revokeObjectURL = revokeObjectURL
+
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPanel />)
+
+    await user.click(screen.getByRole('button', { name: /Export My Data/ }))
+
+    expect(mockExportMutateAsync).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalled()
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url')
+    })
+
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+  })
+
+  it('renders the issued CLI token and a Copy button after generation succeeds', async () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: true,
+      is_admin: true,
+    }
+    mockGenerateCLITokenMutateAsync.mockResolvedValueOnce({
+      token: 'cli-token-xyz-789',
+    })
+
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPanel />)
+
+    await user.click(
+      screen.getByRole('button', { name: /Generate CLI Token/ })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('cli-token-xyz-789')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(/This token will expire in 24 hours/)
+    ).toBeInTheDocument()
+    // A "Generate New Token" button now replaces the original.
+    expect(
+      screen.getByRole('button', { name: /Generate New Token/ })
+    ).toBeInTheDocument()
+  })
+
+  it('copies the issued CLI token to the clipboard when Copy is clicked', async () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: true,
+      is_admin: true,
+    }
+    mockGenerateCLITokenMutateAsync.mockResolvedValueOnce({
+      token: 'cli-copyable-token',
+    })
+
+    // userEvent v14 installs a clipboard stub on navigator.clipboard at
+    // setup() time. Spying after setup() ensures the test sees the call.
+    const user = userEvent.setup()
+    const writeTextSpy = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue(undefined)
+
+    renderWithProviders(<SettingsPanel />)
+
+    await user.click(
+      screen.getByRole('button', { name: /Generate CLI Token/ })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('cli-copyable-token')).toBeInTheDocument()
+    })
+
+    // Find the icon-only Copy button — it sits next to the token <code>.
+    const tokenCodeEl = screen.getByText('cli-copyable-token')
+    const copyBtn = tokenCodeEl.parentElement?.querySelector('button')
+    expect(copyBtn).toBeTruthy()
+    await user.click(copyBtn!)
+
+    await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledWith('cli-copyable-token')
+    })
+
+    writeTextSpy.mockRestore()
+  })
+
+  it('opens delete account dialog AND closes it via onOpenChange(false)', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPanel />)
+
+    // Dialog mock surfaces when open=true (per the vi.mock above).
+    await user.click(
+      screen.getByRole('button', { name: /Delete Account/ })
+    )
+    expect(screen.getByTestId('delete-dialog')).toBeInTheDocument()
+  })
+
+  // ---- Structural / ordering smoke test (the panel is single-column, not tabs) ----
+
+  it('renders sub-sections in expected vertical order: cities, notifications, reply permission', () => {
+    const { container } = renderWithProviders(<SettingsPanel />)
+
+    const sectionIds = [
+      'favorite-cities',
+      'notification-settings',
+      'reply-permission-settings',
+    ]
+    const positions = sectionIds.map(id =>
+      Array.from(container.querySelectorAll('[data-testid]')).findIndex(
+        el => el.getAttribute('data-testid') === id
+      )
+    )
+    // Each section is present (positions[i] !== -1) and in ascending order.
+    expect(positions.every(p => p !== -1)).toBe(true)
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1])
+    }
   })
 })

--- a/frontend/components/settings/api-token-management.test.tsx
+++ b/frontend/components/settings/api-token-management.test.tsx
@@ -403,24 +403,24 @@ describe('APITokenManagement', () => {
     writeTextSpy.mockRestore()
   })
 
-  it('disables the Create Token submit button while the mutation is pending', () => {
+  it('disables the in-dialog Create Token submit button while the mutation is pending', async () => {
     mockTokensData = { tokens: [] }
     mockCreateMutationState = {
       isPending: true,
       isError: false,
       error: null,
     }
+    const user = userEvent.setup()
     renderWithProviders(<APITokenManagement />)
 
-    // Open dialog — the trigger button is also disabled-friendly but the
-    // confirm button inside the dialog reflects mutation.isPending.
-    // We re-render with pending=true, so the trigger isn't pressed; instead
-    // verify the trigger still mounts and the in-dialog state would be
-    // disabled (we don't open the dialog here — just check pending propagates
-    // via the surfaced spinner-friendly button label area).
-    // Since the dialog is closed, just assert the trigger remains in the doc.
-    expect(
-      screen.getByRole('button', { name: /Create Token/ })
-    ).toBeInTheDocument()
+    // Open the dialog so the in-dialog submit button is mounted; the
+    // `mutation.isPending` flag drives `disabled` on that button.
+    await user.click(screen.getByRole('button', { name: /Create Token/ }))
+
+    const submitBtn = screen
+      .getAllByRole('button', { name: /Create Token/ })
+      .find(btn => btn.closest('[role="dialog"]'))
+    expect(submitBtn).toBeDefined()
+    expect(submitBtn).toBeDisabled()
   })
 })

--- a/frontend/components/settings/api-token-management.test.tsx
+++ b/frontend/components/settings/api-token-management.test.tsx
@@ -261,4 +261,166 @@ describe('APITokenManagement', () => {
 
     vi.useRealTimers()
   })
+
+  it('calls revokeToken mutation when Revoke Token is confirmed in dialog', async () => {
+    mockTokensData = {
+      tokens: [
+        {
+          id: 42,
+          description: 'Confirm-revoke token',
+          scope: 'admin',
+          created_at: '2025-06-01T10:00:00Z',
+          expires_at: '2025-12-01T10:00:00Z',
+          last_used_at: null,
+          is_expired: false,
+        },
+      ],
+    }
+    mockRevokeMutateAsync.mockResolvedValueOnce(undefined)
+
+    const user = userEvent.setup()
+    renderWithProviders(<APITokenManagement />)
+
+    // Open revoke dialog via the trash icon button on the row.
+    const allButtons = screen.getAllByRole('button')
+    const deleteBtn = allButtons.find(
+      btn =>
+        btn.textContent !== 'Create Token' &&
+        !btn.textContent?.includes('Create')
+    )
+    await user.click(deleteBtn!)
+
+    // Click the destructive confirm button inside the dialog.
+    await waitFor(() => {
+      expect(screen.getByText('Revoke API Token')).toBeInTheDocument()
+    })
+    const confirmBtn = screen.getByRole('button', { name: 'Revoke Token' })
+    await user.click(confirmBtn)
+
+    expect(mockRevokeMutateAsync).toHaveBeenCalledWith(42)
+  })
+
+  it('calls createToken with description + parsed expiration_days, then shows the issued token', async () => {
+    mockTokensData = { tokens: [] }
+    mockCreateMutateAsync.mockResolvedValueOnce({
+      token: 'ph_test_token_abcdef123',
+    })
+
+    const user = userEvent.setup()
+    renderWithProviders(<APITokenManagement />)
+
+    // Open create dialog.
+    await user.click(screen.getByRole('button', { name: /Create Token/ }))
+
+    // Fill description, override expiration_days.
+    await user.type(
+      screen.getByLabelText('Description (optional)'),
+      'Discovery laptop'
+    )
+    const expirationInput = screen.getByLabelText('Expiration (days)')
+    await user.clear(expirationInput)
+    await user.type(expirationInput, '30')
+
+    // Submit (the dialog has two "Create Token" buttons — the trigger and the
+    // confirm button inside the dialog footer). Pick the dialog one.
+    const submitBtn = screen.getAllByRole('button', { name: /Create Token/ })
+      .find(btn => btn.closest('[role="dialog"]'))
+    expect(submitBtn).toBeDefined()
+    await user.click(submitBtn!)
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+      description: 'Discovery laptop',
+      expiration_days: 30,
+    })
+
+    // The issued-token state should render the new token + a Copy button.
+    await waitFor(() => {
+      expect(screen.getByText('Token Created')).toBeInTheDocument()
+    })
+    expect(screen.getByText('ph_test_token_abcdef123')).toBeInTheDocument()
+  })
+
+  it('omits empty description from create payload and defaults expiration_days to 90', async () => {
+    mockTokensData = { tokens: [] }
+    mockCreateMutateAsync.mockResolvedValueOnce({ token: 'ph_default' })
+
+    const user = userEvent.setup()
+    renderWithProviders(<APITokenManagement />)
+
+    await user.click(screen.getByRole('button', { name: /Create Token/ }))
+
+    // Don't touch the description (empty) or expiration_days (default 90).
+    const submitBtn = screen.getAllByRole('button', { name: /Create Token/ })
+      .find(btn => btn.closest('[role="dialog"]'))
+    await user.click(submitBtn!)
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+      description: undefined,
+      expiration_days: 90,
+    })
+  })
+
+  it('copies the issued token to the clipboard and shows "Copied!" feedback', async () => {
+    mockTokensData = { tokens: [] }
+    mockCreateMutateAsync.mockResolvedValueOnce({
+      token: 'ph_copyable_token',
+    })
+
+    // userEvent v14 installs a clipboard stub on navigator.clipboard at
+    // setup() time. Spying after setup() ensures the test sees the call.
+    const user = userEvent.setup()
+    const writeTextSpy = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue(undefined)
+
+    renderWithProviders(<APITokenManagement />)
+
+    // Issue the token first.
+    await user.click(screen.getByRole('button', { name: /Create Token/ }))
+    const submitBtn = screen.getAllByRole('button', { name: /Create Token/ })
+      .find(btn => btn.closest('[role="dialog"]'))
+    await user.click(submitBtn!)
+
+    // Wait for the issued-token panel to render.
+    await waitFor(() => {
+      expect(screen.getByText('ph_copyable_token')).toBeInTheDocument()
+    })
+
+    // The Copy icon button is the sibling button to the <code> element
+    // inside the issued-token panel.
+    const tokenCodeEl = screen.getByText('ph_copyable_token')
+    const copyBtn = tokenCodeEl.parentElement?.querySelector('button')
+    expect(copyBtn).toBeTruthy()
+    await user.click(copyBtn!)
+
+    await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledWith('ph_copyable_token')
+    })
+    expect(
+      screen.getByText('Token copied to clipboard!')
+    ).toBeInTheDocument()
+
+    writeTextSpy.mockRestore()
+  })
+
+  it('disables the Create Token submit button while the mutation is pending', () => {
+    mockTokensData = { tokens: [] }
+    mockCreateMutationState = {
+      isPending: true,
+      isError: false,
+      error: null,
+    }
+    renderWithProviders(<APITokenManagement />)
+
+    // Open dialog — the trigger button is also disabled-friendly but the
+    // confirm button inside the dialog reflects mutation.isPending.
+    // We re-render with pending=true, so the trigger isn't pressed; instead
+    // verify the trigger still mounts and the in-dialog state would be
+    // disabled (we don't open the dialog here — just check pending propagates
+    // via the surfaced spinner-friendly button label area).
+    // Since the dialog is closed, just assert the trigger remains in the doc.
+    expect(
+      screen.getByRole('button', { name: /Create Token/ })
+    ).toBeInTheDocument()
+  })
 })

--- a/frontend/components/settings/change-password.test.tsx
+++ b/frontend/components/settings/change-password.test.tsx
@@ -232,14 +232,28 @@ describe('ChangePassword', () => {
     expect(input).toHaveAttribute('type', 'text')
   })
 
-  it('shows "Changing password..." label and disables the submit button while mutation is pending', () => {
+  it('shows "Changing password..." label while the mutation is pending', () => {
     mockMutationState = { isPending: true, isError: false, error: null }
     renderForm()
 
-    // Pending label replaces "Change Password".
+    // The submit-button label switches from "Change Password" to the pending
+    // copy whenever mutation.isPending is true (independent of form-validity).
     expect(screen.getByText('Changing password...')).toBeInTheDocument()
-    // The submit button is the only button rendered as a button[type=submit].
-    // Pull it via the label area.
+    expect(
+      screen.queryByRole('button', { name: 'Change Password' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps the submit button disabled when the mutation is pending even with valid inputs', async () => {
+    mockMutationState = { isPending: true, isError: false, error: null }
+    const { user } = renderForm()
+
+    // Fill in valid form values so canSubmit isn't the reason the button is
+    // disabled — the disabled state must be driven by mutation.isPending alone.
+    await user.type(screen.getByLabelText('Current Password'), 'oldpassword123')
+    await user.type(screen.getByLabelText('New Password'), 'newSecurePassword123!')
+    await user.type(screen.getByLabelText('Confirm New Password'), 'newSecurePassword123!')
+
     const submitButton = screen.getByText('Changing password...').closest('button')
     expect(submitButton).toBeDisabled()
   })

--- a/frontend/components/settings/change-password.test.tsx
+++ b/frontend/components/settings/change-password.test.tsx
@@ -231,4 +231,47 @@ describe('ChangePassword', () => {
 
     expect(input).toHaveAttribute('type', 'text')
   })
+
+  it('shows "Changing password..." label and disables the submit button while mutation is pending', () => {
+    mockMutationState = { isPending: true, isError: false, error: null }
+    renderForm()
+
+    // Pending label replaces "Change Password".
+    expect(screen.getByText('Changing password...')).toBeInTheDocument()
+    // The submit button is the only button rendered as a button[type=submit].
+    // Pull it via the label area.
+    const submitButton = screen.getByText('Changing password...').closest('button')
+    expect(submitButton).toBeDisabled()
+  })
+
+  it('clears the password fields after a successful change', async () => {
+    mockMutate.mockImplementation((_data: unknown, opts: { onSuccess: (d: { message: string }) => void }) => {
+      opts.onSuccess({ message: 'Password changed successfully' })
+    })
+    const { user } = renderForm()
+
+    await user.type(screen.getByLabelText('Current Password'), 'oldpassword123')
+    await user.type(screen.getByLabelText('New Password'), 'newSecurePassword123!')
+    await user.type(screen.getByLabelText('Confirm New Password'), 'newSecurePassword123!')
+    await user.click(screen.getByRole('button', { name: 'Change Password' }))
+
+    // After success, form.reset() empties the inputs.
+    await waitFor(() => {
+      expect(screen.getByText('Password changed successfully')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Current Password')).toHaveValue('')
+    expect(screen.getByLabelText('New Password')).toHaveValue('')
+    expect(screen.getByLabelText('Confirm New Password')).toHaveValue('')
+  })
+
+  it('falls back to generic error copy when mutation error has no message', () => {
+    mockMutationState = {
+      isPending: false,
+      isError: true,
+      error: new Error(''),
+    }
+    renderForm()
+
+    expect(screen.getByText('Failed to change password')).toBeInTheDocument()
+  })
 })

--- a/frontend/components/settings/delete-account-dialog.test.tsx
+++ b/frontend/components/settings/delete-account-dialog.test.tsx
@@ -337,4 +337,93 @@ describe('DeleteAccountDialog', () => {
 
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
+
+  it('includes a non-empty reason in the deleteAccount payload', async () => {
+    mockDeleteMutateAsync.mockResolvedValue({
+      success: true,
+      deletion_date: '2026-04-06T00:00:00Z',
+    })
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await user.type(screen.getByLabelText('Password'), 'mypassword123')
+    await user.type(
+      screen.getByLabelText('Why are you leaving? (optional)'),
+      'Moving to another service.'
+    )
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(
+      screen.getByRole('button', { name: 'Delete My Account' })
+    )
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({
+      password: 'mypassword123',
+      reason: 'Moving to another service.',
+    })
+  })
+
+  it('disables Delete My Account when user has no password (OAuth-only)', async () => {
+    mockDeletionSummaryState = {
+      ...mockDeletionSummaryState,
+      data: {
+        shows_count: 0,
+        saved_shows_count: 0,
+        passkeys_count: 0,
+        has_password: false,
+      },
+    }
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    // No password field is rendered when has_password=false.
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
+
+    // Checking the confirm box still leaves the Delete button disabled —
+    // OAuth-only accounts are blocked from in-app deletion.
+    await user.click(screen.getByRole('checkbox'))
+    const deleteBtn = screen.getByRole('button', {
+      name: 'Delete My Account',
+    })
+    expect(deleteBtn).toBeDisabled()
+  })
+
+  it('renders the Go to Home button + auto-redirect copy on the success step', async () => {
+    mockDeleteMutateAsync.mockResolvedValue({
+      success: true,
+      deletion_date: '2026-04-06T00:00:00Z',
+    })
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+    await user.type(screen.getByLabelText('Password'), 'mypassword123')
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(
+      screen.getByRole('button', { name: 'Delete My Account' })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Redirecting to home page...')).toBeInTheDocument()
+    })
+
+    // Clicking "Go to Home" triggers the router.push('/') side effect.
+    await user.click(screen.getByRole('button', { name: 'Go to Home' }))
+    expect(mockRouterPush).toHaveBeenCalledWith('/')
+  })
+
+  it('falls back to generic error copy when mutation error has no message', async () => {
+    mockDeleteMutationState = {
+      ...mockDeleteMutationState,
+      isError: true,
+      error: new Error(''),
+    }
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    expect(
+      screen.getByText('Failed to delete account. Please try again.')
+    ).toBeInTheDocument()
+  })
 })

--- a/frontend/components/settings/favorite-cities.test.tsx
+++ b/frontend/components/settings/favorite-cities.test.tsx
@@ -240,4 +240,65 @@ describe('FavoriteCitiesSettings', () => {
       screen.getByText('Failed to save. Please try again.')
     ).toBeInTheDocument()
   })
+
+  it('disables Clear all button while the mutation is pending', () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    mockProfileData = {
+      user: {
+        preferences: {
+          favorite_cities: [{ city: 'Phoenix', state: 'AZ' }],
+        },
+      },
+    }
+    mockMutationState = { isPending: true, isError: false, isSuccess: false }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    // Clear all is rendered as a <button>; it should be disabled while pending.
+    const clearAllBtn = screen.getByText('Clear all').closest('button')
+    expect(clearAllBtn).toBeDisabled()
+  })
+
+  it('appends a new city to existing favorites rather than replacing the list', async () => {
+    mockCitiesData = {
+      cities: [
+        { city: 'Phoenix', state: 'AZ', show_count: 8 },
+        { city: 'Tempe', state: 'AZ', show_count: 3 },
+      ],
+    }
+    mockProfileData = {
+      user: {
+        preferences: {
+          favorite_cities: [{ city: 'Phoenix', state: 'AZ' }],
+        },
+      },
+    }
+
+    const user = userEvent.setup()
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    // Phoenix already selected; toggling Tempe should send BOTH.
+    await user.click(screen.getByText('Tempe, AZ'))
+
+    expect(mockMutate).toHaveBeenCalledWith([
+      { city: 'Phoenix', state: 'AZ' },
+      { city: 'Tempe', state: 'AZ' },
+    ])
+  })
+
+  it('does not show Saved indicator while a fresh mutation is still pending', () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    // isPending+isSuccess together happens briefly during a re-trigger; the
+    // UI should NOT show "Saved" until pending clears.
+    mockMutationState = { isPending: true, isError: false, isSuccess: true }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+  })
 })

--- a/frontend/components/settings/notification-settings.test.tsx
+++ b/frontend/components/settings/notification-settings.test.tsx
@@ -292,4 +292,40 @@ describe('NotificationSettings', () => {
       expect(errors.length).toBeGreaterThanOrEqual(1)
     })
   })
+
+  // ----- Pending spinner placement (both rows) -----
+
+  it('renders independent pending state per row — show-reminders pending does not disable digest', () => {
+    mockShowRemindersState = { isPending: true, isError: false, error: null }
+    renderWithProviders(<NotificationSettings />)
+
+    const showRemindersToggle = screen.getByRole('switch', {
+      name: 'Show reminders',
+    })
+    const digestToggle = screen.getByRole('switch', {
+      name: /Weekly digest of new items in collections I follow/,
+    })
+
+    // Only show-reminders is mutating; the digest row must remain interactive.
+    expect(showRemindersToggle).toBeDisabled()
+    expect(digestToggle).toBeEnabled()
+  })
+
+  it('does not call the digest mutation when toggling show reminders', async () => {
+    mockProfileData = {
+      user: {
+        preferences: {
+          show_reminders: false,
+          notify_on_collection_digest: false,
+        },
+      },
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<NotificationSettings />)
+
+    await user.click(screen.getByRole('switch', { name: 'Show reminders' }))
+
+    expect(mockShowRemindersMutate).toHaveBeenCalledTimes(1)
+    expect(mockCollectionDigestMutate).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/components/settings/oauth-accounts.test.tsx
+++ b/frontend/components/settings/oauth-accounts.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
 import { OAuthAccounts } from './oauth-accounts'
@@ -389,5 +389,71 @@ describe('OAuthAccounts', () => {
     // The disconnect button should be disabled during pending
     const disconnectBtn = screen.getByRole('button', { name: /Disconnect/ })
     expect(disconnectBtn).toBeDisabled()
+  })
+
+  it('closes the confirmation dialog after a successful unlink', async () => {
+    mockOAuthData = {
+      accounts: [
+        {
+          provider: 'google',
+          email: 'user@gmail.com',
+          connected_at: '2025-06-15T10:00:00Z',
+        },
+      ],
+    }
+    mockUnlinkMutateAsync.mockResolvedValueOnce(undefined)
+
+    const user = userEvent.setup()
+    renderWithProviders(<OAuthAccounts />)
+
+    await user.click(screen.getByRole('button', { name: /Disconnect/ }))
+    expect(screen.getByText('Disconnect Google Account?')).toBeInTheDocument()
+
+    // Confirm disconnect.
+    const dialogDisconnect = screen.getAllByRole('button').find(
+      btn => btn.textContent === 'Disconnect' && btn.closest('[role="dialog"]')
+    )
+    if (dialogDisconnect) {
+      await user.click(dialogDisconnect)
+    }
+
+    // After the awaited mutateAsync resolves, the dialog should close —
+    // `setUnlinkProvider(null)` in handleUnlink triggers the close.
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Disconnect Google Account?')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('keeps the confirmation dialog open when unlink rejects', async () => {
+    mockOAuthData = {
+      accounts: [
+        {
+          provider: 'google',
+          email: 'user@gmail.com',
+          connected_at: '2025-06-15T10:00:00Z',
+        },
+      ],
+    }
+    mockUnlinkMutateAsync.mockRejectedValueOnce(new Error('Server error'))
+
+    const user = userEvent.setup()
+    renderWithProviders(<OAuthAccounts />)
+
+    await user.click(screen.getByRole('button', { name: /Disconnect/ }))
+
+    const dialogDisconnect = screen.getAllByRole('button').find(
+      btn => btn.textContent === 'Disconnect' && btn.closest('[role="dialog"]')
+    )
+    if (dialogDisconnect) {
+      await user.click(dialogDisconnect)
+    }
+
+    // After Sentry capture, the dialog should stay open so the user can retry.
+    await waitFor(() => {
+      expect(mockCaptureException).toHaveBeenCalled()
+    })
+    expect(screen.getByText('Disconnect Google Account?')).toBeInTheDocument()
   })
 })

--- a/frontend/components/settings/passkey-management.test.tsx
+++ b/frontend/components/settings/passkey-management.test.tsx
@@ -195,4 +195,210 @@ describe('PasskeyManagement', () => {
       expect(screen.getByTestId('register-passkey-btn')).toBeInTheDocument()
     })
   })
+
+  it('deletes a credential when the user confirms the prompt and removes it from the list', async () => {
+    // Use a controlled fetch that returns the initial list, then 200 on DELETE.
+    const fetchMock = vi.fn()
+      // initial list fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          credentials: [
+            {
+              id: 7,
+              display_name: 'YubiKey',
+              created_at: '2025-06-15T10:00:00Z',
+              last_used_at: null,
+              backup_eligible: false,
+              backup_state: false,
+            },
+          ],
+        }),
+      } as Response)
+      // DELETE response
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response)
+
+    vi.spyOn(global, 'fetch').mockImplementation(fetchMock)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const user = userEvent.setup()
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('YubiKey')).toBeInTheDocument()
+    })
+
+    // Click the destructive ghost icon button on the row.
+    const deleteBtn = screen
+      .getAllByRole('button')
+      .find(btn => btn.className.includes('text-destructive'))
+    expect(deleteBtn).toBeDefined()
+    await user.click(deleteBtn!)
+
+    // Verify the confirm dialog was shown + the DELETE was issued.
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Are you sure you want to remove this passkey?'
+    )
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/auth/passkey/credentials/7'),
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    // Row removed from UI after success.
+    await waitFor(() => {
+      expect(screen.queryByText('YubiKey')).not.toBeInTheDocument()
+    })
+
+    confirmSpy.mockRestore()
+  })
+
+  it('does NOT call DELETE when the user cancels the confirm prompt', async () => {
+    const initialListResponse = {
+      ok: true,
+      json: async () => ({
+        success: true,
+        credentials: [
+          {
+            id: 99,
+            display_name: 'Phone passkey',
+            created_at: '2025-06-15T10:00:00Z',
+            last_used_at: null,
+            backup_eligible: false,
+            backup_state: false,
+          },
+        ],
+      }),
+    } as Response
+
+    const fetchMock = vi.fn().mockResolvedValue(initialListResponse)
+    vi.spyOn(global, 'fetch').mockImplementation(fetchMock)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    const user = userEvent.setup()
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Phone passkey')).toBeInTheDocument()
+    })
+
+    const deleteBtn = screen
+      .getAllByRole('button')
+      .find(btn => btn.className.includes('text-destructive'))
+    await user.click(deleteBtn!)
+
+    expect(confirmSpy).toHaveBeenCalled()
+    // The credential is still visible — only the initial list fetch ran.
+    expect(screen.getByText('Phone passkey')).toBeInTheDocument()
+    // Only the initial list fetch happened (no DELETE call).
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'DELETE' })
+    )
+
+    confirmSpy.mockRestore()
+  })
+
+  it('shows the server message when DELETE returns success=false', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          credentials: [
+            {
+              id: 5,
+              display_name: 'Old key',
+              created_at: '2025-06-15T10:00:00Z',
+              last_used_at: null,
+              backup_eligible: false,
+              backup_state: false,
+            },
+          ],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: false,
+          message: 'Cannot delete last passkey',
+        }),
+      } as Response)
+
+    vi.spyOn(global, 'fetch').mockImplementation(fetchMock)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const user = userEvent.setup()
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Old key')).toBeInTheDocument()
+    })
+
+    const deleteBtn = screen
+      .getAllByRole('button')
+      .find(btn => btn.className.includes('text-destructive'))
+    await user.click(deleteBtn!)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Cannot delete last passkey')
+      ).toBeInTheDocument()
+    })
+    // Credential should remain in the list since DELETE failed server-side.
+    expect(screen.getByText('Old key')).toBeInTheDocument()
+
+    confirmSpy.mockRestore()
+  })
+
+  it('refetches credentials after PasskeyRegisterButton fires onSuccess', async () => {
+    // Initial list: empty. After re-fetch: one credential.
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, credentials: [] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          credentials: [
+            {
+              id: 1,
+              display_name: 'Newly registered',
+              created_at: '2025-06-15T10:00:00Z',
+              last_used_at: null,
+              backup_eligible: false,
+              backup_state: false,
+            },
+          ],
+        }),
+      } as Response)
+
+    vi.spyOn(global, 'fetch').mockImplementation(fetchMock)
+
+    const user = userEvent.setup()
+    renderWithProviders(<PasskeyManagement />)
+
+    // Empty state visible.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No passkeys registered yet/)
+      ).toBeInTheDocument()
+    })
+
+    // The mock PasskeyRegisterButton fires onSuccess on click → triggers refetch.
+    await user.click(screen.getByTestId('register-passkey-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Newly registered')).toBeInTheDocument()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
 })

--- a/frontend/components/settings/reply-permission-settings.test.tsx
+++ b/frontend/components/settings/reply-permission-settings.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { ReplyPermissionSettings } from './reply-permission-settings'
+
+// --- Mocks ---
+
+let mockProfileData: {
+  user?: {
+    preferences?: {
+      default_reply_permission?: 'anyone' | 'followers' | 'author_only'
+    }
+  }
+} = {}
+
+const mockMutate = vi.fn()
+let mockMutationState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}
+
+vi.mock('@/features/auth', () => ({
+  useProfile: () => ({ data: mockProfileData }),
+}))
+
+vi.mock('@/features/comments', async () => {
+  const actual = await vi.importActual<typeof import('@/features/comments')>(
+    '@/features/comments'
+  )
+  return {
+    // Re-export the real ReplyPermissionSelect component so we exercise the
+    // actual <select> DOM and the user-visible labels.
+    ReplyPermissionSelect: actual.ReplyPermissionSelect,
+    useSetDefaultReplyPermission: () => ({
+      mutate: mockMutate,
+      ...mockMutationState,
+    }),
+  }
+})
+
+// --- Tests ---
+
+describe('ReplyPermissionSettings', () => {
+  beforeEach(() => {
+    mockProfileData = {}
+    mockMutate.mockReset()
+    mockMutationState = { isPending: false, isError: false, error: null }
+  })
+
+  it('renders card title and helper copy', () => {
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    expect(screen.getByText('Default reply permission')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Applied to new comments you create. You can still change this per-comment./
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('renders the labeled select control with the "Who can reply" label', () => {
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    expect(screen.getByLabelText('Who can reply')).toBeInTheDocument()
+    expect(screen.getByTestId('reply-permission-select')).toBeInTheDocument()
+  })
+
+  it('defaults to "anyone" when no preference is set on the user profile', () => {
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    const select = screen.getByTestId(
+      'reply-permission-select'
+    ) as HTMLSelectElement
+    expect(select.value).toBe('anyone')
+  })
+
+  it('reflects the saved preference when the profile carries default_reply_permission', () => {
+    mockProfileData = {
+      user: { preferences: { default_reply_permission: 'followers' } },
+    }
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    const select = screen.getByTestId(
+      'reply-permission-select'
+    ) as HTMLSelectElement
+    expect(select.value).toBe('followers')
+  })
+
+  it('reflects "author_only" (Replies disabled) when saved', () => {
+    mockProfileData = {
+      user: { preferences: { default_reply_permission: 'author_only' } },
+    }
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    const select = screen.getByTestId(
+      'reply-permission-select'
+    ) as HTMLSelectElement
+    expect(select.value).toBe('author_only')
+  })
+
+  it('calls the mutation with the new value when the user selects "Followers only"', async () => {
+    mockProfileData = {
+      user: { preferences: { default_reply_permission: 'anyone' } },
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    const select = screen.getByTestId('reply-permission-select')
+    await user.selectOptions(select, 'followers')
+
+    expect(mockMutate).toHaveBeenCalledTimes(1)
+    expect(mockMutate).toHaveBeenCalledWith('followers')
+  })
+
+  it('calls the mutation with "author_only" when the user selects "Replies disabled"', async () => {
+    mockProfileData = {
+      user: { preferences: { default_reply_permission: 'anyone' } },
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    const select = screen.getByTestId('reply-permission-select')
+    await user.selectOptions(select, 'author_only')
+
+    expect(mockMutate).toHaveBeenCalledWith('author_only')
+  })
+
+  it('does NOT call the mutation when the selected value matches the current value', async () => {
+    mockProfileData = {
+      user: { preferences: { default_reply_permission: 'followers' } },
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    // Re-select the already-active option — should be a no-op.
+    const select = screen.getByTestId('reply-permission-select')
+    await user.selectOptions(select, 'followers')
+
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('disables the select while the mutation is pending', () => {
+    mockMutationState = { isPending: true, isError: false, error: null }
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    const select = screen.getByTestId(
+      'reply-permission-select'
+    ) as HTMLSelectElement
+    expect(select).toBeDisabled()
+  })
+
+  it('renders an inline error message when the mutation fails', () => {
+    mockMutationState = {
+      isPending: false,
+      isError: true,
+      error: new Error('Server error'),
+    }
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    expect(
+      screen.getByText('Failed to update setting. Please try again.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders all three user-facing reply-permission options in the dropdown', () => {
+    renderWithProviders(<ReplyPermissionSettings />)
+
+    // The labels are sourced from REPLY_PERMISSION_LABELS in the real module.
+    expect(screen.getByRole('option', { name: 'Everyone' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Followers only' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Replies disabled' })
+    ).toBeInTheDocument()
+  })
+
+  it('persists across reload — re-rendering with the new server state reflects the new value', () => {
+    mockProfileData = {
+      user: { preferences: { default_reply_permission: 'anyone' } },
+    }
+    const { unmount } = renderWithProviders(<ReplyPermissionSettings />)
+    expect(
+      (screen.getByTestId('reply-permission-select') as HTMLSelectElement).value
+    ).toBe('anyone')
+    unmount()
+
+    // Simulate the profile query coming back with the saved followers value.
+    mockProfileData = {
+      user: { preferences: { default_reply_permission: 'followers' } },
+    }
+    renderWithProviders(<ReplyPermissionSettings />)
+    expect(
+      (screen.getByTestId('reply-permission-select') as HTMLSelectElement).value
+    ).toBe('followers')
+  })
+})


### PR DESCRIPTION
## Summary
- Strengthen 8 existing settings test files with form/mutation/error/interaction coverage
- Add `reply-permission-settings.test.tsx` (NEW — 12 cases covering render, default fallback, all 3 saved values, mutation per option, no-op when unchanged, pending disables select, error)
- 41 new test cases total (142 baseline → 184 passing)

## Test plan
- [x] cd frontend && bun run typecheck — passed (no errors)
- [x] cd frontend && bun run test:run components/settings — passed (10 files, 184 tests)

## Manual repro
test:run components/settings — 41 new test cases across 8 strengthened files + 1 new file. Verified:
- api-token: CRUD payload assertions (description + expiration_days), copy-to-clipboard via `vi.spyOn(navigator.clipboard, 'writeText')`, revoke confirm calls mutation, in-dialog submit disabled while pending.
- change-password: pending-disabled isolated from canSubmit, fields reset after success, generic error fallback.
- delete-account: reason captured in payload, OAuth-only blocked, Go-to-Home navigation triggers router.push('/'), generic error fallback.
- favorite-cities: append vs replace, Clear all disabled while pending, Saved hidden during pending re-trigger.
- notification-settings: per-row independence (one pending doesn't disable the other), no cross-mutation calls.
- oauth-accounts: dialog closes after successful unlink, dialog stays open on reject.
- passkey-management: full delete flow (`window.confirm` spy + DELETE fetch + UI removal), cancel skips DELETE, server-side `success=false` renders message, register success refetches.
- SettingsPanel: Send Verification success UI, data-export download flow (with try/finally for URL.* restore), CLI token render + Copy via clipboard spy, section ordering smoke test.
- reply-permission-settings (NEW): full coverage of the previously untested component.

## Code review
4 findings caught + fixed in a follow-up commit: (1) URL.createObjectURL leak wrapped in try/finally, (2) delete-dialog test name/assertions aligned, (3) api-token pending test now opens the dialog and asserts disabled, (4) change-password pending split to isolate `isPending` from `canSubmit`.

Closes PSY-716