### PR TITLE
PSY-883: RefreshToken fail-closed for authService==nil

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -291,15 +291,24 @@ func (h *AuthHandler) RefreshTokenHandler(ctx context.Context, input *struct{}) 
 	requestID := logger.GetRequestID(ctx)
 	resp.Body.RequestID = requestID
 
+	// Fail-closed: an unwired auth service is a server-config defect; surface it
+	// as 5xx so monitoring and on-call see the incident with the same uniform
+	// shape as the post-service-call failure branches below. The response body
+	// stays byte-identical with the prior HTTP-200 SERVICE_UNAVAILABLE path;
+	// only the transport-level status flips.
 	if h.authService == nil {
-		logger.AuthError(ctx, "refresh_token_failed", autherrors.ErrServiceUnavailable("auth", nil))
+		authErr := autherrors.ErrServiceUnavailable("refresh_token_auth_service_unwired", nil)
+		logger.AuthError(ctx, "refresh_token_failed", authErr)
 		resp.Body.Success = false
-		resp.Body.Message = "Auth service not available"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Extract user from JWT context (set by middleware)
+	// Extract user from JWT context (set by middleware). A nil contextUser here
+	// means the middleware contract was violated (route mounted without auth
+	// middleware, or middleware bug) — fundamentally different from a service
+	// failure, so this stays HTTP 200 + CodeUnauthorized rather than a 5xx.
 	contextUser := middleware.GetUserFromContext(ctx)
 	if contextUser == nil {
 		logger.AuthWarn(ctx, "refresh_token_no_user")

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -159,18 +159,44 @@ func TestLogoutHandler_WithUser(t *testing.T) {
 
 // --- RefreshTokenHandler ---
 
-func TestRefreshTokenHandler_NilAuthService(t *testing.T) {
+// TestRefreshTokenHandler_NilAuthServiceReturnsServerError locks in the
+// fail-closed convention for the unwired-auth-service early exit: a nil
+// authService is a server-config defect, and the handler must surface it as a
+// 5xx (non-nil returned error wrapping an *AuthError of CodeServiceUnavailable)
+// so monitoring sees the same uniform shape as the post-service-call failure
+// branches. The body shape stays byte-identical with the prior HTTP-200
+// SERVICE_UNAVAILABLE path; only the transport status flips.
+func TestRefreshTokenHandler_NilAuthServiceReturnsServerError(t *testing.T) {
 	h := testAuthHandler() // authService is nil
 
 	resp, err := h.RefreshTokenHandler(context.Background(), &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	// Handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx with the structured body.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape so
+	// callers do not see an internal-step leak (e.g. "Auth service not available").
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #860 (PSY-874): applies the same fail-closed shape to the `authService == nil` early-exit path that #860 explicitly carved out of scope. An unwired auth service is a server-config defect; surfacing it as HTTP 200 + `SERVICE_UNAVAILABLE` body hides the incident from monitoring and misclassifies the error budget, exactly the same way the post-service-call branches did before #860.
- Single-path flip + 1 regression test. The `contextUser == nil` branch below stays HTTP 200 + `CodeUnauthorized` (middleware-contract violation, not service failure) — scope decision preserved from PR #860.
- Body shape stays byte-identical with the existing `SERVICE_UNAVAILABLE` path: `ErrorCode` unchanged; `Message` switches from the ad-hoc `"Auth service not available"` to the canonical `ToExternalMessage(CodeServiceUnavailable)` so all three service-failure paths now emit the same external copy. Only the transport status flips from 200 to 5xx.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/api/handlers/auth/... ./internal/errors/...` — pass (1 new regression test, 4 existing PR-#860 RefreshTokenHandler tests still pass, full auth suite green in 8.2s)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — exit 0 (0 issues; required a one-time `golangci-lint cache clean` because the shared cache had stale entries from a parallel agent's worktree on a separate ticket)

## Manual repro
Backend-only single-path flip; the new unit test IS the manual repro per the PSY-592 pattern.

- `TestRefreshTokenHandler_NilAuthServiceReturnsServerError` (new): constructs handler with `authService = nil`; assertions:
  - Returned `error` is non-nil (Huma emits 5xx HTTP status).
  - `errors.As` unwraps to `*AuthError{Code: CodeServiceUnavailable}` (apperror mapper translates to 5xx with structured body).
  - `resp.Body.Success == false`, `resp.Body.ErrorCode == SERVICE_UNAVAILABLE`.
  - `resp.Body.Message == ToExternalMessage(CodeServiceUnavailable)` ("Service temporarily unavailable") — confirms no internal-step leak.
  - PASSED.
- `TestRefreshTokenHandler_NoUserContext` (untouched): still passes — confirms the middleware-contract branch stays HTTP 200 + `CodeUnauthorized` as the AC requires.
- `TestRefreshTokenHandler_ProfileFails` / `TestRefreshTokenHandler_TokenFails` / `TestRefreshTokenHandler_Success` (from PR #860): all still pass — confirms the other two service-failure branches and happy path are unaffected.

## Code review
Inline 3-lens (sub-agent context: no Agent tool, per `pattern_subagent_inline_code_review.md`). Edited 2 files, +42 / -7 net lines.

- **Reuse**: change reuses the exact primitives PR #860 established for the sibling branches (`autherrors.ErrServiceUnavailable` + `ToExternalMessage` + `logger.AuthError`); all three RefreshTokenHandler service-failure paths now emit a uniform shape. No new helpers introduced.
- **Quality**: scope matches the AC exactly. Comment names the WHY (server-config defect, uniform shape for monitoring) without a `PSY-883` ref per `feedback_strip_ticket_refs_from_doc_comments.md`. Test renamed from `_NilAuthService` to `_NilAuthServiceReturnsServerError` to describe the contract, not the input. Pre-existing minor: `ErrServiceUnavailable("scope", nil)` produces a `%!w(<nil>)` artifact in the wrapped error string when `internal == nil` — this matches PR #860's identical use of `("auth", nil)` on the same path and is not a new regression; a follow-up could teach `ErrServiceUnavailable` to skip `%w` when internal is nil, but that's out of scope for this single-path flip.
- **Efficiency**: hot path unchanged (early-exit only fires when authService is nil, a server-startup defect, not a per-request branch). No new allocations beyond PR #860's pattern.

Closes PSY-883