### PR TITLE
PSY-863: fix frontend Codecov upload — files path nested under cwd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
           files: backend/coverage.out
           flags: backend
           disable_search: true
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # PSY-772: backend lint gate.
@@ -229,9 +230,10 @@ jobs:
       - name: Upload frontend coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: frontend/coverage/lcov.info
+          files: coverage/lcov.info
           flags: frontend
           disable_search: true
+          fail_ci_if_error: true
           working-directory: ./frontend
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

- PSY-852 (PR #819) added `working-directory: ./frontend` to the frontend codecov-action step intentionally — lcov.info uses paths relative to `frontend/` (e.g. `SF:app/global-error.tsx`), so Codecov needs that prefix to map them back to repo files. But the `files:` value was left as `frontend/coverage/lcov.info`, which now resolves relative to the new CWD → `./frontend/frontend/coverage/lcov.info`, which doesn't exist. The upload has been silently failing every run since.
- Concrete log evidence (run 26460526348 on main, commit 90627a84):
  ```
  warning - Some files were not found ---
    {"not_found_files": ["frontend/coverage/lcov.info"]}
  info - Found 0 coverage files to report
  Error: No coverage reports found.
  ```
- Change `files:` to `coverage/lcov.info` (relative to working-directory), keep `working-directory` (PSY-852's path-mapping intent). Add `fail_ci_if_error: true` to **both** upload steps so a future incomplete fix can't recur silently — `fail_ci_if_error` defaulted to false, which is exactly why PSY-852's gap went undetected for weeks.

Closes PSY-863

## Test plan

- [ ] After merge, next main CI run's "Upload frontend coverage to Codecov" step logs `Found 1 coverage files to report` (not `Found 0`)
- [ ] After merge, app.codecov.io/gh/mtrifilo/psychic-homily-web file tree shows both `backend/` and `frontend/` directories
- [ ] `frontend` flag on Codecov reports frontend-only line counts (not 0)
- [ ] Backend upload continues to work post-`fail_ci_if_error: true` flip (no behavior change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)