### PR TITLE
PSY-862: strengthen 5 remaining shared component tests

### DIFF
--- a/frontend/components/shared/BracketLink.test.tsx
+++ b/frontend/components/shared/BracketLink.test.tsx
@@ -91,4 +91,64 @@ describe('BracketLink', () => {
     expect(openBracket).toHaveAttribute('aria-hidden', 'true')
     expect(closeBracket).toHaveAttribute('aria-hidden', 'true')
   })
+
+  // Per-branch a11y coverage (PSY-862). The button + link branches build
+  // independent accessible-name attributes, so each branch needs its own
+  // explicit assertion.
+
+  describe('link branch a11y', () => {
+    it('uses label as accessible name on the link branch by default', () => {
+      render(<BracketLink label="View history" href="/x/history" />)
+      // `getByRole('link', { name })` resolves via accessible name —
+      // tests that the `aria-label={ariaLabel ?? label}` default fires
+      // for the link path, not just the button path.
+      expect(
+        screen.getByRole('link', { name: 'View history' })
+      ).toBeInTheDocument()
+    })
+
+    it('uses ariaLabel override on the link branch', () => {
+      render(
+        <BracketLink
+          label="History"
+          ariaLabel="Open revision history"
+          href="/x/history"
+        />
+      )
+      expect(
+        screen.getByRole('link', { name: 'Open revision history' })
+      ).toBeInTheDocument()
+    })
+
+    it('forwards title to the link branch', () => {
+      render(
+        <BracketLink label="History" href="/x/history" title="See full history" />
+      )
+      expect(screen.getByRole('link')).toHaveAttribute('title', 'See full history')
+    })
+
+    it('passes href through verbatim on the link branch', () => {
+      render(
+        <BracketLink
+          label="Filter by tag"
+          href="/shows?tag=post-punk&year=2024"
+        />
+      )
+      expect(
+        screen.getByRole('link', { name: 'Filter by tag' })
+      ).toHaveAttribute('href', '/shows?tag=post-punk&year=2024')
+    })
+  })
+
+  describe('href + disabled fallback (anchors have no native disabled state)', () => {
+    it('renders a disabled button (not a link) when href AND disabled are both set', () => {
+      // Anchors cannot be natively disabled. The component falls back to
+      // a `<button disabled>` to prevent click-through and keep AT users
+      // from bypassing the disabled state.
+      render(<BracketLink label="Follow" href="/somewhere" disabled />)
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+      const button = screen.getByRole('button', { name: 'Follow' })
+      expect(button).toBeDisabled()
+    })
+  })
 })

--- a/frontend/components/shared/SocialLinks.test.tsx
+++ b/frontend/components/shared/SocialLinks.test.tsx
@@ -2,150 +2,291 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { SocialLinks } from './SocialLinks'
 
