### PR TITLE
PSY-878: sweep aria-label on worst-offender icon-only buttons (post-PSY-767)

### DIFF
--- a/frontend/app/admin/artists/_components/ArtistManagement.tsx
+++ b/frontend/app/admin/artists/_components/ArtistManagement.tsx
@@ -65,6 +65,7 @@ function AliasManager({ artist }: { artist: Artist }) {
                 }
                 disabled={deleteAlias.isPending}
                 className="ml-1 rounded-full p-0.5 hover:bg-destructive/20"
+                aria-label={`Remove alias ${alias.alias}`}
               >
                 <X className="h-3 w-3" />
               </button>
@@ -88,6 +89,7 @@ function AliasManager({ artist }: { artist: Artist }) {
           size="sm"
           onClick={handleAdd}
           disabled={createAlias.isPending || !newAlias.trim()}
+          aria-label="Add alias"
         >
           {createAlias.isPending ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -136,6 +138,7 @@ function ArtistSelector({
               onSelect(null)
               setQuery('')
             }}
+            aria-label={`Clear selected artist ${selected.name}`}
           >
             <X className="h-4 w-4" />
           </Button>

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -1216,7 +1216,7 @@ function StationDetailPanel({
                     <Button
                       variant="ghost"
                       size="sm"
-                      title="Import episodes"
+                      aria-label={`Import episodes for ${show.name}`}
                       onClick={() => toggleShowExpanded(show.id)}
                     >
                       <Upload className="h-4 w-4" />
@@ -1224,6 +1224,7 @@ function StationDetailPanel({
                     <Button
                       variant="ghost"
                       size="sm"
+                      aria-label={`Edit ${show.name}`}
                       onClick={() => { setSelectedShow(show); setDialogMode('edit-show') }}
                     >
                       <Pencil className="h-4 w-4" />
@@ -1232,6 +1233,7 @@ function StationDetailPanel({
                       variant="ghost"
                       size="sm"
                       className="text-destructive"
+                      aria-label={`Delete ${show.name}`}
                       onClick={() => { setSelectedShow(show); setDialogMode('delete-show') }}
                     >
                       <Trash2 className="h-4 w-4" />

--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -505,7 +505,7 @@ function SubmissionShowCard({
                   size="sm"
                   onClick={() => setIsEditing(false)}
                   className="h-7 w-7 p-0"
-                  title="Cancel editing"
+                  aria-label="Cancel editing"
                 >
                   <X className="h-4 w-4" />
                 </Button>
@@ -833,7 +833,6 @@ function FollowingEntityCard({ entity }: { entity: FollowingEntity }) {
           onClick={handleUnfollow}
           disabled={unfollow.isPending}
           className="text-muted-foreground hover:text-destructive shrink-0"
-          title="Unfollow"
           aria-label={`Unfollow ${entity.name}`}
         >
           {unfollow.isPending ? (

--- a/frontend/e2e/pages/add-to-collection.spec.ts
+++ b/frontend/e2e/pages/add-to-collection.spec.ts
@@ -90,9 +90,9 @@ test.describe('Add to Collection', () => {
       // card (CollectionItemCard) doesn't expose a per-item Remove control;
       // only the list-view row does. Switch to list view so the cleanup
       // selectors below — which target the list-view row layout
-      // (div.rounded-lg wrapper + title="Remove from collection") — keep
-      // working. The view toggle renders unconditionally in the items
-      // header, so awaiting the click is safe.
+      // (div.rounded-lg wrapper + per-item aria-label) — keep working.
+      // The view toggle renders unconditionally in the items header, so
+      // awaiting the click is safe.
       await authenticatedPage.getByTestId('view-mode-list').click()
 
       // 6. Verify the show appears in the collection's items list.
@@ -107,16 +107,27 @@ test.describe('Add to Collection', () => {
       )
 
       // 7. Cleanup — remove the item so the test is idempotent across reruns.
-      // The remove flow is two-step: click the X (title="Remove from collection"),
-      // then confirm by clicking the "Remove" button that replaces it. Scope to
-      // the item row so the selectors stay specific even if other items land
-      // in the collection in the future.
+      // The remove flow is two-step: click the per-item X (PSY-878:
+      // aria-label="Remove <entity_name> from collection"), then confirm by
+      // clicking the "Remove" button that replaces it. Scope to the item row
+      // so the selectors stay specific even if other items land in the
+      // collection in the future.
       const itemRow = authenticatedPage
         .locator('div.rounded-lg')
         .filter({ has: itemLink })
         .first()
 
-      await itemRow.getByTitle('Remove from collection').click()
+      // Escape regex special chars in title ('[' and ']') so the literal
+      // square brackets are matched (and not interpreted as a char class).
+      const escapedTitle = RESERVED_SHOW_TITLE.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        '\\$&'
+      )
+      await itemRow
+        .getByRole('button', {
+          name: new RegExp(`Remove ${escapedTitle} from collection`, 'i'),
+        })
+        .click()
 
       await Promise.all([
         authenticatedPage.waitForResponse(

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -1088,7 +1088,7 @@ describe('CollectionDetail', () => {
       render(<CollectionDetail slug="test-collection" />)
 
       // First Move down button (corresponds to index 0 → swap with index 1)
-      const moveDownButtons = screen.getAllByRole('button', { name: 'Move down' })
+      const moveDownButtons = screen.getAllByRole('button', { name: /move .* down/i })
       await user.click(moveDownButtons[0])
 
       expect(mockReorderMutate).toHaveBeenCalledWith({
@@ -1111,7 +1111,7 @@ describe('CollectionDetail', () => {
       render(<CollectionDetail slug="test-collection" />)
 
       // Last Move up button corresponds to index 2 → swap with index 1
-      const moveUpButtons = screen.getAllByRole('button', { name: 'Move up' })
+      const moveUpButtons = screen.getAllByRole('button', { name: /move .* up/i })
       await user.click(moveUpButtons[moveUpButtons.length - 1])
 
       expect(mockReorderMutate).toHaveBeenCalledWith({
@@ -1131,7 +1131,7 @@ describe('CollectionDetail', () => {
         error: null,
       })
       render(<CollectionDetail slug="test-collection" />)
-      const moveUpButtons = screen.getAllByRole('button', { name: 'Move up' })
+      const moveUpButtons = screen.getAllByRole('button', { name: /move .* up/i })
       expect(moveUpButtons[0]).toBeDisabled()
     })
 
@@ -1142,7 +1142,7 @@ describe('CollectionDetail', () => {
         error: null,
       })
       render(<CollectionDetail slug="test-collection" />)
-      const moveDownButtons = screen.getAllByRole('button', { name: 'Move down' })
+      const moveDownButtons = screen.getAllByRole('button', { name: /move .* down/i })
       expect(moveDownButtons[moveDownButtons.length - 1]).toBeDisabled()
     })
 
@@ -1925,7 +1925,7 @@ describe('CollectionDetail', () => {
       render(<CollectionDetail slug="test-collection" />)
 
       const moveDownButtons = screen.getAllByRole('button', {
-        name: 'Move down',
+        name: /move .* down/i,
       })
       expect(moveDownButtons).toHaveLength(3)
       await user.click(moveDownButtons[0])
@@ -1949,7 +1949,7 @@ describe('CollectionDetail', () => {
       const user = userEvent.setup()
       render(<CollectionDetail slug="test-collection" />)
 
-      const moveUpButtons = screen.getAllByRole('button', { name: 'Move up' })
+      const moveUpButtons = screen.getAllByRole('button', { name: /move .* up/i })
       await user.click(moveUpButtons[moveUpButtons.length - 1])
 
       expect(mockReorderMutate).toHaveBeenCalledWith({
@@ -1970,7 +1970,7 @@ describe('CollectionDetail', () => {
       })
       render(<CollectionDetail slug="test-collection" />)
 
-      const moveUpButtons = screen.getAllByRole('button', { name: 'Move up' })
+      const moveUpButtons = screen.getAllByRole('button', { name: /move .* up/i })
       expect(moveUpButtons[0]).toBeDisabled()
     })
 
@@ -1983,7 +1983,7 @@ describe('CollectionDetail', () => {
       render(<CollectionDetail slug="test-collection" />)
 
       const moveDownButtons = screen.getAllByRole('button', {
-        name: 'Move down',
+        name: /move .* down/i,
       })
       expect(moveDownButtons[moveDownButtons.length - 1]).toBeDisabled()
     })

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -1318,7 +1318,6 @@ function CollectionItemRow({
               {...listeners}
               className="touch-none cursor-grab active:cursor-grabbing h-7 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-label={`Drag to reorder ${item.entity_name}. Use space to lift, arrow keys to move.`}
-              title="Drag to reorder"
               data-testid="drag-handle"
             >
               <GripVertical className="h-4 w-4" />
@@ -1330,8 +1329,7 @@ function CollectionItemRow({
                 className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
                 onClick={() => onMoveUp(index)}
                 disabled={index === 0 || isReordering}
-                title="Move up"
-                aria-label="Move up"
+                aria-label={`Move ${item.entity_name} up`}
               >
                 <ChevronUp className="h-3.5 w-3.5" />
               </Button>
@@ -1341,8 +1339,7 @@ function CollectionItemRow({
                 className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
                 onClick={() => onMoveDown(index)}
                 disabled={index === totalItems - 1 || isReordering}
-                title="Move down"
-                aria-label="Move down"
+                aria-label={`Move ${item.entity_name} down`}
               >
                 <ChevronDown className="h-3.5 w-3.5" />
               </Button>
@@ -1403,7 +1400,7 @@ function CollectionItemRow({
                   setNotesValue(item.notes ?? '')
                   setIsEditingNotes(true)
                 }}
-                title="Edit notes"
+                aria-label={`Edit notes for ${item.entity_name}`}
               >
                 <Pencil className="h-3.5 w-3.5" />
               </Button>
@@ -1417,7 +1414,7 @@ function CollectionItemRow({
                 className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
                 onClick={() => setShowRemoveConfirm(true)}
                 disabled={removeMutation.isPending}
-                title="Remove from collection"
+                aria-label={`Remove ${item.entity_name} from collection`}
               >
                 <X className="h-4 w-4" />
               </Button>

--- a/frontend/features/collections/components/CollectionItemCard.tsx
+++ b/frontend/features/collections/components/CollectionItemCard.tsx
@@ -268,7 +268,6 @@ export function CollectionItemCard({
             {...listeners}
             className="touch-none cursor-grab active:cursor-grabbing h-6 w-6 flex items-center justify-center rounded text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={`Drag to reorder ${item.entity_name}. Use space to lift, arrow keys to move.`}
-            title="Drag to reorder"
             data-testid="collection-item-card-drag-handle"
           >
             <GripVertical className="h-3.5 w-3.5" />
@@ -279,8 +278,7 @@ export function CollectionItemCard({
             className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
             onClick={() => reorder.onMoveUp(reorder.index)}
             disabled={reorder.index === 0 || reorder.isPending}
-            title="Move up"
-            aria-label="Move up"
+            aria-label={`Move ${item.entity_name} up`}
           >
             <ChevronUp className="h-3.5 w-3.5" />
           </Button>
@@ -290,8 +288,7 @@ export function CollectionItemCard({
             className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
             onClick={() => reorder.onMoveDown(reorder.index)}
             disabled={reorder.index === reorder.totalItems - 1 || reorder.isPending}
-            title="Move down"
-            aria-label="Move down"
+            aria-label={`Move ${item.entity_name} down`}
           >
             <ChevronDown className="h-3.5 w-3.5" />
           </Button>

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -1037,6 +1037,7 @@ function LineupManagement({ festivalId }: { festivalId: number }) {
                   size="sm"
                   onClick={() => openEditArtist(artist)}
                   className="h-8 w-8 p-0"
+                  aria-label={`Edit lineup entry for ${artist.artist_name}`}
                 >
                   <Pencil className="h-3.5 w-3.5" />
                 </Button>
@@ -1046,6 +1047,7 @@ function LineupManagement({ festivalId }: { festivalId: number }) {
                   onClick={() => handleRemoveArtist(artist.artist_id)}
                   disabled={removeArtistMutation.isPending}
                   className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                  aria-label={`Remove ${artist.artist_name} from lineup`}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </Button>
@@ -1342,6 +1344,7 @@ function VenueManagement({ festivalId }: { festivalId: number }) {
                 onClick={() => handleRemoveVenue(venue.venue_id)}
                 disabled={removeVenueMutation.isPending}
                 className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove ${venue.venue_name} from venues`}
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>

--- a/frontend/features/labels/admin/LabelManagement.tsx
+++ b/frontend/features/labels/admin/LabelManagement.tsx
@@ -967,6 +967,7 @@ export function LabelManagement() {
                       size="sm"
                       onClick={() => openEdit(label.id)}
                       className="h-8 w-8 p-0"
+                      aria-label={`Edit ${label.name}`}
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </Button>
@@ -975,6 +976,7 @@ export function LabelManagement() {
                       size="sm"
                       onClick={() => openDelete(label.id, label.name)}
                       className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                      aria-label={`Delete ${label.name}`}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>

--- a/frontend/features/notifications/components/FilterCard.test.tsx
+++ b/frontend/features/notifications/components/FilterCard.test.tsx
@@ -223,7 +223,9 @@ describe('FilterCard', () => {
       <FilterCard filter={filter} onEdit={mockOnEdit} />
     )
 
-    await user.click(screen.getByTitle('Edit filter'))
+    await user.click(
+      screen.getByRole('button', { name: /edit filter phx punk shows/i })
+    )
 
     expect(mockOnEdit).toHaveBeenCalledWith(filter)
   })
@@ -246,15 +248,11 @@ describe('FilterCard', () => {
       <FilterCard filter={makeFilter()} onEdit={mockOnEdit} />
     )
 
-    // Open dropdown menu (the "more" button)
-    const moreButtons = screen.getAllByRole('button')
-    // The dropdown trigger is the last button in the actions area
-    const dropdownTrigger = moreButtons.find(
-      b => b.querySelector('svg') && !b.getAttribute('title')
+    // Open the More-actions dropdown menu via accessible name
+    // (PSY-878: trigger now exposes aria-label="More actions for ...").
+    await user.click(
+      screen.getByRole('button', { name: /more actions for phx punk shows/i })
     )
-    if (dropdownTrigger) {
-      await user.click(dropdownTrigger)
-    }
 
     // Click Delete in dropdown
     const deleteMenuItem = await screen.findByText('Delete')
@@ -271,14 +269,10 @@ describe('FilterCard', () => {
       <FilterCard filter={makeFilter({ id: 42 })} onEdit={mockOnEdit} />
     )
 
-    // Open dropdown
-    const moreButtons = screen.getAllByRole('button')
-    const dropdownTrigger = moreButtons.find(
-      b => b.querySelector('svg') && !b.getAttribute('title')
+    // Open the More-actions dropdown menu via accessible name
+    await user.click(
+      screen.getByRole('button', { name: /more actions for phx punk shows/i })
     )
-    if (dropdownTrigger) {
-      await user.click(dropdownTrigger)
-    }
 
     // Click Delete in dropdown
     const deleteMenuItem = await screen.findByText('Delete')
@@ -306,14 +300,10 @@ describe('FilterCard', () => {
       <FilterCard filter={makeFilter()} onEdit={mockOnEdit} />
     )
 
-    // Open dropdown and click Delete
-    const moreButtons = screen.getAllByRole('button')
-    const dropdownTrigger = moreButtons.find(
-      b => b.querySelector('svg') && !b.getAttribute('title')
+    // Open the More-actions dropdown menu via accessible name
+    await user.click(
+      screen.getByRole('button', { name: /more actions for phx punk shows/i })
     )
-    if (dropdownTrigger) {
-      await user.click(dropdownTrigger)
-    }
     const deleteMenuItem = await screen.findByText('Delete')
     await user.click(deleteMenuItem)
 

--- a/frontend/features/notifications/components/FilterCard.tsx
+++ b/frontend/features/notifications/components/FilterCard.tsx
@@ -87,7 +87,7 @@ export function FilterCard({ filter, onEdit }: FilterCardProps) {
             size="sm"
             onClick={() => onEdit(filter)}
             className="h-8 w-8 p-0"
-            title="Edit filter"
+            aria-label={`Edit filter ${filter.name}`}
           >
             <Pencil className="h-3.5 w-3.5" />
           </Button>
@@ -98,6 +98,7 @@ export function FilterCard({ filter, onEdit }: FilterCardProps) {
                 variant="ghost"
                 size="sm"
                 className="h-8 w-8 p-0"
+                aria-label={`More actions for ${filter.name}`}
               >
                 <MoreHorizontal className="h-3.5 w-3.5" />
               </Button>

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -201,6 +201,7 @@ function ArtistPicker({
                 size="sm"
                 onClick={() => onRemove(index)}
                 className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove ${artist.artist_name}`}
               >
                 <X className="h-3.5 w-3.5" />
               </Button>
@@ -271,7 +272,13 @@ function LinkEditor({
             }}
           />
         </div>
-        <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleAdd}
+          aria-label="Add external link"
+        >
           <Plus className="h-4 w-4" />
         </Button>
       </div>
@@ -297,6 +304,7 @@ function LinkEditor({
                 size="sm"
                 onClick={() => onRemove(index)}
                 className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove link ${link.url}`}
               >
                 <X className="h-3.5 w-3.5" />
               </Button>
@@ -379,6 +387,7 @@ function ExistingLinkManager({
           size="sm"
           onClick={handleAdd}
           disabled={addLinkMutation.isPending}
+          aria-label="Add external link"
         >
           {addLinkMutation.isPending ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -416,6 +425,7 @@ function ExistingLinkManager({
                 onClick={() => handleRemove(link.id)}
                 disabled={removeLinkMutation.isPending}
                 className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove link ${link.url}`}
               >
                 <X className="h-3.5 w-3.5" />
               </Button>
@@ -1158,6 +1168,7 @@ export function ReleaseManagement() {
                     size="sm"
                     onClick={() => openEdit(release.id)}
                     className="h-8 w-8 p-0"
+                    aria-label={`Edit ${release.title}`}
                   >
                     <Pencil className="h-3.5 w-3.5" />
                   </Button>
@@ -1166,6 +1177,7 @@ export function ReleaseManagement() {
                     size="sm"
                     onClick={() => openDelete(release.id, release.title)}
                     className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                    aria-label={`Delete ${release.title}`}
                   >
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>

--- a/frontend/features/shows/components/ShowCard.test.tsx
+++ b/frontend/features/shows/components/ShowCard.test.tsx
@@ -237,12 +237,16 @@ describe('ShowCard', () => {
 
   it('does not show admin edit button for non-admin', () => {
     render(<ShowCard show={makeShow()} isAdmin={false} />)
-    expect(screen.queryByTitle('Edit show')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /edit show/i })
+    ).not.toBeInTheDocument()
   })
 
   it('shows admin edit button for admin', () => {
     render(<ShowCard show={makeShow()} isAdmin={true} />)
-    expect(screen.getByTitle('Edit show')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /edit show/i })
+    ).toBeInTheDocument()
   })
 
   it('toggles inline edit form when admin clicks edit', async () => {
@@ -251,17 +255,19 @@ describe('ShowCard', () => {
 
     expect(screen.queryByTestId('show-form')).not.toBeInTheDocument()
 
-    await user.click(screen.getByTitle('Edit show'))
+    await user.click(screen.getByRole('button', { name: /edit show/i }))
     expect(screen.getByTestId('show-form')).toBeInTheDocument()
 
-    // Title changes to "Cancel editing"
-    await user.click(screen.getByTitle('Cancel editing'))
+    // Label changes to "Cancel editing"
+    await user.click(screen.getByRole('button', { name: /cancel editing/i }))
     expect(screen.queryByTestId('show-form')).not.toBeInTheDocument()
   })
 
   it('shows delete button for admin', () => {
     render(<ShowCard show={makeShow()} isAdmin={true} />)
-    expect(screen.getByTitle('Delete show')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /delete show/i })
+    ).toBeInTheDocument()
   })
 
   it('shows delete button for show owner', () => {
@@ -273,7 +279,9 @@ describe('ShowCard', () => {
     })
     const show = makeShow({ submitted_by: 42 })
     render(<ShowCard show={show} isAdmin={false} userId="42" />)
-    expect(screen.getByTitle('Delete show')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /delete show/i })
+    ).toBeInTheDocument()
   })
 
   it('does not show delete button for non-owner non-admin', () => {
@@ -285,7 +293,9 @@ describe('ShowCard', () => {
     })
     const show = makeShow({ submitted_by: 42 })
     render(<ShowCard show={show} isAdmin={false} userId="99" />)
-    expect(screen.queryByTitle('Delete show')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /delete show/i })
+    ).not.toBeInTheDocument()
   })
 
   it('opens delete dialog when delete button clicked', async () => {
@@ -293,7 +303,7 @@ describe('ShowCard', () => {
     render(<ShowCard show={makeShow()} isAdmin={true} />)
 
     expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument()
-    await user.click(screen.getByTitle('Delete show'))
+    await user.click(screen.getByRole('button', { name: /delete show/i }))
     expect(screen.getByTestId('delete-dialog')).toBeInTheDocument()
   })
 
@@ -344,7 +354,9 @@ describe('ShowCard', () => {
         ],
       })
       render(<ShowCard show={show} isAdmin={false} />)
-      expect(screen.getByTitle('Discover artist music')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /discover artist music/i })
+      ).toBeInTheDocument()
     })
 
     it('does not show expand button when no artist has music', () => {
@@ -360,7 +372,9 @@ describe('ShowCard', () => {
         ],
       })
       render(<ShowCard show={show} isAdmin={false} />)
-      expect(screen.queryByTitle('Discover artist music')).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /discover artist music/i })
+      ).not.toBeInTheDocument()
     })
 
     it('toggles expanded music section on click', async () => {
@@ -379,10 +393,14 @@ describe('ShowCard', () => {
 
       expect(screen.queryByTestId('music-embed')).not.toBeInTheDocument()
 
-      await user.click(screen.getByTitle('Discover artist music'))
+      await user.click(
+        screen.getByRole('button', { name: /discover artist music/i })
+      )
       expect(screen.getByTestId('music-embed')).toBeInTheDocument()
 
-      await user.click(screen.getByTitle('Hide artist music'))
+      await user.click(
+        screen.getByRole('button', { name: /hide artist music/i })
+      )
       expect(screen.queryByTestId('music-embed')).not.toBeInTheDocument()
     })
   })

--- a/frontend/features/shows/components/ShowCard.tsx
+++ b/frontend/features/shows/components/ShowCard.tsx
@@ -352,7 +352,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                         size="sm"
                         onClick={() => setIsExpanded(!isExpanded)}
                         className="h-7 w-7 p-0"
-                        title={
+                        aria-label={
                           isExpanded ? 'Hide artist music' : 'Discover artist music'
                         }
                       >
@@ -377,7 +377,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                     <Link
                       href={detailsHref}
                       className="inline-flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
-                      title="View details"
+                      aria-label="View show details"
                     >
                       <ExternalLink className="h-3.5 w-3.5" />
                     </Link>
@@ -390,7 +390,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                         size="sm"
                         onClick={() => setIsEditing(!isEditing)}
                         className="h-7 w-7 p-0"
-                        title={isEditing ? 'Cancel editing' : 'Edit show'}
+                        aria-label={isEditing ? 'Cancel editing' : 'Edit show'}
                       >
                         {isEditing ? (
                           <X className="h-4 w-4" />
@@ -419,7 +419,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                         size="sm"
                         onClick={() => setIsDeleteDialogOpen(true)}
                         className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-                        title="Delete show"
+                        aria-label="Delete show"
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>
@@ -591,7 +591,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                       size="sm"
                       onClick={() => setIsExpanded(!isExpanded)}
                       className="h-7 w-7 p-0"
-                      title={
+                      aria-label={
                         isExpanded ? 'Hide artist music' : 'Discover artist music'
                       }
                     >
@@ -618,7 +618,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                   <Link
                     href={detailsHref}
                     className="inline-flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
-                    title="View details"
+                    aria-label="View show details"
                   >
                     <ExternalLink className="h-3.5 w-3.5" />
                   </Link>
@@ -632,7 +632,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                       size="sm"
                       onClick={() => setIsEditing(!isEditing)}
                       className="h-7 w-7 p-0"
-                      title={isEditing ? 'Cancel editing' : 'Edit show'}
+                      aria-label={isEditing ? 'Cancel editing' : 'Edit show'}
                     >
                       {isEditing ? (
                         <X className="h-4 w-4" />
@@ -663,7 +663,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
                       size="sm"
                       onClick={() => setIsDeleteDialogOpen(true)}
                       className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-                      title="Delete show"
+                      aria-label="Delete show"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>

--- a/frontend/features/venues/components/VenueCard.test.tsx
+++ b/frontend/features/venues/components/VenueCard.test.tsx
@@ -327,8 +327,12 @@ describe('VenueCard', () => {
         logout: vi.fn(),
       })
       render(<VenueCard venue={makeVenue()} />)
-      expect(screen.getByTitle('Edit venue')).toBeInTheDocument()
-      expect(screen.getByTitle('Delete venue')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /edit the rebel lounge/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /delete the rebel lounge/i })
+      ).toBeInTheDocument()
     })
 
     it('hides edit button for non-admin venue owner (PSY-503: direct edit is admin-only; owners suggest via VenueDetail drawer)', () => {
@@ -339,8 +343,12 @@ describe('VenueCard', () => {
         logout: vi.fn(),
       })
       render(<VenueCard venue={makeVenue({ submitted_by: 42 })} />)
-      expect(screen.queryByTitle('Edit venue')).not.toBeInTheDocument()
-      expect(screen.queryByTitle('Delete venue')).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /edit the rebel lounge/i })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /delete the rebel lounge/i })
+      ).not.toBeInTheDocument()
     })
 
     it('opens edit form when edit button clicked', async () => {
@@ -354,7 +362,9 @@ describe('VenueCard', () => {
       render(<VenueCard venue={makeVenue()} />)
 
       expect(screen.queryByTestId('edit-form')).not.toBeInTheDocument()
-      await user.click(screen.getByTitle('Edit venue'))
+      await user.click(
+        screen.getByRole('button', { name: /edit the rebel lounge/i })
+      )
       expect(screen.getByTestId('edit-form')).toBeInTheDocument()
     })
 
@@ -369,7 +379,9 @@ describe('VenueCard', () => {
       render(<VenueCard venue={makeVenue()} />)
 
       expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument()
-      await user.click(screen.getByTitle('Delete venue'))
+      await user.click(
+        screen.getByRole('button', { name: /delete the rebel lounge/i })
+      )
       expect(screen.getByTestId('delete-dialog')).toBeInTheDocument()
     })
   })

--- a/frontend/features/venues/components/VenueCard.tsx
+++ b/frontend/features/venues/components/VenueCard.tsx
@@ -96,7 +96,7 @@ export function VenueCard({ venue }: VenueCardProps) {
                       setIsEditingVenue(true)
                     }}
                     className="p-1 rounded-md hover:bg-muted transition-colors"
-                    title="Edit venue"
+                    aria-label={`Edit ${venue.name}`}
                   >
                     <Pencil className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
                   </button>
@@ -106,7 +106,7 @@ export function VenueCard({ venue }: VenueCardProps) {
                       setIsDeleteVenueOpen(true)
                     }}
                     className="p-1 rounded-md hover:bg-destructive/10 transition-colors"
-                    title="Delete venue"
+                    aria-label={`Delete ${venue.name}`}
                   >
                     <Trash2 className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
                   </button>


### PR DESCRIPTION
## Summary
- First pass of the icon-only-button sweep (PSY-767 follow-up): add `aria-label` to worst-offender files; update tests to use `getByRole('button', { name: ... })` instead of class workarounds (per PSY-859)
- Production a11y additions across: `RadioManagement`, `ArtistManagement`, `library/page.tsx`, `CollectionDetail`, `CollectionItemCard`, `FestivalManagement`, `LabelManagement`, `FilterCard`, `ReleaseManagement`, `ShowCard` (title→aria-label + extras), `VenueCard`
- Test files updated to use accessible queries: `CollectionDetail.test.tsx`, `FilterCard.test.tsx`, `ShowCard.test.tsx`, `VenueCard.test.tsx` (class queries REMOVED per PSY-859, not kept alongside)
- E2E `add-to-collection.spec.ts` updated to use accessible queries
- Net: 16 files, +132/-85 lines

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run` — passed (424 files, 5204 tests, 56.26s)
- [x] `/code-review` — agent ran multiple verification angles + sweep, returned `[]`; verified the `getByRole({name: /move .* down/i})` regex matches exactly the 3 expected buttons without colliding with drag handles, etc.

## Manual repro
`test:run` full suite — 5204 tests pass. Per-area verification: each touched icon button now reachable via `getByRole('button', { name: ... })`; `ShowCard.tsx` swapped `title=""` → `aria-label=""` (title was not reliable accessible name for screen readers); admin Management rows (Festival/Label/Release) gain per-entity aria-labels (`Edit ${entity.name}` / `Delete ${entity.name}`); CollectionDetail's notes-edit / remove-from-collection / drag handles labeled.

## Scope deviation
**This is a first pass — NOT the full sweep.** PSY-767 estimated ~30-50 true icon-only sites; this PR addresses the worst-offender set explicitly enumerated in PSY-878's ticket body. Remaining surfaces (EntityEditDrawer, CommentCard, FieldNoteForm, TagHierarchyEditor, StreamingWorklist, FeaturedAdmin, ModerationQueue, and any others surfaced by re-running the candidate scanner) should be addressed in a follow-up sweep. The orchestrator did NOT file a separate follow-up ticket — the PSY-878 ticket itself remains In Progress to track the remaining work, OR you can mark Done and file a new ticket to scope the remainder.

## eslint-plugin-jsx-a11y decision
NOT enabled in this PR (consistent with the deferred-rather-than-fix-all strategy). If enabled now, it would surface violations across the deferred files. Recommend enabling as a separate ticket AFTER the full sweep completes, so the lint rule lands clean.

## Code review
No changes — `/code-review` ran multiple sweep angles (line scan, removed-behavior audit, cross-file tracer, language pitfalls, wrapper correctness, drag-handle regex collision check), returned `[]`. The `/move .* down/i` regex was specifically verified to match exactly the 3 expected buttons.

## Orchestrator-takeover disclosure
Dispatched agent shipped two commits (worst-offender pass + admin RadioManagement/ArtistManagement pass) and ran `/code-review` to completion (`[]`), then stalled before push. **PSY-768 (form-init conversion) and several backend errcheck PRs merged to main during the agent's run**, leaving this branch stale-based with massive false removals (15-172 lines per affected file across skills/auth/forms test files). Orchestrator (this session) rebased onto current `origin/main`, auto-merged cleanly (form-init conversions and a11y additions are structurally disjoint within FestivalManagement / LabelManagement / ReleaseManagement / TagManagement), re-ran `bun run typecheck` + full `bun run test:run` (both green, 5204/5204), force-pushed with `--force-with-lease`. Same shape as PSY-768 stale-base recovery earlier this wave.

Closes part of PSY-878 (worst-offender pass); ticket stays In Progress to track remaining surfaces.