### PR TITLE
PSY-717: strengthen layout tests + add providers/theme tests

### DIFF
--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -271,6 +271,171 @@ describe('CommandPalette', () => {
 
     expect(screen.getByPlaceholderText('Search entities or go to page...')).toBeInTheDocument()
   })
+
+  // Avoid false coverage: the previous Cmd+K test only checked the search
+  // input was visible. Pinning the dialog role here ensures the palette
+  // actually OPENED rather than something rendering the input incidentally.
+  it('should open the dialog (role="dialog") on Cmd+K', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CommandPalette />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    await user.keyboard('{Meta>}k{/Meta}')
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('should toggle closed on a second Cmd+K press', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CommandPalette />)
+
+    await user.keyboard('{Meta>}k{/Meta}')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Meta>}k{/Meta}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('clears the search query after closing and reopening', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CommandPalette />)
+
+    // Seed the input
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+    const input = screen.getByPlaceholderText('Search entities or go to page...')
+    await user.type(input, 'shoegaze')
+    expect(input).toHaveValue('shoegaze')
+
+    // Close + reopen — useEffect on `open` resets the query.
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+    const reopened = screen.getByPlaceholderText('Search entities or go to page...')
+    expect(reopened).toHaveValue('')
+  })
+
+  it('shows a Clear button that empties the query without closing the palette', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CommandPalette />)
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+
+    const input = screen.getByPlaceholderText('Search entities or go to page...')
+    await user.type(input, 'doom')
+    expect(input).toHaveValue('doom')
+    // Clear button only appears with a non-empty query
+    const clearButton = screen.getByRole('button', { name: 'Clear search' })
+    await user.click(clearButton)
+    expect(input).toHaveValue('')
+    // Dialog still open after clearing
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('clearing recent searches removes the Recent group from the palette', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CommandPalette />)
+
+    // Open + select to seed a recent search
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+    await user.click(screen.getByText('Shows'))
+
+    // Reopen — Recent group should now exist
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+    expect(screen.getByText('Recent')).toBeInTheDocument()
+
+    // Click the inline "Clear" button on the Recent header. cmdk renders
+    // the heading itself with role="button" whose accessible name includes
+    // child text ("Recent Clear"); the actual <button> is a child element,
+    // so target it by text instead of role.
+    await user.click(screen.getByText('Clear'))
+
+    // Recent group disappears immediately
+    expect(screen.queryByText('Recent')).not.toBeInTheDocument()
+  })
+
+  it('navigates to an entity result when an entity row is clicked', async () => {
+    const user = userEvent.setup()
+    mockEntitySearchResult = {
+      data: {
+        ...emptyEntityData,
+        artists: [
+          {
+            id: 7,
+            slug: 'sunn-o',
+            name: 'Sunn O)))',
+            subtitle: 'Seattle, WA',
+            entityType: 'artist',
+            href: '/artists/sunn-o',
+          },
+        ],
+      },
+      isSearching: false,
+      totalResults: 1,
+      isFetching: false,
+      searchError: false,
+    }
+
+    renderWithProviders(<CommandPalette />)
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+
+    const input = screen.getByPlaceholderText('Search entities or go to page...')
+    await user.type(input, 'sun')
+
+    const row = screen.getByText('Sunn O)))')
+    await user.click(row)
+
+    expect(mockPush).toHaveBeenCalledWith('/artists/sunn-o')
+  })
+
+  it('shows a loading spinner while isSearching is true', async () => {
+    const user = userEvent.setup()
+    mockEntitySearchResult = {
+      data: emptyEntityData,
+      isSearching: true,
+      totalResults: 0,
+      isFetching: true,
+      searchError: false,
+    }
+    renderWithProviders(<CommandPalette />)
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+
+    const input = screen.getByPlaceholderText('Search entities or go to page...')
+    await user.type(input, 'do')
+
+    // Clear button is suppressed while searching; spinner replaces it.
+    expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument()
+  })
 })
 
 describe('CommandPalette — tag row official indicator (PSY-453)', () => {
@@ -332,6 +497,51 @@ describe('CommandPalette — tag row official indicator (PSY-453)', () => {
     const markers = screen.getAllByRole('img', { name: 'Official tag' })
     expect(markers).toHaveLength(1)
     expect(markers[0]).toHaveAttribute('title', 'shoegaze (Official)')
+  })
+})
+
+describe('CommandPalette — contextual Explore graph entries (PSY-366)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockAuthContext.user = null
+    mockAuthContext.isAuthenticated = false
+    mockPathname = '/'
+    mockEntitySearchResult = {
+      data: emptyEntityData,
+      isSearching: false,
+      totalResults: 0,
+      isFetching: false,
+      searchError: false,
+    }
+  })
+
+  it('shows "Explore graph for this artist" on /artists/[slug]', async () => {
+    mockPathname = '/artists/sunn-o'
+    renderWithProviders(<CommandPalette />)
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+
+    expect(screen.getByText('Explore graph for this artist')).toBeInTheDocument()
+  })
+
+  it('does NOT show contextual graph entry on a non-entity page', async () => {
+    // mockPathname stays at '/' from beforeEach.
+    renderWithProviders(<CommandPalette />)
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+
+    expect(screen.queryByText('Explore graph for this artist')).not.toBeInTheDocument()
+    expect(screen.queryByText('Explore graph for this venue')).not.toBeInTheDocument()
+    expect(screen.queryByText('Explore graph for this scene')).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -433,6 +433,8 @@ describe('CommandPalette', () => {
     const input = screen.getByPlaceholderText('Search entities or go to page...')
     await user.type(input, 'do')
 
+    // Loader2 renders with .animate-spin while isSearching is true.
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
     // Clear button is suppressed while searching; spinner replaces it.
     expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument()
   })

--- a/frontend/components/layout/CookieConsentBanner.test.tsx
+++ b/frontend/components/layout/CookieConsentBanner.test.tsx
@@ -204,5 +204,81 @@ describe('CookieConsentBanner', () => {
       const { container } = render(<CookieConsentBanner />)
       expect(container).toBeTruthy()
     })
+
+    it('opens the preferences dialog and shows toggles when preferencesOpen=true', () => {
+      mockUseCookieConsent.mockReturnValue({
+        showBanner: false,
+        gpcSignalDetected: false,
+        acceptAll: mockAcceptAll,
+        rejectAll: mockRejectAll,
+        openPreferences: mockOpenPreferences,
+        closePreferences: mockClosePreferences,
+        savePreferences: mockSavePreferences,
+        preferencesOpen: true,
+        consent: {
+          version: 1,
+          timestamp: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 86400000).toISOString(),
+          gpcDetected: false,
+          categories: { essential: true, analytics: false },
+          consentMethod: 'banner_reject_all' as const,
+        },
+      })
+      render(<CookieConsentBanner />)
+      expect(screen.getByText('Essential Cookies')).toBeInTheDocument()
+      expect(screen.getByText('Analytics Cookies')).toBeInTheDocument()
+    })
+  })
+})
+
+// Verify the banner's context handlers are wired so each visible button
+// invokes the matching context method ONCE per click (catches accidental
+// double-binding regressions). Persistence + GPC detection live in the
+// CookieConsentContext unit tests; here we pin the component's contract
+// against the hook surface it consumes.
+describe('CookieConsentBanner — handler wiring contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCookieConsent.mockReturnValue({
+      showBanner: true,
+      gpcSignalDetected: false,
+      acceptAll: mockAcceptAll,
+      rejectAll: mockRejectAll,
+      openPreferences: mockOpenPreferences,
+      closePreferences: mockClosePreferences,
+      savePreferences: mockSavePreferences,
+      preferencesOpen: false,
+      consent: null,
+    })
+  })
+
+  it('Accept All click does NOT also call rejectAll or openPreferences', async () => {
+    const user = userEvent.setup()
+    render(<CookieConsentBanner />)
+    await user.click(screen.getByText('Accept All'))
+
+    expect(mockAcceptAll).toHaveBeenCalledOnce()
+    expect(mockRejectAll).not.toHaveBeenCalled()
+    expect(mockOpenPreferences).not.toHaveBeenCalled()
+  })
+
+  it('Reject All click does NOT also call acceptAll or openPreferences', async () => {
+    const user = userEvent.setup()
+    render(<CookieConsentBanner />)
+    await user.click(screen.getByText('Reject All'))
+
+    expect(mockRejectAll).toHaveBeenCalledOnce()
+    expect(mockAcceptAll).not.toHaveBeenCalled()
+    expect(mockOpenPreferences).not.toHaveBeenCalled()
+  })
+
+  it('Customize click does NOT also call accept or reject', async () => {
+    const user = userEvent.setup()
+    render(<CookieConsentBanner />)
+    await user.click(screen.getByText('Customize'))
+
+    expect(mockOpenPreferences).toHaveBeenCalledOnce()
+    expect(mockAcceptAll).not.toHaveBeenCalled()
+    expect(mockRejectAll).not.toHaveBeenCalled()
   })
 })

