### PR TITLE
PSY-860: add error banner to Approve/Reject/BatchReject admin dialogs

### DIFF
--- a/frontend/components/admin/ApproveShowDialog.test.tsx
+++ b/frontend/components/admin/ApproveShowDialog.test.tsx
@@ -6,11 +6,15 @@ import type { ShowResponse } from '@/features/shows'
 
 const mockMutate = vi.fn()
 let mockIsPending = false
+let mockIsError = false
+let mockError: Error | null = null
 
 vi.mock('@/lib/hooks/admin/useAdminShows', () => ({
   useApproveShow: () => ({
     mutate: mockMutate,
     isPending: mockIsPending,
+    isError: mockIsError,
+    error: mockError,
   }),
 }))
 
@@ -60,6 +64,8 @@ describe('ApproveShowDialog', () => {
     // only resets call history — implementations persist across tests.
     mockMutate.mockReset()
     mockIsPending = false
+    mockIsError = false
+    mockError = null
   })
 
   it('renders nothing when closed', () => {
@@ -285,6 +291,39 @@ describe('ApproveShowDialog', () => {
 
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
     expect(screen.getByText('Approving...')).toBeInTheDocument()
+  })
+
+  it('shows approve error banner when useApproveShow is in error state', () => {
+    mockIsError = true
+    mockError = new Error('Server unreachable')
+    render(
+      <ApproveShowDialog
+        show={makeShow()}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    // Dialog stays open AND banner renders with the error message.
+    expect(screen.getByText('Approve Show')).toBeInTheDocument()
+    expect(screen.getByText('Server unreachable')).toBeInTheDocument()
+  })
+
+  it('falls back to canned copy when error has no message', () => {
+    mockIsError = true
+    mockError = null
+    render(
+      <ApproveShowDialog
+        show={makeShow()}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    expect(screen.getByText('Approve Show')).toBeInTheDocument()
+    expect(
+      screen.getByText('Failed to approve show. Please try again.')
+    ).toBeInTheDocument()
   })
 
   it('closes dialog via onSuccess callback when mutation succeeds', async () => {

--- a/frontend/components/admin/ApproveShowDialog.tsx
+++ b/frontend/components/admin/ApproveShowDialog.tsx
@@ -109,6 +109,13 @@ export function ApproveShowDialog({
           </div>
         )}
 
+        {approveMutation.isError && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {approveMutation.error?.message ||
+              'Failed to approve show. Please try again.'}
+          </div>
+        )}
+
         <DialogFooter>
           <Button
             variant="outline"

--- a/frontend/components/admin/BatchRejectDialog.test.tsx
+++ b/frontend/components/admin/BatchRejectDialog.test.tsx
@@ -5,11 +5,15 @@ import { BatchRejectDialog } from './BatchRejectDialog'
 
 const mockMutate = vi.fn()
 let mockIsPending = false
+let mockIsError = false
+let mockError: Error | null = null
 
 vi.mock('@/lib/hooks/admin/useAdminShows', () => ({
   useBatchRejectShows: () => ({
     mutate: mockMutate,
     isPending: mockIsPending,
+    isError: mockIsError,
+    error: mockError,
   }),
 }))
 
@@ -24,6 +28,8 @@ describe('BatchRejectDialog', () => {
     // only resets call history — implementations persist across tests.
     mockMutate.mockReset()
     mockIsPending = false
+    mockIsError = false
+    mockError = null
   })
 
   it('renders nothing when closed', () => {
@@ -239,6 +245,39 @@ describe('BatchRejectDialog', () => {
 
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
     expect(screen.getByText('Rejecting...')).toBeInTheDocument()
+  })
+
+  it('shows batch reject error banner when useBatchRejectShows is in error state', () => {
+    mockIsError = true
+    mockError = new Error('Server unreachable')
+    render(
+      <BatchRejectDialog
+        showIds={[1, 2]}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    // Dialog stays open AND banner renders with the error message.
+    expect(screen.getAllByText(/Reject 2 Shows/).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Server unreachable')).toBeInTheDocument()
+  })
+
+  it('falls back to canned copy when error has no message', () => {
+    mockIsError = true
+    mockError = null
+    render(
+      <BatchRejectDialog
+        showIds={[1, 2]}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    expect(screen.getAllByText(/Reject 2 Shows/).length).toBeGreaterThanOrEqual(1)
+    expect(
+      screen.getByText('Failed to batch reject shows. Please try again.')
+    ).toBeInTheDocument()
   })
 
   it('fires onSuccess callback, clears form, and closes dialog when mutation succeeds', async () => {

--- a/frontend/components/admin/BatchRejectDialog.tsx
+++ b/frontend/components/admin/BatchRejectDialog.tsx
@@ -123,6 +123,13 @@ export function BatchRejectDialog({
           </div>
         </div>
 
+        {batchRejectMutation.isError && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {batchRejectMutation.error?.message ||
+              'Failed to batch reject shows. Please try again.'}
+          </div>
+        )}
+
         <DialogFooter>
           <Button
             variant="outline"

--- a/frontend/components/admin/RejectShowDialog.test.tsx
+++ b/frontend/components/admin/RejectShowDialog.test.tsx
@@ -6,11 +6,15 @@ import type { ShowResponse } from '@/features/shows'
 
 const mockMutate = vi.fn()
 let mockIsPending = false
+let mockIsError = false
+let mockError: Error | null = null
 
 vi.mock('@/lib/hooks/admin/useAdminShows', () => ({
   useRejectShow: () => ({
     mutate: mockMutate,
     isPending: mockIsPending,
+    isError: mockIsError,
+    error: mockError,
   }),
 }))
 
@@ -60,6 +64,8 @@ describe('RejectShowDialog', () => {
     // only resets call history — implementations persist across tests.
     mockMutate.mockReset()
     mockIsPending = false
+    mockIsError = false
+    mockError = null
   })
 
   it('renders nothing when closed', () => {
@@ -255,6 +261,39 @@ describe('RejectShowDialog', () => {
 
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
     expect(screen.getByText('Rejecting...')).toBeInTheDocument()
+  })
+
+  it('shows reject error banner when useRejectShow is in error state', () => {
+    mockIsError = true
+    mockError = new Error('Server unreachable')
+    render(
+      <RejectShowDialog
+        show={makeShow()}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    // Dialog stays open AND banner renders with the error message.
+    expect(screen.getByRole('heading', { name: /Reject Show/i })).toBeInTheDocument()
+    expect(screen.getByText('Server unreachable')).toBeInTheDocument()
+  })
+
+  it('falls back to canned copy when error has no message', () => {
+    mockIsError = true
+    mockError = null
+    render(
+      <RejectShowDialog
+        show={makeShow()}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: /Reject Show/i })).toBeInTheDocument()
+    expect(
+      screen.getByText('Failed to reject show. Please try again.')
+    ).toBeInTheDocument()
   })
 
   it('clears reason and closes dialog when mutation succeeds (onSuccess fires)', async () => {

--- a/frontend/components/admin/RejectShowDialog.tsx
+++ b/frontend/components/admin/RejectShowDialog.tsx
@@ -81,6 +81,13 @@ export function RejectShowDialog({
           </div>
         </div>
 
+        {rejectMutation.isError && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {rejectMutation.error?.message ||
+              'Failed to reject show. Please try again.'}
+          </div>
+        )}
+
         <DialogFooter>
           <Button
             variant="outline"


### PR DESCRIPTION
## Summary
- Add PSY-589 inline error banner to the 3 admin dialogs that were missing it (Approve / Reject / BatchReject) — the other 4 (Dismiss / Resolve variants) already had it
- Banner uses `error?.message` if set, else "Failed to <verb>" canned copy
- Dialog stays OPEN on error (no auto-close), so the user can retry or cancel
- Extend test files with 2 standard error-banner test cases per dialog (+6 tests)

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run components/admin` — passed (13 files, 171 tests, 3.29s)
- [x] `/code-review` — 0 findings (diff faithfully mirrors the 4-sibling canonical pattern; small 3 × 7-line implementation; test mocks symmetrically extend the existing pattern)

## Manual repro
`test:run components/admin` — 171 tests pass. Categories verified for each newly-wired dialog: error banner renders when `mutation.isError` is true, falls back to "Failed to <verb>" copy when `error?.message` is null, dialog stays open on error so the user can retry. Matches the canonical PSY-589 pattern in `DismissReportDialog` / `ResolveReportDialog` and follows `pattern_mutation_feedback.md`.

## Code review
No changes — `/code-review` ran 5 angles and found 0 candidates. Diff is a faithful mirror of the established sibling-dialog pattern.

## Orchestrator-takeover disclosure
Dispatched agent committed the implementation + ran `/code-review` cleanly, then stalled before push. Orchestrator (this session) verified diff scope (6 files matched ticket exactly: 3 dialog components + 3 test files), re-ran `bun run typecheck` and `bun run test:run components/admin` from the worktree (both green), pushed, and opened this PR. Same shape as PSY-785 + PSY-715 (Wave 3) and PSY-842 (May 2026) — post-`/code-review` stalls in agents handling test-only or mirror-pattern diffs.

Closes PSY-860