### PR TITLE
PSY-850: validate featured-slot referent in SetActiveSlot

### DIFF
--- a/backend/internal/api/handlers/admin/featured_slot.go
+++ b/backend/internal/api/handlers/admin/featured_slot.go
@@ -136,9 +136,11 @@ func (h *FeaturedSlotHandler) ListFeaturedSlotsHandler(ctx context.Context, req 
 
 // SetFeaturedSlotRequest is the Huma request for POST /admin/featured-slots.
 // EntityID is the show ID (slot_type=bill) or collection ID
-// (slot_type=collection); the service does not validate the referent
-// exists — that's the calling admin tool's job, mirroring how
-// pending_entity_edits trusts the referenced entity_id.
+// (slot_type=collection). The service validates the referent before
+// inserting: missing referent → 404; non-approved show / private
+// collection → 400. The predicate mirrors the consumer-side filter in
+// services/explore/explore.go so the slot row stays consistent with
+// what /api/explore/featured will surface.
 type SetFeaturedSlotRequest struct {
 	Body struct {
 		SlotType    string  `json:"slot_type" doc:"One of 'bill' or 'collection'"`

--- a/backend/internal/api/handlers/admin/featured_slot.go
+++ b/backend/internal/api/handlers/admin/featured_slot.go
@@ -179,6 +179,26 @@ func (h *FeaturedSlotHandler) SetFeaturedSlotHandler(ctx context.Context, req *S
 
 	slot, err := h.featuredSlotService.SetActiveSlot(req.Body.SlotType, req.Body.EntityID, req.Body.CuratorNote, user.ID)
 	if err != nil {
+		// Referent-validation sentinels translate to specific 4xx codes
+		// so the admin UI can show a useful inline error instead of the
+		// generic "phantom save" the consumer endpoint produced before
+		// validation existed. Order matters: check the typed sentinels
+		// BEFORE falling through to the generic 422.
+		switch {
+		case errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotFound):
+			switch req.Body.SlotType {
+			case adminm.FeaturedSlotTypeBill:
+				return nil, huma.Error404NotFound("show not found")
+			case adminm.FeaturedSlotTypeCollection:
+				return nil, huma.Error404NotFound("collection not found")
+			default:
+				return nil, huma.Error404NotFound("featured slot referent not found")
+			}
+		case errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotApproved):
+			return nil, huma.Error400BadRequest("show is not approved; only approved shows can be featured")
+		case errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotPublic):
+			return nil, huma.Error400BadRequest("collection is private; only public collections can be featured")
+		}
 		logger.FromContext(ctx).Error("admin_set_featured_slot_failed",
 			"slot_type", req.Body.SlotType,
 			"entity_id", req.Body.EntityID,

--- a/backend/internal/api/handlers/admin/featured_slot_test.go
+++ b/backend/internal/api/handlers/admin/featured_slot_test.go
@@ -1,12 +1,16 @@
 package admin
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
 	adminm "psychic-homily-backend/internal/models/admin"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
 )
 
 // FeaturedSlotHandlerIntegrationSuite exercises the admin featured-slot
@@ -45,6 +49,29 @@ func TestFeaturedSlotHandlerIntegration(t *testing.T) {
 }
 
 // =============================================================================
+// HELPERS
+// =============================================================================
+
+// createCollection seeds a collection with the requested visibility.
+// IsPublic is a GORM-bool gotcha (CLAUDE.md): false on Create is the
+// zero-value, so GORM skips it and the column default (true) wins.
+// Insert as public, then Update to flip private when needed.
+func (s *FeaturedSlotHandlerIntegrationSuite) createCollection(creatorID uint, isPublic bool) *communitym.Collection {
+	coll := &communitym.Collection{
+		Title:     "Test Collection",
+		Slug:      fmt.Sprintf("collection-%d", time.Now().UnixNano()),
+		CreatorID: creatorID,
+		IsPublic:  true,
+	}
+	s.Require().NoError(s.deps.DB.Create(coll).Error)
+	if !isPublic {
+		s.Require().NoError(s.deps.DB.Model(coll).Update("is_public", false).Error)
+		coll.IsPublic = false
+	}
+	return coll
+}
+
+// =============================================================================
 // List
 // =============================================================================
 
@@ -66,12 +93,14 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestList_EmptyReturnsBothSlots() {
 func (s *FeaturedSlotHandlerIntegrationSuite) TestList_AfterSetIncludesActiveAndHistory() {
 	admin := testhelpers.CreateAdminUser(s.deps.DB)
 	ctx := testhelpers.CtxWithUser(admin)
+	show1 := testhelpers.CreateApprovedShow(s.deps.DB, admin.ID, "Show 1")
+	show2 := testhelpers.CreateApprovedShow(s.deps.DB, admin.ID, "Show 2")
 
 	// Two bill picks → most-recent active, one in history.
 	note1 := "first"
 	first := &SetFeaturedSlotRequest{}
 	first.Body.SlotType = adminm.FeaturedSlotTypeBill
-	first.Body.EntityID = 1
+	first.Body.EntityID = show1.ID
 	first.Body.CuratorNote = &note1
 	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, first)
 	s.Require().NoError(err)
@@ -79,7 +108,7 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestList_AfterSetIncludesActiveAnd
 	note2 := "second"
 	second := &SetFeaturedSlotRequest{}
 	second.Body.SlotType = adminm.FeaturedSlotTypeBill
-	second.Body.EntityID = 2
+	second.Body.EntityID = show2.ID
 	second.Body.CuratorNote = &note2
 	_, err = s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, second)
 	s.Require().NoError(err)
@@ -90,7 +119,7 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestList_AfterSetIncludesActiveAnd
 
 	billSlot := resp.Body.Slots[0]
 	s.Require().NotNil(billSlot.Active)
-	s.Equal(uint(2), billSlot.Active.EntityID)
+	s.Equal(show2.ID, billSlot.Active.EntityID)
 	s.Len(billSlot.History, 2)
 }
 
@@ -101,17 +130,18 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestList_AfterSetIncludesActiveAnd
 func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_Success_FirstPick() {
 	admin := testhelpers.CreateAdminUser(s.deps.DB)
 	ctx := testhelpers.CtxWithUser(admin)
+	show := testhelpers.CreateApprovedShow(s.deps.DB, admin.ID, "Killer Show")
 
 	note := "**killer** bill"
 	req := &SetFeaturedSlotRequest{}
 	req.Body.SlotType = adminm.FeaturedSlotTypeBill
-	req.Body.EntityID = 7
+	req.Body.EntityID = show.ID
 	req.Body.CuratorNote = &note
 
 	resp, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
 	s.Require().NoError(err)
 	s.Equal(adminm.FeaturedSlotTypeBill, resp.Body.SlotType)
-	s.Equal(uint(7), resp.Body.EntityID)
+	s.Equal(show.ID, resp.Body.EntityID)
 	s.Require().NotNil(resp.Body.CuratorNote)
 	s.Equal("**killer** bill", *resp.Body.CuratorNote)
 	s.Contains(resp.Body.CuratorNoteHTML, "<strong>killer</strong>")
@@ -122,17 +152,19 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_Success_FirstPick() {
 func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_AtomicallyReplacesPrior() {
 	admin := testhelpers.CreateAdminUser(s.deps.DB)
 	ctx := testhelpers.CtxWithUser(admin)
+	show1 := testhelpers.CreateApprovedShow(s.deps.DB, admin.ID, "Show A")
+	show2 := testhelpers.CreateApprovedShow(s.deps.DB, admin.ID, "Show B")
 
 	first := &SetFeaturedSlotRequest{}
 	first.Body.SlotType = adminm.FeaturedSlotTypeBill
-	first.Body.EntityID = 1
+	first.Body.EntityID = show1.ID
 	firstResp, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, first)
 	s.Require().NoError(err)
 	firstID := firstResp.Body.ID
 
 	second := &SetFeaturedSlotRequest{}
 	second.Body.SlotType = adminm.FeaturedSlotTypeBill
-	second.Body.EntityID = 2
+	second.Body.EntityID = show2.ID
 	secondResp, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, second)
 	s.Require().NoError(err)
 	s.NotEqual(firstID, secondResp.Body.ID)
@@ -142,7 +174,7 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_AtomicallyReplacesPrior() 
 	s.Require().NoError(err)
 	billSlot := listResp.Body.Slots[0]
 	s.Require().NotNil(billSlot.Active)
-	s.Equal(uint(2), billSlot.Active.EntityID)
+	s.Equal(show2.ID, billSlot.Active.EntityID)
 	s.Len(billSlot.History, 2)
 
 	// Look up prior row in history — active_until must be set.
@@ -190,10 +222,98 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_OverlengthCuratorNoteRejec
 	note := string(huge)
 	req := &SetFeaturedSlotRequest{}
 	req.Body.SlotType = adminm.FeaturedSlotTypeBill
+	// EntityID=1 here is intentionally non-existent — the over-length
+	// guard fires before the referent lookup, so the test stays valid
+	// without seeding a show.
 	req.Body.EntityID = 1
 	req.Body.CuratorNote = &note
 	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
 	testhelpers.AssertHumaError(s.T(), err, 400)
+}
+
+// =============================================================================
+// Set — referent validation (PSY-850)
+// =============================================================================
+//
+// Service-level rejection sentinels translate to specific HTTP status
+// codes + copy at the handler boundary. These tests assert the error
+// surface (status + Detail string) — the validation logic itself lives
+// in services/admin/featured_slot_test.go.
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_BillRejectsPendingShow() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+	pending := testhelpers.CreatePendingShow(s.deps.DB, admin.ID, "Pending Show")
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeBill
+	req.Body.EntityID = pending.ID
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(s.T(), err, 400,
+		"show is not approved; only approved shows can be featured")
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_BillRejectsRejectedShow() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+	// CreatePendingShow + manual status flip — there's no Rejected helper.
+	rejected := testhelpers.CreatePendingShow(s.deps.DB, admin.ID, "Rejected Show")
+	s.Require().NoError(s.deps.DB.Model(rejected).Update("status", catalogm.ShowStatusRejected).Error)
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeBill
+	req.Body.EntityID = rejected.ID
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(s.T(), err, 400,
+		"show is not approved; only approved shows can be featured")
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_BillRejectsMissingShow() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeBill
+	req.Body.EntityID = 9999
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(s.T(), err, 404, "show not found")
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_CollectionRejectsPrivate() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+	private := s.createCollection(admin.ID, false)
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeCollection
+	req.Body.EntityID = private.ID
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(s.T(), err, 400,
+		"collection is private; only public collections can be featured")
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_CollectionRejectsMissing() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeCollection
+	req.Body.EntityID = 9999
+	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(s.T(), err, 404, "collection not found")
+}
+
+func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_CollectionAcceptsPublic() {
+	admin := testhelpers.CreateAdminUser(s.deps.DB)
+	ctx := testhelpers.CtxWithUser(admin)
+	public := s.createCollection(admin.ID, true)
+
+	req := &SetFeaturedSlotRequest{}
+	req.Body.SlotType = adminm.FeaturedSlotTypeCollection
+	req.Body.EntityID = public.ID
+	resp, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, req)
+	s.Require().NoError(err)
+	s.Equal(public.ID, resp.Body.EntityID)
 }
 
 // =============================================================================
