### PR TITLE
PSY-861: fail closed when IncrementFailedAttempts errors

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -114,12 +114,12 @@ func (h *AuthHandler) LoginHandler(ctx context.Context, input *LoginRequest) (*L
 				resp.Body.ErrorCode = autherrors.ToExternalCode(autherrors.CodeInvalidCredentials)
 				return resp, nil
 			case autherrors.CodeServiceUnavailable:
-				// Fail-closed surface from AuthenticateUserWithPassword (PSY-861):
-				// the lockout-counter write failed, so we cannot let the request
+				// Fail-closed surface from AuthenticateUserWithPassword: the
+				// lockout-counter write failed, so we cannot let the request
 				// fall through to ErrInvalidCredentials — that would hand an
-				// attacker a free guess. Propagate the AuthError so Huma emits a
-				// 5xx and the client retries; the message stays generic so we do
-				// not leak which step failed.
+				// attacker a free guess. Propagate the AuthError so Huma emits
+				// a 5xx and the client retries; the message stays generic so
+				// we do not leak which step failed.
 				logger.AuthError(ctx, "login_service_unavailable", err,
 					"email_hash", logger.HashEmail(input.Body.Email),
 				)

--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -113,6 +113,20 @@ func (h *AuthHandler) LoginHandler(ctx context.Context, input *LoginRequest) (*L
 				resp.Body.Message = authErr.UserMessage()
 				resp.Body.ErrorCode = autherrors.ToExternalCode(autherrors.CodeInvalidCredentials)
 				return resp, nil
+			case autherrors.CodeServiceUnavailable:
+				// Fail-closed surface from AuthenticateUserWithPassword (PSY-861):
+				// the lockout-counter write failed, so we cannot let the request
+				// fall through to ErrInvalidCredentials — that would hand an
+				// attacker a free guess. Propagate the AuthError so Huma emits a
+				// 5xx and the client retries; the message stays generic so we do
+				// not leak which step failed.
+				logger.AuthError(ctx, "login_service_unavailable", err,
+					"email_hash", logger.HashEmail(input.Body.Email),
+				)
+				resp.Body.Success = false
+				resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
+				resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+				return resp, authErr // Return actual error for 5xx HTTP status
 			}
 		}
 

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -800,6 +800,49 @@ func TestLoginHandler_AccountLocked(t *testing.T) {
 	}
 }
 