--- a/frontend/components/layout/CookiePreferencesDialog.test.tsx
+++ b/frontend/components/layout/CookiePreferencesDialog.test.tsx
@@ -268,4 +268,66 @@ describe('CookiePreferencesDialog', () => {
     // should reset the internal state
     expect(screen.getByLabelText('Analytics cookies')).toHaveAttribute('data-state', 'checked')
   })
+
+  // Cancel must NOT also persist preferences — earlier regressions sometimes
+  // bound Save to both buttons by accident.
+  it('Cancel does NOT call onSave', async () => {
+    const user = userEvent.setup()
+    render(
+      <CookiePreferencesDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        gpcSignalDetected={false}
+        currentAnalytics={false}
+        onSave={onSave}
+      />
+    )
+
+    // Toggle to a non-default state to make sure save would HAVE changed something.
+    await user.click(screen.getByLabelText('Analytics cookies'))
+    await user.click(screen.getByText('Cancel'))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  // Save with currentAnalytics=true (the user already has consent) and no
+  // toggle change must persist `true` — this is the "no-op" save path that
+  // a regression could swap to `false`.
+  it('Save without toggling persists current value (true → true)', async () => {
+    const user = userEvent.setup()
+    render(
+      <CookiePreferencesDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        gpcSignalDetected={false}
+        currentAnalytics={true}
+        onSave={onSave}
+      />
+    )
+
+    await user.click(screen.getByText('Save Preferences'))
+    expect(onSave).toHaveBeenCalledWith(true)
+  })
+
+  it('Essential Cookies toggle stays disabled even after analytics interaction', async () => {
+    const user = userEvent.setup()
+    render(
+      <CookiePreferencesDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        gpcSignalDetected={false}
+        currentAnalytics={false}
+        onSave={onSave}
+      />
+    )
+
+    const essentialSwitch = screen.getByLabelText('Essential cookies (always enabled)')
+    expect(essentialSwitch).toBeDisabled()
+
+    // Click analytics — must not unlock essential.
+    await user.click(screen.getByLabelText('Analytics cookies'))
+    expect(essentialSwitch).toBeDisabled()
+    expect(essentialSwitch).toHaveAttribute('data-state', 'checked')
+  })
 })

--- a/frontend/components/layout/Footer.test.tsx
+++ b/frontend/components/layout/Footer.test.tsx
@@ -92,4 +92,46 @@ describe('Footer', () => {
     expect(links?.length).toBe(3)
     expect(buttons?.length).toBe(1)
   })
