### PR TITLE
PSY-854: fix dormant Huma response-envelope type in FeaturedAdmin

### DIFF
--- a/frontend/features/admin/components/FeaturedAdmin/types.ts
+++ b/frontend/features/admin/components/FeaturedAdmin/types.ts
@@ -54,12 +54,14 @@ export interface SetFeaturedSlotInput {
 }
 
 /**
- * The single-slot response wrapper backend returns from POST
- * /admin/featured-slots — Huma nests the row under `body`.
+ * Backend POST /admin/featured-slots returns the new active row
+ * directly — Huma serializes the handler's `Body` field VALUE as the
+ * JSON response, so the wire shape is a flat `FeaturedSlotResponse`,
+ * NOT `{ body: FeaturedSlotResponse }` (PSY-854 followup to PSY-838).
+ * Alias kept so importers don't need to switch to `FeaturedSlotResponse`
+ * at call sites.
  */
-export interface SetFeaturedSlotResponse {
-  body: FeaturedSlotResponse
-}
+export type SetFeaturedSlotResponse = FeaturedSlotResponse
 
 export interface RetireFeaturedSlotResponse {
   slot_type: FeaturedSlotType

--- a/frontend/features/admin/components/FeaturedAdmin/useFeaturedSlots.test.tsx
+++ b/frontend/features/admin/components/FeaturedAdmin/useFeaturedSlots.test.tsx
@@ -95,16 +95,17 @@ describe('useSetFeaturedSlot', () => {
   })
 
   it('POSTs the slot payload and invalidates BOTH list + explore caches', async () => {
+    // Wire shape is a flat FeaturedSlotResponse — Huma serializes the
+    // handler's `Body` field VALUE as the JSON response, with no
+    // `{ body: ... }` envelope (PSY-854).
     mockApiRequest.mockResolvedValueOnce({
-      body: {
-        id: 5,
-        slot_type: 'bill',
-        entity_id: 101,
-        active_from: '2026-05-24T00:00:00Z',
-        created_by: 1,
-        created_at: '2026-05-24T00:00:00Z',
-        updated_at: '2026-05-24T00:00:00Z',
-      },
+      id: 5,
+      slot_type: 'bill',
+      entity_id: 101,
+      active_from: '2026-05-24T00:00:00Z',
+      created_by: 1,
+      created_at: '2026-05-24T00:00:00Z',
+      updated_at: '2026-05-24T00:00:00Z',
     })
     const { queryClient, invalidateSpy } = setupClient()
 
@@ -139,6 +140,42 @@ describe('useSetFeaturedSlot', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['explore', 'featured'],
     })
+  })
+
+  it('returns the new slot row directly (no `{body: ...}` envelope) — PSY-854', async () => {
+    // Regression guard for the Huma envelope trap: if a future consumer
+    // tries `.body` on the mutation result, this test should be the
+    // signal that the wire shape is flat, not wrapped.
+    const slotRow = {
+      id: 7,
+      slot_type: 'bill' as const,
+      entity_id: 202,
+      curator_note: 'Sharp bill.',
+      curator_note_html: '<p>Sharp bill.</p>',
+      active_from: '2026-05-24T00:00:00Z',
+      created_by: 1,
+      created_at: '2026-05-24T00:00:00Z',
+      updated_at: '2026-05-24T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(slotRow)
+    const { queryClient } = setupClient()
+
+    const { result } = renderHook(() => useSetFeaturedSlot(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    let returned: unknown
+    await act(async () => {
+      returned = await result.current.mutateAsync({
+        slot_type: 'bill',
+        entity_id: 202,
+        curator_note: 'Sharp bill.',
+      })
+    })
+
+    // The mutation result is the slot row itself; there is NO `body` key.
+    expect(returned).toEqual(slotRow)
+    expect(returned).not.toHaveProperty('body')
   })
 })
 


### PR DESCRIPTION
## Summary
- `SetFeaturedSlotResponse` was declared as `{ body: FeaturedSlotResponse }`, but Huma serializes the Go-side `Body` field's VALUE as the JSON response — there is no `body` key on the wire. Verified the four FeaturedAdmin endpoint shapes via curl; only the POST type was wrong.
- Redefined `SetFeaturedSlotResponse` as a type alias of `FeaturedSlotResponse` (less call-site churn than dropping the name).
- Existing consumer (`FeaturedAdmin.tsx`) only touches `.mutate` / `.isPending` so no runtime behavior changes; this was the dormant trap PSY-854 calls out.
- Added a regression test that asserts the mutation returns the flat slot row with no `body` property — hardens against a future consumer typoing `.body`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/admin` — 29 passed (4 files; includes 1 new test in `useFeaturedSlots.test.tsx`)

## Manual repro
Wire-shape verification (curl outputs verbatim against the shared-mode dev stack on :53470, admin = `e2e-admin@test.local`):

POST `/admin/featured-slots`:
```
{
  "$schema": "http://localhost:53470/schemas/FeaturedSlotResponse.json",
  "id": 1,
  "slot_type": "bill",
  "entity_id": 56,
  "curator_note": "smoke",
  "curator_note_html": "<p>smoke</p>\n",
  "active_from": "2026-05-26T18:46:28.62824-07:00",
  "created_by": 6,
  "created_at": "2026-05-26T18:46:28.629721-07:00",
  "updated_at": "2026-05-26T18:46:28.629721-07:00"
}
```

GET `/admin/featured-slots`:
```
{
  "$schema": "http://localhost:53470/schemas/ListFeaturedSlotsResponseBody.json",
  "slots": [
    { "slot_type": "bill", "active": { ... }, "history": [ { ... } ] },
    { "slot_type": "collection", "history": [] }
  ]
}
```

DELETE `/admin/featured-slots/bill`:
```
{
  "$schema": "http://localhost:53470/schemas/DeleteFeaturedSlotResponseBody.json",
  "slot_type": "bill",
  "message": "Featured slot retired"
}
```

GET `/explore/featured`:
```
{
  "$schema": "http://localhost:53470/schemas/ExploreFeaturedResponse.json",
  "bill": null,
  "collection": null
}
```

All four shapes are flat. Only `SetFeaturedSlotResponse` was misdeclared — the other three TS types in `types.ts` already matched the wire.

## Code review
`/code-review` at max effort — no findings; type-only fix with verified wire shape, regression test in place, consumers unaffected.

Closes PSY-854