+// TestLoginHandler_ServiceUnavailable asserts that a CodeServiceUnavailable
+// AuthError from AuthenticateUserWithPassword (the PSY-861 fail-closed signal
+// emitted when IncrementFailedAttempts errors) propagates as a real error to
+// Huma — NOT silently downgraded to INVALID_CREDENTIALS via the fallback path.
+// The body still carries SERVICE_UNAVAILABLE so clients can branch, and the
+// returned error drives the HTTP status into the 5xx band.
+func TestLoginHandler_ServiceUnavailable(t *testing.T) {
+	svcErr := autherrors.ErrServiceUnavailable("user_increment_failed_attempts", fmt.Errorf("db hiccup"))
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			AuthenticateUserWithPasswordFn: func(email, password string) (*authm.User, error) {
+				return nil, svcErr
+			},
+		}
+	})
+
+	input := &LoginRequest{}
+	input.Body.Email = "test@example.com"
+	input.Body.Password = "wrong"
+
+	resp, err := h.LoginHandler(context.Background(), input)
+
+	// The handler MUST return the AuthError so Huma emits a 5xx.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// Regression guard: the fall-through path used to map every unknown
+	// AuthError to INVALID_CREDENTIALS, which would hand an attacker a free
+	// guess. Lock that branch out.
+	if resp.Body.ErrorCode == autherrors.CodeInvalidCredentials {
+		t.Error("regression: SERVICE_UNAVAILABLE must not be downgraded to INVALID_CREDENTIALS")
+	}
+}
+
 func TestLoginHandler_TokenFails(t *testing.T) {
 	h := authHandler(func(ah *AuthHandler) {
 		ah.userService = &testhelpers.MockUserService{

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -156,8 +156,8 @@ type UserService struct {
 	// AuthenticateUserWithPassword routes the lockout-counter increment through
 	// this function instead of s.IncrementFailedAttempts directly. The seam
 	// exists to deterministically exercise the fail-closed path on counter-
-	// write failure (PSY-861) without resorting to DB-state manipulation that
-	// would race with the rest of the integration suite. Leave nil in production.
+	// write failure without resorting to DB-state manipulation that would race
+	// with the rest of the integration suite. Leave nil in production.
 	incrementFailedAttemptsFn func(userID uint) error
 }
 

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -151,6 +151,14 @@ func (s *UserService) ListUsers(limit, offset int, filters contracts.AdminUserFi
 // UserService handles user-related business logic
 type UserService struct {
 	db *gorm.DB
+
+	// incrementFailedAttemptsFn is a test-only seam. When non-nil,
+	// AuthenticateUserWithPassword routes the lockout-counter increment through
+	// this function instead of s.IncrementFailedAttempts directly. The seam
+	// exists to deterministically exercise the fail-closed path on counter-
+	// write failure (PSY-861) without resorting to DB-state manipulation that
+	// would race with the rest of the integration suite. Leave nil in production.
+	incrementFailedAttemptsFn func(userID uint) error
 }
 
 // NewUserService creates a new user service
@@ -353,15 +361,23 @@ func (s *UserService) AuthenticateUserWithPassword(email, password string) (*aut
 	}
 
 	if err := s.VerifyPassword(*user.PasswordHash, password); err != nil {
-		// Increment failed attempts on password failure. Log + continue on
-		// counter-write failure: the auth attempt still fails (correct), but a
-		// silent counter failure would weaken brute-force lockout — surface it
-		// so ops can investigate without blocking the user-facing error.
-		if incErr := s.IncrementFailedAttempts(user.ID); incErr != nil {
+		// Increment failed attempts on password failure. Fail closed if the
+		// counter write itself fails: silently returning ErrInvalidCredentials
+		// when Increment errors would let an attacker brute-force without ever
+		// tripping the lockout (the invariant ">= N failures locks the account"
+		// only holds if every failure is recorded). A 503 is the right
+		// alternative — generic message, no account-state leak; a legitimate
+		// user during a DB hiccup retries until DB recovers.
+		incrementFn := s.IncrementFailedAttempts
+		if s.incrementFailedAttemptsFn != nil {
+			incrementFn = s.incrementFailedAttemptsFn
+		}
+		if incErr := incrementFn(user.ID); incErr != nil {
 			logger.Default().Error("user_increment_failed_attempts_failed",
 				"user_id", user.ID,
 				"error", incErr,
 			)
+			return nil, apperrors.ErrServiceUnavailable("user_increment_failed_attempts", incErr)
 		}
 		return nil, apperrors.ErrInvalidCredentials(nil)
 	}

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -992,6 +992,49 @@ func (suite *UserServiceIntegrationTestSuite) TestAuthenticate_InactiveUser() {
 	suite.Contains(err.Error(), "user account is not active")
 }
 
+// TestAuthenticateUserWithPassword_IncrementErrorFailsClosed asserts the
+// PSY-861 fail-closed contract: when the lockout-counter write fails on a
+// wrong-password attempt, AuthenticateUserWithPassword MUST surface a
+// CodeServiceUnavailable AuthError — NOT CodeInvalidCredentials. Falling
+// through to ErrInvalidCredentials would mean the user got a free guess
+// without the counter advancing, which under sustained DB stress would let
+// an attacker brute-force without ever tripping lockout.
+func (suite *UserServiceIntegrationTestSuite) TestAuthenticateUserWithPassword_IncrementErrorFailsClosed() {
+	// Create a real user the auth flow can find + bcrypt-verify.
+	_, err := suite.userService.CreateUserWithPassword(
+		"failclosed@example.com", "CorrectPassword1!", "Fail", "Closed",
+	)
+	suite.Require().NoError(err)
+
+	// Build a separate UserService that shares the suite's DB (so
+	// GetUserByEmail + VerifyPassword work) but routes IncrementFailedAttempts
+	// through a hook that simulates a counter-write failure (transient DB
+	// hiccup, deadlock, pool exhaustion, etc.). The hook fires only on the
+	// password-mismatch branch we are exercising; the happy-path Increment
+	// covered elsewhere in the suite remains untouched.
+	failingSvc := &UserService{
+		db: suite.db,
+		incrementFailedAttemptsFn: func(uint) error {
+			return errors.New("simulated db failure on increment")
+		},
+	}
+
+	user, err := failingSvc.AuthenticateUserWithPassword(
+		"failclosed@example.com", "WrongPassword!",
+	)
+
+	suite.Require().Error(err)
+	suite.Nil(user)
+
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr),
+		"expected *apperrors.AuthError, got %T", err)
+	suite.Equal(apperrors.CodeServiceUnavailable, authErr.Code,
+		"fail-closed contract: must be SERVICE_UNAVAILABLE, NOT INVALID_CREDENTIALS")
+	suite.NotEqual(apperrors.CodeInvalidCredentials, authErr.Code,
+		"regression guard: falling back to INVALID_CREDENTIALS would hand an attacker a free guess")
+}
+
 // =============================================================================
 // NEW INTEGRATION TESTS: Account Lockout
 // =============================================================================


### PR DESCRIPTION
## Summary
- Convert PSY-849's log-only handling at `AuthenticateUserWithPassword` (`backend/internal/services/user/user.go:~360`) to fail-closed: when the `IncrementFailedAttempts` write itself errors, return `apperrors.ErrServiceUnavailable` instead of falling through to `ErrInvalidCredentials`.
- Add the matching `CodeServiceUnavailable` case to `LoginHandler` (`backend/internal/api/handlers/auth/auth.go`) so the new AuthError propagates as a real `(resp, err)` return value — Huma emits a 5xx; the generic-fallback path no longer downgrades it to a 200/`INVALID_CREDENTIALS`. Body still carries `SERVICE_UNAVAILABLE` so clients can branch.
- Reuse the existing `apperrors.ErrServiceUnavailable` constructor — no new error type added.
- Leave the `ResetFailedAttempts` site UNCHANGED — PSY-849's log-only is the right trade-off there: the user has already proven possession of the password, so a stale-counter degradation is strictly better than rejecting a verified login.

## Why
A DB write failure on `IncrementFailedAttempts` silently breaks the lockout invariant (`>= N failed attempts → account locked`). Under sustained DB stress an attacker could brute-force passwords without ever tripping lockout, since each counter-write failure on a wrong-password attempt returned `INVALID_CREDENTIALS` with the counter never advancing. Fail-closed eliminates the bypass: a transient DB hiccup now produces a 5xx that the legitimate user retries past once the DB recovers, while the attacker doesn't get a free guess.

## Implementation notes
- The integration test injects a counter-write failure through a small test-only seam (`incrementFailedAttemptsFn` function field on `UserService`, nil in production, documented as test-only on the struct). DB-state manipulation would race with the rest of the integration suite; mocking the interface from inside the same `*UserService` method receiver is not possible.
- Peer-coverage handler test (`TestLoginHandler_ServiceUnavailable`) locks the fallback path out as a regression guard so this can't accidentally regress back to silent downgrade.
- OpenAPI: Huma generates the spec from handler signatures at runtime; the new error return causes Huma to surface a 5xx response on `/auth/login`. No committed spec file to update.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/services/user/... ./internal/api/handlers/auth/...` — pass (incl new `TestAuthenticateUserWithPassword_IncrementErrorFailsClosed` + `TestLoginHandler_ServiceUnavailable`)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues (errcheck stays gated)

## Manual repro
`TestUserServiceIntegrationTestSuite/TestAuthenticateUserWithPassword_IncrementErrorFailsClosed` passes. The test creates a real user via the suite's testcontainer Postgres, constructs a parallel `UserService` whose `incrementFailedAttemptsFn` seam returns `errors.New("simulated db failure on increment")`, calls `AuthenticateUserWithPassword(email, wrongPassword)`, and asserts:

- `err` is a `*apperrors.AuthError`
- `authErr.Code == apperrors.CodeServiceUnavailable` (fail-closed contract)
- `authErr.Code != apperrors.CodeInvalidCredentials` (regression guard against the silent-downgrade behavior)

Log output during the test confirms the `user_increment_failed_attempts_failed` log line fires before the AuthError is returned.

## Code review
`/code-review` (alias: `simplify`) ran inline (no parallel-agent runner available in this environment). Findings: ticket-refs in two production doc-comments were stripped per `feedback_strip_ticket_refs_from_doc_comments.md`. No reuse, quality, or efficiency issues remained after the cleanup. Tests + lint re-verified clean after the edits.

Closes PSY-861