+
+  it('Cookie Preferences button click fires openPreferences exactly once and does not navigate', async () => {
+    const user = userEvent.setup()
+    render(<Footer />)
+
+    await user.click(screen.getByText('Cookie Preferences'))
+    expect(mockOpenPreferences).toHaveBeenCalledOnce()
+
+    // Double-click should fire twice (sanity check the binding is direct,
+    // not throttled, since the cookie dialog needs to remount cleanly).
+    await user.click(screen.getByText('Cookie Preferences'))
+    expect(mockOpenPreferences).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the same href for Privacy and Cookie Preferences contexts (privacy page)', () => {
+    render(<Footer />)
+    // Privacy link is the long-form policy page; the cookie preferences
+    // dialog is a separate trigger. Pin that they're independent UX paths.
+    const privacy = screen.getByText('Privacy Policy').closest('a')!
+    const cookie = screen.getByText('Cookie Preferences')
+    expect(privacy.getAttribute('href')).toBe('/privacy')
+    expect(cookie.tagName).toBe('BUTTON') // NOT a link to /privacy
+  })
+
+  it('keeps Privacy Policy and Terms of Service links in tab order before Contact', () => {
+    render(<Footer />)
+    const nav = document.querySelector('nav')!
+    const linkTexts = Array.from(nav.querySelectorAll('a')).map(a => a.textContent)
+    // The legal pair must come first so screen-reader / keyboard users hit
+    // them before the mailto. If a future refactor reorders these silently,
+    // this catches it.
+    expect(linkTexts).toEqual(['Privacy Policy', 'Terms of Service', 'Contact'])
+  })
+
+  it('renders the year reactively (does not regress if NaN/zero)', () => {
+    render(<Footer />)
+    const currentYear = new Date().getFullYear()
+    // Catches a bug where the year is computed once at module load and
+    // mistakenly cached as `0` or `NaN`.
+    expect(currentYear).toBeGreaterThan(2020)
+    expect(screen.getByText(new RegExp(`${currentYear}.*Psychic Homily`))).toBeInTheDocument()
+  })
 })

--- a/frontend/components/layout/Footer.test.tsx
+++ b/frontend/components/layout/Footer.test.tsx
@@ -126,12 +126,14 @@ describe('Footer', () => {
     expect(linkTexts).toEqual(['Privacy Policy', 'Terms of Service', 'Contact'])
   })
 
-  it('renders the year reactively (does not regress if NaN/zero)', () => {
+  it('renders the year as a 4-digit number, not NaN or 0', () => {
     render(<Footer />)
-    const currentYear = new Date().getFullYear()
-    // Catches a bug where the year is computed once at module load and
-    // mistakenly cached as `0` or `NaN`.
-    expect(currentYear).toBeGreaterThan(2020)
-    expect(screen.getByText(new RegExp(`${currentYear}.*Psychic Homily`))).toBeInTheDocument()
+    const text = screen.getByText(/Psychic Homily/).textContent ?? ''
+    // Pin the format: 4-digit year, NOT "NaN" or "0" (defensive against
+    // a regression that pre-computes the year at module load with a
+    // broken Date constructor).
+    expect(text).toMatch(/©\s+\d{4}\s+Psychic Homily/)
+    expect(text).not.toMatch(/NaN/)
+    expect(text).not.toMatch(/©\s+0\s+/)
   })
 })

--- a/frontend/components/layout/PostHogProvider.test.tsx
+++ b/frontend/components/layout/PostHogProvider.test.tsx
@@ -33,7 +33,14 @@ vi.mock('@/lib/context/CookieConsentContext', () => ({
   useCookieConsent: () => mockUseCookieConsent(),
 }))
 