+// All asserts on this primitive use `getByRole('link', { name })` over
+// `getByTitle()`, because the `sr-only` <span> is what assistive tech
+// actually reads — `title` is only a hover tooltip and isn't guaranteed to
+// be the accessible name. Locking in the accessible-name behaviour catches
+// a regression where the sr-only span is dropped (a real risk when
+// icon-only links get refactored).
+
 describe('SocialLinks', () => {
-  it('returns null when social is null', () => {
-    const { container } = render(<SocialLinks social={null} />)
-    expect(container.firstChild).toBeNull()
+  describe('null / empty branches', () => {
+    it('returns null when social is null', () => {
+      const { container } = render(<SocialLinks social={null} />)
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('returns null when social is undefined', () => {
+      const { container } = render(<SocialLinks />)
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('returns null when all social fields are null', () => {
+      const { container } = render(
+        <SocialLinks
+          social={{
+            website: null,
+            instagram: null,
+            facebook: null,
+            twitter: null,
+            youtube: null,
+            spotify: null,
+            bandcamp: null,
+            soundcloud: null,
+          }}
+        />
+      )
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('returns null when all social fields are empty strings', () => {
+      const { container } = render(
+        <SocialLinks
+          social={{
+            website: '',
+            instagram: '',
+            facebook: '',
+            twitter: '',
+            youtube: '',
+            spotify: '',
+            bandcamp: '',
+            soundcloud: '',
+          }}
+        />
+      )
+      // Filter rejects falsy values, including empty strings.
+      expect(container.firstChild).toBeNull()
+    })
   })
 
-  it('returns null when social is undefined', () => {
-    const { container } = render(<SocialLinks />)
-    expect(container.firstChild).toBeNull()
+  describe('per-platform href + accessible name', () => {
+    it('renders a Website link with full URL passthrough and accessible name', () => {
+      render(<SocialLinks social={{ website: 'https://example.com' }} />)
+      const link = screen.getByRole('link', { name: 'Website' })
+      expect(link).toHaveAttribute('href', 'https://example.com')
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('renders Instagram link from handle with accessible name', () => {
+      render(<SocialLinks social={{ instagram: 'bandname' }} />)
+      const link = screen.getByRole('link', { name: 'Instagram' })
+      expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
+    })
+
+    it('renders Instagram link from handle with @ prefix (strips @)', () => {
+      render(<SocialLinks social={{ instagram: '@bandname' }} />)
+      const link = screen.getByRole('link', { name: 'Instagram' })
+      expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
+    })
+
+    it('passes through a full Instagram URL untouched', () => {
+      render(
+        <SocialLinks social={{ instagram: 'https://instagram.com/bandname' }} />
+      )
+      const link = screen.getByRole('link', { name: 'Instagram' })
+      expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
+    })
+
+    it('renders Facebook link from handle with accessible name', () => {
+      render(<SocialLinks social={{ facebook: 'bandpage' }} />)
+      const link = screen.getByRole('link', { name: 'Facebook' })
+      expect(link).toHaveAttribute('href', 'https://facebook.com/bandpage')
+    })
+
+    it('renders Twitter link with accessible name "Twitter/X"', () => {
+      render(<SocialLinks social={{ twitter: 'bandname' }} />)
+      // The label is intentionally "Twitter/X" so screen readers announce
+      // both names (post-rebrand). Locking the string here catches a
+      // regression that drops the X suffix.
+      const link = screen.getByRole('link', { name: 'Twitter/X' })
+      expect(link).toHaveAttribute('href', 'https://twitter.com/bandname')
+    })
+
+    it('renders YouTube link from handle with accessible name', () => {
+      render(<SocialLinks social={{ youtube: 'channel123' }} />)
+      const link = screen.getByRole('link', { name: 'YouTube' })
+      expect(link).toHaveAttribute('href', 'https://youtube.com/channel123')
+    })
+
+    it('renders Spotify link from artist path with accessible name', () => {
+      render(<SocialLinks social={{ spotify: 'artist/123' }} />)
+      const link = screen.getByRole('link', { name: 'Spotify' })
+      expect(link).toHaveAttribute('href', 'https://open.spotify.com/artist/123')
+    })
+
+    it('renders Bandcamp link from full URL with accessible name', () => {
+      render(<SocialLinks social={{ bandcamp: 'https://band.bandcamp.com' }} />)
+      const link = screen.getByRole('link', { name: 'Bandcamp' })
+      expect(link).toHaveAttribute('href', 'https://band.bandcamp.com')
+    })
+
+    it('renders SoundCloud link from handle with accessible name', () => {
+      render(<SocialLinks social={{ soundcloud: 'bandname' }} />)
+      const link = screen.getByRole('link', { name: 'SoundCloud' })
+      expect(link).toHaveAttribute('href', 'https://soundcloud.com/bandname')
+    })
   })
 
-  it('returns null when all social fields are null', () => {
-    const { container } = render(
-      <SocialLinks
-        social={{
-          website: null,
-          instagram: null,
-          facebook: null,
-          twitter: null,
-          youtube: null,
-          spotify: null,
-          bandcamp: null,
-          soundcloud: null,
-        }}
-      />
-    )
-    expect(container.firstChild).toBeNull()
+  describe('omit-empty branches', () => {
+    it('only renders links for non-null social fields', () => {
+      render(
+        <SocialLinks
+          social={{
+            instagram: 'band',
+            facebook: null,
+            twitter: null,
+          }}
+        />
+      )
+      expect(screen.getByRole('link', { name: 'Instagram' })).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Facebook' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Twitter/X' })).not.toBeInTheDocument()
+    })
+
+    it('only renders links for non-empty-string social fields', () => {
+      render(
+        <SocialLinks
+          social={{
+            instagram: 'band',
+            facebook: '',
+            twitter: '',
+          }}
+        />
+      )
+      // Empty-string fields are filtered out the same way nulls are — both
+      // are falsy under the `socialLinks.filter(...)` gate.
+      expect(screen.getByRole('link', { name: 'Instagram' })).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Facebook' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Twitter/X' })).not.toBeInTheDocument()
+    })
+
+    it('only renders the exact set of platforms supplied (no stale platforms)', () => {
+      render(
+        <SocialLinks
+          social={{
+            instagram: 'band',
+            spotify: 'https://open.spotify.com/artist/abc',
+          }}
+        />
+      )
+      const links = screen.getAllByRole('link')
+      // Two platforms supplied → exactly two links rendered. This catches a
+      // regression where the filter pulls in extras.
+      expect(links).toHaveLength(2)
+      const names = links.map((link) =>
+        link.getAttribute('aria-label') ??
+        link.querySelector('.sr-only')?.textContent ??
+        link.textContent
+      )
+      expect(names).toEqual(expect.arrayContaining(['Instagram', 'Spotify']))
+    })
   })
 
-  it('renders a link for a full website URL', () => {
-    render(<SocialLinks social={{ website: 'https://example.com' }} />)
-    const link = screen.getByTitle('Website')
-    expect(link).toHaveAttribute('href', 'https://example.com')
-    expect(link).toHaveAttribute('target', '_blank')
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  describe('multi-platform rendering', () => {
+    it('renders multiple social links when multiple are present', () => {
+      render(
+        <SocialLinks
+          social={{
+            instagram: 'band',
+            spotify: 'https://open.spotify.com/artist/abc',
+            website: 'https://band.com',
+          }}
+        />
+      )
+      expect(screen.getByRole('link', { name: 'Instagram' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Spotify' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Website' })).toBeInTheDocument()
+    })
+
+    it('preserves the source-of-truth platform order (website → instagram → facebook → twitter → youtube → spotify → bandcamp → soundcloud)', () => {
+      // Reordering the social platforms is a visual decision — if the
+      // declared order changes, this test should fail and force a
+      // conscious update rather than silently shifting.
+      render(
+        <SocialLinks
+          social={{
+            soundcloud: 'sc',
+            website: 'https://w.com',
+            instagram: 'ig',
+            facebook: 'fb',
+            twitter: 'tw',
+            youtube: 'yt',
+            spotify: 'sp',
+            bandcamp: 'https://b.bandcamp.com',
+          }}
+        />
+      )
+      const links = screen.getAllByRole('link')
+      const accessibleNames = links.map(
+        (link) => link.querySelector('.sr-only')?.textContent
+      )
+      expect(accessibleNames).toEqual([
+        'Website',
+        'Instagram',
+        'Facebook',
+        'Twitter/X',
+        'YouTube',
+        'Spotify',
+        'Bandcamp',
+        'SoundCloud',
+      ])
+    })
+
+    it('opens every link in a new tab with safe rel', () => {
+      render(
+        <SocialLinks
+          social={{
+            instagram: 'a',
+            facebook: 'b',
+            spotify: 'https://open.spotify.com/c',
+          }}
+        />
+      )
+      for (const link of screen.getAllByRole('link')) {
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+      }
+    })
   })
 
-  it('renders Instagram link from handle', () => {
-    render(<SocialLinks social={{ instagram: 'bandname' }} />)
-    const link = screen.getByTitle('Instagram')
-    expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
+  describe('URL normalization', () => {
+    it('normalizes partial URL with domain but no protocol', () => {
+      render(<SocialLinks social={{ website: 'example.com/page' }} />)
+      const link = screen.getByRole('link', { name: 'Website' })
+      expect(link).toHaveAttribute('href', 'https://example.com/page')
+    })
+
+    it('passes a website value with no protocol through the fallback https prefix', () => {
+      // The `website` row has `baseUrl: null`, so a bare token without a
+      // protocol falls through to the final `https://` prefix branch.
+      render(<SocialLinks social={{ website: 'example.com' }} />)
+      const link = screen.getByRole('link', { name: 'Website' })
+      expect(link).toHaveAttribute('href', 'https://example.com')
+    })
   })
 
-  it('renders Instagram link from handle with @ prefix', () => {
-    render(<SocialLinks social={{ instagram: '@bandname' }} />)
-    const link = screen.getByTitle('Instagram')
-    expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
-  })
+  describe('layout / styling', () => {
+    it('applies custom className', () => {
+      const { container } = render(
+        <SocialLinks
+          social={{ website: 'https://example.com' }}
+          className="mt-4"
+        />
+      )
+      expect(container.firstChild).toHaveClass('mt-4')
+    })
 
-  it('renders Instagram link from full URL', () => {
-    render(<SocialLinks social={{ instagram: 'https://instagram.com/bandname' }} />)
-    const link = screen.getByTitle('Instagram')
-    expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
-  })
+    it('renders an icon (Lucide or custom SVG) inside each link', () => {
+      render(<SocialLinks social={{ instagram: 'band', spotify: 'sp' }} />)
 
-  it('renders Facebook link from handle', () => {
-    render(<SocialLinks social={{ facebook: 'bandpage' }} />)
-    const link = screen.getByTitle('Facebook')
-    expect(link).toHaveAttribute('href', 'https://facebook.com/bandpage')
-  })
-
-  it('renders Twitter link from handle', () => {
-    render(<SocialLinks social={{ twitter: 'bandname' }} />)
-    const link = screen.getByTitle('Twitter/X')
-    expect(link).toHaveAttribute('href', 'https://twitter.com/bandname')
-  })
-
-  it('renders YouTube link from handle', () => {
-    render(<SocialLinks social={{ youtube: 'channel123' }} />)
-    const link = screen.getByTitle('YouTube')
-    expect(link).toHaveAttribute('href', 'https://youtube.com/channel123')
-  })
-
-  it('renders Spotify link from handle', () => {
-    render(<SocialLinks social={{ spotify: 'artist/123' }} />)
-    const link = screen.getByTitle('Spotify')
-    expect(link).toHaveAttribute('href', 'https://open.spotify.com/artist/123')
-  })
-
-  it('renders Bandcamp link from full URL', () => {
-    render(<SocialLinks social={{ bandcamp: 'https://band.bandcamp.com' }} />)
-    const link = screen.getByTitle('Bandcamp')
-    expect(link).toHaveAttribute('href', 'https://band.bandcamp.com')
-  })
-
-  it('renders SoundCloud link from handle', () => {
-    render(<SocialLinks social={{ soundcloud: 'bandname' }} />)
-    const link = screen.getByTitle('SoundCloud')
-    expect(link).toHaveAttribute('href', 'https://soundcloud.com/bandname')
-  })
-
-  it('renders multiple social links when multiple are present', () => {
-    render(
-      <SocialLinks
-        social={{
-          instagram: 'band',
-          spotify: 'https://open.spotify.com/artist/abc',
-          website: 'https://band.com',
-        }}
-      />
-    )
-    expect(screen.getByTitle('Instagram')).toBeInTheDocument()
-    expect(screen.getByTitle('Spotify')).toBeInTheDocument()
-    expect(screen.getByTitle('Website')).toBeInTheDocument()
-  })
-
-  it('only renders links for non-null social fields', () => {
-    render(
-      <SocialLinks
-        social={{
-          instagram: 'band',
-          facebook: null,
-          twitter: null,
-        }}
-      />
-    )
-    expect(screen.getByTitle('Instagram')).toBeInTheDocument()
-    expect(screen.queryByTitle('Facebook')).not.toBeInTheDocument()
-    expect(screen.queryByTitle('Twitter/X')).not.toBeInTheDocument()
-  })
-
-  it('renders screen reader labels for each link', () => {
-    render(
-      <SocialLinks
-        social={{
-          instagram: 'band',
-          youtube: 'channel',
-        }}
-      />
-    )
-    expect(screen.getByText('Instagram')).toBeInTheDocument()
-    expect(screen.getByText('YouTube')).toBeInTheDocument()
-  })
-
-  it('applies custom className', () => {
-    const { container } = render(
-      <SocialLinks social={{ website: 'https://example.com' }} className="mt-4" />
-    )
-    expect(container.firstChild).toHaveClass('mt-4')
-  })
-
-  it('normalizes partial URL with domain but no protocol', () => {
-    render(<SocialLinks social={{ website: 'example.com/page' }} />)
-    const link = screen.getByTitle('Website')
-    expect(link).toHaveAttribute('href', 'https://example.com/page')
+      for (const link of screen.getAllByRole('link')) {
+        const icon = link.querySelector('svg')
+        expect(icon).toBeInTheDocument()
+        // Icons are aria-hidden so the sr-only label is the sole
+        // accessible name.
+        expect(icon).toHaveAttribute('aria-hidden', 'true')
+      }
+    })
   })
 })

--- a/frontend/components/shared/SubmissionSuccessDialog.test.tsx
+++ b/frontend/components/shared/SubmissionSuccessDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SubmissionSuccessDialog } from './SubmissionSuccessDialog'
 
@@ -46,5 +46,91 @@ describe('SubmissionSuccessDialog', () => {
   it('renders a dialog element', () => {
     render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
     expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  // Focus-management + dismissal coverage (PSY-862): the dialog wraps Radix
+  // Dialog primitives, so it inherits the focus-trap + escape-to-close
+  // contract. Locking these behaviours into the test ensures that a future
+  // primitive swap or wrapping change can't silently regress a11y.
+
+  it('moves focus inside the dialog on open', async () => {
+    render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
+
+    const dialog = await screen.findByRole('dialog')
+    // Radix focuses the first focusable element (or the dialog itself) on
+    // open. Either lands inside the dialog tree — we just need to assert
+    // that focus did NOT remain on document.body.
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    })
+    expect(document.activeElement).not.toBe(document.body)
+  })
+
+  it('closes via onOpenChange(false) when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    render(<SubmissionSuccessDialog open={true} onOpenChange={onOpenChange} />)
+
+    // Dialog must be mounted before Escape can reach it.
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    // Radix Dialog forwards Escape to the controlled onOpenChange; the
+    // parent (test) is responsible for actually unmounting the content by
+    // re-rendering with open={false}. Assert the contract (callback fires
+    // with false) rather than the post-unmount state.
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('unmounts content when the parent re-renders with open=false', () => {
+    const { rerender } = render(
+      <SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    rerender(<SubmissionSuccessDialog open={false} onOpenChange={vi.fn()} />)
+
+    // After the parent flips open→false the Radix portal teardown removes
+    // the dialog from the DOM. (Smoke test for the controlled-open
+    // contract — guards against a regression where the dialog stops
+    // honouring its open prop and "sticks" open.)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens when the parent re-renders open=false→true', async () => {
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <SubmissionSuccessDialog open={false} onOpenChange={onOpenChange} />
+    )
+
+    // No dialog mounted yet.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    rerender(<SubmissionSuccessDialog open={true} onOpenChange={onOpenChange} />)
+
+    // Mounting an open Radix dialog is async (portal + focus sequencing).
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Private Show Added')).toBeInTheDocument()
+  })
+
+  it('"Got it" button has the leading success icon (Lucide check variant)', () => {
+    render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
+
+    // The button's success affordance is a Lucide check-style icon paired
+    // with the "Got it" label. The exact class name has churned across
+    // Lucide major versions (`lucide-check-circle-2` → `lucide-circle-check`
+    // → `lucide-circle-check-big`), so match the family rather than the
+    // exact class. Asserting the icon presence keeps the success-action
+    // affordance from being silently demoted (e.g. dropping the icon and
+    // shipping a text-only button).
+    const button = screen.getByRole('button', { name: /Got it/ })
+    const checkIcon = button.querySelector(
+      'svg[class*="lucide-check"], svg[class*="lucide-circle-check"]'
+    )
+    expect(checkIcon).toBeInTheDocument()
   })
 })

--- a/frontend/components/shared/TagPill.test.tsx
+++ b/frontend/components/shared/TagPill.test.tsx
@@ -3,68 +3,184 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TagPill } from './TagPill'
 
+// The pill renders either as a <Link> (when `href` is provided) or a
+// <button type="button">. The two branches must be functionally exclusive:
+// providing `href` should NEVER emit a button, providing onClick + no href
+// should NEVER emit an anchor. Asserting both directions catches a refactor
+// that picks the wrong branch for the wrong props.
+
 describe('TagPill', () => {
-  it('renders label text', () => {
-    render(<TagPill label="post-punk" />)
-    expect(screen.getByText('post-punk')).toBeInTheDocument()
+  describe('label rendering', () => {
+    it('renders label text', () => {
+      render(<TagPill label="post-punk" />)
+      expect(screen.getByText('post-punk')).toBeInTheDocument()
+    })
+
+    it('renders label as the accessible name on the button branch', () => {
+      render(<TagPill label="shoegaze" />)
+      // The single observable contract that "the pill works as a clickable
+      // affordance" is that its role + accessible name resolve.
+      expect(
+        screen.getByRole('button', { name: 'shoegaze' })
+      ).toBeInTheDocument()
+    })
+
+    it('renders label as the accessible name on the link branch', () => {
+      render(<TagPill label="shoegaze" href="/shows?tag=shoegaze" />)
+      expect(
+        screen.getByRole('link', { name: 'shoegaze' })
+      ).toBeInTheDocument()
+    })
   })
 
-  it('renders as a button when no href is provided', () => {
-    render(<TagPill label="shoegaze" />)
-    expect(screen.getByRole('button')).toBeInTheDocument()
+  describe('href branch (link)', () => {
+    it('renders as a link when href is provided', () => {
+      render(<TagPill label="shoegaze" href="/shows?tag=shoegaze" />)
+      const link = screen.getByRole('link', { name: 'shoegaze' })
+      expect(link).toHaveAttribute('href', '/shows?tag=shoegaze')
+    })
+
+    it('does NOT render a button when href is provided', () => {
+      // The two branches are exclusive. If a future refactor renders both
+      // a wrapping <a> AND a <button>, Playwright strict-mode lookups
+      // (CLAUDE.md "One link per entity card") would break.
+      render(<TagPill label="post-punk" href="/tag/post-punk" />)
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('forwards a relative href as-is', () => {
+      render(<TagPill label="ambient" href="/tag/ambient" />)
+      expect(
+        screen.getByRole('link', { name: 'ambient' })
+      ).toHaveAttribute('href', '/tag/ambient')
+    })
+
+    it('forwards a query-string-shaped href as-is', () => {
+      render(<TagPill label="noise" href="/shows?tag=noise&year=2024" />)
+      expect(
+        screen.getByRole('link', { name: 'noise' })
+      ).toHaveAttribute('href', '/shows?tag=noise&year=2024')
+    })
   })
 
-  it('renders as a link when href is provided', () => {
-    render(<TagPill label="shoegaze" href="/shows?tag=shoegaze" />)
-    const link = screen.getByRole('link')
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', '/shows?tag=shoegaze')
+  describe('button branch (onClick)', () => {
+    it('renders as a button when no href is provided', () => {
+      render(<TagPill label="shoegaze" />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('does NOT render a link when no href is provided', () => {
+      render(<TagPill label="shoegaze" onClick={vi.fn()} />)
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    })
+
+    it('button has type="button" attribute (form-submit guard)', () => {
+      render(<TagPill label="ambient" />)
+      // Default <button> in a form is type="submit"; this would
+      // accidentally submit any wrapping form. Explicit type="button" is
+      // load-bearing.
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+    })
+
+    it('calls onClick handler exactly once per click', async () => {
+      const user = userEvent.setup()
+      const onClick = vi.fn()
+      render(<TagPill label="shoegaze" onClick={onClick} />)
+
+      await user.click(screen.getByRole('button', { name: 'shoegaze' }))
+      expect(onClick).toHaveBeenCalledOnce()
+    })
+
+    it('does not fire onClick when href is present (link branch ignores onClick)', async () => {
+      const user = userEvent.setup()
+      const onClick = vi.fn()
+      render(
+        <TagPill label="shoegaze" href="/shows?tag=shoegaze" onClick={onClick} />
+      )
+
+      await user.click(screen.getByRole('link', { name: 'shoegaze' }))
+      // The link branch does not bind onClick at all (see source) — this
+      // locks that behaviour in so a refactor that adds onClick to the
+      // link path doesn't silently double-fire.
+      expect(onClick).not.toHaveBeenCalled()
+    })
   })
 
-  it('displays positive vote count with + prefix', () => {
-    render(<TagPill label="post-punk" voteCount={12} />)
-    expect(screen.getByText('+12')).toBeInTheDocument()
+  describe('vote count', () => {
+    it('displays positive vote count with + prefix', () => {
+      render(<TagPill label="post-punk" voteCount={12} />)
+      expect(screen.getByText('+12')).toBeInTheDocument()
+    })
+
+    it('displays zero vote count with + prefix', () => {
+      render(<TagPill label="post-punk" voteCount={0} />)
+      // 0 reads as "+0" rather than "0" or "-0" — the source treats
+      // zero as a non-negative for prefix purposes.
+      expect(screen.getByText('+0')).toBeInTheDocument()
+    })
+
+    it('displays negative vote count without + prefix (uses native -)', () => {
+      render(<TagPill label="post-punk" voteCount={-3} />)
+      expect(screen.getByText('-3')).toBeInTheDocument()
+    })
+
+    it('does not display vote count when undefined', () => {
+      render(<TagPill label="post-punk" />)
+      // Asserts the explicit unset state — undefined should suppress the
+      // counter entirely (no "+undefined" or "+null").
+      expect(screen.queryByText(/^[+-]/)).not.toBeInTheDocument()
+    })
+
+    it('renders both label and vote count together in a link', () => {
+      render(
+        <TagPill label="noise-rock" voteCount={7} href="/tag/noise-rock" />
+      )
+      const link = screen.getByRole('link')
+      expect(link).toHaveTextContent('noise-rock')
+      expect(link).toHaveTextContent('+7')
+    })
+
+    it('renders both label and vote count together in a button', () => {
+      render(<TagPill label="noise-rock" voteCount={7} onClick={vi.fn()} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveTextContent('noise-rock')
+      expect(button).toHaveTextContent('+7')
+    })
   })
 
-  it('displays zero vote count with + prefix', () => {
-    render(<TagPill label="post-punk" voteCount={0} />)
-    expect(screen.getByText('+0')).toBeInTheDocument()
-  })
+  describe('styling', () => {
+    it('applies custom className to the button branch', () => {
+      render(<TagPill label="jazz" className="mt-2" />)
+      const button = screen.getByRole('button')
+      expect(button.className).toContain('mt-2')
+    })
 
-  it('displays negative vote count without + prefix', () => {
-    render(<TagPill label="post-punk" voteCount={-3} />)
-    expect(screen.getByText('-3')).toBeInTheDocument()
-  })
+    it('applies custom className to the link branch', () => {
+      render(<TagPill label="jazz" href="/tag/jazz" className="mt-2" />)
+      const link = screen.getByRole('link')
+      expect(link.className).toContain('mt-2')
+    })
 
-  it('does not display vote count when undefined', () => {
-    render(<TagPill label="post-punk" />)
-    expect(screen.queryByText(/\+/)).not.toBeInTheDocument()
-  })
+    it('shares pill chrome classes between both branches', () => {
+      // Both branches share the same `pillClasses` constant — the visual
+      // shape must not diverge between Link and button. Picks a few
+      // load-bearing classes from `cn(...)` to lock the shared chrome.
+      const { rerender } = render(<TagPill label="x" />)
+      const buttonClasses = screen.getByRole('button').className
 
-  it('calls onClick handler when button is clicked', async () => {
-    const user = userEvent.setup()
-    const onClick = vi.fn()
-    render(<TagPill label="shoegaze" onClick={onClick} />)
+      rerender(<TagPill label="x" href="/x" />)
+      const linkClasses = screen.getByRole('link').className
 
-    await user.click(screen.getByRole('button'))
-    expect(onClick).toHaveBeenCalledOnce()
-  })
-
-  it('applies custom className', () => {
-    render(<TagPill label="jazz" className="mt-2" />)
-    const button = screen.getByRole('button')
-    expect(button.className).toContain('mt-2')
-  })
-
-  it('renders both label and vote count together in a link', () => {
-    render(<TagPill label="noise-rock" voteCount={7} href="/tag/noise-rock" />)
-    const link = screen.getByRole('link')
-    expect(link).toHaveTextContent('noise-rock')
-    expect(link).toHaveTextContent('+7')
-  })
-
-  it('button has type="button" attribute', () => {
-    render(<TagPill label="ambient" />)
-    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+      for (const cls of [
+        'inline-flex',
+        'rounded-md',
+        'bg-muted',
+        'text-muted-foreground',
+        'border-border/50',
+      ]) {
+        expect(buttonClasses).toContain(cls)
+        expect(linkClasses).toContain(cls)
+      }
+    })
   })
 })

--- a/frontend/components/shared/UserAttribution.test.tsx
+++ b/frontend/components/shared/UserAttribution.test.tsx
@@ -134,4 +134,65 @@ describe('UserAttribution', () => {
     expect(screen.queryByText(/User #/)).not.toBeInTheDocument()
     expect(screen.queryByText(/user #/)).not.toBeInTheDocument()
   })
+
+  // Canonical resolver-chain mirror tests (PSY-862). The backend's
+  // `ResolveUserName` (services/shared/user_resolver.go) walks
+  // `username → first+last → email-prefix → "Anonymous"` and emits a
+  // single `name` string + nil-or-set `username` for linkability. The
+  // primitive's branch logic must render correctly for each shape the
+  // backend can produce. See pattern_user_attribution.md.
+
+  describe('canonical resolver-chain shapes', () => {
+    it('tier 1 (username present): renders as a /users/{username} link', () => {
+      // Backend: name=resolved-from-username, username=set.
+      render(<UserAttribution name="moonchild" username="moonchild" />)
+
+      const link = screen.getByRole('link', { name: 'moonchild' })
+      expect(link).toHaveAttribute('href', '/users/moonchild')
+    })
+
+    it('tier 2 (first+last name, no username): renders plain text only', () => {
+      // Backend: user with no username slug; resolver fell to first+last.
+      // No public profile to link to → username should be nil → text only.
+      render(<UserAttribution name="Jane Doe" username={null} />)
+
+      expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    })
+
+    it('tier 3 (email-prefix fallback): renders plain text only', () => {
+      // Backend: account with only an email; resolver derives display name
+      // from the prefix (`alice@example.com` → `alice`). Still no
+      // username, still plain text.
+      render(<UserAttribution name="alice" username={null} />)
+
+      expect(screen.getByText('alice')).toBeInTheDocument()
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    })
+
+    it('tier 4 (terminal "Anonymous"): renders the fallback as plain text', () => {
+      // Backend: deleted / system-attributed row. Both name and username
+      // missing → primitive emits the configured fallback.
+      render(<UserAttribution name={null} username={null} />)
+
+      expect(screen.getByText('Anonymous')).toBeInTheDocument()
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    })
+
+    it('no-email-leak invariant: an email-shaped name still renders as text only when username is nil', () => {
+      // Defensive: if a row sneaks past the backend resolver with an
+      // email-shaped name (PSY-598 audit guard), the primitive must NOT
+      // turn it into a URL slug. The link branch is gated on `username`
+      // alone, so an email-as-name is safe — but lock it in.
+      render(
+        <UserAttribution
+          name="alice@example.com"
+          username={null}
+        />
+      )
+
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Strengthen 5 of 7 named `components/shared/` tests per PSY-713 follow-up scope
- 2 named components (InlineErrorBanner, StatusBanner) already substantive AND the ticket-scope features that would justify adding more (dismiss button, info/warning/error variants) don't exist in those components — documented below, no edits
- Baseline 311 → 342 tests across 23 files (+31)

## Per-component coverage added

- **SubmissionSuccessDialog (+5 tests, 7→12)**: focus moves inside the dialog on open (asserts via `document.activeElement` + `dialog.contains`), Escape fires `onOpenChange(false)` (Radix controlled-open contract), open→false unmounts the portal, false→true re-mounts it, "Got it" button keeps its Lucide check icon (regression guard for accidental text-only refactor).
- **SocialLinks (+6 net tests, 18→24)**: switch every per-platform assertion from `getByTitle` (tooltip-only) to `getByRole('link', { name })` (accessible name via `.sr-only` label). Add empty-string field filtering parity with null, exclusive link-count, source-of-truth platform-order lock-in, `target=_blank` + safe `rel` on every link, icon-present + `aria-hidden` assertion.
- **TagPill (+10 net tests, 11→21)**: switch label assertions to `getByRole` with accessible name on both branches. Add: link branch never emits a button (and vice versa — mutually exclusive), `type="button"` form-submit guard, onClick ignored on link branch so it can never double-fire, href passthrough for relative + query-string shapes, vote-count + label coexisting on both branches, shared pill-chrome classes asserted to not diverge between branches.
- **UserAttribution (+5 tests, 14→19)**: mirror the canonical resolver chain from `pattern_user_attribution.md` with one explicit test per tier — tier 1 (username → `/users/{username}` link), tier 2 (first+last → text only), tier 3 (email-prefix fallback → text only), tier 4 (terminal "Anonymous" → text only). Plus a no-email-leak invariant: an email-shaped name with nil username must NOT be turned into a URL slug.
- **BracketLink (+5 tests, 14→19)**: add link-branch a11y coverage that was only tested on the button branch — accessible name via `label` default, `ariaLabel` override, `title` forwarding, href passthrough for query-string-shaped URLs. Plus an explicit assertion that href + disabled falls back to a real disabled `<button>` (anchors have no native disabled state).

## Components left as-is (documented per ticket scope)

- **InlineErrorBanner (14 tests, unchanged)**: already covers `role="alert"`, both `default` + `queryFallback` variants, className merge, testId forwarding, complex children, default-tone Tailwind class set. The ticket scope's "dismissible behavior (dismiss button fires close callback)" doesn't exist — the component has no dismiss button and takes only `children` + `variant` + `className` + `testId`. Adding a dismiss-button test would require inventing a component feature.
- **StatusBanner (15 tests, unchanged)**: already covers `role="status"` + `aria-live="polite"`, both `success` + `pending` variants with their chrome classes + default icons, icon-override prop (including `icon={null}` suppression), auto-dismiss timer behaviour (visibility + onDismiss callback + unmount cleanup + indefinite-visibility-when-unset). The ticket scope's `info/warning/success/error` variant set doesn't exist — the component only supports `success | pending`. The scope's "dismissible behavior" maps to the auto-dismiss timer, already tested.

## Unnamed `components/shared/*` files reviewed but skipped

No additional unnamed files strengthened — `LoadingSpinner`, `Breadcrumb`, `EntityHeader`, `SectionHeader`, `StatsList`, `DenseTable`, `EntityCardTitle`, `RelationshipBadge`, `MusicEmbed`, `DensityToggle`, `EntityDetailLayout`, `EntityDescription`, and `RevisionHistory` are either already substantive (most have 8-25 tests covering observable behavior + branch logic + a11y) or pure presentational primitives with no interaction surface worth additional coverage (`LoadingSpinner`).

## Test plan

- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run components/shared` — passed (342 tests / 23 files)
- [x] `cd frontend && bun run test:run` (full suite regression check) — passed (5106 tests / 422 files)

## Manual repro

`test:run components/shared` — 342 tests pass across 23 files. Per-component delta:
- BracketLink 14→19 (link-branch a11y + href+disabled fallback)
- SocialLinks 18→24 (accessible-name over title + empty-string + order + icon)
- TagPill 11→21 (branch exclusivity + per-branch a11y + onClick on link branch ignored)
- SubmissionSuccessDialog 7→12 (focus + Escape + controlled-open round-trip + icon)
- UserAttribution 14→19 (per-tier resolver-chain mirror + no-email-leak)
- InlineErrorBanner 14 unchanged (already substantive; component has no dismiss button)
- StatusBanner 15 unchanged (already substantive; component has no info/warning/error variants)

## Code review

`/code-review` ran at max effort across 5 angles + sweep. No defects surfaced; tests use observable assertions, avoid the PSY-859 false-coverage anti-patterns (no `rerender()`-without-`expect()`, no hardcoded historical dates, no test-name/assertion mismatch), and correctly mirror canonical patterns (UserAttribution resolver chain per `pattern_user_attribution.md`, SocialLinks accessible-name from sr-only span, TagPill branch exclusivity, SubmissionSuccessDialog focus pattern matching `dialog.tsx` primitive tests).

Closes PSY-862