### PR TITLE
PSY-766: replace entityType+'s' concat in useReportEntity with map

### DIFF
--- a/frontend/features/contributions/hooks/useReportEntity.test.tsx
+++ b/frontend/features/contributions/hooks/useReportEntity.test.tsx
@@ -31,21 +31,25 @@ describe('useReportEntity', () => {
     expect(typeof result.current.mutate).toBe('function')
   })
 
-  // URL-shape enumeration locks the CURRENT behavior of useReportEntity per
-  // entity type. The non-comment, non-show branch builds its path via a raw
-  // `entityType + 's'` plural concatenation (the "plural-concat" anti-pattern)
-  // — that is the subject of audit PSY-766 and is intentionally NOT fixed
-  // here. These cases document what the hook builds today so PSY-766 has a
-  // characterization baseline; if PSY-766 swaps in an explicit plural map,
-  // the expected URLs below stay identical for these inputs.
+  // Exhaustive enumeration of ReportableEntityType — verifies that
+  // REPORT_PLURAL and REPORT_SUFFIX stay in sync with the union (PSY-766).
+  // Adding a new entity type without populating both maps is a TS error;
+  // changing a URL shape without updating this list is a test failure.
+  // The `entityType + 's'` concatenation antipattern (audited and removed
+  // by PSY-766) is intentionally NOT recreated here — each entry below is
+  // the literal URL the hook is contractually required to build.
   const cases: Array<{ entityType: ReportableEntityType; expectedPath: string }> = [
     { entityType: 'artist', expectedPath: 'artists/42/report' },
     { entityType: 'venue', expectedPath: 'venues/42/report' },
     { entityType: 'festival', expectedPath: 'festivals/42/report' },
-    // collection happens to pluralize correctly under raw +'s', but it still
-    // flows through the same concat branch as artist/venue/festival.
     { entityType: 'collection', expectedPath: 'collections/42/report' },
-    // show uses /entity-report (not /report) — distinct backend route.
+    // comment uses the same /{plural}/{id}/report shape as artist/venue;
+    // the dedicated /comments handler family is a backend implementation
+    // detail. URL identity is what this test pins.
+    { entityType: 'comment', expectedPath: 'comments/42/report' },
+    // show is the one irregular suffix — /shows/{id}/entity-report — and
+    // is the most likely site of a silent regression if the suffix map
+    // ever drifts.
     { entityType: 'show', expectedPath: 'shows/42/entity-report' },
   ]
 
@@ -88,34 +92,6 @@ describe('useReportEntity', () => {
       )
     }
   )