-const mockUseAuthContext = vi.fn(() => ({
+// Widen the user type so individual tests can swap in a real user
+// without TS narrowing from the default-null literal (same pattern as
+// Sidebar / TopBar test files).
+type MockAuthContextValue = {
+  user: { id: string; email: string; is_admin?: boolean } | null
+  isAuthenticated: boolean
+}
+const mockUseAuthContext = vi.fn<() => MockAuthContextValue>(() => ({
   user: null,
   isAuthenticated: false,
 }))
@@ -105,5 +112,167 @@ describe('PostHogProvider — consent sync', () => {
   it('still initializes PostHog on mount regardless of consent', () => {
     render(<PostHogProvider>child</PostHogProvider>)
     expect(mockInitPostHog).toHaveBeenCalledTimes(1)
+  })
+})
+
+// PSY-728 reference: the prev-consent comparison must read PostHog's own
+// persisted state (`posthog.has_opted_in_capturing()`) — NOT a per-mount
+// ref that would flip every page load and re-fire opt-in / session
+// recording for users already opted in. The tests above pin the post-fix
+// behavior. This block adds explicit transition tests (granted → withdrawn,
+// withdrawn → granted) within a single mounted instance, which the
+// original ref-based code mishandled.
+describe('PostHogProvider — consent transition within a single mount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    mockUseAuthContext.mockReturnValue({ user: null, isAuthenticated: false })
+  })
+
+  it('granted → withdrawn (re-render) triggers exactly one opt-out call', () => {
+    // Start opted in (mocked PostHog state agrees with consent).
+    mockHasOptedInCapturing.mockReturnValue(true)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    const { rerender } = render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptOutPostHog).not.toHaveBeenCalled()
+
+    // User withdraws consent. After the user clicked "Reject all",
+    // PostHog's persisted state is still opted in until we opt out.
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    rerender(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptOutPostHog).toHaveBeenCalledTimes(1)
+    expect(mockOptInPostHog).not.toHaveBeenCalled()
+  })
+
+  it('withdrawn → granted (re-render) triggers exactly one opt-in call', () => {
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    const { rerender } = render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptInPostHog).not.toHaveBeenCalled()
+
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    rerender(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptInPostHog).toHaveBeenCalledTimes(1)
+    expect(mockOptOutPostHog).not.toHaveBeenCalled()
+  })
+})
+
+// User identification side-effect: PostHog should identify on auth, reset
+// on logout, and do nothing while consent is withheld. Distinct from
+// opt-in/out wiring since identify() and reset() are independent calls.
+describe('PostHogProvider — user identification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    mockUseAuthContext.mockReturnValue({ user: null, isAuthenticated: false })
+  })
+
+  it('identifies the user when authenticated AND consent granted', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    mockUseAuthContext.mockReturnValue({
+      user: { id: 'u-123', email: 'fan@test.com', is_admin: false },
+      isAuthenticated: true,
+    })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockIdentify).toHaveBeenCalledWith('u-123', {
+      email: 'fan@test.com',
+      is_admin: false,
+    })
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it('resets PostHog when consent granted but user is logged out', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    mockUseAuthContext.mockReturnValue({ user: null, isAuthenticated: false })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockReset).toHaveBeenCalledTimes(1)
+    expect(mockIdentify).not.toHaveBeenCalled()
+  })
+
+  it('does NOT identify or reset when consent is withheld', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    mockUseAuthContext.mockReturnValue({
+      user: { id: 'u-123', email: 'fan@test.com', is_admin: false },
+      isAuthenticated: true,
+    })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockIdentify).not.toHaveBeenCalled()
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+})
+
+// Children render through unchanged — provider must never block its
+// subtree on consent state, network state, or anything else.
+describe('PostHogProvider — children render', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    mockUseAuthContext.mockReturnValue({ user: null, isAuthenticated: false })
+  })
+
+  it('renders children when consent loaded + analytics off', () => {
+    const { getByText } = render(
+      <PostHogProvider>
+        <div>child-content</div>
+      </PostHogProvider>
+    )
+    expect(getByText('child-content')).toBeInTheDocument()
+  })
+
+  it('renders children when consent loaded + analytics on', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    const { getByText } = render(
+      <PostHogProvider>
+        <div>child-content</div>
+      </PostHogProvider>
+    )
+    expect(getByText('child-content')).toBeInTheDocument()
+  })
+
+  it('renders children while consent context is still loading', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: false })
+    const { getByText } = render(
+      <PostHogProvider>
+        <div>child-content</div>
+      </PostHogProvider>
+    )
+    expect(getByText('child-content')).toBeInTheDocument()
+  })
+})
+
+// Pageview capture: the inner PostHogPageView component should call
+// posthog.capture('$pageview', …) ONLY when canUseAnalytics is true.
+describe('PostHogProvider — pageview capture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseAuthContext.mockReturnValue({ user: null, isAuthenticated: false })
+  })
+
+  it('captures $pageview when consent granted', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockCapture).toHaveBeenCalled()
+    const pageviewCall = mockCapture.mock.calls.find(c => c[0] === '$pageview')
+    expect(pageviewCall).toBeDefined()
+  })
+
+  it('does NOT capture $pageview when consent withheld', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    const pageviewCall = mockCapture.mock.calls.find(c => c[0] === '$pageview')
+    expect(pageviewCall).toBeUndefined()
   })
 })

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -201,4 +201,74 @@ describe('Sidebar', () => {
     const link = screen.getByText('Shows').closest('a')!
     expect(link).not.toHaveAttribute('target')
   })
+
+  // Active state: the current route should get the active class; siblings
+  // should NOT. Catches regressions where every link styles as active.
+  // We match on the exact active token (with surrounding whitespace) to
+  // avoid colliding with hover utility `bg-sidebar-accent/50`.
+  const ACTIVE_TOKEN = 'bg-sidebar-accent text-sidebar-accent-foreground'
+
+  it('marks the current route as active when pathname matches exactly', () => {
+    mockPathname.mockReturnValue('/shows')
+    render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    const showsLink = screen.getByText('Shows').closest('a')!
+    expect(showsLink.className).toContain(ACTIVE_TOKEN)
+    expect(showsLink.className).not.toContain('text-sidebar-foreground/70')
+  })
+
+  it('does NOT mark sibling routes as active', () => {
+    mockPathname.mockReturnValue('/shows')
+    render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    const venuesLink = screen.getByText('Venues').closest('a')!
+    expect(venuesLink.className).toContain('text-sidebar-foreground/70')
+    expect(venuesLink.className).not.toContain(ACTIVE_TOKEN)
+  })
+
+  it('marks a route active for sub-paths (pathname.startsWith(href + "/"))', () => {
+    mockPathname.mockReturnValue('/artists/sunn-o')
+    render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    const artistsLink = screen.getByText('Artists').closest('a')!
+    expect(artistsLink.className).toContain(ACTIVE_TOKEN)
+  })
+
+  it('does NOT mark external links as active even on a matching pathname', () => {
+    mockPathname.mockReturnValue('https://psychichomily.substack.com/')
+    render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    const substack = screen.getByText('Substack').closest('a')!
+    // External items are never treated as "active" so the highlight follows
+    // in-app navigation only.
+    expect(substack.className).not.toContain(ACTIVE_TOKEN)
+  })
+
+  // Collapsible behavior: the collapse button is the canonical way to flip
+  // state. The label flip (Collapse → expand) drives the existing tests; add
+  // explicit aria-label on each branch.
+  it('collapse button toggles aria-label between collapsed/expanded states', () => {
+    const { rerender } = render(
+      <Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />
+    )
+    expect(screen.getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
+
+    rerender(<Sidebar collapsed={true} onToggleCollapse={onToggleCollapse} />)
+    expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
+  })
+
+  it('collapsed mode keeps nav links present (icons-only) — labels hidden', () => {
+    mockPathname.mockReturnValue('/shows')
+    render(<Sidebar collapsed={true} onToggleCollapse={onToggleCollapse} />)
+    // The label "Shows" should NOT render in collapsed mode...
+    expect(screen.queryByText('Shows')).not.toBeInTheDocument()
+    // ...but the underlying nav still has the /shows link element so
+    // tooltips (rendered on hover) and clickable icons still work.
+    const links = document.querySelectorAll('a')
+    const showsLink = Array.from(links).find(a => a.getAttribute('href') === '/shows')
+    expect(showsLink).toBeTruthy()
+  })
+
+  it('collapse button calls onToggleCollapse exactly once per click', async () => {
+    const user = userEvent.setup()
+    render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }))
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1)
+  })
 })

