### PR TITLE
PSY-876: DeleteAccountHandler — fail closed on SoftDeleteAccount failure

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -1263,15 +1263,19 @@ func (h *AuthHandler) DeleteAccountHandler(ctx context.Context, input *DeleteAcc
 		return resp, nil
 	}
 
-	// Perform soft delete
+	// Perform soft delete. Fail-closed on service failure: by the time we get
+	// here, the user is authenticated and password-verified, so this is the
+	// destructive step. Surface as a 5xx so on-call alerting fires instead of
+	// silently returning HTTP 200 on a destructive op that didn't complete.
 	if err := h.userService.SoftDeleteAccount(contextUser.ID, input.Body.Reason); err != nil {
+		authErr := autherrors.ErrServiceUnavailable("delete_account", err)
 		logger.AuthError(ctx, "delete_account_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to delete account"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr // Return actual error for 5xx HTTP status
 	}
 
 	// Clear auth cookie to log out the user

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1944,7 +1944,15 @@ func TestDeleteAccountHandler_WrongPassword(t *testing.T) {
 	}
 }
 
-func TestDeleteAccountHandler_SoftDeleteFails(t *testing.T) {
+// TestDeleteAccountHandler_SoftDeleteFailsClosed asserts that a SoftDeleteAccount
+// service failure propagates as a 5xx instead of being silently returned as
+// HTTP 200 + SERVICE_UNAVAILABLE in the body. By the time execution reaches
+// this branch the user is authenticated and password-verified, so this is the
+// DESTRUCTIVE step — an unexpected service failure here must fire alerting
+// rather than masquerade as a successful response. Locks in the fail-closed
+// convention so a future "silent 200 on destructive op" regression is caught.
+func TestDeleteAccountHandler_SoftDeleteFailsClosed(t *testing.T) {
+	rawErr := fmt.Errorf("db error")
 	hash := "$2a$10$fakehash"
 	h := authHandler(func(ah *AuthHandler) {
 		ah.userService = &testhelpers.MockUserService{
@@ -1952,7 +1960,7 @@ func TestDeleteAccountHandler_SoftDeleteFails(t *testing.T) {
 				return nil
 			},
 			SoftDeleteAccountFn: func(userID uint, reason *string) error {
-				return fmt.Errorf("db error")
+				return rawErr
 			},
 		}
 	})
@@ -1962,14 +1970,35 @@ func TestDeleteAccountHandler_SoftDeleteFails(t *testing.T) {
 	input.Body.Password = "correct"
 
 	resp, err := h.DeleteAccountHandler(ctx, input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	// The handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx with the structured shape
+	// clients branch on.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
-		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+		t.Errorf("expected response error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape — no
+	// leak about which internal step failed and consistent with the LoginHandler
+	// fail-closed branches so clients render one error consistently.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary

`DeleteAccountHandler` has five error paths. Four are intentional and stay (validation, auth, no-enumeration — HTTP 200 + structured ErrorCode in body). The fifth — `SoftDeleteAccount` returning an unexpected service-layer error — was silently downgraded to HTTP 200 + `CodeServiceUnavailable` in the body, no error returned to Huma, no 5xx.

By the time execution reaches that branch the caller is authenticated AND password-verified. This is the destructive step. An unexpected service failure here MUST:

- fire on-call alerting (5xx is the hook; HTTP 200 hides it),
- protect user trust on an irreversible operation,
- align with the PSY-864 LoginHandler convention.

Wrap via `autherrors.ErrServiceUnavailable("delete_account", err)` and return the wrapped error so the apperror mapper produces a 5xx. The response body's `ErrorCode` + `Message` match the canonical SERVICE_UNAVAILABLE shape byte-for-byte so we do not leak which internal step failed.

Out of scope: the four pre-destruction paths and every other handler in this file. RefreshTokenHandler (PSY-874) and VerifyMagicLinkHandler (PSY-875) ship in parallel as sibling fail-closed audits.

## Test plan

- [x] `go build ./...` (whole-graph compile) — clean
- [x] `go vet ./...` — clean
- [x] `go generate ./...` + `git diff --exit-code` on generated files — only intended edits present
- [x] `go test ./internal/api/handlers/auth/...` — pass (7.1s)
- [x] `go test ./internal/api/...` — pass across all handler packages
- [x] New regression test: `TestDeleteAccountHandler_SoftDeleteFailsClosed` — asserts non-nil returned error, wrapped `*AuthError` of `CodeServiceUnavailable`, response `ErrorCode` + `Message` match canonical SERVICE_UNAVAILABLE shape. Would catch a future "silent 200 on destructive op" regression.

## Manual repro

Integration test IS the manual repro for this branch: `TestDeleteAccountHandler_SoftDeleteFailsClosed` injects a raw `fmt.Errorf("db error")` via the userService mock seam, exercises the production code path, and asserts the post-fix behavior (5xx-shaped error returned + canonical SERVICE_UNAVAILABLE body). Asserted outcome: PASS.

## Code review

`/code-review` at max effort across 5 angles (line-by-line, removed-behavior, cross-file tracer, language-pitfall, wrapper/proxy) + sweep. Cross-file tracer surfaced the frontend dependency on the legacy "Failed to delete account" body message — verified that `apiRequest` in `frontend/lib/api.ts` throws a generic `ApiError` on 5xx, and `delete-account-dialog.tsx` surfaces `error.message` (now "Service temporarily unavailable. Please try again." from the canonical Huma error envelope, with a literal fallback). UX preserved/improved. No findings of bug severity. No code-review fix commit.

Closes PSY-876