### PR TITLE
PSY-767: add aria-label to icon-only buttons + role=status to LoadingSpinner

### DIFF
--- a/frontend/components/shared/LoadingSpinner.test.tsx
+++ b/frontend/components/shared/LoadingSpinner.test.tsx
@@ -3,9 +3,12 @@ import { render, screen } from '@testing-library/react'
 import { LoadingSpinner } from './LoadingSpinner'
 
 describe('LoadingSpinner', () => {
-  it('renders a div element with spinner styling', () => {
-    const { container } = render(<LoadingSpinner />)
-    const spinner = container.firstChild as HTMLElement
+  it('exposes role="status" with a default accessible name', () => {
+    render(<LoadingSpinner />)
+    // role="status" + aria-label makes the spinner announceable to assistive
+    // tech. Querying by role is the authoritative shape; sizing/class assertions
+    // below cover the visual contract separately.
+    const spinner = screen.getByRole('status', { name: 'Loading' })
     expect(spinner).toBeInTheDocument()
     expect(spinner.tagName).toBe('DIV')
     expect(spinner.className).toContain('animate-spin')
@@ -13,42 +16,43 @@ describe('LoadingSpinner', () => {
     expect(spinner.className).toContain('border-b-2')
   })
 
+  it('accepts a custom accessible label', () => {
+    render(<LoadingSpinner label="Loading collections" />)
+    expect(
+      screen.getByRole('status', { name: 'Loading collections' })
+    ).toBeInTheDocument()
+  })
+
   it('defaults to medium size', () => {
-    const { container } = render(<LoadingSpinner />)
-    const spinner = container.firstChild as HTMLElement
+    render(<LoadingSpinner />)
+    const spinner = screen.getByRole('status')
     expect(spinner.className).toContain('h-8')
     expect(spinner.className).toContain('w-8')
   })
 
   it('renders small size', () => {
-    const { container } = render(<LoadingSpinner size="sm" />)
-    const spinner = container.firstChild as HTMLElement
+    render(<LoadingSpinner size="sm" />)
+    const spinner = screen.getByRole('status')
     expect(spinner.className).toContain('h-4')
     expect(spinner.className).toContain('w-4')
   })
 
   it('renders large size', () => {
-    const { container } = render(<LoadingSpinner size="lg" />)
-    const spinner = container.firstChild as HTMLElement
+    render(<LoadingSpinner size="lg" />)
+    const spinner = screen.getByRole('status')
     expect(spinner.className).toContain('h-12')
     expect(spinner.className).toContain('w-12')
   })
 
-  it('has animate-spin class for animation', () => {
-    const { container } = render(<LoadingSpinner />)
-    const spinner = container.firstChild as HTMLElement
-    expect(spinner.className).toContain('animate-spin')
-  })
-
   it('applies custom className', () => {
-    const { container } = render(<LoadingSpinner className="mt-4" />)
-    const spinner = container.firstChild as HTMLElement
+    render(<LoadingSpinner className="mt-4" />)
+    const spinner = screen.getByRole('status')
     expect(spinner.className).toContain('mt-4')
   })
 
   it('merges custom className with default classes', () => {
-    const { container } = render(<LoadingSpinner size="sm" className="text-red-500" />)
-    const spinner = container.firstChild as HTMLElement
+    render(<LoadingSpinner size="sm" className="text-red-500" />)
+    const spinner = screen.getByRole('status')
     expect(spinner.className).toContain('animate-spin')
     expect(spinner.className).toContain('text-red-500')
     expect(spinner.className).toContain('h-4')

--- a/frontend/components/shared/LoadingSpinner.tsx
+++ b/frontend/components/shared/LoadingSpinner.tsx
@@ -3,6 +3,12 @@ import { cn } from '@/lib/utils'
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg'
   className?: string
+  /**
+   * Accessible label announced to assistive tech. Defaults to "Loading".
+   * Override when the spinner sits inside a more specific context
+   * (e.g. "Loading collections") so screen reader users get useful detail.
+   */
+  label?: string
 }
 
 const sizeClasses = {
@@ -11,9 +17,16 @@ const sizeClasses = {
   lg: 'h-12 w-12',
 }
 
-export function LoadingSpinner({ size = 'md', className }: LoadingSpinnerProps) {
+export function LoadingSpinner({
+  size = 'md',
+  className,
+  label = 'Loading',
+}: LoadingSpinnerProps) {
   return (
     <div
+      role="status"
+      aria-label={label}
+      aria-live="polite"
       className={cn(
         'animate-spin rounded-full border-b-2 border-foreground',
         sizeClasses[size],

--- a/frontend/features/festivals/admin/FestivalManagement.test.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.test.tsx
@@ -81,6 +81,9 @@ describe('FestivalManagement', () => {
       error: null,
     })
     renderWithProviders(<FestivalManagement />)
+    // Loading state uses an inline Loader2 icon (not the shared LoadingSpinner
+    // primitive), so the role="status" gain doesn't reach this site. Target
+    // the animation class, which is the stable hook for inline spinners.
     expect(document.querySelector('.animate-spin')).toBeInTheDocument()
   })
 
@@ -182,15 +185,13 @@ describe('FestivalManagement', () => {
       isLoading: false,
       error: null,
     })
-    const { container } = renderWithProviders(<FestivalManagement />)
+    renderWithProviders(<FestivalManagement />)
 
-    // Edit/Delete are icon-only buttons with no accessible name; the delete
-    // button is the only one carrying the destructive hover affordance.
-    const deleteButton = container.querySelector<HTMLButtonElement>(
-      'button.hover\\:text-destructive'
+    // Edit/Delete are icon-only but each row buttons carry per-festival
+    // aria-labels so they're addressable by accessible name.
+    await user.click(
+      screen.getByRole('button', { name: /delete FORM Arcosanti/i })
     )
-    expect(deleteButton).not.toBeNull()
-    await user.click(deleteButton!)
 
     expect(
       screen.getByRole('heading', { name: 'Delete Festival' })
@@ -198,6 +199,23 @@ describe('FestivalManagement', () => {
     // The confirmation copy echoes the name (quoted) in a bold span. The row
     // behind the dialog also shows the name, so match the quoted variant.
     expect(screen.getByText('"FORM Arcosanti"')).toBeInTheDocument()
+  })
+
+  it('exposes per-row Edit/Delete buttons with accessible names', () => {
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [makeFestival({ name: 'FORM Arcosanti' })], count: 1 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+    // Positive assertion: per-row icon-only buttons must be reachable by
+    // accessible name so keyboard + screen reader users can target them.
+    expect(
+      screen.getByRole('button', { name: /edit FORM Arcosanti/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /delete FORM Arcosanti/i })
+    ).toBeInTheDocument()
   })
 
   it('navigates into the lineup management panel', async () => {

--- a/frontend/features/festivals/admin/FestivalManagement.test.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.test.tsx
@@ -218,6 +218,37 @@ describe('FestivalManagement', () => {
     ).toBeInTheDocument()
   })
 
+  it('disambiguates same-name festivals across editions in aria-labels', () => {
+    // Festival names are not unique across editions (e.g. Coachella 2025 +
+    // Coachella 2026). Per-row aria-labels must include edition_year so
+    // screen reader users (and getByRole {name}) can target a specific row.
+    mockUseFestivals.mockReturnValue({
+      data: {
+        festivals: [
+          makeFestival({ id: 1, name: 'Coachella', edition_year: 2025 }),
+          makeFestival({ id: 2, name: 'Coachella', edition_year: 2026 }),
+        ],
+        count: 2,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    expect(
+      screen.getByRole('button', { name: 'Edit Coachella 2025' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Edit Coachella 2026' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Delete Coachella 2025' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Delete Coachella 2026' })
+    ).toBeInTheDocument()
+  })
+
   it('navigates into the lineup management panel', async () => {
     const user = userEvent.setup()
     mockUseFestivals.mockReturnValue({

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -1622,6 +1622,7 @@ export function FestivalManagement() {
                       size="sm"
                       onClick={() => openEdit(festival.id)}
                       className="h-8 w-8 p-0"
+                      aria-label={`Edit ${festival.name}`}
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </Button>
@@ -1630,6 +1631,7 @@ export function FestivalManagement() {
                       size="sm"
                       onClick={() => openDelete(festival.id, festival.name)}
                       className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                      aria-label={`Delete ${festival.name}`}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -1622,7 +1622,7 @@ export function FestivalManagement() {
                       size="sm"
                       onClick={() => openEdit(festival.id)}
                       className="h-8 w-8 p-0"
-                      aria-label={`Edit ${festival.name}`}
+                      aria-label={`Edit ${festival.name} ${festival.edition_year}`}
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </Button>
@@ -1631,7 +1631,7 @@ export function FestivalManagement() {
                       size="sm"
                       onClick={() => openDelete(festival.id, festival.name)}
                       className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                      aria-label={`Delete ${festival.name}`}
+                      aria-label={`Delete ${festival.name} ${festival.edition_year}`}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>

--- a/frontend/features/requests/components/RequestDetail.test.tsx
+++ b/frontend/features/requests/components/RequestDetail.test.tsx
@@ -140,15 +140,10 @@ function makeRequest(overrides: Partial<Request> = {}): Request {
   }
 }
 
-// The delete action is an icon-only button with no accessible name, so it
-// can't be reached via getByRole name. It is the only action styled with the
-// destructive class, which is the stable hook the test targets.
+// The delete action is icon-only but carries an aria-label so screen readers
+// can announce it. Querying by role+name is the authoritative shape.
 function getDeleteButton(): HTMLElement {
-  const deleteBtn = screen
-    .getAllByRole('button')
-    .find(b => b.className.includes('text-destructive'))
-  if (!deleteBtn) throw new Error('delete button not found')
-  return deleteBtn
+  return screen.getByRole('button', { name: /delete request/i })
 }
 
 function queryResult(

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -352,6 +352,7 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                     onClick={handleDelete}
                     disabled={deleteMutation.isPending}
                     className="text-destructive hover:text-destructive"
+                    aria-label="Delete request"
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>

--- a/frontend/features/scenes/components/SceneList.test.tsx
+++ b/frontend/features/scenes/components/SceneList.test.tsx
@@ -59,10 +59,10 @@ describe('SceneList', () => {
 
   it('renders a loading spinner while fetching', () => {
     mockUseScenes.mockReturnValue({ data: undefined, isLoading: true, error: null })
-    const { container } = renderWithProviders(<SceneList />)
-    // LoadingSpinner is an unlabeled spinner div; assert on its animate-spin
-    // class rather than a role it doesn't expose.
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+    renderWithProviders(<SceneList />)
+    // LoadingSpinner exposes role="status" so the loading state is
+    // announceable to assistive tech and addressable by tests.
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
     // No scene cards while loading.
     expect(screen.queryByText(/, AZ$/)).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary
- Add `role="status"` + configurable `aria-label` (default `"Loading"`) + `aria-live="polite"` to the shared `LoadingSpinner` primitive — covers every consumer in one place.
- Add `aria-label="Delete request"` to the icon-only delete button in `RequestDetail`.
- Add `aria-label={`Edit/Delete ${name} ${edition_year}`}` to the icon-only Edit/Delete buttons on each `FestivalManagement` admin row. Edition year disambiguates festivals that share a name across years (e.g. Coachella 2025 vs. Coachella 2026).
- Update tests previously targeting these elements via class workarounds to use accessible queries — per PSY-859 anti-false-coverage guidance, the role query REPLACES the class query (not kept alongside).

## Test plan
- [x] `cd frontend && bun run typecheck` — passed (no output).
- [x] `cd frontend && bun run test:run components/shared` — 23 files, 342 tests passed (includes `LoadingSpinner.test.tsx`).
- [x] `cd frontend && bun run test:run features/requests` — 5 files, 102 tests passed.
- [x] `cd frontend && bun run test:run features/festivals` — 17 files, 129 tests passed (includes new `FestivalManagement.test.tsx` disambiguation test).
- [x] `cd frontend && bun run test:run features/scenes` — 8 files, 62 tests passed (`SceneList.test.tsx` now uses `getByRole('status')`).

## Sweep results

A Python scanner over `frontend/**/*.tsx` was used to find `<Button>` / `<button>` blocks whose body is icon-only (single capitalized JSX child, no visible text) and that lack `aria-label` / `sr-only` / `iconOnly`:

- **Raw flag count: 121 sites across ~50 files.** The heuristic overcounts because it can't see visible text inside JSX expression fragments (`{isPending ? <>...</> : 'Save'}`), so the true count of icon-only-button defects is meaningfully lower (manual sampling: ~30–50 confirmed sites).
- **Animate-spin (status-element) sweep:** 174 files use `animate-spin`. Most are inline `<Loader2>` icons in feature surfaces; fixing the shared `LoadingSpinner` primitive covers ~20+ page-level consumers.
- **jsx-a11y lint rule status:** **not configured.** `frontend/eslint.config.mjs` only extends `next/core-web-vitals` + `next/typescript`. `eslint-plugin-jsx-a11y` is not in `frontend/package.json`. Enabling it would catch this class of issue at build time but requires a baseline-then-ratchet rollout because of the existing >10 violations. Decision deferred to the follow-up ticket.

**Scope decision: per the ticket rule (>10 additional sites → defer), this PR fixes the named 3 + the primitive only. The broader sweep is filed as a follow-up.**

**Follow-up ticket:** [PSY-878 — Sweep remaining icon-only buttons missing aria-label (post-PSY-767)](https://linear.app/psychic-homily/issue/PSY-878/sweep-remaining-icon-only-buttons-missing-aria-label-post-psy-767) (`confidence:75`, Low priority, Frontend Test Coverage Hardening — May 2026 project). Worst-offender files documented inline.

## Manual repro
Per-component verification via the test runner:
- `LoadingSpinner`: `getByRole('status', { name: 'Loading' })` now finds it; new test covers `label="Loading collections"` custom label.
- `RequestDetail` delete: `getByRole('button', { name: /delete request/i })` finds it without the `text-destructive` class workaround.
- `FestivalManagement` row Edit/Delete: `getByRole('button', { name: 'Edit/Delete <name> <year>' })` finds each row's button without the `button.hover\\:text-destructive` workaround.
- `SceneList` loading state: `getByRole('status', { name: /loading/i })` finds the primitive without `container.querySelector('.animate-spin')`.

## Code review
Surfaced one finding: per-row aria-label initially used only `festival.name`, but festival names are not unique across editions — two same-name festivals would produce identical accessible names. Fixed in a separate `code-review pass` commit by appending `edition_year`, plus a regression test that asserts the year-disambiguated labels on a 2-row same-name fixture.

Closes PSY-767

🤖 Generated with [Claude Code](https://claude.com/claude-code)