-
-  it('routes comment reports to the dedicated /comments/{id}/report endpoint', async () => {
-    mockApiRequest.mockResolvedValueOnce({ success: true })
-
-    const { result } = renderHook(() => useReportEntity(), {
-      wrapper: createWrapper(),
-    })
-
-    result.current.mutate({
-      entityType: 'comment',
-      entityId: 88,
-      reportType: 'spam',
-      details: 'advertising',
-    })
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-
-    expect(mockApiRequest).toHaveBeenCalledWith(
-      'http://localhost:8080/comments/88/report',
-      {
-        method: 'POST',
-        body: JSON.stringify({
-          report_type: 'spam',
-          details: 'advertising',
-        }),
-      }
-    )
-  })
 
   it('omits the details field from the body when not provided', async () => {
     mockApiRequest.mockResolvedValueOnce({ success: true })

--- a/frontend/features/contributions/hooks/useReportEntity.ts
+++ b/frontend/features/contributions/hooks/useReportEntity.ts
@@ -20,6 +20,40 @@ interface ReportEntityResponse {
   }
 }
 
+/**
+ * Explicit singular → URL plural map for the report endpoint. Mirrors the
+ * canonical pattern from `useSuggestEdit.ts` (PSY-726): an exhaustive
+ * `Record<ReportableEntityType, string>` makes adding a new entity — or one
+ * with an irregular plural — a compile error here, not a silent 404 at
+ * runtime. The previous `entityType + 's'` concatenation only worked by
+ * coincidence (every current entity has a regular plural) and was the
+ * subject of audit PSY-766.
+ */
+const REPORT_PLURAL: Record<ReportableEntityType, string> = {
+  artist: 'artists',
+  venue: 'venues',
+  festival: 'festivals',
+  show: 'shows',
+  comment: 'comments',
+  collection: 'collections',
+}
+
+/**
+ * Per-type URL suffix for the report endpoint. Shows route to
+ * `/shows/{id}/entity-report` (the generic entity-report queue introduced
+ * after the original `/shows/{id}/report` handler); every other type uses
+ * `/report`. Exhaustive map so a new entity must declare its suffix
+ * explicitly instead of inheriting the default and silently breaking.
+ */
+const REPORT_SUFFIX: Record<ReportableEntityType, string> = {
+  artist: 'report',
+  venue: 'report',
+  festival: 'report',
+  show: 'entity-report',
+  comment: 'report',
+  collection: 'report',
+}
+
 export const useReportEntity = () => {
   return useMutation({
     mutationFn: async ({
@@ -28,26 +62,11 @@ export const useReportEntity = () => {
       reportType,
       details,
     }: ReportEntityInput): Promise<ReportEntityResponse> => {
-      // Comments use /comments/{id}/report
-      if (entityType === 'comment') {
-        return apiRequest<ReportEntityResponse>(
-          `${API_BASE_URL}/comments/${entityId}/report`,
-          {
-            method: 'POST',
-            body: JSON.stringify({
-              report_type: reportType,
-              ...(details ? { details } : {}),
-            }),
-          }
-        )
-      }
-
-      // Shows use /entity-report instead of /report
-      const reportPath = entityType === 'show' ? 'entity-report' : 'report'
-      const pluralType = entityType + 's'
+      const pluralType = REPORT_PLURAL[entityType]
+      const suffix = REPORT_SUFFIX[entityType]
 
       return apiRequest<ReportEntityResponse>(
-        `${API_BASE_URL}/${pluralType}/${entityId}/${reportPath}`,
+        `${API_BASE_URL}/${pluralType}/${entityId}/${suffix}`,
         {
           method: 'POST',
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Convert `useReportEntity.ts` off the `entityType + 's'` plural-concatenation pattern to an exhaustive `Record<ReportableEntityType, string>` map (mirror of PSY-726's `useSuggestEdit.ts` fix)
- TypeScript exhaustiveness over `ReportableEntityType` catches any future entity added without updating the map
- Test enumerates every `ReportableEntityType` member, asserting the URL

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run features/contributions` — passed (15 files, 99 tests, 2.88s)
- [x] `/code-review` — 8-sweep analysis returned `[]`; no findings (diff faithfully mirrors PSY-726 canonical pattern; URL routes verified against backend registered routes; no removed-behavior gaps; mitigation against silent typos in map values is the per-type test enumeration)

## Manual repro
`test:run features/contributions` — 99 tests pass. The enumerated test asserts the URL for each `ReportableEntityType` member; adding a new type without updating the map fails TypeScript exhaustiveness; renaming a value (e.g. `artist: 'artist'` missing `s`) fails the per-type URL assertion.

## Code review
No changes — `/code-review` ran 8 sweep angles + verification against backend routes, returned `[]`. All sweep findings were refuted (URL routes match backend registrations; no coverage loss from deleted overlap test; pre-existing API_BASE_URL trailing-slash behavior unchanged; mock-leak risk addressed by `beforeEach`).

## Orchestrator-takeover disclosure
Dispatched agent committed implementation + ran `/code-review` to completion (8 sweep angles, returned `[]`), then stalled before push. Orchestrator (this session) verified diff scope (2 files, +51/-56 lines), re-ran `bun run typecheck` and `bun run test:run features/contributions` from the worktree (both green), pushed, and opened this PR.

Closes PSY-766