--- a/frontend/components/layout/SidebarLayout.test.tsx
+++ b/frontend/components/layout/SidebarLayout.test.tsx
@@ -158,6 +158,9 @@ describe('SidebarLayout', () => {
     const user = userEvent.setup()
 
     // Re-mock TopBar so onSearchClick is exposed as a button we can click.
+    // Use try/finally so a failed assertion doesn't leak the doMock to
+    // sibling tests in the same vitest worker (the file-level vi.mock would
+    // otherwise stay overridden for any future dynamic import of TopBar).
     vi.doMock('./TopBar', () => ({
       TopBar: ({ onSearchClick }: { onSearchClick?: () => void }) => (
         <button data-testid="topbar-search" onClick={onSearchClick}>
@@ -165,24 +168,26 @@ describe('SidebarLayout', () => {
         </button>
       ),
     }))
-    vi.resetModules()
-    const { SidebarLayout: FreshLayout } = await import('./SidebarLayout')
+    try {
+      vi.resetModules()
+      const { SidebarLayout: FreshLayout } = await import('./SidebarLayout')
 
-    render(
-      <FreshLayout>
-        <div>content</div>
-      </FreshLayout>
-    )
+      render(
+        <FreshLayout>
+          <div>content</div>
+        </FreshLayout>
+      )
 
-    await user.click(screen.getByTestId('topbar-search'))
+      await user.click(screen.getByTestId('topbar-search'))
 
-    // openCommandPalette() dispatches a custom event named "open-command-palette"
-    const event = dispatchSpy.mock.calls.find(
-      call => call[0] instanceof Event && (call[0] as Event).type === 'open-command-palette'
-    )
-    expect(event).toBeDefined()
-
-    dispatchSpy.mockRestore()
-    vi.doUnmock('./TopBar')
+      // openCommandPalette() dispatches a custom event named "open-command-palette"
+      const event = dispatchSpy.mock.calls.find(
+        call => call[0] instanceof Event && (call[0] as Event).type === 'open-command-palette'
+      )
+      expect(event).toBeDefined()
+    } finally {
+      dispatchSpy.mockRestore()
+      vi.doUnmock('./TopBar')
+    }
   })
 })

--- a/frontend/components/layout/SidebarLayout.test.tsx
+++ b/frontend/components/layout/SidebarLayout.test.tsx
@@ -96,4 +96,93 @@ describe('SidebarLayout', () => {
     await user.click(screen.getByText('menu'))
     expect(screen.getByTestId('topbar')).toHaveAttribute('data-mobile-open', 'true')
   })
+
+  it('mounts the CommandPalette so global Cmd+K works', () => {
+    render(
+      <SidebarLayout>
+        <div>content</div>
+      </SidebarLayout>
+    )
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument()
+  })
+
+  it('mobile menu closes when toggled again (close branch)', async () => {
+    const user = userEvent.setup()
+    render(
+      <SidebarLayout>
+        <div>content</div>
+      </SidebarLayout>
+    )
+
+    await user.click(screen.getByText('menu'))
+    expect(screen.getByTestId('topbar')).toHaveAttribute('data-mobile-open', 'true')
+    await user.click(screen.getByText('menu'))
+    expect(screen.getByTestId('topbar')).toHaveAttribute('data-mobile-open', 'false')
+  })
+
+  it('persists the collapsed=true state after a second toggle round-trip', async () => {
+    const user = userEvent.setup()
+    render(
+      <SidebarLayout>
+        <div>content</div>
+      </SidebarLayout>
+    )
+
+    // Default false → collapse → expand → collapse again — localStorage
+    // must reflect the FINAL state, not the first.
+    await user.click(screen.getByTestId('toggle-collapse'))
+    await user.click(screen.getByTestId('toggle-collapse'))
+    await user.click(screen.getByTestId('toggle-collapse'))
+    expect(localStorage.getItem('sidebar-collapsed')).toBe('true')
+    expect(screen.getByTestId('sidebar')).toHaveAttribute('data-collapsed', 'true')
+  })
+
+  it('treats localStorage value other than "true" as expanded (defensive)', async () => {
+    localStorage.setItem('sidebar-collapsed', 'maybe')
+    await act(async () => {
+      render(
+        <SidebarLayout>
+          <div>content</div>
+        </SidebarLayout>
+      )
+    })
+    // Anything except the string "true" leaves the default expanded state.
+    expect(screen.getByTestId('sidebar')).toHaveAttribute('data-collapsed', 'false')
+  })
+
+  it('opens the command palette in response to the openCommandPalette custom event', async () => {
+    // SidebarLayout's TopBar invokes openCommandPalette() on search click,
+    // which dispatches a window event the palette listens for. Verify the
+    // event fires when handleSearchClick runs.
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const user = userEvent.setup()
+
+    // Re-mock TopBar so onSearchClick is exposed as a button we can click.
+    vi.doMock('./TopBar', () => ({
+      TopBar: ({ onSearchClick }: { onSearchClick?: () => void }) => (
+        <button data-testid="topbar-search" onClick={onSearchClick}>
+          search
+        </button>
+      ),
+    }))
+    vi.resetModules()
+    const { SidebarLayout: FreshLayout } = await import('./SidebarLayout')
+
+    render(
+      <FreshLayout>
+        <div>content</div>
+      </FreshLayout>
+    )
+
+    await user.click(screen.getByTestId('topbar-search'))
+
+    // openCommandPalette() dispatches a custom event named "open-command-palette"
+    const event = dispatchSpy.mock.calls.find(
+      call => call[0] instanceof Event && (call[0] as Event).type === 'open-command-palette'
+    )
+    expect(event).toBeDefined()
+
+    dispatchSpy.mockRestore()
+    vi.doUnmock('./TopBar')
+  })
 })

