### PR TITLE
PSY-874: RefreshTokenHandler — fail-closed on service failures

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -313,28 +313,37 @@ func (h *AuthHandler) RefreshTokenHandler(ctx context.Context, input *struct{}) 
 		"user_id", contextUser.ID,
 	)
 
-	// Fetch fresh user data and generate new token
+	// Fetch fresh user data and generate new token.
+	// Fail-closed: an unexpected DB/service failure here propagates as a 5xx so
+	// the HTTP layer cannot hand callers (or monitoring) a misleading HTTP 200
+	// SERVICE_UNAVAILABLE body. The response body shape is unchanged; only the
+	// transport-level status flips from 200 to 5xx.
 	user, err := h.authService.GetUserProfile(contextUser.ID)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("refresh_token_profile", err)
 		logger.AuthError(ctx, "refresh_token_profile_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to refresh token"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Generate new JWT token using the JWT service
+	// Generate new JWT token using the JWT service.
+	// Fail-closed: same rationale as the profile-fetch branch above — JWT
+	// service outages must surface as 5xx, not as HTTP 200 with a sad-path
+	// body.
 	newToken, err := h.authService.RefreshUserToken(user)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("refresh_token_generation", err)
 		logger.AuthError(ctx, "refresh_token_generation_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to generate new token"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	logger.AuthInfo(ctx, "refresh_token_success",

--- a/backend/internal/api/handlers/auth/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth/auth_integration_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -282,7 +283,15 @@ func (s *AuthHandlerIntegrationSuite) TestRefreshToken_UserDeletedFromDB() {
 	_, _ = sqlDB.Exec("DELETE FROM users WHERE id = $1", user.ID)
 
 	resp, err := h.RefreshTokenHandler(ctx, &struct{}{})
-	s.Require().NoError(err)
+
+	// Fail-closed: profile fetch against a deleted user surfaces as a 5xx so
+	// the HTTP layer does not hand callers an HTTP 200 with a sad-path body.
+	// The body shape still carries SERVICE_UNAVAILABLE for the structured
+	// error-code branch on clients; only the transport status flips.
+	s.Require().Error(err)
+	var authErr *autherrors.AuthError
+	s.Require().True(errors.As(err, &authErr), "expected returned error to wrap *AuthError")
+	s.Equal(autherrors.CodeServiceUnavailable, authErr.Code)
 	s.False(resp.Body.Success)
 	s.Equal(autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 }

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1202,19 +1202,40 @@ func TestRefreshTokenHandler_Success(t *testing.T) {
 	}
 }
 
+// TestRefreshTokenHandler_ProfileFails asserts that an unexpected service
+// failure in GetUserProfile (DB outage, raw error from the user service)
+// propagates as a 5xx so the HTTP layer does not hand callers an HTTP 200
+// with a SERVICE_UNAVAILABLE body. The body shape stays the same as the old
+// HTTP-200 path; only the transport status flips. Locks in the fail-closed
+// convention for the token-refresh session-lifecycle surface.
 func TestRefreshTokenHandler_ProfileFails(t *testing.T) {
+	rawErr := fmt.Errorf("db error")
 	h := authHandler(func(ah *AuthHandler) {
 		ah.authService = &testhelpers.MockAuthService{
 			GetUserProfileFn: func(userID uint) (*authm.User, error) {
-				return nil, fmt.Errorf("db error")
+				return nil, rawErr
 			},
 		}
 	})
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	resp, err := h.RefreshTokenHandler(ctx, &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	// Handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx with the structured body.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
@@ -1222,30 +1243,61 @@ func TestRefreshTokenHandler_ProfileFails(t *testing.T) {
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape so
+	// callers do not see "Failed to refresh token" as an internal-step leak.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
 }
 
+// TestRefreshTokenHandler_TokenFails asserts that an unexpected failure in
+// RefreshUserToken (JWT service outage, signing failure) propagates as a 5xx
+// for the same reason as the profile-failure branch — a session-lifecycle
+// surface returning HTTP 200 on a transport-level outage hides a real
+// incident from monitoring.
 func TestRefreshTokenHandler_TokenFails(t *testing.T) {
+	rawErr := fmt.Errorf("token error")
 	h := authHandler(func(ah *AuthHandler) {
 		ah.authService = &testhelpers.MockAuthService{
 			GetUserProfileFn: func(userID uint) (*authm.User, error) {
 				return &authm.User{ID: userID}, nil
 			},
 			RefreshUserTokenFn: func(user *authm.User) (string, error) {
-				return "", fmt.Errorf("token error")
+				return "", rawErr
 			},
 		}
 	})
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	resp, err := h.RefreshTokenHandler(ctx, &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	// Handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx with the structured body.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape so
+	// callers do not see "Failed to generate new token" as an internal-step
+	// leak.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Convert `RefreshTokenHandler`'s `GetUserProfile` failure (auth.go:317-326) and `RefreshUserToken` failure (auth.go:328-338) branches from silent HTTP-200 `SERVICE_UNAVAILABLE` downgrades to fail-closed 5xx via `autherrors.ErrServiceUnavailable("refresh_token_*", err)`.
- Body shape stays byte-identical with the existing `SERVICE_UNAVAILABLE` path (ErrorCode unchanged; Message now matches the canonical `ToExternalMessage(CodeServiceUnavailable)` = "Service temporarily unavailable" instead of "Failed to refresh token" / "Failed to generate new token"); only the transport status flips from 200 to 5xx.
- Out of scope per the ticket: `authService == nil` (server-config defense) and `contextUser == nil` (middleware contract) — both stay HTTP 200, untouched.

Continues the PSY-864 (#842) convention: unexpected service failures on auth surfaces must propagate as 5xx so monitoring sees the incident and clients do not see a misleading success status. RefreshTokenHandler sits in the session lifecycle — this is a high-blast-radius surface to keep mis-classified.

## Why
The two branches treated DB / JWT service outages as user-visible "sad path" responses (HTTP 200 + `SERVICE_UNAVAILABLE` body). That misclassifies the error budget for on-call and lets attackers / monitoring see a 200 on a backend outage. The change keeps the body shape identical (so structured-error-code client branches keep working) and only flips the transport status.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go generate ./... && git diff --exit-code` — no mock drift
- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test ./internal/api/handlers/auth/...` — pass (5 RefreshTokenHandler unit tests + 2 integration tests, including the two updated branches and the integration `TestRefreshToken_UserDeletedFromDB` which exercises the live profile-failure path)

## Manual repro
Backend-only change, no migration — integration tests are the manual repro per the PSY-592 pattern. Verified outcomes:

- `TestRefreshTokenHandler_ProfileFails` (unit): mock returns `fmt.Errorf("db error")` from `GetUserProfile` → handler returns non-nil error (Huma emits 5xx), `errors.As` unwraps to `*AuthError{Code: CodeServiceUnavailable}` (proves `ErrServiceUnavailable` wrapper fires), body `ErrorCode == SERVICE_UNAVAILABLE`, body `Message == ToExternalMessage(CodeServiceUnavailable)`.
- `TestRefreshTokenHandler_TokenFails` (unit): mock returns `fmt.Errorf("token error")` from `RefreshUserToken` (with successful profile fetch) → same shape: non-nil error, unwraps to `*AuthError{CodeServiceUnavailable}`, body fields match.
- `TestAuthHandlerIntegration/TestRefreshToken_UserDeletedFromDB` (integration): hard-deletes a user out from under the JWT context → `GetUserProfile` returns `record not found`, handler now returns a non-nil error wrapping `*AuthError{CodeServiceUnavailable}` (was previously `NoError` + HTTP 200), body fields match the SERVICE_UNAVAILABLE shape.
- `TestRefreshTokenHandler_NilAuthService` and `TestRefreshTokenHandler_NoUserContext` (untouched branches) still pass — confirms the out-of-scope branches stay HTTP 200 as the ticket requires.
- `TestRefreshTokenHandler_Success` and `TestAuthHandlerIntegration/TestRefreshToken_Success` still pass — happy path unchanged.

## Code review
`/code-review` (max effort, 5 angles + verifier + sweep) returned no findings. The change is a small, tightly-scoped mirror of the PSY-864 pattern. Cross-file trace: no callers of `RefreshTokenHandler` other than Huma routing; no FE callers string-match on the old `Body.Message` values ("Failed to refresh token" / "Failed to generate new token") — confirmed via repo-wide grep across `frontend/`.

## Scope-adjacent observations (filed for follow-up, not widened here)
- `GetUserProfile` returning a generic `error` (not a typed `*AuthError` of `CodeUserNotFound`) means the deleted-user scenario is currently routed to a 5xx via the catch-all branch. Promoting the user service to return a typed `CodeUserNotFound` would let the handler route this case as 401 instead of 5xx — semantically more accurate but out of scope here. Worth a separate ticket if we want to tighten the session-lifecycle semantics further.

## Parallel-work note
PSY-875 (VerifyMagicLinkHandler) and PSY-876 (DeleteAccountHandler) are dispatched in parallel against the same file at non-overlapping line ranges. If this PR merges second/third, a trivial rebase is expected.

Closes PSY-874