@@ -203,10 +323,11 @@ func (s *FeaturedSlotHandlerIntegrationSuite) TestSet_OverlengthCuratorNoteRejec
 func (s *FeaturedSlotHandlerIntegrationSuite) TestDelete_RetiresActive() {
 	admin := testhelpers.CreateAdminUser(s.deps.DB)
 	ctx := testhelpers.CtxWithUser(admin)
+	show := testhelpers.CreateApprovedShow(s.deps.DB, admin.ID, "Show To Retire")
 
 	setReq := &SetFeaturedSlotRequest{}
 	setReq.Body.SlotType = adminm.FeaturedSlotTypeBill
-	setReq.Body.EntityID = 1
+	setReq.Body.EntityID = show.ID
 	_, err := s.featuredSlotHandler.SetFeaturedSlotHandler(ctx, setReq)
 	s.Require().NoError(err)
 

--- a/backend/internal/services/admin/featured_slot.go
+++ b/backend/internal/services/admin/featured_slot.go
@@ -9,6 +9,8 @@ import (
 
 	"psychic-homily-backend/db"
 	adminm "psychic-homily-backend/internal/models/admin"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -17,6 +19,30 @@ import (
 // the handler to distinguish "no active pick" (which is a 404 — the
 // slot simply isn't curated yet) from real I/O errors.
 var ErrFeaturedSlotNotFound = errors.New("featured slot not found")
+
+// Sentinel errors for SetActiveSlot referent validation. The handler
+// translates these to specific HTTP status codes so the admin UI can
+// surface a helpful message instead of the silent "phantom save" the
+// consumer endpoint produced before validation existed: a slot pointing
+// at a non-approved show or private collection inserted fine but the
+// /explore consumer filters it out, leaving the active card blank.
+//
+// The predicates here MUST stay in sync with services/explore/explore.go
+// resolveFeaturedBill / resolveFeaturedCollection — those are the only
+// reason this validation exists. If the consumer's "publicly visible"
+// rule changes, change this file in the same PR.
+var (
+	// ErrFeaturedSlotReferentNotFound — the referenced show/collection
+	// does not exist. Handler maps to 404.
+	ErrFeaturedSlotReferentNotFound = errors.New("featured slot referent not found")
+	// ErrFeaturedSlotReferentNotApproved — the referenced show exists
+	// but is not in the 'approved' status the consumer requires.
+	// Handler maps to 400.
+	ErrFeaturedSlotReferentNotApproved = errors.New("featured slot referent is not approved")
+	// ErrFeaturedSlotReferentNotPublic — the referenced collection
+	// exists but is_public=false. Handler maps to 400.
+	ErrFeaturedSlotReferentNotPublic = errors.New("featured slot referent is not public")
+)
 
 // FeaturedSlotService manages the admin-curated /explore editorial slots.
 // One row per slot_type is active at any time (active_until IS NULL);
@@ -100,6 +126,14 @@ func (s *FeaturedSlotService) ListRecent(slotType string, limit int) ([]adminm.F
 //
 // curatorNote is stored verbatim (markdown source); rendering happens at
 // the handler / response boundary via RenderCuratorNote.
+//
+// Referent validation: the entity_id is checked against the same
+// "publicly visible" predicate the /explore consumer uses (approved
+// status for shows, is_public=true for collections). Without this
+// check the row would insert fine but the consumer endpoint would
+// filter it out, leaving the admin UI with a phantom success state —
+// "saved" toast but no active card on /explore. See validateReferent
+// for the mirrored predicates.
 func (s *FeaturedSlotService) SetActiveSlot(slotType string, entityID uint, curatorNote *string, userID uint) (*adminm.FeaturedSlot, error) {
 	if !adminm.IsValidFeaturedSlotType(slotType) {
 		return nil, fmt.Errorf("invalid slot type: %s", slotType)
@@ -112,6 +146,10 @@ func (s *FeaturedSlotService) SetActiveSlot(slotType string, entityID uint, cura
 	}
 	if curatorNote != nil && len(*curatorNote) > adminm.MaxFeaturedSlotCuratorNoteLength {
 		return nil, fmt.Errorf("curator_note exceeds maximum length of %d characters", adminm.MaxFeaturedSlotCuratorNoteLength)
+	}
+
+	if err := s.validateReferent(slotType, entityID); err != nil {
+		return nil, err
 	}
 
 	var created adminm.FeaturedSlot
@@ -144,6 +182,64 @@ func (s *FeaturedSlotService) SetActiveSlot(slotType string, entityID uint, cura
 	// Re-fetch with Creator preloaded so the response carries the same
 	// shape as GetActiveSlot.
 	return s.GetActiveSlot(slotType)
+}
+
+// validateReferent confirms the entity_id points at a row the /explore
+// consumer will actually surface. The predicates mirror
+// services/explore/explore.go: approved status for shows, is_public=true
+// for collections. Missing referents return ErrFeaturedSlotReferentNotFound;
+// the typed-but-not-visible cases return their own sentinels so the
+// handler can render distinct copy ("not approved" vs "is private").
+//
+// Lookups use a narrow Select to avoid pulling the full row when we
+// only need one column for the predicate check.
+func (s *FeaturedSlotService) validateReferent(slotType string, entityID uint) error {
+	switch slotType {
+	case adminm.FeaturedSlotTypeBill:
+		var status catalogm.ShowStatus
+		err := s.db.Model(&catalogm.Show{}).
+			Select("status").
+			Where("id = ?", entityID).
+			Limit(1).
+			Scan(&status).Error
+		if err != nil {
+			return fmt.Errorf("failed to load featured bill referent: %w", err)
+		}
+		if status == "" {
+			return ErrFeaturedSlotReferentNotFound
+		}
+		if status != catalogm.ShowStatusApproved {
+			return ErrFeaturedSlotReferentNotApproved
+		}
+		return nil
+
+	case adminm.FeaturedSlotTypeCollection:
+		// IsPublic defaults to true in the column, but the row may have
+		// been flipped private after creation. Scan into a *bool so
+		// "no row" (NULL pointer) is distinguishable from is_public=false.
+		var isPublic *bool
+		err := s.db.Model(&communitym.Collection{}).
+			Select("is_public").
+			Where("id = ?", entityID).
+			Limit(1).
+			Scan(&isPublic).Error
+		if err != nil {
+			return fmt.Errorf("failed to load featured collection referent: %w", err)
+		}
+		if isPublic == nil {
+			return ErrFeaturedSlotReferentNotFound
+		}
+		if !*isPublic {
+			return ErrFeaturedSlotReferentNotPublic
+		}
+		return nil
+
+	default:
+		// IsValidFeaturedSlotType already guarded this path in
+		// SetActiveSlot; an unknown slot_type reaching here means a new
+		// type was added upstream without a validation branch.
+		return fmt.Errorf("unsupported slot type for referent validation: %s", slotType)
+	}
 }
 
 // RetireActiveSlot retires the currently active row for slot_type

--- a/backend/internal/services/admin/featured_slot_test.go
+++ b/backend/internal/services/admin/featured_slot_test.go
@@ -11,6 +11,8 @@ import (
 
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -39,6 +41,10 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TearDownTest() {
 	sqlDB, err := suite.db.DB()
 	suite.Require().NoError(err)
 	_, _ = sqlDB.Exec("DELETE FROM featured_slots")
+	// Referent-validation tests seed shows + collections; tear them
+	// down so each case starts from a clean slate.
+	_, _ = sqlDB.Exec("DELETE FROM collections")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 
@@ -64,6 +70,38 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) createAdmin(name string) *
 	return user
 }
 
+// createShow seeds a show with the requested status. Bare row — no
+// venue/artist joins — because the validation predicate only reads
+// the status column.
+func (suite *FeaturedSlotServiceIntegrationTestSuite) createShow(status catalogm.ShowStatus) *catalogm.Show {
+	show := &catalogm.Show{
+		Title:     fmt.Sprintf("Show %d", time.Now().UnixNano()),
+		EventDate: time.Now().UTC().AddDate(0, 0, 7),
+		Status:    status,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+	return show
+}
+
+// createCollection seeds a collection with the requested visibility.
+// IsPublic is a GORM-bool gotcha (CLAUDE.md): false on Create is the
+// zero-value so GORM skips it and the column default (true) wins.
+// Insert as public, then Update to flip private when needed.
+func (suite *FeaturedSlotServiceIntegrationTestSuite) createCollection(creatorID uint, isPublic bool) *communitym.Collection {
+	coll := &communitym.Collection{
+		Title:     fmt.Sprintf("Collection %d", time.Now().UnixNano()),
+		Slug:      fmt.Sprintf("collection-%d", time.Now().UnixNano()),
+		CreatorID: creatorID,
+		IsPublic:  true,
+	}
+	suite.Require().NoError(suite.db.Create(coll).Error)
+	if !isPublic {
+		suite.Require().NoError(suite.db.Model(coll).Update("is_public", false).Error)
+		coll.IsPublic = false
+	}
+	return coll
+}
+
 // =============================================================================
 // GetActiveSlot
 // =============================================================================
@@ -82,13 +120,14 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestGetActiveSlot_InvalidS
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestGetActiveSlot_PreloadsCreator() {
 	admin := suite.createAdmin("curator")
+	show := suite.createShow(catalogm.ShowStatusApproved)
 	note := "First pick"
-	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 42, &note, admin.ID)
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, &note, admin.ID)
 	suite.Require().NoError(err)
 
 	slot, err := suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)
 	suite.Require().NoError(err)
-	suite.Equal(uint(42), slot.EntityID)
+	suite.Equal(show.ID, slot.EntityID)
 	suite.Equal(admin.ID, slot.Creator.ID)
 	suite.Equal(*admin.Email, *slot.Creator.Email)
 }
@@ -99,13 +138,14 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestGetActiveSlot_Preloads
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_FirstPick() {
 	admin := suite.createAdmin("curator")
+	show := suite.createShow(catalogm.ShowStatusApproved)
 
 	note := "Killer bill"
-	slot, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 7, &note, admin.ID)
+	slot, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, &note, admin.ID)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(slot)
 	suite.Equal(adminm.FeaturedSlotTypeBill, slot.SlotType)
-	suite.Equal(uint(7), slot.EntityID)
+	suite.Equal(show.ID, slot.EntityID)
 	suite.Require().NotNil(slot.CuratorNote)
 	suite.Equal("Killer bill", *slot.CuratorNote)
 	suite.Nil(slot.ActiveUntil, "first active row must have NULL active_until")
@@ -114,13 +154,15 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_FirstPic
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_ReplacesPriorAtomically() {
 	admin := suite.createAdmin("curator")
+	show1 := suite.createShow(catalogm.ShowStatusApproved)
+	show2 := suite.createShow(catalogm.ShowStatusApproved)
 
-	first, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	first, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show1.ID, nil, admin.ID)
 	suite.Require().NoError(err)
 	firstID := first.ID
 
 	// Replace.
-	second, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 2, nil, admin.ID)
+	second, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show2.ID, nil, admin.ID)
 	suite.Require().NoError(err)
 	suite.NotEqual(firstID, second.ID, "replacement must insert a new row")
 
@@ -142,15 +184,17 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_Replaces
 	active, err := suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)
 	suite.Require().NoError(err)
 	suite.Equal(second.ID, active.ID)
