### PR TITLE
PSY-875: VerifyMagicLinkHandler fail-closed for token mint

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -909,13 +909,30 @@ type VerifyMagicLinkResponse struct {
 	}
 }
 
-// VerifyMagicLinkHandler verifies a magic link token and logs the user in
+// VerifyMagicLinkHandler verifies a magic link token and logs the user in.
+//
+// The five pre-eligibility-check error paths below (validation, invalid
+// token, user lookup, email mismatch, inactive account) intentionally
+// return 200 + ErrorCode rather than a 5xx. Each path could otherwise
+// be turned into an enumeration oracle by an attacker varying the token
+// claim contents: a 5xx on "invalid token" vs 200 on "valid token but
+// inactive user" would leak account state, and a 5xx on email mismatch
+// would leak that the email-on-file changed. Per the enumeration-safe
+// response convention established by the magic-link send and account-
+// recovery handlers, these stay 200 + ErrorCode with terse generic
+// copy so the response shape is identical across the failure modes.
+//
+// Only the post-eligibility-check session-token mint path below them
+// fails closed as 5xx: by that point the user has cleared every gate
+// and a JWT-service failure is genuinely unexpected — surfacing 200 +
+// SERVICE_UNAVAILABLE there would silently mask infrastructure
+// failures from on-call monitoring without any enumeration benefit.
 func (h *AuthHandler) VerifyMagicLinkHandler(ctx context.Context, input *VerifyMagicLinkRequest) (*VerifyMagicLinkResponse, error) {
 	resp := &VerifyMagicLinkResponse{}
 	requestID := logger.GetRequestID(ctx)
 	resp.Body.RequestID = requestID
 
-	// Validate token presence
+	// Enumeration-safe: empty token → 200 + ErrorCode (validation).
 	if input.Body.Token == "" {
 		logger.AuthWarn(ctx, "magic_link_no_token")
 		resp.Body.Success = false
@@ -924,7 +941,9 @@ func (h *AuthHandler) VerifyMagicLinkHandler(ctx context.Context, input *VerifyM
 		return resp, nil
 	}
 
-	// Validate the magic link token
+	// Enumeration-safe: invalid or expired token → 200 + INVALID_TOKEN.
+	// UX prompts user to request a new link without leaking whether the
+	// token was malformed, expired, or signed with a rotated key.
 	claims, err := h.jwtService.ValidateMagicLinkToken(input.Body.Token)
 	if err != nil {
 		logger.AuthWarn(ctx, "magic_link_invalid_token",
@@ -936,7 +955,9 @@ func (h *AuthHandler) VerifyMagicLinkHandler(ctx context.Context, input *VerifyM
 		return resp, nil
 	}
 
-	// Get the user
+	// Enumeration-safe: user lookup failure → 200 + CodeUnauthorized.
+	// A 5xx here would let an attacker probe which user_id claims map to
+	// real rows; the 200 shape mirrors a valid-but-rejected token.
 	user, err := h.userService.GetUserByID(claims.UserID)
 	if err != nil {
 		logger.AuthError(ctx, "magic_link_user_not_found", err,
@@ -948,7 +969,9 @@ func (h *AuthHandler) VerifyMagicLinkHandler(ctx context.Context, input *VerifyM
 		return resp, nil
 	}
 
-	// Verify the email still matches (in case user changed email)
+	// Enumeration-safe: email mismatch → 200 + INVALID_TOKEN. Suppresses
+	// any signal that the user's email-on-file has changed since the
+	// magic link was minted.
 	if user.Email == nil || *user.Email != claims.Email {
 		logger.AuthWarn(ctx, "magic_link_email_mismatch",
 			"user_id", user.ID,
@@ -960,7 +983,9 @@ func (h *AuthHandler) VerifyMagicLinkHandler(ctx context.Context, input *VerifyM
 		return resp, nil
 	}
 
-	// Check user is still active
+	// Enumeration-safe: inactive account → 200 + CodeUnauthorized.
+	// Identical shape to a wrong-user response so account-state cannot
+	// be inferred from the response shape alone.
 	if !user.IsActive {
 		logger.AuthWarn(ctx, "magic_link_user_inactive",
 			"user_id", user.ID,
@@ -971,16 +996,24 @@ func (h *AuthHandler) VerifyMagicLinkHandler(ctx context.Context, input *VerifyM
 		return resp, nil
 	}
 
-	// Generate JWT token for session
+	// Post-eligibility-check JWT-mint failure → 5xx (fail-closed).
+	// By this point the user has cleared every enumeration-safety gate
+	// above, so a CreateToken failure is genuine infrastructure error
+	// territory — config / key-rotation / dependency outage — not an
+	// attacker probe. Wrap via ErrServiceUnavailable so the apperror
+	// mapper produces a 5xx; the body's external message + ErrorCode
+	// match the shipped SERVICE_UNAVAILABLE shape so legacy clients
+	// branching on ErrorCode continue to work.
 	token, err := h.jwtService.CreateToken(user)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("verify_magic_link_session_token", err)
 		logger.AuthError(ctx, "magic_link_session_token_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to create session"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr // Return actual error for 5xx HTTP status
 	}
 
 	// Set HTTP-only cookie

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1747,6 +1747,75 @@ func TestVerifyMagicLinkHandler_InactiveUser(t *testing.T) {
 	}
 }
 
+// TestVerifyMagicLinkHandler_SessionTokenFailureReturnsServerError asserts
+// that a JWT CreateToken failure AFTER the user has cleared every
+// enumeration-safety gate (token valid, user found, email matches, account
+// active) propagates as a 5xx instead of being silently downgraded to an
+// HTTP 200 + SERVICE_UNAVAILABLE response. The pre-eligibility-check error
+// paths above this point intentionally stay 200 + ErrorCode to avoid an
+// enumeration oracle; this branch is genuinely unexpected infrastructure
+// failure territory and must surface to on-call monitoring.
+func TestVerifyMagicLinkHandler_SessionTokenFailureReturnsServerError(t *testing.T) {
+	email := "test@example.com"
+	mintErr := fmt.Errorf("simulated jwt signing failure")
+	h := authHandler(func(ah *AuthHandler) {
+		ah.jwtService = &testhelpers.MockJWTService{
+			ValidateMagicLinkTokenFn: func(tokenString string) (*contracts.MagicLinkTokenClaims, error) {
+				return &contracts.MagicLinkTokenClaims{UserID: 1, Email: email}, nil
+			},
+			CreateTokenFn: func(u *authm.User) (string, error) {
+				return "", mintErr
+			},
+		}
+		ah.userService = &testhelpers.MockUserService{
+			GetUserByIDFn: func(userID uint) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &email, IsActive: true}, nil
+			},
+		}
+	})
+
+	input := &VerifyMagicLinkRequest{}
+	input.Body.Token = "valid-magic-token"
+
+	resp, err := h.VerifyMagicLinkHandler(context.Background(), input)
+
+	// The handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must itself be an AuthError of CodeServiceUnavailable
+	// so the apperror mapper translates it to a 5xx. Mirrors the LoginHandler
+	// JWT-mint failure shape.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped AuthError code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// Regression guard: a session-token mint failure must not silently downgrade
+	// to a 200 OK — that was the pre-existing fall-through and the convention
+	// this test locks in.
+	if resp.Body.Token != "" {
+		t.Errorf("expected empty token on failure, got %q", resp.Body.Token)
+	}
+	// External message must match the shipped SERVICE_UNAVAILABLE shape so
+	// legacy clients branching on the error_code continue to work.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected SERVICE_UNAVAILABLE message %q, got %q",
+			autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable), resp.Body.Message)
+	}
+}
+
 // --- ChangePasswordHandler mock tests ---
 
 func TestChangePasswordHandler_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
- Applies PSY-864's fail-closed convention to VerifyMagicLinkHandler's session-token mint path (line 975) only — the silent HTTP 200 downgrade on JWT `CreateToken` failure now wraps via `apperrors.ErrServiceUnavailable("verify_magic_link_session_token", err)` so Huma emits a 5xx that on-call monitoring can act on.
- 5 enumeration-safe paths above it (empty token, invalid/expired token, user lookup, email mismatch, inactive account) stay 200 + ErrorCode with reinforcing per-branch + top-of-handler doc comments naming the security intent (enumeration oracle suppression) and the prior-art convention (magic-link send + account recovery).

## Test plan
- [x] `cd backend && go build ./...` — passed (no output)
- [x] `cd backend && go test ./internal/api/handlers/auth/... ./internal/errors/...` — passed (1 new regression test, 5 existing `TestVerifyMagicLinkHandler_*` tests still pass)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — exit 0 (0 issues)

## Manual repro
- `TestVerifyMagicLinkHandler_SessionTokenFailureReturnsServerError` — mock `JWTService.CreateToken` returns `fmt.Errorf("simulated jwt signing failure")` after the user passes every enumeration-safety gate. Asserts: handler returns non-nil error (Huma 5xx), error unwraps to `*AuthError` of `CodeServiceUnavailable`, response body matches the shipped `SERVICE_UNAVAILABLE` shape, and empty-token regression guard. **PASSED.**
- Existing 5 `TestVerifyMagicLinkHandler_*` tests (EmptyToken, InvalidToken, Success, UserNotFound, InactiveUser): **all PASSED** — no UX regression on the enumeration-safe paths.

## Code review
No changes — inline 3-lens pass (sub-agent has no Agent tool, per `pattern_subagent_inline_code_review.md`). Reuse: delegates to `apperrors.ErrServiceUnavailable` + `ToExternalMessage` exactly like LoginHandler line 165 / 159 — no new helper needed. Quality: naming (`authErr`) + branch-trailing comment ("Return actual error for 5xx HTTP status") mirror the canonical LoginHandler shape; doc comments cite the security convention (enumeration oracle) without ticket-ID rot per `feedback_strip_ticket_refs_from_doc_comments.md`. Efficiency: one wrap-allocation on the error path, zero runtime change on the happy path.

Closes PSY-875