### PR TITLE
PSY-864: LoginHandler — fail-closed default for unknown auth codes

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -127,18 +127,36 @@ func (h *AuthHandler) LoginHandler(ctx context.Context, input *LoginRequest) (*L
 				resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 				resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
 				return resp, authErr // Return actual error for 5xx HTTP status
+			default:
+				// Fail-closed: any AuthError code without an explicit handler
+				// case is treated as "we don't know what went wrong" and
+				// propagates as 5xx. Adding a new AuthError code that SHOULD
+				// be 401-shaped requires an explicit case here — that is the
+				// intent: code review forces a UX decision per code instead
+				// of accepting a silent INVALID_CREDENTIALS downgrade.
+				logger.AuthError(ctx, "login_unhandled_authcode", err,
+					"email_hash", logger.HashEmail(input.Body.Email),
+					"auth_code", string(authErr.Code),
+				)
+				resp.Body.Success = false
+				resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
+				resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+				return resp, authErr // Return actual error for 5xx HTTP status
 			}
 		}
 
-		// Generic fallback for unexpected errors
-		logger.AuthWarn(ctx, "login_failed",
+		// Outer fallback: err is NOT an AuthError. Genuine "unexpected error"
+		// territory — config failures, raw DB errors, account-state checks
+		// that have not yet been promoted to typed AuthErrors. Fail-closed
+		// with a generic message so we do not hand attackers signal about
+		// which internal step failed, and surface a 5xx so the client retries.
+		logger.AuthError(ctx, "login_unexpected_error", err,
 			"email_hash", logger.HashEmail(input.Body.Email),
-			"error", err.Error(),
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Invalid email or password"
-		resp.Body.ErrorCode = autherrors.CodeInvalidCredentials
-		return resp, nil
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
+		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+		return resp, autherrors.ErrServiceUnavailable("login", err)
 	}
 
 	// Generate JWT token

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -846,10 +846,10 @@ func TestLoginHandler_ServiceUnavailable(t *testing.T) {
 
 // TestLoginHandler_UnknownAuthCodeFailsClosed asserts that an AuthError whose
 // Code is not explicitly handled by the LoginHandler switch propagates as a
-// 5xx instead of falling through to the historical INVALID_CREDENTIALS HTTP
-// 200 downgrade. This locks in the fail-closed convention: any new AuthError
-// code added without a dedicated handler case must surface as SERVICE_UNAVAILABLE
-// — adding an explicit 401-shaped case requires a UX decision in code review.
+// 5xx instead of falling through to an INVALID_CREDENTIALS HTTP 200 downgrade.
+// Locks in the fail-closed convention: any new AuthError code added without a
+// dedicated handler case must surface as SERVICE_UNAVAILABLE — adding an
+// explicit 401-shaped case requires a UX decision in code review.
 func TestLoginHandler_UnknownAuthCodeFailsClosed(t *testing.T) {
 	// CodeUnknown is the canonical "we have an AuthError but the code is not
 	// one we explicitly route" signal. Any other unrouted code (e.g. a future
@@ -883,8 +883,8 @@ func TestLoginHandler_UnknownAuthCodeFailsClosed(t *testing.T) {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 	}
 	// Regression guard: an unrouted AuthError code must not silently downgrade
-	// to INVALID_CREDENTIALS — that was the pre-PSY-864 fall-through behavior
-	// and the convention this ticket inverts.
+	// to INVALID_CREDENTIALS — that was the pre-existing fall-through behavior
+	// and the convention this test locks in.
 	if resp.Body.ErrorCode == autherrors.CodeInvalidCredentials {
 		t.Error("regression: unknown AuthError code must not be downgraded to INVALID_CREDENTIALS")
 	}
@@ -944,8 +944,8 @@ func TestLoginHandler_NonAuthErrorFailsClosed(t *testing.T) {
 		t.Errorf("expected response error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 	}
 	// Regression guard: a non-AuthError must not silently downgrade to
-	// INVALID_CREDENTIALS — that was the pre-PSY-864 outer-fallback behavior
-	// and the convention this ticket inverts.
+	// INVALID_CREDENTIALS — that was the pre-existing outer-fallback behavior
+	// and the convention this test locks in.
 	if resp.Body.ErrorCode == autherrors.CodeInvalidCredentials {
 		t.Error("regression: non-AuthError must not be downgraded to INVALID_CREDENTIALS")
 	}

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -840,6 +841,119 @@ func TestLoginHandler_ServiceUnavailable(t *testing.T) {
 	// guess. Lock that branch out.
 	if resp.Body.ErrorCode == autherrors.CodeInvalidCredentials {
 		t.Error("regression: SERVICE_UNAVAILABLE must not be downgraded to INVALID_CREDENTIALS")
+	}
+}
+
+// TestLoginHandler_UnknownAuthCodeFailsClosed asserts that an AuthError whose
+// Code is not explicitly handled by the LoginHandler switch propagates as a
+// 5xx instead of falling through to the historical INVALID_CREDENTIALS HTTP
+// 200 downgrade. This locks in the fail-closed convention: any new AuthError
+// code added without a dedicated handler case must surface as SERVICE_UNAVAILABLE
+// — adding an explicit 401-shaped case requires a UX decision in code review.
+func TestLoginHandler_UnknownAuthCodeFailsClosed(t *testing.T) {
+	// CodeUnknown is the canonical "we have an AuthError but the code is not
+	// one we explicitly route" signal. Any other unrouted code (e.g. a future
+	// addition without a switch arm) would exercise the same default branch.
+	unknownErr := &autherrors.AuthError{Code: autherrors.CodeUnknown, Message: "unrouted auth code"}
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			AuthenticateUserWithPasswordFn: func(email, password string) (*authm.User, error) {
+				return nil, unknownErr
+			},
+		}
+	})
+
+	input := &LoginRequest{}
+	input.Body.Email = "test@example.com"
+	input.Body.Password = "any"
+
+	resp, err := h.LoginHandler(context.Background(), input)
+
+	// The handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// Regression guard: an unrouted AuthError code must not silently downgrade
+	// to INVALID_CREDENTIALS — that was the pre-PSY-864 fall-through behavior
+	// and the convention this ticket inverts.
+	if resp.Body.ErrorCode == autherrors.CodeInvalidCredentials {
+		t.Error("regression: unknown AuthError code must not be downgraded to INVALID_CREDENTIALS")
+	}
+	// External message must match the existing SERVICE_UNAVAILABLE shape — no
+	// leak about whether the unknown was an AuthError sub-code or a raw error.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestLoginHandler_NonAuthErrorFailsClosed asserts that a raw (non-AuthError)
+// error returned by the user service — e.g. the config / DB / account-state
+// fmt.Errorf sites in AuthenticateUserWithPassword that have not been promoted
+// to typed AuthErrors — propagates as a 5xx instead of being silently mapped
+// to INVALID_CREDENTIALS HTTP 200. The outer fallback used to swallow these
+// errors and hand attackers a free guess on DB-stress; this regression test
+// locks that branch out.
+func TestLoginHandler_NonAuthErrorFailsClosed(t *testing.T) {
+	rawErr := fmt.Errorf("simulated config error")
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			AuthenticateUserWithPasswordFn: func(email, password string) (*authm.User, error) {
+				return nil, rawErr
+			},
+		}
+	})
+
+	input := &LoginRequest{}
+	input.Body.Email = "test@example.com"
+	input.Body.Password = "any"
+
+	resp, err := h.LoginHandler(context.Background(), input)
+
+	// The handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must itself be an AuthError of CodeServiceUnavailable
+	// so the apperror mapper translates it to a 5xx. A non-AuthError leaking out
+	// here would be downstream-classified by Huma into a generic 500 with no
+	// structured error code — fine, but the explicit shape is what callers
+	// (and clients) branch on. The handler wraps via ErrServiceUnavailable.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected response error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// Regression guard: a non-AuthError must not silently downgrade to
+	// INVALID_CREDENTIALS — that was the pre-PSY-864 outer-fallback behavior
+	// and the convention this ticket inverts.
+	if resp.Body.ErrorCode == autherrors.CodeInvalidCredentials {
+		t.Error("regression: non-AuthError must not be downgraded to INVALID_CREDENTIALS")
+	}
+	// External message must match the existing SERVICE_UNAVAILABLE shape — no
+	// leak about whether the cause was a config error, raw DB failure, or
+	// some other internal step.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `default:` arm to LoginHandler's AuthError switch — unknown AuthError code → 5xx instead of silent 200 + INVALID_CREDENTIALS.
- Replace outer fallback (previously lines 133-141) with the same fail-closed shape — non-AuthError errors (config / raw DB / etc.) also propagate as 5xx via `apperrors.ErrServiceUnavailable("login", err)`.
- Two regression tests cover both new paths.

Builds on PSY-861 (#838): PSY-861 added the explicit `CodeServiceUnavailable` case; this ticket hardens the convention so future AuthError additions fail closed by default instead of requiring an explicit handler case.

## Why
PSY-861 fixed one specific silent-downgrade bug (`CodeServiceUnavailable` from a DB-write failure was being collapsed to "invalid credentials" HTTP 200). The pattern itself remained vulnerable — any other AuthError code without an explicit case OR any non-AuthError raw error still got the same silent downgrade. Three non-AuthError returns in `AuthenticateUserWithPassword` (lines 314, 319, 354 of `services/user/user.go`) currently hit the outer fallback (config error, raw DB failure, account-state).

Convention shift: adding a new AuthError code now requires either an explicit handler case OR conscious acceptance of the SERVICE_UNAVAILABLE default at code review — code review forces a UX decision per code instead of accepting a silent INVALID_CREDENTIALS downgrade.

Both new paths share the same generic external message + ErrorCode as the existing `CodeServiceUnavailable` case (PSY-861 wired this) — no leak about whether the unknown was an AuthError sub-code or a raw error.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/api/handlers/auth/... ./internal/services/user/...` — passed (incl 2 new regression tests; 9/9 LoginHandler tests green)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues
- [x] Existing LoginHandler tests (`CodeAccountLocked`, `CodeInvalidCredentials`, `CodeServiceUnavailable`, `Success`, `TokenFails`, `EmptyCredentials`, `MissingPassword`) still pass — no regression in explicitly-handled codes.

## Manual repro
Both regression tests reuse the existing PSY-861 `testhelpers.MockUserService` + `AuthenticateUserWithPasswordFn` seam:

- `TestLoginHandler_UnknownAuthCodeFailsClosed`: mocked service returns `&AuthError{Code: CodeUnknown}` → handler returns non-nil error (so Huma emits 5xx), `Body.ErrorCode == SERVICE_UNAVAILABLE`, `Body.Message == ToExternalMessage(CodeServiceUnavailable)`, explicit guard against INVALID_CREDENTIALS. Verbose log confirms `login_unhandled_authcode` fires with `email_hash` + `auth_code=UNKNOWN`.
- `TestLoginHandler_NonAuthErrorFailsClosed`: mocked service returns `fmt.Errorf("simulated config error")` → handler returns non-nil error that unwraps via `errors.As` to `*AuthError{Code: CodeServiceUnavailable}` (proves `ErrServiceUnavailable` wrapper fires), `Body.ErrorCode == SERVICE_UNAVAILABLE`, explicit guard against INVALID_CREDENTIALS. Verbose log confirms `login_unexpected_error` fires with `email_hash`.

## Code review
/code-review (inline, single-agent — sub-agent thread; no parent to spawn parallel reviewers) found one cleanup: stripped `(pre-PSY-864)` parentheticals from two test doc comments per `feedback_strip_ticket_refs_from_doc_comments.md`. Reuse, quality, and efficiency otherwise clean — both new arms reuse existing helpers (`logger.HashEmail`, `autherrors.ToExternalMessage`, `autherrors.ErrServiceUnavailable`), log event names follow the `login_*` convention and are unique, no copy-paste worth abstracting (the two arms have different return semantics — inner returns `authErr` directly, outer wraps via `ErrServiceUnavailable`), and the new code is in the rare-error path (no hot-path concern).

## Scope-adjacent observations (filed for follow-up, not widened here)
- `OAuthLoginHandler` (`auth.go:187`) and other auth handlers in this file have their own fall-through shapes worth scrutinizing in a separate ticket.
- `services/user/user.go:354` returns `fmt.Errorf("user account is not active")` — should arguably be a typed `CodeAccountInactive` AuthError with a clear "account inactive" UX instead of 5xx. Out of scope here.

Closes PSY-864