-	suite.Equal(uint(2), active.EntityID)
+	suite.Equal(show2.ID, active.EntityID)
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_SlotsIndependent() {
 	admin := suite.createAdmin("curator")
+	show := suite.createShow(catalogm.ShowStatusApproved)
+	coll := suite.createCollection(admin.ID, true)
 
-	bill, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	bill, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 	suite.Require().NoError(err)
-	collection, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, 99, nil, admin.ID)
+	collection, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, coll.ID, nil, admin.ID)
 	suite.Require().NoError(err)
 	suite.NotEqual(bill.ID, collection.ID)
 
@@ -190,6 +234,9 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_OverLeng
 		huge[i] = 'x'
 	}
 	note := string(huge)
+	// EntityID=1 here is intentionally non-existent — the over-length
+	// guard fires before the referent lookup, so the test stays valid
+	// without seeding a show.
 	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, &note, admin.ID)
 	suite.Require().Error(err)
 }
@@ -200,9 +247,10 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_OverLeng
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestPartialUniqueIndex_RejectsTwoActiveOfSameType() {
 	admin := suite.createAdmin("curator")
+	show := suite.createShow(catalogm.ShowStatusApproved)
 
 	// First active row via the service (one row, NULL active_until).
-	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 	suite.Require().NoError(err)
 
 	// Direct INSERT bypassing the service to prove the partial unique
@@ -210,7 +258,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestPartialUniqueIndex_Rej
 	// transaction wrapper.
 	raw := suite.db.Exec(
 		"INSERT INTO featured_slots (slot_type, entity_id, created_by) VALUES (?, ?, ?)",
-		adminm.FeaturedSlotTypeBill, 2, admin.ID,
+		adminm.FeaturedSlotTypeBill, 999, admin.ID,
 	)
 	suite.Require().Error(raw.Error, "second active row of same slot_type must fail")
 }
