### PR TITLE
PSY-843: consolidate unsubscribe-signature helpers into Scoped

### DIFF
--- a/backend/internal/api/handlers/auth/unsubscribe_collection_digest.go
+++ b/backend/internal/api/handlers/auth/unsubscribe_collection_digest.go
@@ -45,7 +45,7 @@ func (h *UserPreferencesHandler) UnsubscribeCollectionDigestPageHandler(w http.R
 	}
 	uid := uint(uid64)
 
-	if !engagement.VerifyCollectionDigestUnsubscribeSignature(uid, sig, h.jwtSecret) {
+	if !engagement.VerifyScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeCollectionDigest, sig, h.jwtSecret) {
 		writeUnsubscribeError(w, r, http.StatusForbidden, "This unsubscribe link is invalid or has been tampered with.")
 		return
 	}

--- a/backend/internal/api/handlers/auth/unsubscribe_collection_digest_test.go
+++ b/backend/internal/api/handlers/auth/unsubscribe_collection_digest_test.go
@@ -46,7 +46,7 @@ func TestUnsubscribeCollectionDigestPage_InvalidSignature(t *testing.T) {
 func TestUnsubscribeCollectionDigestPage_GET_Success(t *testing.T) {
 	secret := "test-secret"
 	uid := uint(99)
-	sig := engagement.ComputeCollectionDigestUnsubscribeSignature(uid, secret)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeCollectionDigest, secret)
 
 	var receivedUID uint
 	var receivedEnabled bool
@@ -88,7 +88,7 @@ func TestUnsubscribeCollectionDigestPage_GET_Success(t *testing.T) {
 func TestUnsubscribeCollectionDigestPage_POST_OneClick_Success(t *testing.T) {
 	secret := "test-secret"
 	uid := uint(7)
-	sig := engagement.ComputeCollectionDigestUnsubscribeSignature(uid, secret)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeCollectionDigest, secret)
 
 	var called bool
 	mock := &testhelpers.MockUserService{
@@ -144,7 +144,7 @@ func TestUnsubscribeCollectionDigestPage_POST_InvalidSig_JSON(t *testing.T) {
 func TestUnsubscribeCollectionDigestPage_ServiceError_GET(t *testing.T) {
 	secret := "test-secret"
 	uid := uint(50)
-	sig := engagement.ComputeCollectionDigestUnsubscribeSignature(uid, secret)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeCollectionDigest, secret)
 
 	mock := &testhelpers.MockUserService{
 		SetNotifyOnCollectionDigestFn: func(uint, bool) error {
@@ -169,7 +169,7 @@ func TestUnsubscribeCollectionDigestPage_ServiceError_GET(t *testing.T) {
 func TestUnsubscribeCollectionDigestPage_ServiceError_POST(t *testing.T) {
 	secret := "test-secret"
 	uid := uint(50)
-	sig := engagement.ComputeCollectionDigestUnsubscribeSignature(uid, secret)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeCollectionDigest, secret)
 
 	mock := &testhelpers.MockUserService{
 		SetNotifyOnCollectionDigestFn: func(uint, bool) error {

--- a/backend/internal/api/handlers/auth/user_preferences.go
+++ b/backend/internal/api/handlers/auth/user_preferences.go
@@ -157,7 +157,7 @@ type UnsubscribeShowRemindersResponse struct {
 
 // UnsubscribeShowRemindersHandler handles POST /auth/unsubscribe/show-reminders (public, no auth)
 func (h *UserPreferencesHandler) UnsubscribeShowRemindersHandler(ctx context.Context, req *UnsubscribeShowRemindersRequest) (*UnsubscribeShowRemindersResponse, error) {
-	if !engagement.VerifyUnsubscribeSignature(req.Body.UID, req.Body.Sig, h.jwtSecret) {
+	if !engagement.VerifyScopedUnsubscribeSignature(req.Body.UID, engagement.UnsubscribeScopeShowReminders, req.Body.Sig, h.jwtSecret) {
 		return nil, huma.Error403Forbidden("Invalid unsubscribe link")
 	}
 
@@ -414,7 +414,7 @@ type UnsubscribeMentionResponse struct {
 // UnsubscribeMentionHandler handles POST /unsubscribe/mention. Flips the
 // user's notify_on_mention preference to false. Public — HMAC-signed.
 func (h *UserPreferencesHandler) UnsubscribeMentionHandler(ctx context.Context, req *UnsubscribeMentionRequest) (*UnsubscribeMentionResponse, error) {
-	if !engagement.VerifyMentionUnsubscribeSignature(req.Body.UID, req.Body.Sig, h.jwtSecret) {
+	if !engagement.VerifyScopedUnsubscribeSignature(req.Body.UID, engagement.UnsubscribeScopeMention, req.Body.Sig, h.jwtSecret) {
 		return nil, huma.Error403Forbidden("Invalid unsubscribe link")
 	}
 

--- a/backend/internal/api/handlers/auth/user_preferences_test.go
+++ b/backend/internal/api/handlers/auth/user_preferences_test.go
@@ -190,7 +190,7 @@ func TestUnsubscribeShowRemindersHandler_ServiceError(t *testing.T) {
 
 // computeTestUnsubscribeSig generates a valid HMAC signature for testing
 func computeTestUnsubscribeSig(uid uint, secret string) string {
-	return engagement.ComputeUnsubscribeSignature(uid, secret)
+	return engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeShowReminders, secret)
 }
 
 // ──────────────────────────────────────────────
@@ -328,7 +328,7 @@ func TestUnsubscribeMentionHandler_InvalidSignature(t *testing.T) {
 func TestUnsubscribeMentionHandler_Success(t *testing.T) {
 	secret := "hmac-secret"
 	uid := uint(8)
-	sig := engagement.ComputeMentionUnsubscribeSignature(uid, secret)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeMention, secret)
 
 	var called bool
 	mock := &testhelpers.MockUserService{

--- a/backend/internal/services/engagement/collection_digest.go
+++ b/backend/internal/services/engagement/collection_digest.go
@@ -2,9 +2,6 @@ package engagement
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -532,22 +529,6 @@ func (s *CollectionDigestService) RunDigestCycleNow() {
 // page on GET and accepts an RFC 8058 one-click POST. See
 // handlers.UnsubscribeCollectionDigestPageHandler.
 func GenerateCollectionDigestUnsubscribeURL(baseURL string, userID uint, secret string) string {
-	sig := ComputeCollectionDigestUnsubscribeSignature(userID, secret)
+	sig := ComputeScopedUnsubscribeSignature(userID, UnsubscribeScopeCollectionDigest, secret)
 	return fmt.Sprintf("%s/unsubscribe/collection-digest?uid=%d&sig=%s", baseURL, userID, sig)
-}
-
-// VerifyCollectionDigestUnsubscribeSignature checks the HMAC for an unsubscribe request.
-func VerifyCollectionDigestUnsubscribeSignature(userID uint, signature, secret string) bool {
-	expected := ComputeCollectionDigestUnsubscribeSignature(userID, secret)
-	return hmac.Equal([]byte(expected), []byte(signature))
-}
-
-// ComputeCollectionDigestUnsubscribeSignature hashes userID under secret.
-// Bound to the "collection-digest" domain string so a signature minted for
-// one notification type can't be replayed against another.
-func ComputeCollectionDigestUnsubscribeSignature(userID uint, secret string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	// hash.Hash.Write never returns an error; the drop is intentional.
-	_, _ = fmt.Fprintf(mac, "unsubscribe:collection-digest:%d", userID)
-	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/collection_digest_test.go
+++ b/backend/internal/services/engagement/collection_digest_test.go
@@ -62,20 +62,20 @@ func TestHMAC_CollectionDigestRoundTrip(t *testing.T) {
 	assert.Contains(t, urlStr, "/unsubscribe/collection-digest")
 	assert.Contains(t, urlStr, "uid=99")
 
-	sig := ComputeCollectionDigestUnsubscribeSignature(userID, secret)
-	assert.True(t, VerifyCollectionDigestUnsubscribeSignature(userID, sig, secret))
+	sig := ComputeScopedUnsubscribeSignature(userID, UnsubscribeScopeCollectionDigest, secret)
+	assert.True(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeCollectionDigest, sig, secret))
 
 	// Tamper: wrong user ID
-	assert.False(t, VerifyCollectionDigestUnsubscribeSignature(userID+1, sig, secret))
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID+1, UnsubscribeScopeCollectionDigest, sig, secret))
 	// Tamper: wrong secret
-	assert.False(t, VerifyCollectionDigestUnsubscribeSignature(userID, sig, "different"))
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeCollectionDigest, sig, "different"))
 	// Empty sig
-	assert.False(t, VerifyCollectionDigestUnsubscribeSignature(userID, "", secret))
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeCollectionDigest, "", secret))
 
 	// A signature minted for a *mention* unsubscribe must NOT verify against
 	// the collection-digest scheme — defense-in-depth.
-	mentionSig := ComputeMentionUnsubscribeSignature(userID, secret)
-	assert.False(t, VerifyCollectionDigestUnsubscribeSignature(userID, mentionSig, secret))
+	mentionSig := ComputeScopedUnsubscribeSignature(userID, UnsubscribeScopeMention, secret)
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeCollectionDigest, mentionSig, secret))
 }
 
 // TestCollectionDigestService_Construction_DefaultInterval verifies the

--- a/backend/internal/services/engagement/comment_notification.go
+++ b/backend/internal/services/engagement/comment_notification.go
@@ -590,21 +590,6 @@ func ComputeCommentSubscriptionUnsubscribeSignature(userID uint, entityType stri
 // recipient's `notify_on_mention` preference off. Keyed by userID only —
 // the preference is account-wide.
 func GenerateMentionUnsubscribeURL(baseURL string, userID uint, secret string) string {
-	sig := ComputeMentionUnsubscribeSignature(userID, secret)
+	sig := ComputeScopedUnsubscribeSignature(userID, UnsubscribeScopeMention, secret)
 	return fmt.Sprintf("%s/unsubscribe/mention?uid=%d&sig=%s", baseURL, userID, sig)
-}
-
-// VerifyMentionUnsubscribeSignature checks the HMAC for a mention
-// unsubscribe request.
-func VerifyMentionUnsubscribeSignature(userID uint, signature, secret string) bool {
-	expected := ComputeMentionUnsubscribeSignature(userID, secret)
-	return hmac.Equal([]byte(expected), []byte(signature))
-}
-
-// ComputeMentionUnsubscribeSignature hashes userID under secret.
-func ComputeMentionUnsubscribeSignature(userID uint, secret string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	// hash.Hash.Write never returns an error; the drop is intentional.
-	_, _ = fmt.Fprintf(mac, "unsubscribe:mention:%d", userID)
-	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/comment_notification_test.go
+++ b/backend/internal/services/engagement/comment_notification_test.go
@@ -151,15 +151,15 @@ func TestHMAC_MentionRoundTrip(t *testing.T) {
 	assert.Contains(t, urlStr, "/unsubscribe/mention")
 	assert.Contains(t, urlStr, "uid=42")
 
-	sig := ComputeMentionUnsubscribeSignature(userID, secret)
-	assert.True(t, VerifyMentionUnsubscribeSignature(userID, sig, secret))
-	assert.False(t, VerifyMentionUnsubscribeSignature(userID+1, sig, secret))
-	assert.False(t, VerifyMentionUnsubscribeSignature(userID, sig, "different-secret"))
+	sig := ComputeScopedUnsubscribeSignature(userID, UnsubscribeScopeMention, secret)
+	assert.True(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeMention, sig, secret))
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID+1, UnsubscribeScopeMention, sig, secret))
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeMention, sig, "different-secret"))
 
 	// Mention signatures must NOT verify against comment-subscription
 	// signatures (defense-in-depth against swapped domains).
 	csSig := ComputeCommentSubscriptionUnsubscribeSignature(userID, "artist", 1, secret)
-	assert.False(t, VerifyMentionUnsubscribeSignature(userID, csSig, secret))
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeMention, csSig, secret))
 }
 
 func TestStripMarkdownToPlain(t *testing.T) {

--- a/backend/internal/services/engagement/reminder.go
+++ b/backend/internal/services/engagement/reminder.go
@@ -2,9 +2,6 @@ package engagement
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -206,21 +203,9 @@ func (s *ReminderService) RunReminderCycleNow() {
 }
 
 // GenerateUnsubscribeURL creates an HMAC-signed URL for one-click unsubscribe
+// from show reminder emails. Thin wrapper over the generic scoped helper —
+// keeps the call sites in the email send path readable.
 func GenerateUnsubscribeURL(baseURL string, userID uint, secret string) string {
-	sig := ComputeUnsubscribeSignature(userID, secret)
+	sig := ComputeScopedUnsubscribeSignature(userID, UnsubscribeScopeShowReminders, secret)
 	return fmt.Sprintf("%s/unsubscribe/show-reminders?uid=%d&sig=%s", baseURL, userID, sig)
-}
-
-// VerifyUnsubscribeSignature checks the HMAC signature for an unsubscribe request
-func VerifyUnsubscribeSignature(userID uint, signature, secret string) bool {
-	expected := ComputeUnsubscribeSignature(userID, secret)
-	return hmac.Equal([]byte(expected), []byte(signature))
-}
-
-// ComputeUnsubscribeSignature computes HMAC-SHA256 of the user ID
-func ComputeUnsubscribeSignature(userID uint, secret string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	// hash.Hash.Write never returns an error; the drop is intentional.
-	_, _ = fmt.Fprintf(mac, "unsubscribe:show-reminders:%d", userID)
-	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/backend/internal/services/engagement/reminder_test.go
+++ b/backend/internal/services/engagement/reminder_test.go
@@ -26,40 +26,10 @@ import (
 
 const testSecret = "test-jwt-secret-key-for-hmac"
 
-func TestComputeUnsubscribeSignature_Deterministic(t *testing.T) {
-	sig1 := ComputeUnsubscribeSignature(42, testSecret)
-	sig2 := ComputeUnsubscribeSignature(42, testSecret)
-
-	assert.NotEmpty(t, sig1)
-	assert.Equal(t, sig1, sig2, "same inputs should produce the same signature")
-}
-
-func TestComputeUnsubscribeSignature_DifferentUsers(t *testing.T) {
-	sig1 := ComputeUnsubscribeSignature(1, testSecret)
-	sig2 := ComputeUnsubscribeSignature(2, testSecret)
-
-	assert.NotEqual(t, sig1, sig2, "different user IDs should produce different signatures")
-}
-
-func TestComputeUnsubscribeSignature_DifferentSecrets(t *testing.T) {
-	sig1 := ComputeUnsubscribeSignature(1, "secret-a")
-	sig2 := ComputeUnsubscribeSignature(1, "secret-b")
-
-	assert.NotEqual(t, sig1, sig2, "different secrets should produce different signatures")
-}
-
-func TestComputeUnsubscribeSignature_HexEncoded(t *testing.T) {
-	sig := ComputeUnsubscribeSignature(1, testSecret)
-
-	// HMAC-SHA256 produces 32 bytes = 64 hex chars
-	assert.Len(t, sig, 64, "HMAC-SHA256 hex output should be 64 characters")
-
-	// Verify it's valid hex
-	for _, c := range sig {
-		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
-			"signature should be lowercase hex, got char: %c", c)
-	}
-}
+// Generic HMAC property tests (determinism, different-users-different-sigs,
+// different-secrets-different-sigs, hex output, tampering rejection) live in
+// unsubscribe_scope_test.go — exercising the shared compute/verify helpers.
+// The tests below only assert the show-reminders URL shape and round-trip.
 
 func TestGenerateUnsubscribeURL_Format(t *testing.T) {
 	result := GenerateUnsubscribeURL("https://example.com", 42, testSecret)
@@ -79,42 +49,8 @@ func TestGenerateUnsubscribeURL_EmbeddedSignature(t *testing.T) {
 	parsed, err := url.Parse(result)
 	assert.NoError(t, err)
 
-	expectedSig := ComputeUnsubscribeSignature(99, testSecret)
+	expectedSig := ComputeScopedUnsubscribeSignature(99, UnsubscribeScopeShowReminders, testSecret)
 	assert.Equal(t, expectedSig, parsed.Query().Get("sig"))
-}
-
-func TestVerifyUnsubscribeSignature_Valid(t *testing.T) {
-	sig := ComputeUnsubscribeSignature(42, testSecret)
-	assert.True(t, VerifyUnsubscribeSignature(42, sig, testSecret))
-}
-
-func TestVerifyUnsubscribeSignature_InvalidSignature(t *testing.T) {
-	assert.False(t, VerifyUnsubscribeSignature(42, "totally-wrong-signature", testSecret))
-}
-
-func TestVerifyUnsubscribeSignature_WrongUserID(t *testing.T) {
-	sig := ComputeUnsubscribeSignature(42, testSecret)
-	// Signature for user 42 should not verify for user 43
-	assert.False(t, VerifyUnsubscribeSignature(43, sig, testSecret))
-}
-
-func TestVerifyUnsubscribeSignature_WrongSecret(t *testing.T) {
-	sig := ComputeUnsubscribeSignature(42, "secret-a")
-	assert.False(t, VerifyUnsubscribeSignature(42, sig, "secret-b"))
-}
-
-func TestVerifyUnsubscribeSignature_EmptySignature(t *testing.T) {
-	assert.False(t, VerifyUnsubscribeSignature(42, "", testSecret))
-}
-
-func TestVerifyUnsubscribeSignature_TamperedSignature(t *testing.T) {
-	sig := ComputeUnsubscribeSignature(42, testSecret)
-	// Flip the last character
-	tampered := sig[:len(sig)-1] + "0"
-	if sig[len(sig)-1] == '0' {
-		tampered = sig[:len(sig)-1] + "1"
-	}
-	assert.False(t, VerifyUnsubscribeSignature(42, tampered, testSecret))
 }
 
 func TestHMACRoundTrip(t *testing.T) {
@@ -131,11 +67,11 @@ func TestHMACRoundTrip(t *testing.T) {
 	extractedSig := parsed.Query().Get("sig")
 	assert.NotEmpty(t, extractedSig)
 
-	assert.True(t, VerifyUnsubscribeSignature(userID, extractedSig, secret),
+	assert.True(t, VerifyScopedUnsubscribeSignature(userID, UnsubscribeScopeShowReminders, extractedSig, secret),
 		"round-trip: signature generated in URL should verify successfully")
 
 	// Also verify it fails for a different user
-	assert.False(t, VerifyUnsubscribeSignature(userID+1, extractedSig, secret),
+	assert.False(t, VerifyScopedUnsubscribeSignature(userID+1, UnsubscribeScopeShowReminders, extractedSig, secret),
 		"round-trip: signature should not verify for a different user ID")
 }
 

--- a/backend/internal/services/engagement/unsubscribe_scope.go
+++ b/backend/internal/services/engagement/unsubscribe_scope.go
@@ -14,14 +14,15 @@ import (
 const (
 	UnsubscribeScopeTierNotifications = "tier-notifications"
 	UnsubscribeScopeEditNotifications = "edit-notifications"
+	UnsubscribeScopeShowReminders     = "show-reminders"
+	UnsubscribeScopeMention           = "mention"
+	UnsubscribeScopeCollectionDigest  = "collection-digest"
 )
 
 // ComputeScopedUnsubscribeSignature computes HMAC-SHA256 over
-// "unsubscribe:<scope>:<userID>" — the same payload shape as the older
-// per-domain helpers (ComputeUnsubscribeSignature for show-reminders,
-// ComputeCollectionDigestUnsubscribeSignature for collection-digest), but with
-// the scope passed in rather than baked into the function. Used for the
-// tier-change and edit-review categories.
+// "unsubscribe:<scope>:<userID>". The scope discriminates inbox URLs across
+// notification types so a link minted for one category can't be replayed
+// against another.
 func ComputeScopedUnsubscribeSignature(userID uint, scope, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	// hash.Hash.Write never returns an error; the drop is intentional.

--- a/backend/internal/services/engagement/unsubscribe_scope_test.go
+++ b/backend/internal/services/engagement/unsubscribe_scope_test.go
@@ -1,13 +1,17 @@
 package engagement
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// PSY-756: tests for the generic scoped unsubscribe HMAC helpers.
+// Tests for the generic scoped unsubscribe HMAC helpers.
 
 func TestComputeScopedUnsubscribeSignature_Deterministic(t *testing.T) {
 	sig1 := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeTierNotifications, testSecret)
@@ -15,6 +19,27 @@ func TestComputeScopedUnsubscribeSignature_Deterministic(t *testing.T) {
 	assert.NotEmpty(t, sig1)
 	assert.Equal(t, sig1, sig2, "same inputs should produce the same signature")
 	assert.Len(t, sig1, 64, "HMAC-SHA256 hex output should be 64 characters")
+}
+
+func TestComputeScopedUnsubscribeSignature_DifferentUsers(t *testing.T) {
+	sig1 := ComputeScopedUnsubscribeSignature(1, UnsubscribeScopeShowReminders, testSecret)
+	sig2 := ComputeScopedUnsubscribeSignature(2, UnsubscribeScopeShowReminders, testSecret)
+	assert.NotEqual(t, sig1, sig2, "different user IDs should produce different signatures")
+}
+
+func TestComputeScopedUnsubscribeSignature_DifferentSecrets(t *testing.T) {
+	sig1 := ComputeScopedUnsubscribeSignature(1, UnsubscribeScopeShowReminders, "secret-a")
+	sig2 := ComputeScopedUnsubscribeSignature(1, UnsubscribeScopeShowReminders, "secret-b")
+	assert.NotEqual(t, sig1, sig2, "different secrets should produce different signatures")
+}
+
+func TestComputeScopedUnsubscribeSignature_HexEncoded(t *testing.T) {
+	sig := ComputeScopedUnsubscribeSignature(1, UnsubscribeScopeShowReminders, testSecret)
+	assert.Len(t, sig, 64, "HMAC-SHA256 hex output should be 64 characters")
+	for _, c := range sig {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+			"signature should be lowercase hex, got char: %c", c)
+	}
 }
 
 func TestComputeScopedUnsubscribeSignature_ScopeIsolation(t *testing.T) {
@@ -28,13 +53,44 @@ func TestComputeScopedUnsubscribeSignature_ScopeIsolation(t *testing.T) {
 		"a tier-scope signature must not verify under the edit scope")
 }
 
-func TestComputeScopedUnsubscribeSignature_DistinctFromShowReminders(t *testing.T) {
-	// The legacy show-reminders helper hardcodes the "show-reminders" scope;
-	// the generic helper must produce a different value for other scopes so
-	// the domains stay separated.
-	legacy := ComputeUnsubscribeSignature(42, testSecret)
-	tier := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeTierNotifications, testSecret)
-	assert.NotEqual(t, legacy, tier)
+// TestComputeScopedUnsubscribeSignature_MatchesLegacyHelpers is the
+// backwards-compat regression gate for the show-reminders, mention, and
+// collection-digest scopes. Existing one-click unsubscribe URLs in users'
+// inboxes were minted by the per-domain helpers (since deleted) and must keep
+// verifying after the cutover. Each case inlines the deleted helper's exact
+// payload format and asserts byte-identical hex output against the generic
+// helper. Sentinel inputs (NOT production secret rotation) so the assertion
+// stays stable across deploys.
+func TestComputeScopedUnsubscribeSignature_MatchesLegacyHelpers(t *testing.T) {
+	const (
+		uid    = uint(42)
+		secret = "test-secret-32bytes-pad-padxxx"
+	)
+
+	cases := []struct {
+		name           string
+		scope          string
+		legacyTemplate string // exact format string the deleted helper used
+	}{
+		{"show-reminders", UnsubscribeScopeShowReminders, "unsubscribe:show-reminders:%d"},
+		{"mention", UnsubscribeScopeMention, "unsubscribe:mention:%d"},
+		{"collection-digest", UnsubscribeScopeCollectionDigest, "unsubscribe:collection-digest:%d"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Inline the deleted helper's body: HMAC-SHA256(secret) over the
+			// exact legacy payload, hex-encoded.
+			mac := hmac.New(sha256.New, []byte(secret))
+			_, _ = fmt.Fprintf(mac, tc.legacyTemplate, uid)
+			legacy := hex.EncodeToString(mac.Sum(nil))
+
+			scoped := ComputeScopedUnsubscribeSignature(uid, tc.scope, secret)
+			assert.Equal(t, legacy, scoped,
+				"scope %q must produce byte-identical hex to the deleted per-domain helper so inbox URLs remain verifiable",
+				tc.scope)
+		})
+	}
 }
 
 func TestVerifyScopedUnsubscribeSignature(t *testing.T) {


### PR DESCRIPTION
## Summary
- Collapses 3 per-domain HMAC helper pairs (show-reminders, mention, collection-digest) into the existing `ComputeScopedUnsubscribeSignature` / `VerifyScopedUnsubscribeSignature` generic pair via 3 new scope constants.
- Net: 6 functions deleted across `reminder.go`, `comment_notification.go`, `collection_digest.go`; ~20 call sites swap to the generic helpers; the three `Generate*UnsubscribeURL` wrappers stay (each owns a distinct route path).
- Backwards-compat regression gate `TestComputeScopedUnsubscribeSignature_MatchesLegacyHelpers` inlines each deleted helper's exact payload format and asserts byte-identical hex output against the generic helper — confirms one-click unsubscribe URLs in users' inboxes keep verifying.

## Test plan
- [x] `cd backend && go build ./...` — passed (no missed call sites)
- [x] `cd backend && go test ./...` — passed (all packages OK including `engagement` + `api/handlers/auth`)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — exit 0
- [x] `grep -rn "Compute.*UnsubscribeSignature\|Verify.*UnsubscribeSignature" backend/ --include="*.go"` — only `Scoped` / `CommentSubscription` / `Filter` matches remain

## Manual repro
`TestComputeScopedUnsubscribeSignature_MatchesLegacyHelpers` (table-driven across all 3 scopes) asserts that `ComputeScopedUnsubscribeSignature(uid=42, "show-reminders", "test-secret-32bytes-pad-padxxx")` produces hex identical to what the deleted `ComputeUnsubscribeSignature(uid=42, secret)` would have (similar for "mention" + "collection-digest"). Passed locally. URL-in-inbox compat verified — existing one-click unsubscribe links continue to verify successfully through the cutover.

## Code review
Inline 3-lens review by orchestrator (sub-agent stalled before reaching `/code-review`): no changes. Reuse ✓ (removes 3 duplicate helper pairs; keeps differentiated `Generate*UnsubscribeURL` wrappers correctly). Quality ✓ (constants follow existing naming convention; doc comment strips PSY-756 ref per project convention; backwards-compat test has strong WHY comment as a permanent regression gate). Efficiency ✓ (same HMAC computation, slight binary shrink from 6 deleted funcs).

## Stall-takeover disclosure
Sub-agent (general-purpose isolated worktree) stalled at the 600s watchdog immediately after completing the implementation commit, before running `/code-review` and `git push`. Per psy-dispatch's stall-takeover carveout: orchestrator re-verified the diff scope (12 files, -159/+103 net, exactly the ticket's enumerated call-site list), re-ran `go build` + `go test ./...` + `golangci-lint` from the worktree (all clean), ran the 3-lens inline code-review (orchestrator has Agent tool but the diff was small enough that inline was sufficient), pushed, opened this PR. Tests + grep AC re-verified locally before push per \`feedback_local_test_before_push.md\`.

Closes PSY-843