### PR TITLE
PSY-876: DeleteAccountHandler fail-closed for SoftDeleteAccount

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -1265,13 +1265,28 @@ func (h *AuthHandler) DeleteAccountHandler(ctx context.Context, input *DeleteAcc
 
 	// Perform soft delete
 	if err := h.userService.SoftDeleteAccount(contextUser.ID, input.Body.Reason); err != nil {
+		// Fail-closed on the post-authentication destructive operation. The
+		// four pre-destruction branches above intentionally return 200 + a
+		// structured ErrorCode (validation / no-enumeration / middleware
+		// contract). This branch is different: by the time we reach it the
+		// caller is authenticated and password-verified, and an unexpected
+		// service-layer failure here means the destructive operation did NOT
+		// complete. Returning HTTP 200 would (a) hide the failure from on-call
+		// monitoring (5xx is the alerting signal), and (b) tell the user
+		// "deletion scheduled" when nothing was actually persisted. Surface
+		// it as a 5xx via the apperror wrapper; the body's external message
+		// + ErrorCode match the existing SERVICE_UNAVAILABLE shape so we do
+		// not leak which internal step failed. Cookie-clear ordering stays
+		// after this block — on failure, the cookie remains set and the user
+		// stays logged in because the deletion did not actually happen.
+		authErr := autherrors.ErrServiceUnavailable("delete_account", err)
 		logger.AuthError(ctx, "delete_account_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to delete account"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	// Clear auth cookie to log out the user

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1944,15 +1944,27 @@ func TestDeleteAccountHandler_WrongPassword(t *testing.T) {
 	}
 }
 
-func TestDeleteAccountHandler_SoftDeleteFails(t *testing.T) {
+// TestDeleteAccountHandler_SoftDeleteFailureReturnsServerError asserts that an
+// unexpected service-layer failure on the destructive SoftDeleteAccount call
+// propagates as a 5xx (not a silent HTTP 200 + ErrorCode downgrade) so:
+//   - on-call monitoring sees the failure signal (5xx is the alerting hook),
+//   - the user is NOT told "deletion scheduled" when nothing was persisted,
+//   - the auth cookie remains set so the user stays logged in (the deletion
+//     did not actually happen — clearing the cookie would log them out of an
+//     account they still have, which is a worse UX than a clear service error).
+//
+// The four pre-destruction validation/auth branches above this point
+// intentionally stay 200 + ErrorCode and are exercised by sibling tests.
+func TestDeleteAccountHandler_SoftDeleteFailureReturnsServerError(t *testing.T) {
 	hash := "$2a$10$fakehash"
+	rawErr := fmt.Errorf("db error")
 	h := authHandler(func(ah *AuthHandler) {
 		ah.userService = &testhelpers.MockUserService{
 			VerifyPasswordFn: func(hashedPassword, password string) error {
 				return nil
 			},
 			SoftDeleteAccountFn: func(userID uint, reason *string) error {
-				return fmt.Errorf("db error")
+				return rawErr
 			},
 		}
 	})
@@ -1962,14 +1974,44 @@ func TestDeleteAccountHandler_SoftDeleteFails(t *testing.T) {
 	input.Body.Password = "correct"
 
 	resp, err := h.DeleteAccountHandler(ctx, input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	// The handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx with the canonical shape.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
-		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+		t.Errorf("expected response error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape so we
+	// do not leak which internal step failed.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+	// Regression guard on the cookie-clear UX invariant. On the success path
+	// the handler sets resp.SetCookie = ClearAuthCookie() (MaxAge=-1). On this
+	// failure path the destructive op did NOT complete, so the cookie MUST NOT
+	// be cleared — the user stays logged in. The zero-value http.Cookie left
+	// on resp has MaxAge=0, which is distinct from the cleared cookie's -1.
+	if resp.SetCookie.MaxAge == -1 {
+		t.Error("regression: failed SoftDeleteAccount must not clear the auth cookie (user must stay logged in)")
+	}
+	if resp.SetCookie.Name != "" {
+		t.Errorf("expected zero-value cookie (Name=\"\"), got Name=%q", resp.SetCookie.Name)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Applies PSY-864's fail-closed convention to DeleteAccountHandler's `SoftDeleteAccount` failure path (line 1267–1275) only.
- 4 pre-destruction validation/auth paths above it stay 200 + ErrorCode (intentional UX shapes — no-enumeration on password verify, OAuth-only confirm-via-email UX, middleware-contract on no-context-user, validation on no-password).
- Cookie-clear ordering preserved: on `SoftDeleteAccount` failure, the cookie remains the zero-value `http.Cookie` so the user stays logged in (the deletion didn't actually happen). Clearing the cookie when the destructive op failed would log them out of an account they still have — worse UX than a clear service error.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/api/handlers/auth/... ./internal/errors/...` — passed (1 new regression test, 5 existing DeleteAccountHandler tests still pass: NoUserContext, OAuthOnlyUser, EmptyPassword, Success, WrongPassword)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — exit 0 (`0 issues.`)

## Manual repro
- `TestDeleteAccountHandler_SoftDeleteFailureReturnsServerError` — mock `SoftDeleteAccount` returns `fmt.Errorf("db error")`. Assertions all passed:
  - (a) handler returns non-nil error → Huma emits 5xx,
  - (b) returned error unwraps to `*AuthError{Code: CodeServiceUnavailable}` via `errors.As`,
  - (c) `resp.Body.ErrorCode == CodeServiceUnavailable` and `resp.Body.Message == ToExternalMessage(CodeServiceUnavailable)` — canonical SERVICE_UNAVAILABLE shape, no leak about which internal step failed,
  - (d) **cookie-clear assertion**: `resp.SetCookie.MaxAge != -1` AND `resp.SetCookie.Name == ""` — the zero-value `http.Cookie` is left in place (the cleared cookie has `MaxAge=-1`), so the user stays logged in. BOTH PASSED.

## Code review
No changes — inline 3-lens pass (reuse / quality / efficiency) on the diff. Reuse: `ErrServiceUnavailable`, `ToExternalMessage`, `errors.As`, `MockUserService` seam, and the `MaxAge` cookie idiom all already in use elsewhere in this file. Quality: code comment names the WHY (on-call alerting, user-trust on destructive op, no-leak shape, cookie-clear UX invariant), no `PSY-876` doc-comment refs per the strip-ticket-refs convention. Efficiency: single allocation on the error path only, no hot-path impact.

Closes PSY-876