### PR TITLE
PSY-815: close StartImportJob double-start race via conditional UPDATE

### DIFF
--- a/backend/internal/services/catalog/radio_import_job.go
+++ b/backend/internal/services/catalog/radio_import_job.go
@@ -60,29 +60,48 @@ func (s *RadioService) CreateImportJob(showID uint, since, until string) (*contr
 }
 
 // StartImportJob transitions a pending job to running and launches the background goroutine.
+//
+// The pending→running transition is performed as a single conditional UPDATE
+// (WHERE status = pending) and the launch only fires when RowsAffected == 1.
+// Two concurrent callers therefore cannot both succeed: the loser sees
+// RowsAffected == 0, reads the row to surface the actual current status, and
+// returns an error without spawning a duplicate runImportJob goroutine.
 func (s *RadioService) StartImportJob(jobID uint) error {
 	if s.db == nil {
 		return fmt.Errorf("database not initialized")
 	}
 
+	// First confirm the job exists so the not-found path returns a clear error
+	// rather than the generic "not in pending status" RowsAffected==0 fallback.
 	var job catalogm.RadioImportJob
 	if err := s.db.First(&job, jobID).Error; err != nil {
 		return fmt.Errorf("job not found: %w", err)
 	}
 
-	if job.Status != catalogm.RadioImportJobStatusPending {
+	now := time.Now()
+	result := s.db.Model(&catalogm.RadioImportJob{}).
+		Where("id = ? AND status = ?", jobID, catalogm.RadioImportJobStatusPending).
+		Updates(map[string]interface{}{
+			"status":     catalogm.RadioImportJobStatusRunning,
+			"started_at": now,
+		})
+	if result.Error != nil {
+		return fmt.Errorf("starting import job: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		// Either the status changed between First() and Updates() (race with
+		// another StartImportJob/CancelImportJob call), or it was never
+		// pending. Re-read to report the actual current status.
+		if err := s.db.Select("status").First(&job, jobID).Error; err != nil {
+			return fmt.Errorf("job not found: %w", err)
+		}
 		return fmt.Errorf("job is not in pending status (current: %s)", job.Status)
 	}
 
-	now := time.Now()
-	s.db.Model(&job).Updates(map[string]interface{}{
-		"status":     catalogm.RadioImportJobStatusRunning,
-		"started_at": now,
-	})
-
-	// Launch the import goroutine
+	// Launch the import goroutine. Safe to do unconditionally now: only the
+	// caller that won the conditional UPDATE reaches this line.
 	shared.GoSafe(context.Background(), "radio_import_job", func() {
-		s.runImportJob(job.ID)
+		s.runImportJob(jobID)
 	})
 
 	return nil

--- a/backend/internal/services/catalog/radio_import_job_test.go
+++ b/backend/internal/services/catalog/radio_import_job_test.go
@@ -162,6 +162,91 @@ func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_InvalidUnti
 	suite.Contains(err.Error(), "invalid until date")
 }
 
+// ─── StartImportJob Tests ──────────────────────────────────────────────────
+
+// TestStartImportJob_RejectsAlreadyRunning verifies that StartImportJob refuses
+// to start a job whose status is already 'running'. The conditional UPDATE on
+// (status = pending) must fail with RowsAffected == 0 and surface the actual
+// current status without spawning a duplicate runImportJob goroutine.
+func (suite *RadioImportJobIntegrationTestSuite) TestStartImportJob_RejectsAlreadyRunning() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	job, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	// Pretend a prior StartImportJob call already won the race.
+	suite.db.Model(&catalogm.RadioImportJob{}).Where("id = ?", job.ID).
+		Update("status", catalogm.RadioImportJobStatusRunning)
+
+	err = suite.radioService.StartImportJob(job.ID)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "not in pending status")
+	suite.Contains(err.Error(), catalogm.RadioImportJobStatusRunning)
+}
+
+// TestStartImportJob_NotFound verifies the not-found path returns a clear
+// "job not found" error before reaching the conditional UPDATE.
+func (suite *RadioImportJobIntegrationTestSuite) TestStartImportJob_NotFound() {
+	err := suite.radioService.StartImportJob(99999)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "job not found")
+}
+
+// TestStartImportJob_RaceOnlyOneWins simulates two concurrent StartImportJob
+// callers for the same pending job and verifies exactly one wins. This is the
+// core race-condition guard: without the conditional UPDATE both callers could
+// pass an unguarded check-then-act, transition the job to RUNNING, and spawn
+// duplicate runImportJob goroutines that would import the same episodes twice.
+//
+// The winner does spawn a runImportJob goroutine via shared.GoSafe, but with a
+// no-PlaylistSource test station that goroutine fails fast inside
+// importShowEpisodesWithProgress and calls failJob, so the final status is
+// FAILED rather than RUNNING. The race-condition assertion lives in the
+// success/failure counts (1/1) — the post-state is captured loosely.
+func (suite *RadioImportJobIntegrationTestSuite) TestStartImportJob_RaceOnlyOneWins() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	job, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	// Two parallel starters race on the same job.
+	type startResult struct{ err error }
+	results := make(chan startResult, 2)
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			results <- startResult{err: suite.radioService.StartImportJob(job.ID)}
+		}()
+	}
+	close(start)
+
+	var successes, failures int
+	for i := 0; i < 2; i++ {
+		r := <-results
+		if r.err == nil {
+			successes++
+		} else {
+			failures++
+			suite.Contains(r.err.Error(), "not in pending status",
+				"loser should report status-precondition failure")
+		}
+	}
+	suite.Equal(1, successes, "exactly one caller should win")
+	suite.Equal(1, failures, "exactly one caller should lose")
+
+	// The winner spawned exactly one runImportJob goroutine. With a test
+	// station that has no PlaylistSource, that goroutine fails fast inside
+	// importShowEpisodesWithProgress and the job ends up FAILED. The job
+	// MUST NOT remain in pending — the conditional UPDATE always fired once.
+	updated, err := suite.radioService.GetImportJob(job.ID)
+	suite.Require().NoError(err)
+	suite.NotEqual(catalogm.RadioImportJobStatusPending, updated.Status,
+		"job should have transitioned out of pending exactly once")
+}
+
 // ─── CancelImportJob Tests ─────────────────────────────────────────────────
 
 func (suite *RadioImportJobIntegrationTestSuite) TestCancelImportJob_Success() {


### PR DESCRIPTION
## Summary
- Close the `StartImportJob` double-start race (PSY-815 candidate 3): the prior UPDATE set `status = RUNNING` unconditionally; two near-simultaneous calls both flipped status and both spawned `runImportJob` goroutines
- New shape: conditional UPDATE `WHERE status = 'pending'` + check `RowsAffected` to detect the lost race
- Loser returns "not in pending status" error; winner spawns the goroutine. Leverages Postgres row-level locking inside the single UPDATE — works under any isolation level
- Tests added: rejects-already-running case + concurrent-race-only-one-wins case (proves at most one runImportJob goroutine spawns when 2 callers race)

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/catalog/...` — passed (30.776s, uncached)
- [x] `/code-review` — 2 LOW-severity test-cleanliness findings in the new race test (goroutine cleanup, error-string assertion brittleness); production fix is correct under all Postgres isolation levels. Findings flagged in agent's report but not blocking — both are minor

## Manual repro
`go test -count=1 ./internal/services/catalog/...` — full catalog suite passes including the 2 new tests:
- `TestStartImportJob_RejectsAlreadyRunning` — pre-poisoning the job row to `running`, then calling `StartImportJob` returns "not in pending status"
- `TestStartImportJob_RaceOnlyOneWins` — concurrent goroutines racing `StartImportJob`; asserts exactly 1 succeeds + 1 fails with "not in pending status"

## Triage summary (PSY-815 candidates 1-4)
This PR closes **candidate 3 only**. Full triage:

| # | Candidate | Disposition | Reference |
| --- | --- | --- | --- |
| 1 | Circuit breaker wedge | **File follow-up** — needs design | [PSY-887](https://linear.app/psychic-homily/issue/PSY-887) |
| 2 | Batch insert whole-batch loss | **File follow-up** — needs design | [PSY-888](https://linear.app/psychic-homily/issue/PSY-888) |
| 3 | StartImportJob race | **Fix in-place** | THIS PR |
| 4 | Name normalization ASCII-only | **Defer** — low/enhancement, design discussion needed | (no ticket; defer until acute) |

Detailed verification + dispositions posted as a comment on PSY-815.

## Code review
2 LOW-severity findings in the test code (goroutine cleanup in race test; error-string assertion brittleness). Production fix is correct under all Postgres isolation levels — leverages row-level locking inside the UPDATE. The conditional `WHERE status = 'pending'` + `RowsAffected` check is the canonical Postgres-safe shape for compare-and-swap. Findings did NOT require fixes for this PR; flagged here for visibility.

## Orchestrator-takeover disclosure
Dispatched agent verified all 4 candidates against code, shipped the candidate 3 fix + tests, ran `/code-review`, then stalled before pushing and before posting the triage comment. Orchestrator (this session) verified the remaining 3 candidates against code (circuit breaker confirmed at `radio_fetch_service.go:226-265`; batch insert confirmed at `radio_import.go:576`; normalization confirmed at `radio_matching.go:135,141,158,172`), filed PSY-887 + PSY-888 with design-choice options, posted comprehensive triage comment on PSY-815, then pushed the PR.

Closes part of PSY-815 (candidate 3 only). PSY-887, PSY-888 track candidates 1 + 2. Candidate 4 deferred.