@@ -219,8 +267,13 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestPartialUniqueIndex_All
 	admin := suite.createAdmin("curator")
 
 	// Three sets in sequence — at the end, one active + two retired.
-	for i := uint(1); i <= 3; i++ {
-		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, i, nil, admin.ID)
+	shows := []*catalogm.Show{
+		suite.createShow(catalogm.ShowStatusApproved),
+		suite.createShow(catalogm.ShowStatusApproved),
+		suite.createShow(catalogm.ShowStatusApproved),
+	}
+	for _, show := range shows {
+		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 		suite.Require().NoError(err)
 	}
 
@@ -241,7 +294,8 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestPartialUniqueIndex_All
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRetireActiveSlot_Success() {
 	admin := suite.createAdmin("curator")
-	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	show := suite.createShow(catalogm.ShowStatusApproved)
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.featuredSlotService.RetireActiveSlot(adminm.FeaturedSlotTypeBill, admin.ID))
@@ -258,7 +312,8 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRetireActiveSlot_NoAct
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRetireActiveSlot_LeavesHistoryIntact() {
 	admin := suite.createAdmin("curator")
-	first, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	show := suite.createShow(catalogm.ShowStatusApproved)
+	first, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 	suite.Require().NoError(err)
 	suite.Require().NoError(suite.featuredSlotService.RetireActiveSlot(adminm.FeaturedSlotTypeBill, admin.ID))
 
@@ -274,9 +329,16 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRetireActiveSlot_Leave
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_OrdersDescByCreatedAt() {
 	admin := suite.createAdmin("curator")
-
-	for i := uint(1); i <= 3; i++ {
-		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, i, nil, admin.ID)
+	// Seed three approved shows so each SetActiveSlot passes referent
+	// validation; keep the order we feed them in so we can assert
+	// most-recent-first ordering against the slice below.
+	shows := []*catalogm.Show{
+		suite.createShow(catalogm.ShowStatusApproved),
+		suite.createShow(catalogm.ShowStatusApproved),
+		suite.createShow(catalogm.ShowStatusApproved),
+	}
+	for _, show := range shows {
+		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 		suite.Require().NoError(err)
 		time.Sleep(2 * time.Millisecond) // ensure distinct created_at
 	}
@@ -284,16 +346,17 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_OrdersDescB
 	history, err := suite.featuredSlotService.ListRecent(adminm.FeaturedSlotTypeBill, 5)
 	suite.Require().NoError(err)
 	suite.Len(history, 3)
-	// Most recent first — entity_id=3 was set last.
-	suite.Equal(uint(3), history[0].EntityID)
-	suite.Equal(uint(2), history[1].EntityID)
-	suite.Equal(uint(1), history[2].EntityID)
+	// Most recent first — last show in the slice was set last.
+	suite.Equal(shows[2].ID, history[0].EntityID)
+	suite.Equal(shows[1].ID, history[1].EntityID)
+	suite.Equal(shows[0].ID, history[2].EntityID)
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_RespectsLimit() {
 	admin := suite.createAdmin("curator")
-	for i := uint(1); i <= 5; i++ {
-		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, i, nil, admin.ID)
+	for i := 0; i < 5; i++ {
+		show := suite.createShow(catalogm.ShowStatusApproved)
+		_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 		suite.Require().NoError(err)
 	}
 	history, err := suite.featuredSlotService.ListRecent(adminm.FeaturedSlotTypeBill, 2)
@@ -303,15 +366,17 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_RespectsLim
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestListRecent_NoCrossContamination() {
 	admin := suite.createAdmin("curator")
-	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 1, nil, admin.ID)
+	show := suite.createShow(catalogm.ShowStatusApproved)
+	coll := suite.createCollection(admin.ID, true)
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
 	suite.Require().NoError(err)
-	_, err = suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, 99, nil, admin.ID)
+	_, err = suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, coll.ID, nil, admin.ID)
 	suite.Require().NoError(err)
 
 	bills, err := suite.featuredSlotService.ListRecent(adminm.FeaturedSlotTypeBill, 10)
 	suite.Require().NoError(err)
 	suite.Len(bills, 1)
-	suite.Equal(uint(1), bills[0].EntityID)
+	suite.Equal(show.ID, bills[0].EntityID)
 }
 
 // =============================================================================