--- a/frontend/components/layout/TopBar.test.tsx
+++ b/frontend/components/layout/TopBar.test.tsx
@@ -367,5 +367,85 @@ describe('TopBar', () => {
       const artistsLink = screen.getByText('Artists').closest('a')
       expect(artistsLink?.className).toContain('bg-accent')
     })
+
+    it('clicking a mobile nav link closes the mobile menu', async () => {
+      const user = userEvent.setup()
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+
+      await user.click(screen.getByText('Shows'))
+      expect(onMobileOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('mobile theme toggle calls setTheme on click (light branch)', async () => {
+      mockTheme = 'light'
+      const user = userEvent.setup()
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+
+      // The text "Dark mode" lives on the mobile toggle when current is light.
+      await user.click(screen.getByText('Dark mode'))
+      expect(mockSetTheme).toHaveBeenCalledWith('dark')
+    })
+
+    it('mobile theme toggle calls setTheme on click (dark branch)', async () => {
+      mockTheme = 'dark'
+      const user = userEvent.setup()
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+
+      await user.click(screen.getByText('Light mode'))
+      expect(mockSetTheme).toHaveBeenCalledWith('light')
+    })
+
+    it('clicking the mobile Notifications link closes the menu (authenticated)', async () => {
+      mockAuthContext.mockReturnValue({
+        user: { email: 'test@test.com', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      })
+      const user = userEvent.setup()
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+
+      await user.click(screen.getByText('Notifications'))
+      expect(onMobileOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('notification bell visibility', () => {
+    it('renders NotificationBell only when authenticated', () => {
+      // Default mock is unauthenticated → no bell.
+      const { rerender } = render(
+        <TopBar mobileOpen={false} onMobileOpenChange={onMobileOpenChange} />
+      )
+      expect(screen.queryByTestId('notification-bell')).not.toBeInTheDocument()
+
+      mockAuthContext.mockReturnValue({
+        user: { email: 'bell@test.com', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      })
+      rerender(<TopBar mobileOpen={false} onMobileOpenChange={onMobileOpenChange} />)
+      expect(screen.getByTestId('notification-bell')).toBeInTheDocument()
+    })
+
+    it('hides NotificationBell while auth is loading', () => {
+      mockAuthContext.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: true,
+        logout: mockLogout,
+      })
+      render(<TopBar mobileOpen={false} onMobileOpenChange={onMobileOpenChange} />)
+      expect(screen.queryByTestId('notification-bell')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('logo link', () => {
+    it('logo links to the home page', () => {
+      render(<TopBar mobileOpen={false} onMobileOpenChange={onMobileOpenChange} />)
+      const logo = screen.getByAltText('Psychic Homily Logo')
+      const link = logo.closest('a')
+      expect(link).toHaveAttribute('href', '/')
+    })
   })
 })

--- a/frontend/components/layout/mode-toggle.test.tsx
+++ b/frontend/components/layout/mode-toggle.test.tsx
@@ -61,4 +61,59 @@ describe('ModeToggle', () => {
     expect(mockSetTheme).toHaveBeenCalledWith('light')
     expect(mockSetTheme).not.toHaveBeenCalledWith('dark')
   })
+
+  it('clicking twice in light mode alternates dark → light (no idle state)', async () => {
+    const user = userEvent.setup()
+    // Use a stateful mock so the second click reads the new resolvedTheme.
+    let currentTheme = 'light'
+    const statefulSetTheme = vi.fn((t: string) => {
+      currentTheme = t
+      mockSetTheme(t)
+    })
+    mockUseTheme.mockImplementation(() => ({
+      resolvedTheme: currentTheme,
+      setTheme: statefulSetTheme,
+    }))
+
+    const { rerender } = render(<ModeToggle />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle theme' }))
+    expect(mockSetTheme).toHaveBeenNthCalledWith(1, 'dark')
+
+    // Re-render so the next useTheme() call reads the updated currentTheme.
+    rerender(<ModeToggle />)
+    await user.click(screen.getByRole('button', { name: 'Toggle theme' }))
+    expect(mockSetTheme).toHaveBeenNthCalledWith(2, 'light')
+  })
+
+  it('only renders ONE setTheme call per click (no double-bind regression)', async () => {
+    const user = userEvent.setup()
+    render(<ModeToggle />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle theme' }))
+    expect(mockSetTheme).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles undefined resolvedTheme gracefully (initial hydration)', async () => {
+    // next-themes returns undefined briefly during SSR hydration. The
+    // toggle must default sensibly (treat undefined !== 'dark' → set dark)
+    // rather than throw.
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: undefined as unknown as string,
+      setTheme: mockSetTheme,
+    })
+    const user = userEvent.setup()
+    render(<ModeToggle />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle theme' }))
+    // resolvedTheme === undefined → 'dark' branch in toggleTheme
+    expect(mockSetTheme).toHaveBeenCalledWith('dark')
+  })
+
+  it('includes sr-only label so screen readers announce purpose', () => {
+    render(<ModeToggle />)
+    const srLabel = screen.getByText('Toggle theme')
+    expect(srLabel.tagName).toBe('SPAN')
+    expect(srLabel.className).toContain('sr-only')
+  })
 })

--- a/frontend/components/layout/providers.test.tsx
+++ b/frontend/components/layout/providers.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Providers } from './providers'
+
+// Mock the auth feature hooks consumed by AuthProvider. AuthProvider runs
+// `useProfile()` (TanStack Query) + `useLogout()` (mutation) on mount; both
+// would hit the network without a mock.
+const mockUseProfile = vi.fn(() => ({
+  data: undefined,
+  isLoading: false,
+  error: null,
+}))
+const mockUseLogout = vi.fn(() => ({
+  mutateAsync: vi.fn(),
+  isPending: false,
+}))
+
+vi.mock('@/features/auth', () => ({
+  useProfile: () => mockUseProfile(),
+  useLogout: () => mockUseLogout(),
+}))
+
+describe('Providers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseProfile.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    })
+    mockUseLogout.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })
+  })
+
+  it('renders children through the provider tree', () => {
+    render(
+      <Providers>
+        <div>child-content</div>
+      </Providers>
+    )
+    expect(screen.getByText('child-content')).toBeInTheDocument()
+  })
+
+  it('does not crash when wrapping multiple children', () => {
+    render(
+      <Providers>
+        <div>first</div>
+        <div>second</div>
+        <span>third</span>
+      </Providers>
+    )
+    expect(screen.getByText('first')).toBeInTheDocument()
+    expect(screen.getByText('second')).toBeInTheDocument()
+    expect(screen.getByText('third')).toBeInTheDocument()
+  })
+
+  it('makes useAuthContext usable inside subtree (AuthProvider mounted)', async () => {
+    // If AuthProvider isn't mounted, useAuthContext throws
+    // "must be used within an AuthProvider". Render a consumer to prove the
+    // provider is wired.
+    const { useAuthContext } = await import('@/lib/context/AuthContext')
+
+    function Consumer() {
+      const ctx = useAuthContext()
+      return <div data-testid="auth-state">{String(ctx.isAuthenticated)}</div>
+    }
+
+    render(
+      <Providers>
+        <Consumer />
+      </Providers>
+    )
+    // Profile mock returns undefined → user is null → isAuthenticated false.
+    expect(screen.getByTestId('auth-state')).toHaveTextContent('false')
+  })
+
+  it('makes TanStack Query useable inside subtree (QueryClientProvider mounted)', async () => {
+    // Calling useQueryClient without a provider throws — proves the
+    // provider is rendered.
+    const { useQueryClient } = await import('@tanstack/react-query')
+
+    function Consumer() {
+      const qc = useQueryClient()
+      return <div data-testid="qc">{qc ? 'ok' : 'missing'}</div>
+    }
+
+    render(
+      <Providers>
+        <Consumer />
+      </Providers>
+    )
+    expect(screen.getByTestId('qc')).toHaveTextContent('ok')
+  })
+
+  it('reuses the same QueryClient across re-renders (singleton in browser)', async () => {
+    const { useQueryClient } = await import('@tanstack/react-query')
+    const seen: unknown[] = []
+
+    function Consumer() {
+      const qc = useQueryClient()
+      seen.push(qc)
+      return null
+    }
+
+    const { rerender } = render(
+      <Providers>
+        <Consumer />
+      </Providers>
+    )
+    rerender(
+      <Providers>
+        <Consumer />
+      </Providers>
+    )
+
+    // Same QueryClient instance on each render — confirms getQueryClient's
+    // browser-singleton behavior is preserved by Providers.
+    expect(seen.length).toBeGreaterThanOrEqual(2)
+    expect(seen[0]).toBe(seen[seen.length - 1])
+  })
+
+  it('renders without crashing when children is null', () => {
+    // Guard against accidental requirement that children be non-null —
+    // some layout wrappers may render null children during loading states.
+    const { container } = render(<Providers>{null}</Providers>)
+    expect(container).toBeTruthy()
+  })
+})

--- a/frontend/components/layout/theme-provider.test.tsx
+++ b/frontend/components/layout/theme-provider.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useTheme } from 'next-themes'
+import { ThemeProvider } from './theme-provider'
+
+// ThemeProvider is a thin pass-through to next-themes' NextThemesProvider.
+// We exercise it END-TO-END via the real useTheme() hook so a regression
+// in wiring (wrong prop forwarding, missing context, broken default theme)
+// surfaces immediately. Mocking next-themes here would defeat the purpose.
+
+function ThemeConsumer() {
+  const { theme, resolvedTheme, setTheme, themes } = useTheme()
+  return (
+    <div>
+      <div data-testid="theme">{theme ?? 'undefined'}</div>
+      <div data-testid="resolved-theme">{resolvedTheme ?? 'undefined'}</div>
+      <div data-testid="themes">{(themes ?? []).join(',')}</div>
+      <button onClick={() => setTheme('dark')}>dark</button>
+      <button onClick={() => setTheme('light')}>light</button>
+      <button onClick={() => setTheme('system')}>system</button>
+    </div>
+  )
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    // next-themes persists the picked theme in localStorage between mounts.
+    // Clear so tests start from a known default-system state.
+    localStorage.clear()
+    // Reset class attribute (next-themes writes html.classList).
+    document.documentElement.className = ''
+    document.documentElement.removeAttribute('style')
+  })
+
+  it('renders children unchanged', () => {
+    render(
+      <ThemeProvider attribute="class" defaultTheme="system">
+        <div>child-content</div>
+      </ThemeProvider>
+    )
+    expect(screen.getByText('child-content')).toBeInTheDocument()
+  })
+
+  it('provides theme context to descendants', () => {
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+    // Default theme is propagated through context.
+    expect(screen.getByTestId('theme').textContent).toBe('light')
+  })
+
+  it('switches theme via setTheme (dark branch)', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    expect(screen.getByTestId('theme').textContent).toBe('light')
+    await user.click(screen.getByText('dark'))
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark')
+    expect(screen.getByTestId('resolved-theme').textContent).toBe('dark')
+  })
+
+  it('switches theme via setTheme (light branch)', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider attribute="class" defaultTheme="dark">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark')
+    await user.click(screen.getByText('light'))
+
+    expect(screen.getByTestId('theme').textContent).toBe('light')
+    expect(screen.getByTestId('resolved-theme').textContent).toBe('light')
+  })
+
+  it('persists the picked theme to localStorage', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    await user.click(screen.getByText('dark'))
+
+    // next-themes' default storage key is "theme".
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('persistence survives unmount + remount (cross-page theme stickiness)', async () => {
+    const user = userEvent.setup()
+    const { unmount } = render(
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    await user.click(screen.getByText('dark'))
+    expect(localStorage.getItem('theme')).toBe('dark')
+    unmount()
+
+    // Fresh mount must read the persisted value, NOT defaultTheme.
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+    expect(screen.getByTestId('theme').textContent).toBe('dark')
+  })
+
+  it('applies the active class to document element via attribute="class"', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    await user.click(screen.getByText('dark'))
+
+    // attribute="class" → next-themes adds the theme name as a className
+    // on <html>. Pin this so a regression that breaks css-class theming
+    // (e.g. swapping attribute to data-theme silently) gets caught.
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('forwards "system" theme value through context', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    await user.click(screen.getByText('system'))
+    expect(screen.getByTestId('theme').textContent).toBe('system')
+    // resolvedTheme reflects the actual computed theme (light/dark), so
+    // it should be one of those, not "system".
+    const resolved = screen.getByTestId('resolved-theme').textContent
+    expect(['light', 'dark']).toContain(resolved)
+  })
+
+  it('exposes the themes list (default light/dark/system)', () => {
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+    const themesText = screen.getByTestId('themes').textContent ?? ''
+    expect(themesText.split(',')).toEqual(expect.arrayContaining(['light', 'dark']))
+  })
+
+  it('respects a custom storageKey when provided', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="light"
+        enableSystem
+        storageKey="my-theme"
+      >
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    await user.click(screen.getByText('dark'))
+    // The custom key wins.
+    expect(localStorage.getItem('my-theme')).toBe('dark')
+    expect(localStorage.getItem('theme')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Strengthen 8 layout component tests + add 2 new (providers, theme-provider); PostHogProvider gains additional consent-transition + identification + pageview coverage.
- PostHogProvider tests pin behavior after PSY-728 prevConsent fix (alignment, transitions, identification, pageview branches).
- Net: 189 tests across 11 files (up from 120 across 9). +69 tests, +2 new files.

Per-component coverage added:
- **CommandPalette**: Cmd+K dialog assertion (not just placeholder), toggle-twice, query reset on close/reopen, Clear button branch, recent-searches clear, entity-result navigation, contextual Explore graph entries, loading spinner element assertion.
- **CookieConsentBanner**: handler-isolation suite (clicking one button does NOT fire others), `preferencesOpen=true` render path.
- **CookiePreferencesDialog**: Cancel-does-not-save, true→true save no-op, essential-toggle stays disabled through analytics interaction.
- **Footer**: no-throttle double-click, link tab-order pin, year format/NaN/0 guards.
- **mode-toggle**: stateful round-trip, single-bind, undefined-resolvedTheme hydration default, sr-only label.
- **Sidebar**: explicit active-class assertion (exact token match to dodge hover-utility collision), sibling-not-active, sub-path active, external-not-active, collapse-button single-bind.
- **SidebarLayout**: CommandPalette mount, mobile-menu close branch, multi-round-trip persistence, defensive localStorage value, openCommandPalette event wiring (with try/finally to scope the doMock).
- **TopBar**: mobile-link closes menu (authenticated), mobile-theme-toggle both branches, NotificationBell visibility transitions, logo href.

New files:
- **providers.test.tsx**: tree renders, `useAuthContext` + `useQueryClient` resolve, QueryClient singleton stability, null-children safe.
- **theme-provider.test.tsx**: end-to-end via real next-themes — context propagation, both setTheme branches, localStorage persistence, unmount/remount stickiness, `attribute=class` applies `html.dark`, system theme branch, custom storageKey.

## Test plan
- [x] cd frontend && bun run typecheck — passed (no errors)
- [x] cd frontend && bun run test:run components/layout — passed (189 tests, 11 files)

## Manual repro
`bun run test:run components/layout` — 189 tests pass across 11 files (8 strengthened + 2 new + PostHogProvider extended). Per-component:
- CommandPalette (Cmd+K dialog + entity navigation + recent searches + Clear button + spinner + contextual graph entries)
- Cookie banner (display + accept/reject + handler isolation + preferencesOpen render)
- Cookie dialog (toggles + save/cancel + Cancel-does-not-save + Essential stays disabled)
- Footer (links + tab-order + year format guards + double-click no-throttle)
- mode-toggle (dark/light branches + stateful round-trip + undefined-hydration + sr-only)
- Sidebar (nav + active-class match + sibling-not-active + sub-path + external-not-active + collapse)
- SidebarLayout (responsive + persistence + CommandPalette mount + openCommandPalette event wiring)
- TopBar (search + menu + admin gating + mobile-link closes + theme toggle branches + NotificationBell visibility + logo href)
- PostHogProvider (post-PSY-728 alignment + opt-in/out transitions + user identification + pageview branches + children render)
- providers (tree render + useAuthContext + useQueryClient + singleton + null children)
- theme-provider (context + both setTheme + persistence + unmount/remount + html.dark class + system + custom storageKey)

## Code review
`/code-review` ran at max-effort and surfaced 3 actionable items, all fixed in the second commit: (1) wrap SidebarLayout's `vi.doMock`/`resetModules` dance in try/finally; (2) make the CommandPalette spinner test assert on `.animate-spin`; (3) replace tautological year-> 2020 check in Footer with format/NaN/0 guards.

Closes PSY-717

🤖 Generated with [Claude Code](https://claude.com/claude-code)