### PR TITLE
PSY-875: VerifyMagicLinkHandler fails closed on session-token mint

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -971,16 +971,22 @@ func (h *AuthHandler) VerifyMagicLinkHandler(ctx context.Context, input *VerifyM
 		return resp, nil
 	}
 
-	// Generate JWT token for session
+	// Generate JWT token for session. By this point the request has cleared
+	// every enumeration-safety gate (token valid, email still matches, account
+	// active) — the user is genuinely authorized. A JWT mint failure here is
+	// not part of the enumeration-safe surface; it is an unexpected internal
+	// fault. Fail-closed with a 5xx so the client retries and on-call sees
+	// the signal, instead of silently downgrading to HTTP 200.
 	token, err := h.jwtService.CreateToken(user)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("verify_magic_link_session_token", err)
 		logger.AuthError(ctx, "magic_link_session_token_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to create session"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr // Return actual error for 5xx HTTP status
 	}
 
 	// Set HTTP-only cookie

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1747,6 +1747,73 @@ func TestVerifyMagicLinkHandler_InactiveUser(t *testing.T) {
 	}
 }
 
+// TestVerifyMagicLinkHandler_SessionTokenMintFailsClosed asserts that once a
+// magic-link request has cleared every enumeration-safety gate (token valid,
+// email matches, account active), a downstream JWT mint failure surfaces as
+// a 5xx instead of a silent HTTP 200 + SERVICE_UNAVAILABLE downgrade. The
+// gates above this branch deliberately return HTTP 200 so the response shape
+// does not leak whether an account exists or its state; this branch is past
+// those gates and a failure here is a genuine internal fault that on-call
+// must see.
+func TestVerifyMagicLinkHandler_SessionTokenMintFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	mintErr := fmt.Errorf("simulated jwt mint failure")
+	h := authHandler(func(ah *AuthHandler) {
+		ah.jwtService = &testhelpers.MockJWTService{
+			ValidateMagicLinkTokenFn: func(tokenString string) (*contracts.MagicLinkTokenClaims, error) {
+				return &contracts.MagicLinkTokenClaims{UserID: 1, Email: email}, nil
+			},
+			CreateTokenFn: func(u *authm.User) (string, error) {
+				return "", mintErr
+			},
+		}
+		ah.userService = &testhelpers.MockUserService{
+			GetUserByIDFn: func(userID uint) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &email, IsActive: true}, nil
+			},
+		}
+	})
+
+	input := &VerifyMagicLinkRequest{}
+	input.Body.Token = "valid-magic-token"
+
+	resp, err := h.VerifyMagicLinkHandler(context.Background(), input)
+
+	// The handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected response error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape so
+	// no leak about which internal step failed.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+	// Regression guard: a JWT mint failure past the enumeration-safety gates
+	// must not silently downgrade to HTTP 200 — that was the pre-existing
+	// behavior and the convention this test locks in.
+	if err == nil {
+		t.Error("regression: jwt mint failure must not downgrade to HTTP 200")
+	}
+}
+
 // --- ChangePasswordHandler mock tests ---
 
 func TestChangePasswordHandler_Success(t *testing.T) {

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1806,11 +1806,13 @@ func TestVerifyMagicLinkHandler_SessionTokenMintFailsClosed(t *testing.T) {
 	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
 		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
-	// Regression guard: a JWT mint failure past the enumeration-safety gates
-	// must not silently downgrade to HTTP 200 — that was the pre-existing
-	// behavior and the convention this test locks in.
-	if err == nil {
-		t.Error("regression: jwt mint failure must not downgrade to HTTP 200")
+	// Regression guard: the previous branch hard-coded the message
+	// "Failed to create session" and returned a nil error so the response
+	// rode HTTP 200. The handler must no longer surface that literal — the
+	// canonical SERVICE_UNAVAILABLE external message is the only acceptable
+	// shape now that the branch is fail-closed.
+	if resp.Body.Message == "Failed to create session" {
+		t.Error("regression: handler must not surface the pre-fix \"Failed to create session\" message")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `VerifyMagicLinkHandler` had six error paths. Five are deliberate enumeration-safe HTTP 200 + ErrorCode shapes (PSY-749 design — empty/invalid token, user lookup, email mismatch, inactive account) and stay untouched. The sixth — `jwtService.CreateToken` failure at the very bottom of the handler — was a silent HTTP 200 + `SERVICE_UNAVAILABLE` downgrade despite being past every enumeration-safety gate.
- Flip that branch to fail-closed per PSY-864: build `autherrors.ErrServiceUnavailable("verify_magic_link_session_token", err)`, set the response body's external message to the canonical `ToExternalMessage(CodeServiceUnavailable)` shape (no internal-step leak), and return the AuthError so Huma emits a 5xx. ErrorCode on the body stays `CodeServiceUnavailable` — only the HTTP status changes (200 → 5xx).
- One new regression test, `TestVerifyMagicLinkHandler_SessionTokenMintFailsClosed`, sets up a valid magic-link token + active user (clears all five enumeration-safety gates), injects a `CreateTokenFn` returning an error, and asserts: handler returns a non-nil error; `errors.As` unwraps it to `*AuthError` with `Code=CodeServiceUnavailable`; response body has `Success=false`, `ErrorCode=CodeServiceUnavailable`, `Message=ToExternalMessage(CodeServiceUnavailable)`; old "Failed to create session" literal is gone.

## Test plan

- [x] `go build ./...` clean
- [x] `go generate ./...` produces no diff (mocks unchanged)
- [x] `go vet ./internal/api/handlers/auth/...` clean
- [x] `go test ./internal/api/handlers/auth/...` — all tests pass (including `TestVerifyMagicLinkHandler_SessionTokenMintFailsClosed`)

## Manual repro

Per the PSY-592 backend pattern (integration test name + assertion outcome IS the manual repro):

`TestVerifyMagicLinkHandler_SessionTokenMintFailsClosed` injects a JWT-mint failure via the existing `MockJWTService.CreateTokenFn` seam AFTER all 5 enumeration-safety gates pass (valid token, matching email, active user). Assertions:

- Handler returns non-nil error
- `errors.As` unwraps to `*AuthError` with `Code = CodeServiceUnavailable`
- Response body: `Success = false`, `ErrorCode = CodeServiceUnavailable`, `Message = ToExternalMessage(CodeServiceUnavailable)`
- The pre-fix literal `"Failed to create session"` is no longer present (regression guard against the old shape)

Verifies the 200 → 5xx transition end-to-end without needing a stack-up + curl — the test exercises the handler entry point with the exact request shape the route receives.

## Code review

- Ran `/code-review` (max effort): one finding — the test had a dead `if err == nil { t.Error(...) }` regression block after the earlier `t.Fatal` made that branch unreachable. Replaced it with a guard against the pre-fix literal `"Failed to create session"` message (the load-bearing thing the branch changed). Re-ran tests post-fix — all pass.

Closes PSY-875

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>