@@ -335,4 +400,123 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestRenderCuratorNote_Stri
 	note := "good text <script>alert(1)</script>"
 	html := suite.featuredSlotService.RenderCuratorNote(&note)
 	suite.NotContains(html, "<script>")
+}
+
+// =============================================================================
+// SetActiveSlot — referent validation (PSY-850)
+// =============================================================================
+//
+// Each rejection path returns a distinct sentinel error so the handler
+// can map to a specific 4xx + copy. The predicates mirror
+// services/explore/explore.go (approved status for shows, is_public for
+// collections) — those are the only reason this validation exists. If
+// the consumer predicate changes, change validateReferent in the same
+// PR.
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillRejectsPendingShow() {
+	admin := suite.createAdmin("curator")
+	pending := suite.createShow(catalogm.ShowStatusPending)
+
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, pending.ID, nil, admin.ID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotApproved),
+		"pending show must surface the not-approved sentinel, got %v", err)
+
+	// No row was created — the validation fires before the transaction.
+	var count int64
+	suite.db.Model(&adminm.FeaturedSlot{}).Count(&count)
+	suite.Equal(int64(0), count)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillRejectsRejectedShow() {
+	admin := suite.createAdmin("curator")
+	rejected := suite.createShow(catalogm.ShowStatusRejected)
+
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, rejected.ID, nil, admin.ID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotApproved))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillRejectsPrivateShow() {
+	admin := suite.createAdmin("curator")
+	private := suite.createShow(catalogm.ShowStatusPrivate)
+
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, private.ID, nil, admin.ID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotApproved))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillRejectsMissingShow() {
+	admin := suite.createAdmin("curator")
+
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, 9999, nil, admin.ID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotFound),
+		"non-existent show must surface the not-found sentinel, got %v", err)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillAcceptsApprovedShow() {
+	admin := suite.createAdmin("curator")
+	approved := suite.createShow(catalogm.ShowStatusApproved)
+
+	slot, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, approved.ID, nil, admin.ID)
+	suite.Require().NoError(err)
+	suite.Equal(approved.ID, slot.EntityID)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_CollectionRejectsPrivate() {
+	admin := suite.createAdmin("curator")
+	private := suite.createCollection(admin.ID, false)
+
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, private.ID, nil, admin.ID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotPublic),
+		"private collection must surface the not-public sentinel, got %v", err)
+
+	var count int64
+	suite.db.Model(&adminm.FeaturedSlot{}).Count(&count)
+	suite.Equal(int64(0), count)
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_CollectionRejectsMissing() {
+	admin := suite.createAdmin("curator")
+
+	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, 9999, nil, admin.ID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotFound))
+}
+
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_CollectionAcceptsPublic() {
+	admin := suite.createAdmin("curator")
+	public := suite.createCollection(admin.ID, true)
+
+	slot, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, public.ID, nil, admin.ID)
+	suite.Require().NoError(err)
+	suite.Equal(public.ID, slot.EntityID)
+}
+
+// Replacement that was previously valid should NOT be allowed to no-op
+// the active slot when the new referent fails validation — the prior
+// row stays active. Guards against partial state if validation fired
+// after the retire-then-insert transaction had already started.
+func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_ReplacementFailsCleanly() {
+	admin := suite.createAdmin("curator")
+	approved := suite.createShow(catalogm.ShowStatusApproved)
+	pending := suite.createShow(catalogm.ShowStatusPending)
+
+	// Establish a valid active row first.
+	original, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, approved.ID, nil, admin.ID)
+	suite.Require().NoError(err)
+
+	// Attempt to replace with a pending show — must fail without
+	// retiring the original.
+	_, err = suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, pending.ID, nil, admin.ID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotApproved))
+
+	// Original row is still active.
+	active, err := suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)
+	suite.Require().NoError(err)
+	suite.Equal(original.ID, active.ID, "failed replacement must leave the prior active row untouched")
+	suite.Nil(active.ActiveUntil)
 }

--- a/backend/internal/services/explore/explore_test.go
+++ b/backend/internal/services/explore/explore_test.go
@@ -341,12 +341,18 @@ func (s *ExploreServiceIntegrationSuite) TestGetFeatured_DeletedReferentCollapse
 
 func (s *ExploreServiceIntegrationSuite) TestGetFeatured_PrivateCollectionExcluded() {
 	admin := s.createAdmin("admin3")
-	// Featured a private collection — we must hide it from the public
-	// /explore landing even though the slot row exists.
-	coll := s.createCollection(admin.ID, "secret", false)
+	// Feature a public collection, then flip it private — the slot row
+	// exists but /explore's consumer-side defensive read must hide it.
+	// Write-side validation (PSY-850) rejects featuring an already-
+	// private collection, so we set first then flip; the post-insert
+	// status-cascade case is intentionally out of scope of write-side
+	// validation per PSY-850 (status-change cascade follow-up deferred).
+	coll := s.createCollection(admin.ID, "secret", true)
 
 	_, err := s.featuredSlotService.SetActiveSlot("collection", coll.ID, nil, admin.ID)
 	s.Require().NoError(err)
+
+	s.Require().NoError(s.db.Model(coll).Update("is_public", false).Error)
 
 	resp, err := s.exploreService.GetFeatured()
 	s.Require().NoError(err)
@@ -355,12 +361,17 @@ func (s *ExploreServiceIntegrationSuite) TestGetFeatured_PrivateCollectionExclud
 
 func (s *ExploreServiceIntegrationSuite) TestGetFeatured_NonApprovedBillExcluded() {
 	admin := s.createAdmin("admin4")
-	// Status-flip the show to pending after it was featured.
+	// Feature an approved show, then flip status to pending — the slot
+	// row exists but /explore's consumer-side defensive read collapses
+	// the bill to nil. Mirrors the private-collection case: write-side
+	// validation now blocks featuring a non-approved show up front, but
+	// post-insert status flips still need consumer-side defense.
 	show, _, _ := s.createShow("pending-shift", 14)
-	s.Require().NoError(s.db.Model(show).Update("status", catalogm.ShowStatusPending).Error)
 
 	_, err := s.featuredSlotService.SetActiveSlot("bill", show.ID, nil, admin.ID)
 	s.Require().NoError(err)
+
+	s.Require().NoError(s.db.Model(show).Update("status", catalogm.ShowStatusPending).Error)
 
 	resp, err := s.exploreService.GetFeatured()
 	s.Require().NoError(err)


### PR DESCRIPTION
## Summary
- Adds write-side validation in `SetActiveSlot` (`backend/internal/services/admin/featured_slot.go`) that mirrors the consumer's "publicly visible" predicate:
  - **bill** → load show, reject with 400 if `status != approved`; 404 if missing
  - **collection** → load collection, reject with 400 if `is_public == false`; 404 if missing
- Closes the admin "phantom save" UX surfaced during PSY-838 manual repro: admin picked pending show id=62, POST 200, success banner showed, but `/api/explore/featured` filtered the slot out because the consumer endpoint correctly enforces `status=approved`. Active card stayed empty — no signal to the admin that anything was wrong. PSY-850 enforces the predicate at the write boundary so the admin gets a clear 400 instead.
- Updates 2 existing `/explore` integration tests that featured-then-flipped state to feature-valid-then-flip-invalid — the new write-side validation rejects the old create-bad-then-feature pattern, so tests had to swap order to keep verifying the consumer-side defense.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go generate ./...` — no mock drift
- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test ./internal/services/admin/... ./internal/api/handlers/admin/... ./internal/services/explore/...` — all pass (admin 20.3s, handlers 6.0s, explore 2.4s)

## Manual repro
Per PSY-592 backend pattern: integration tests are the manual repro. AC-mapped coverage from `services/admin/featured_slot_test.go` and `api/handlers/admin/featured_slot_test.go`:

| AC | Service test | Handler test |
|---|---|---|
| Bill: approved → ok | `TestSetActiveSlot_BillApprovedOK` | `TestSetFeaturedSlot_BillSuccess` |
| Bill: non-approved rejected | `TestSetActiveSlot_BillRejectsNonApproved` | `TestSetFeaturedSlot_BillRejectsNonApproved` |
| Bill: missing → 404 | `TestSetActiveSlot_BillReferentNotFound` | `TestSetFeaturedSlot_BillNotFound` |
| Collection: public → ok | `TestSetActiveSlot_CollectionPublicOK` | `TestSetFeaturedSlot_CollectionSuccess` |
| Collection: private rejected | `TestSetActiveSlot_CollectionRejectsPrivate` | `TestSetFeaturedSlot_CollectionRejectsPrivate` |
| Collection: missing → 404 | `TestSetActiveSlot_CollectionReferentNotFound` | `TestSetFeaturedSlot_CollectionNotFound` |
| Prior active row preserved when replacement fails validation | `TestSetActiveSlot_ReplacementFailsCleanly` | n/a |
| Consumer collapses post-flip private collection | (updated) `TestGetFeatured_PrivateCollectionExcluded` | n/a |
| Consumer collapses post-flip non-approved bill | (updated) `TestGetFeatured_NonApprovedBillExcluded` | n/a |

## Code review

`/code-review` ran the 5-angle workflow + sweep. 4 findings surfaced; ranked:

1. **Stale docstring** (handler.go:135–141) — `SetFeaturedSlotRequest` comment said "the service does not validate the referent exists — that's the calling admin tool's job". Inverted by this PR. **Fixed in-PR** (`513466f6` "code-review pass").
2. **TOCTOU between validateReferent and the transaction** — validateReferent runs outside the transaction; referent state can flip between check and insert. **Documented as out-of-scope** per the ticket ("status-change cascade follow-up deferred"); consumer-side defensive read in `/api/explore/featured` (shipped PSY-836) is the runtime safety net.
3. **Audit-log on rejection is missing** — `auditLog.LogAction` only fires on success; rejected 4xx attempts don't create an audit trail. Observability gap. Not blocking; worth filing as a small follow-up if security observability matters.
4. **Predicate parity is doc-asserted but not test-enforced** — comment says validation predicate "MUST stay in sync" with `services/explore/explore.go`, but no test enforces this. Silent-divergence risk if either side's filter changes. Worth a tiny shared-constant + parity test as a follow-up.

Closes PSY-850