### PR TITLE
PSY-873: fail-closed default for 10 auth handlers

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -371,15 +371,24 @@ func (h *AuthHandler) GetProfileHandler(ctx context.Context, input *struct{}) (*
 	requestID := logger.GetRequestID(ctx)
 	resp.Body.RequestID = requestID
 
+	// Fail-closed: an unwired auth service is a server-config defect; surface it
+	// as 5xx so monitoring and on-call see the incident with the same uniform
+	// shape as the post-service-call failure branch below. The response body
+	// stays byte-identical with the prior HTTP-200 SERVICE_UNAVAILABLE path;
+	// only the transport-level status flips.
 	if h.authService == nil {
-		logger.AuthError(ctx, "get_profile_failed", autherrors.ErrServiceUnavailable("auth", nil))
+		authErr := autherrors.ErrServiceUnavailable("get_profile_auth_service_unwired", nil)
+		logger.AuthError(ctx, "get_profile_failed", authErr)
 		resp.Body.Success = false
-		resp.Body.Message = "Auth service not available"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Extract user from JWT context (set by middleware)
+	// Extract user from JWT context (set by middleware). A nil contextUser here
+	// means the middleware contract was violated (route mounted without auth
+	// middleware, or middleware bug) — fundamentally different from a service
+	// failure, so this stays HTTP 200 + CodeUnauthorized rather than a 5xx.
 	contextUser := middleware.GetUserFromContext(ctx)
 	if contextUser == nil {
 		logger.AuthWarn(ctx, "get_profile_no_user")
@@ -393,16 +402,21 @@ func (h *AuthHandler) GetProfileHandler(ctx context.Context, input *struct{}) (*
 		"user_id", contextUser.ID,
 	)
 
-	// Fetch fresh user data from database with all relationships
+	// Fetch fresh user data from database with all relationships.
+	// Fail-closed: an unexpected DB/service failure here propagates as a 5xx so
+	// the HTTP layer cannot hand callers (or monitoring) a misleading HTTP 200
+	// SERVICE_UNAVAILABLE body. The response body shape is unchanged; only the
+	// transport-level status flips from 200 to 5xx.
 	user, err := h.authService.GetUserProfile(contextUser.ID)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("get_profile", err)
 		logger.AuthError(ctx, "get_profile_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to fetch user profile"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	logger.AuthDebug(ctx, "get_profile_success",
@@ -536,6 +550,15 @@ func (h *AuthHandler) RegisterHandler(ctx context.Context, input *RegisterReques
 		},
 	)
 	if err != nil {
+		// Silent-downgrade convention intentionally preserved here pending the
+		// email-enumeration design lock for the registration path. Whether
+		// unknown service-failure codes should surface as 5xx, or stay folded
+		// into the CodeUnknown / CodeUserExists shape (to avoid leaking
+		// registered-email state via transport-status differences), is tied
+		// to that broader enumeration-safety decision — which has not landed
+		// yet. Revisit alongside the registration enumeration work; the rest
+		// of this handler family has been converted to the fail-closed
+		// pattern (see GetProfileHandler / SendVerificationEmailHandler / et al.).
 		errorCode := autherrors.CodeUnknown
 		message := "Failed to create user"
 
@@ -647,27 +670,35 @@ func (h *AuthHandler) SendVerificationEmailHandler(ctx context.Context, input *s
 
 	email := *contextUser.Email
 
-	// Generate verification token
+	// Generate verification token.
+	// Fail-closed: a JWT-service outage here is an unexpected backend failure,
+	// not a UX condition. Surfacing it as HTTP 200 + SERVICE_UNAVAILABLE hides
+	// the incident from monitoring; propagating a 5xx keeps the response body
+	// byte-identical with the prior path and forces on-call visibility.
 	token, err := h.jwtService.CreateVerificationToken(contextUser.ID, email)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("send_verification_token", err)
 		logger.AuthError(ctx, "send_verification_token_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to generate verification token"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Send verification email
+	// Send verification email.
+	// Fail-closed: same rationale as the token-mint branch above. Email-service
+	// outages must surface as 5xx, not as HTTP 200 with a sad-path body.
 	if err := h.emailService.SendVerificationEmail(email, token); err != nil {
+		authErr := autherrors.ErrServiceUnavailable("send_verification_email", err)
 		logger.AuthError(ctx, "send_verification_email_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to send verification email"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	logger.AuthInfo(ctx, "send_verification_email_success",
@@ -758,15 +789,25 @@ func (h *AuthHandler) ConfirmVerificationHandler(ctx context.Context, input *Con
 		return resp, nil
 	}
 
-	// Update user to mark email as verified
+	// Update user to mark email as verified.
+	// Fail-closed: the token has already been validated and the user/email
+	// match has already been confirmed by this point, so a SetEmailVerified
+	// failure is an unexpected backend defect rather than a UX condition.
+	// Surfacing it as HTTP 200 + SERVICE_UNAVAILABLE hides the incident from
+	// monitoring; propagating a 5xx keeps the response body byte-identical
+	// with the prior path and forces on-call visibility. The intentional UX
+	// shapes above (INVALID_TOKEN, UNAUTHORIZED, EMAIL_MISMATCH, already-
+	// verified) intentionally stay HTTP 200 with structured ErrorCode so the
+	// frontend can render the corresponding form state.
 	if err := h.userService.SetEmailVerified(user.ID, true); err != nil {
+		authErr := autherrors.ErrServiceUnavailable("confirm_verification_set_verified", err)
 		logger.AuthError(ctx, "confirm_verification_update_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to verify email"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	logger.AuthInfo(ctx, "confirm_verification_success",
@@ -1113,29 +1154,57 @@ func (h *AuthHandler) ChangePasswordHandler(ctx context.Context, input *ChangePa
 
 	// Update password
 	if err := h.userService.UpdatePassword(contextUser.ID, input.Body.CurrentPassword, input.Body.NewPassword); err != nil {
-		errorMessage := "Failed to change password"
-		errorCode := autherrors.CodeUnknown
-
 		var authErr *autherrors.AuthError
 		if errors.As(err, &authErr) {
 			switch authErr.Code {
 			case autherrors.CodeInvalidCredentials:
-				errorMessage = "Current password is incorrect"
-				errorCode = autherrors.CodeInvalidCredentials
+				logger.AuthWarn(ctx, "change_password_failed",
+					"user_id", contextUser.ID,
+					"error", err.Error(),
+				)
+				resp.Body.Success = false
+				resp.Body.Message = "Current password is incorrect"
+				resp.Body.ErrorCode = autherrors.CodeInvalidCredentials
+				return resp, nil
 			case autherrors.CodeNoPasswordSet:
-				errorMessage = authErr.UserMessage()
-				errorCode = autherrors.CodeNoPasswordSet
+				logger.AuthWarn(ctx, "change_password_failed",
+					"user_id", contextUser.ID,
+					"error", err.Error(),
+				)
+				resp.Body.Success = false
+				resp.Body.Message = authErr.UserMessage()
+				resp.Body.ErrorCode = autherrors.CodeNoPasswordSet
+				return resp, nil
+			default:
+				// Fail-closed: any AuthError code without an explicit handler
+				// case is treated as "we don't know what went wrong" and
+				// propagates as 5xx. Adding a new AuthError code that SHOULD
+				// be 401-shaped requires an explicit case here — code review
+				// forces a UX decision per code instead of accepting a silent
+				// CodeUnknown downgrade.
+				logger.AuthError(ctx, "change_password_unhandled_authcode", err,
+					"user_id", contextUser.ID,
+					"auth_code", string(authErr.Code),
+				)
+				resp.Body.Success = false
+				resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
+				resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+				return resp, authErr
 			}
 		}
 
-		logger.AuthWarn(ctx, "change_password_failed",
+		// Outer fallback: err is NOT an AuthError. Genuine "unexpected error"
+		// territory — config failures, raw DB errors, or any service path that
+		// has not been promoted to a typed AuthError. Fail-closed with a
+		// generic message so we do not leak which internal step failed, and
+		// surface a 5xx so the client retries.
+		logger.AuthError(ctx, "change_password_unexpected_error", err,
 			"user_id", contextUser.ID,
-			"error", err.Error(),
 		)
 		resp.Body.Success = false
-		resp.Body.Message = errorMessage
-		resp.Body.ErrorCode = errorCode
-		return resp, nil
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
+		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+		return resp, autherrors.ErrServiceUnavailable("change_password", err)
 	}
 
 	logger.AuthInfo(ctx, "change_password_success",
@@ -1181,16 +1250,22 @@ func (h *AuthHandler) GetDeletionSummaryHandler(ctx context.Context, input *stru
 		"user_id", contextUser.ID,
 	)
 
-	// Get deletion summary from user service
+	// Get deletion summary from user service.
+	// Fail-closed: a service-call failure here is an unexpected backend defect.
+	// Surfacing it as HTTP 200 + SERVICE_UNAVAILABLE hides the incident from
+	// monitoring and lets clients keep reading a sad-path body as if it were
+	// the canonical shape; propagating a 5xx forces on-call visibility while
+	// the body shape stays byte-identical with the prior path.
 	summary, err := h.userService.GetDeletionSummary(contextUser.ID)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("get_deletion_summary", err)
 		logger.AuthError(ctx, "deletion_summary_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to retrieve deletion summary"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	resp.Body.Success = true
@@ -1394,7 +1469,12 @@ type ConfirmAccountRecoveryResponse struct {
 func (h *AuthHandler) ExportDataHandler(ctx context.Context, input *struct{}) (*ExportDataResponse, error) {
 	resp := &ExportDataResponse{}
 
-	// Get authenticated user from context
+	// Extract user from JWT context (set by middleware). A nil contextUser here
+	// means the middleware contract was violated (route mounted without auth
+	// middleware, or middleware bug) — fundamentally different from a service
+	// failure, so this stays HTTP 200 with an inline JSON error body rather
+	// than a 5xx. The byte-body shape is the user-visible behavior here (file
+	// download), so we preserve it as a structured JSON sad-path.
 	contextUser := middleware.GetUserFromContext(ctx)
 	if contextUser == nil {
 		logger.AuthWarn(ctx, "export_data_no_user")
@@ -1408,15 +1488,20 @@ func (h *AuthHandler) ExportDataHandler(ctx context.Context, input *struct{}) (*
 		"user_id", contextUser.ID,
 	)
 
-	// Export user data as JSON
+	// Export user data as JSON.
+	// Fail-closed: a service-call failure here is an unexpected backend defect,
+	// not a UX condition. Surfacing it as HTTP 200 + an inline JSON error body
+	// hides the incident from monitoring; propagating a 5xx via Huma's error
+	// path lets on-call see the actual failure. We do NOT set ContentType /
+	// Body on the resp because Huma's error mapper builds the response from
+	// the returned error directly, producing a canonical JSON 5xx instead of
+	// the byte-body file-download shape.
 	exportData, err := h.userService.ExportUserDataJSON(contextUser.ID)
 	if err != nil {
 		logger.AuthError(ctx, "export_data_failed", err,
 			"user_id", contextUser.ID,
 		)
-		resp.ContentType = "application/json"
-		resp.Body = []byte(`{"success":false,"error":"export_failed","message":"Failed to export user data"}`)
-		return resp, nil
+		return resp, autherrors.ErrServiceUnavailable("export_data", err)
 	}
 
 	logger.AuthInfo(ctx, "export_data_success",
@@ -1513,39 +1598,56 @@ func (h *AuthHandler) RecoverAccountHandler(ctx context.Context, input *RecoverA
 		return invalidCredentials()
 	}
 
-	// Restore the account
+	// Restore the account.
+	// Fail-closed: the post-eligibility surface is NO LONGER enumeration-
+	// sensitive — the caller has already provided correct credentials, so a
+	// RestoreAccount failure is an unexpected backend defect rather than a
+	// guessable account-state. Surfacing it as HTTP 200 + SERVICE_UNAVAILABLE
+	// hides the incident from monitoring; propagating a 5xx forces on-call
+	// visibility while the response body shape stays byte-identical with the
+	// prior path. The enumeration-safe invalidCredentials() closure above
+	// intentionally stays HTTP 200 for the pre-success branches.
 	if err := h.userService.RestoreAccount(user.ID); err != nil {
+		authErr := autherrors.ErrServiceUnavailable("recover_account_restore", err)
 		logger.AuthError(ctx, "recover_account_restore_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to restore account"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Fetch the restored user
+	// Fetch the restored user.
+	// Fail-closed: same rationale as the RestoreAccount branch above — a
+	// post-restore lookup failure is a service-layer defect, not a UX
+	// condition or an enumeration surface.
 	restoredUser, err := h.userService.GetUserByID(user.ID)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("recover_account_fetch", err)
 		logger.AuthError(ctx, "recover_account_fetch_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Account restored but failed to fetch user data"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Generate JWT token and log user in
+	// Generate JWT token and log user in.
+	// Fail-closed: same rationale as the RestoreAccount / fetch branches
+	// above — a JWT-service outage at this stage is a backend failure, not a
+	// UX condition or an enumeration surface.
 	token, err := h.jwtService.CreateToken(restoredUser)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("recover_account_token", err)
 		logger.AuthError(ctx, "recover_account_token_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Account restored but failed to generate authentication token"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	resp.SetCookie = h.config.Session.NewAuthCookie(token, 24*time.Hour)
@@ -1739,39 +1841,57 @@ func (h *AuthHandler) ConfirmAccountRecoveryHandler(ctx context.Context, input *
 		return resp, nil
 	}
 
-	// Restore the account
+	// Restore the account.
+	// Fail-closed: the token + user ID match + recovery eligibility have all
+	// been confirmed by this point, so a RestoreAccount failure is an
+	// unexpected backend defect rather than a UX condition. Surfacing it as
+	// HTTP 200 + SERVICE_UNAVAILABLE hides the incident from monitoring;
+	// propagating a 5xx keeps the response body byte-identical and forces
+	// on-call visibility. The intentional UX shapes above (INVALID_TOKEN,
+	// UNAUTHORIZED, ACCOUNT_ACTIVE, ACCOUNT_NOT_RECOVERABLE) intentionally
+	// stay HTTP 200 with structured ErrorCode so the frontend can render the
+	// corresponding form state.
 	if err := h.userService.RestoreAccount(user.ID); err != nil {
+		authErr := autherrors.ErrServiceUnavailable("confirm_recovery_restore", err)
 		logger.AuthError(ctx, "confirm_recovery_restore_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to restore account"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Fetch the restored user
+	// Fetch the restored user.
+	// Fail-closed: same rationale as the RestoreAccount branch above — a
+	// post-restore lookup failure is a service-layer defect, not a UX
+	// condition.
 	restoredUser, err := h.userService.GetUserByID(user.ID)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("confirm_recovery_fetch", err)
 		logger.AuthError(ctx, "confirm_recovery_fetch_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Account restored but failed to fetch user data"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
-	// Generate JWT token and log user in
+	// Generate JWT token and log user in.
+	// Fail-closed: same rationale as the RestoreAccount / fetch branches
+	// above — a JWT-service outage at this stage is a backend failure, not a
+	// UX condition.
 	token, err := h.jwtService.CreateToken(restoredUser)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("confirm_recovery_token", err)
 		logger.AuthError(ctx, "confirm_recovery_token_failed", err,
 			"user_id", user.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Account restored but failed to generate authentication token"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	resp.SetCookie = h.config.Session.NewAuthCookie(token, 24*time.Hour)
@@ -1824,16 +1944,21 @@ func (h *AuthHandler) GenerateCLITokenHandler(ctx context.Context, input *struct
 		"user_id", contextUser.ID,
 	)
 
-	// Generate a fresh JWT token for CLI use (24 hour expiry)
+	// Generate a fresh JWT token for CLI use (24 hour expiry).
+	// Fail-closed: a JWT-service outage here is an unexpected backend failure,
+	// not a UX condition. Surfacing it as HTTP 200 + SERVICE_UNAVAILABLE hides
+	// the incident from monitoring; propagating a 5xx keeps the response body
+	// byte-identical with the prior path and forces on-call visibility.
 	token, err := h.jwtService.CreateToken(contextUser)
 	if err != nil {
+		authErr := autherrors.ErrServiceUnavailable("generate_cli_token", err)
 		logger.AuthError(ctx, "generate_cli_token_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to generate CLI token"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, authErr
 	}
 
 	logger.AuthInfo(ctx, "generate_cli_token_success",
@@ -1945,16 +2070,39 @@ func (h *AuthHandler) UpdateProfileHandler(ctx context.Context, req *UpdateProfi
 		// CodeUsernameTaken from the user service (the driver-string match
 		// lives there now, isolated to the DB boundary).
 		var authErr *autherrors.AuthError
-		if errors.As(err, &authErr) && authErr.Code == autherrors.CodeUsernameTaken {
-			resp.Body.Success = false
-			resp.Body.Message = authErr.UserMessage()
-			resp.Body.ErrorCode = autherrors.CodeValidationFailed
-			return resp, nil
+		if errors.As(err, &authErr) {
+			switch authErr.Code {
+			case autherrors.CodeUsernameTaken:
+				resp.Body.Success = false
+				resp.Body.Message = authErr.UserMessage()
+				resp.Body.ErrorCode = autherrors.CodeValidationFailed
+				return resp, nil
+			default:
+				// Fail-closed: any AuthError code without an explicit handler
+				// case is treated as "we don't know what went wrong" and
+				// propagates as 5xx. Adding a new AuthError code that SHOULD
+				// be 4xx-shaped requires an explicit case here — code review
+				// forces a UX decision per code instead of accepting a silent
+				// SERVICE_UNAVAILABLE downgrade.
+				logger.AuthError(ctx, "update_profile_unhandled_authcode", err,
+					"user_id", user.ID,
+					"auth_code", string(authErr.Code),
+				)
+				resp.Body.Success = false
+				resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
+				resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+				return resp, authErr
+			}
 		}
+		// Outer fallback: err is NOT an AuthError. Genuine "unexpected error"
+		// territory — config failures, raw DB errors, or any service path that
+		// has not been promoted to a typed AuthError. Fail-closed with a
+		// generic message so we do not leak which internal step failed, and
+		// surface a 5xx so the client retries.
 		resp.Body.Success = false
-		resp.Body.Message = "Failed to update profile"
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, nil
+		return resp, autherrors.ErrServiceUnavailable("update_profile", err)
 	}
 
 	logger.FromContext(ctx).Info("profile_updated",

--- a/backend/internal/api/handlers/auth/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth/auth_integration_test.go
@@ -332,7 +332,14 @@ func (s *AuthHandlerIntegrationSuite) TestSendVerification_SendFails() {
 	ctx := s.ctxWithUser(user)
 
 	resp, err := h.SendVerificationEmailHandler(ctx, &struct{}{})
-	s.Require().NoError(err)
+
+	// Fail-closed: a real email-send failure surfaces as a 5xx so monitoring
+	// sees the incident; the response body carries the canonical
+	// SERVICE_UNAVAILABLE shape even though the transport-level status is 5xx.
+	s.Require().Error(err)
+	var authErr *autherrors.AuthError
+	s.Require().True(errors.As(err, &authErr), "expected returned error to wrap *AuthError")
+	s.Equal(autherrors.CodeServiceUnavailable, authErr.Code)
 	s.False(resp.Body.Success)
 	s.Equal(autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 }

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -219,12 +219,33 @@ func TestRefreshTokenHandler_NoUserContext(t *testing.T) {
 
 // --- GetProfileHandler ---
 
-func TestGetProfileHandler_NilAuthService(t *testing.T) {
-	h := testAuthHandler()
+// TestGetProfileHandler_NilAuthServiceReturnsServerError locks in the
+// fail-closed convention for the unwired-auth-service early exit: a nil
+// authService is a server-config defect, and the handler must surface it as a
+// 5xx (non-nil returned error wrapping an *AuthError of CodeServiceUnavailable)
+// so monitoring sees the same uniform shape as the post-service-call failure
+// branch. The body shape stays byte-identical with the prior HTTP-200
+// SERVICE_UNAVAILABLE path; only the transport status flips.
+func TestGetProfileHandler_NilAuthServiceReturnsServerError(t *testing.T) {
+	h := testAuthHandler() // authService is nil
 
 	resp, err := h.GetProfileHandler(context.Background(), &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	// Handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx with the structured body.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
@@ -232,7 +253,13 @@ func TestGetProfileHandler_NilAuthService(t *testing.T) {
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape so
+	// callers do not see an internal-step leak (e.g. "Auth service not available").
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
 }
+
 
 func TestGetProfileHandler_NoUserContext(t *testing.T) {
 	authSvc := auth.NewAuthService(nil, testConfig(), usersvc.NewUserService(nil))
@@ -1179,6 +1206,11 @@ func TestGetProfileHandler_Success(t *testing.T) {
 	}
 }
 
+// TestGetProfileHandler_ServiceError asserts that a service-call failure from
+// authService.GetUserProfile propagates as a 5xx rather than the prior silent
+// HTTP-200 SERVICE_UNAVAILABLE downgrade. Locks in the fail-closed convention
+// so an unexpected backend defect surfaces in monitoring instead of being
+// read by the client as the canonical body shape.
 func TestGetProfileHandler_ServiceError(t *testing.T) {
 	h := authHandler(func(ah *AuthHandler) {
 		ah.authService = &testhelpers.MockAuthService{
@@ -1190,14 +1222,25 @@ func TestGetProfileHandler_ServiceError(t *testing.T) {
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	resp, err := h.GetProfileHandler(ctx, &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 
@@ -1396,6 +1439,12 @@ func TestSendVerificationEmailHandler_NoEmail(t *testing.T) {
 	}
 }
 
+// TestSendVerificationEmailHandler_TokenFails asserts that a JWT-service
+// failure at the verification-token mint step propagates as a 5xx rather
+// than the prior silent HTTP-200 SERVICE_UNAVAILABLE downgrade. Locks in
+// the fail-closed convention for the post-input-validation backend-failure
+// branches; the intentional UX shapes (ALREADY_VERIFIED, NO_EMAIL, etc.)
+// still return HTTP 200 with structured ErrorCode.
 func TestSendVerificationEmailHandler_TokenFails(t *testing.T) {
 	email := "test@example.com"
 	h := authHandler(func(ah *AuthHandler) {
@@ -1411,14 +1460,69 @@ func TestSendVerificationEmailHandler_TokenFails(t *testing.T) {
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, Email: &email, EmailVerified: false})
 
 	resp, err := h.SendVerificationEmailHandler(ctx, &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestSendVerificationEmailHandler_EmailSendFailsClosed asserts that an
+// email-service failure at the send step propagates as a 5xx rather than the
+// prior silent HTTP-200 SERVICE_UNAVAILABLE downgrade. Same convention as the
+// token-mint branch above; both backend-failure paths now fail closed.
+func TestSendVerificationEmailHandler_EmailSendFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	h := authHandler(func(ah *AuthHandler) {
+		ah.emailService = &testhelpers.MockEmailService{
+			IsConfiguredFn: func() bool { return true },
+			SendVerificationEmailFn: func(toEmail, token string) error {
+				return fmt.Errorf("smtp connection refused")
+			},
+		}
+		ah.jwtService = &testhelpers.MockJWTService{
+			CreateVerificationTokenFn: func(userID uint, e string) (string, error) {
+				return "valid-token", nil
+			},
+		}
+	})
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, Email: &email, EmailVerified: false})
+
+	resp, err := h.SendVerificationEmailHandler(ctx, &struct{}{})
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 
@@ -1513,7 +1617,15 @@ func TestConfirmVerificationHandler_AlreadyVerified(t *testing.T) {
 	}
 }
 
-func TestConfirmVerificationHandler_SetVerifiedFails(t *testing.T) {
+// TestConfirmVerificationHandler_SetVerifiedFailsClosed asserts that a
+// SetEmailVerified failure at the final write step propagates as a 5xx
+// rather than the prior silent HTTP-200 SERVICE_UNAVAILABLE downgrade. The
+// token, user, and email have all been validated by this point — a write
+// failure is an unexpected backend defect, not a UX condition. The
+// intentional UX shapes earlier in the handler (INVALID_TOKEN, UNAUTHORIZED,
+// EMAIL_MISMATCH, already-verified) still return HTTP 200 with structured
+// ErrorCode so the frontend can render the corresponding form state.
+func TestConfirmVerificationHandler_SetVerifiedFailsClosed(t *testing.T) {
 	email := "test@example.com"
 	h := authHandler(func(ah *AuthHandler) {
 		ah.jwtService = &testhelpers.MockJWTService{
@@ -1535,14 +1647,66 @@ func TestConfirmVerificationHandler_SetVerifiedFails(t *testing.T) {
 	input.Body.Token = "valid-token"
 
 	resp, err := h.ConfirmVerificationHandler(context.Background(), input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestConfirmVerificationHandler_AlreadyVerifiedStillSucceeds locks in the
+// intentional UX shape for the "already verified" branch: the response stays
+// HTTP 200 with success=true and a human-readable message even though no
+// write happens. Regression guard against the fail-closed conversion
+// accidentally tipping over the intentional 200-shape branches.
+func TestConfirmVerificationHandler_AlreadyVerifiedStillSucceeds(t *testing.T) {
+	email := "test@example.com"
+	h := authHandler(func(ah *AuthHandler) {
+		ah.jwtService = &testhelpers.MockJWTService{
+			ValidateVerificationTokenFn: func(tokenString string) (*contracts.VerificationTokenClaims, error) {
+				return &contracts.VerificationTokenClaims{UserID: 1, Email: email}, nil
+			},
+		}
+		ah.userService = &testhelpers.MockUserService{
+			GetUserByIDFn: func(userID uint) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &email, EmailVerified: true}, nil
+			},
+			// SetEmailVerifiedFn intentionally absent — the handler must not
+			// reach this call when the email is already verified.
+			SetEmailVerifiedFn: func(userID uint, verified bool) error {
+				t.Fatal("SetEmailVerified must not be called when email is already verified")
+				return nil
+			},
+		}
+	})
+
+	input := &ConfirmVerificationRequest{}
+	input.Body.Token = "valid-token"
+
+	resp, err := h.ConfirmVerificationHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error on already-verified path: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true on already-verified branch")
+	}
+	if !strings.Contains(resp.Body.Message, "already verified") {
+		t.Errorf("expected message about already verified, got %q", resp.Body.Message)
 	}
 }
 
@@ -1971,6 +2135,86 @@ func TestChangePasswordHandler_NoPasswordSet(t *testing.T) {
 	}
 }
 
+// TestChangePasswordHandler_UnknownAuthCodeFailsClosed asserts that an
+// AuthError whose Code is not explicitly handled by the ChangePasswordHandler
+// switch propagates as a 5xx instead of falling through to the prior silent
+// CodeUnknown HTTP-200 downgrade. Locks in the convention so a new AuthError
+// code added without a dedicated handler case must surface as 5xx — code
+// review forces a UX decision per code.
+func TestChangePasswordHandler_UnknownAuthCodeFailsClosed(t *testing.T) {
+	unknownErr := &autherrors.AuthError{Code: autherrors.CodeUnknown, Message: "unrouted auth code"}
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			UpdatePasswordFn: func(userID uint, currentPassword, newPassword string) error {
+				return unknownErr
+			},
+		}
+	})
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	input := &ChangePasswordRequest{}
+	input.Body.CurrentPassword = "old-password-123"
+	input.Body.NewPassword = "new-password-456"
+
+	resp, err := h.ChangePasswordHandler(ctx, input)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestChangePasswordHandler_NonAuthErrorFailsClosed asserts that a raw
+// (non-AuthError) service-call failure propagates as a 5xx via the apperror
+// wrapper rather than the prior silent CodeUnknown HTTP-200 downgrade. Locks
+// in the fail-closed outer fallback so unexpected backend defects surface in
+// monitoring instead of being read by the client as a canonical sad-path body.
+func TestChangePasswordHandler_NonAuthErrorFailsClosed(t *testing.T) {
+	rawErr := fmt.Errorf("simulated db outage")
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			UpdatePasswordFn: func(userID uint, currentPassword, newPassword string) error {
+				return rawErr
+			},
+		}
+	})
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	input := &ChangePasswordRequest{}
+	input.Body.CurrentPassword = "old-password-123"
+	input.Body.NewPassword = "new-password-456"
+
+	resp, err := h.ChangePasswordHandler(ctx, input)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
 // --- GetDeletionSummaryHandler mock tests ---
 
 func TestGetDeletionSummaryHandler_Success(t *testing.T) {
@@ -2009,6 +2253,11 @@ func TestGetDeletionSummaryHandler_Success(t *testing.T) {
 	}
 }
 
+// TestGetDeletionSummaryHandler_ServiceError asserts that a service-call
+// failure from userService.GetDeletionSummary propagates as a 5xx rather
+// than the prior silent HTTP-200 SERVICE_UNAVAILABLE downgrade. Locks in the
+// fail-closed convention so an unexpected backend defect surfaces in
+// monitoring instead of being read by the client as the canonical body shape.
 func TestGetDeletionSummaryHandler_ServiceError(t *testing.T) {
 	h := authHandler(func(ah *AuthHandler) {
 		ah.userService = &testhelpers.MockUserService{
@@ -2020,14 +2269,25 @@ func TestGetDeletionSummaryHandler_ServiceError(t *testing.T) {
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	resp, err := h.GetDeletionSummaryHandler(ctx, &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 
@@ -2177,7 +2437,13 @@ func TestExportDataHandler_Success(t *testing.T) {
 	}
 }
 
-func TestExportDataHandler_ServiceError(t *testing.T) {
+// TestExportDataHandler_ServiceErrorFailsClosed asserts that a service-call
+// failure from userService.ExportUserDataJSON propagates as a 5xx via the
+// apperror wrapper rather than the prior silent HTTP-200 with an inline JSON
+// error body. The byte-body file-download shape is the user-visible behavior
+// of the happy path; on failure, Huma's error mapper builds a canonical JSON
+// 5xx from the returned error directly so monitoring sees the incident.
+func TestExportDataHandler_ServiceErrorFailsClosed(t *testing.T) {
 	h := authHandler(func(ah *AuthHandler) {
 		ah.userService = &testhelpers.MockUserService{
 			ExportUserDataJSONFn: func(userID uint) ([]byte, error) {
@@ -2188,11 +2454,42 @@ func TestExportDataHandler_ServiceError(t *testing.T) {
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	resp, err := h.ExportDataHandler(ctx, &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
 	}
-	if !strings.Contains(string(resp.Body), "export_failed") {
-		t.Errorf("expected error body, got %s", string(resp.Body))
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	// The response Body must NOT carry the prior inline JSON "export_failed"
+	// shape — Huma builds the response from the returned error directly. The
+	// happy-path file-download shape is reserved for success.
+	if len(resp.Body) != 0 {
+		t.Errorf("expected empty resp.Body on service failure (Huma builds the body), got %q", string(resp.Body))
+	}
+}
+
+// TestExportDataHandler_NoUserContextPreservesByteBodyShape locks in the
+// intentional middleware-contract-violation path: a nil contextUser is NOT
+// a service failure, so the response stays HTTP 200 with the inline JSON
+// "unauthorized" body. Regression guard against the fail-closed conversion
+// tipping over the unauthorized branch as well.
+func TestExportDataHandler_NoUserContextPreservesByteBodyShape(t *testing.T) {
+	h := testAuthHandler()
+
+	resp, err := h.ExportDataHandler(context.Background(), &struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error on no-user-context path: %v", err)
+	}
+	if resp.ContentType != "application/json" {
+		t.Errorf("expected content-type application/json, got %s", resp.ContentType)
+	}
+	if !strings.Contains(string(resp.Body), "unauthorized") {
+		t.Errorf("expected body to contain 'unauthorized', got %q", string(resp.Body))
 	}
 }
 
@@ -2320,6 +2617,113 @@ func TestRecoverAccountHandler_ResponseIdenticalAcrossAccountStates(t *testing.T
 				state.name, states[0].name, got.Body, want.Body)
 		}
 	}
+}
+
+// recoverAccountSuccessfulSetup builds an authHandler whose pre-success
+// branches are all green (known recoverable account, correct password). The
+// `tweak` callback flips one of the three post-success-eligibility service
+// calls into a failure so each fail-closed regression test exercises a
+// single specific branch.
+func recoverAccountSuccessfulSetup(email string, tweak func(*testhelpers.MockUserService, *testhelpers.MockJWTService)) *AuthHandler {
+	hash := "$2a$10$fakehash"
+	return authHandler(func(ah *AuthHandler) {
+		us := &testhelpers.MockUserService{
+			GetUserByEmailIncludingDeletedFn: func(string) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &email, PasswordHash: &hash, IsActive: false}, nil
+			},
+			IsAccountRecoverableFn: func(*authm.User) bool { return true },
+			VerifyPasswordFn:       func(string, string) error { return nil },
+			RestoreAccountFn:       func(uint) error { return nil },
+			GetUserByIDFn: func(uint) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &email, IsActive: true}, nil
+			},
+		}
+		js := &testhelpers.MockJWTService{
+			CreateTokenFn: func(*authm.User) (string, error) { return "session-token", nil },
+		}
+		tweak(us, js)
+		ah.userService = us
+		ah.jwtService = js
+	})
+}
+
+// assertRecoverAccountFailedClosed factors out the regression-shape assertion
+// reused by each of the three RecoverAccount post-success-eligibility failure
+// branches: handler must return a non-nil error wrapping an *AuthError of
+// CodeServiceUnavailable, and the response body must match the canonical
+// SERVICE_UNAVAILABLE shape.
+func assertRecoverAccountFailedClosed(t *testing.T, resp *RecoverAccountResponse, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestRecoverAccountHandler_RestoreFailsClosed locks in the post-success-
+// eligibility fail-closed convention for the RestoreAccount branch: the
+// caller has already authenticated (pre-success enumeration safety holds via
+// invalidCredentials), so a service-level failure here is no longer an
+// existence oracle and must surface as 5xx instead of HTTP 200.
+func TestRecoverAccountHandler_RestoreFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	h := recoverAccountSuccessfulSetup(email, func(us *testhelpers.MockUserService, _ *testhelpers.MockJWTService) {
+		us.RestoreAccountFn = func(uint) error { return fmt.Errorf("db error") }
+	})
+
+	input := &RecoverAccountRequest{}
+	input.Body.Email = email
+	input.Body.Password = "correct"
+
+	resp, err := h.RecoverAccountHandler(context.Background(), input)
+	assertRecoverAccountFailedClosed(t, resp, err)
+}
+
+// TestRecoverAccountHandler_FetchFailsClosed mirrors the RestoreFailsClosed
+// regression for the GetUserByID branch.
+func TestRecoverAccountHandler_FetchFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	h := recoverAccountSuccessfulSetup(email, func(us *testhelpers.MockUserService, _ *testhelpers.MockJWTService) {
+		us.GetUserByIDFn = func(uint) (*authm.User, error) { return nil, fmt.Errorf("db error") }
+	})
+
+	input := &RecoverAccountRequest{}
+	input.Body.Email = email
+	input.Body.Password = "correct"
+
+	resp, err := h.RecoverAccountHandler(context.Background(), input)
+	assertRecoverAccountFailedClosed(t, resp, err)
+}
+
+// TestRecoverAccountHandler_TokenFailsClosed mirrors the RestoreFailsClosed
+// regression for the JWT-token-mint branch.
+func TestRecoverAccountHandler_TokenFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	h := recoverAccountSuccessfulSetup(email, func(_ *testhelpers.MockUserService, js *testhelpers.MockJWTService) {
+		js.CreateTokenFn = func(*authm.User) (string, error) { return "", fmt.Errorf("jwt error") }
+	})
+
+	input := &RecoverAccountRequest{}
+	input.Body.Email = email
+	input.Body.Password = "correct"
+
+	resp, err := h.RecoverAccountHandler(context.Background(), input)
+	assertRecoverAccountFailedClosed(t, resp, err)
 }
 
 // --- RequestAccountRecoveryHandler mock tests ---
@@ -2621,6 +3025,113 @@ func TestConfirmAccountRecoveryHandler_AlreadyActive(t *testing.T) {
 	}
 }
 
+// confirmAccountRecoverySuccessfulSetup builds an authHandler whose pre-
+// success branches are all green (valid token, matching user, recoverable
+// inactive account). The `tweak` callback flips one of the three post-
+// success-eligibility service calls into a failure so each fail-closed
+// regression test exercises a single specific branch.
+func confirmAccountRecoverySuccessfulSetup(email string, tweak func(*testhelpers.MockUserService, *testhelpers.MockJWTService)) *AuthHandler {
+	return authHandler(func(ah *AuthHandler) {
+		us := &testhelpers.MockUserService{
+			GetUserByEmailIncludingDeletedFn: func(string) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &email, IsActive: false}, nil
+			},
+			IsAccountRecoverableFn: func(*authm.User) bool { return true },
+			RestoreAccountFn:       func(uint) error { return nil },
+			GetUserByIDFn: func(uint) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &email, IsActive: true}, nil
+			},
+		}
+		js := &testhelpers.MockJWTService{
+			ValidateAccountRecoveryTokenFn: func(string) (*contracts.AccountRecoveryTokenClaims, error) {
+				return &contracts.AccountRecoveryTokenClaims{UserID: 1, Email: email}, nil
+			},
+			CreateTokenFn: func(*authm.User) (string, error) { return "session-token", nil },
+		}
+		tweak(us, js)
+		ah.userService = us
+		ah.jwtService = js
+	})
+}
+
+// assertConfirmAccountRecoveryFailedClosed factors out the regression-shape
+// assertion reused by each of the three ConfirmAccountRecovery post-success-
+// eligibility failure branches.
+func assertConfirmAccountRecoveryFailedClosed(t *testing.T, resp *ConfirmAccountRecoveryResponse, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestConfirmAccountRecoveryHandler_RestoreFailsClosed asserts that a
+// RestoreAccount service failure at the final write step propagates as a 5xx
+// rather than the prior silent HTTP-200 SERVICE_UNAVAILABLE downgrade. By
+// this point the token + user-ID + recoverability checks have all passed, so
+// a service failure is an unexpected backend defect — not a UX condition.
+// The intentional UX shapes earlier in the handler (INVALID_TOKEN,
+// UNAUTHORIZED, ACCOUNT_ACTIVE, ACCOUNT_NOT_RECOVERABLE) still return HTTP
+// 200 with structured ErrorCode so the frontend can render the corresponding
+// form state.
+func TestConfirmAccountRecoveryHandler_RestoreFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	h := confirmAccountRecoverySuccessfulSetup(email, func(us *testhelpers.MockUserService, _ *testhelpers.MockJWTService) {
+		us.RestoreAccountFn = func(uint) error { return fmt.Errorf("db error") }
+	})
+
+	input := &ConfirmAccountRecoveryRequest{}
+	input.Body.Token = "valid-token"
+
+	resp, err := h.ConfirmAccountRecoveryHandler(context.Background(), input)
+	assertConfirmAccountRecoveryFailedClosed(t, resp, err)
+}
+
+// TestConfirmAccountRecoveryHandler_FetchFailsClosed mirrors the
+// RestoreFailsClosed regression for the GetUserByID branch.
+func TestConfirmAccountRecoveryHandler_FetchFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	h := confirmAccountRecoverySuccessfulSetup(email, func(us *testhelpers.MockUserService, _ *testhelpers.MockJWTService) {
+		us.GetUserByIDFn = func(uint) (*authm.User, error) { return nil, fmt.Errorf("db error") }
+	})
+
+	input := &ConfirmAccountRecoveryRequest{}
+	input.Body.Token = "valid-token"
+
+	resp, err := h.ConfirmAccountRecoveryHandler(context.Background(), input)
+	assertConfirmAccountRecoveryFailedClosed(t, resp, err)
+}
+
+// TestConfirmAccountRecoveryHandler_TokenFailsClosed mirrors the
+// RestoreFailsClosed regression for the JWT-token-mint branch.
+func TestConfirmAccountRecoveryHandler_TokenFailsClosed(t *testing.T) {
+	email := "test@example.com"
+	h := confirmAccountRecoverySuccessfulSetup(email, func(_ *testhelpers.MockUserService, js *testhelpers.MockJWTService) {
+		js.CreateTokenFn = func(*authm.User) (string, error) { return "", fmt.Errorf("jwt error") }
+	})
+
+	input := &ConfirmAccountRecoveryRequest{}
+	input.Body.Token = "valid-token"
+
+	resp, err := h.ConfirmAccountRecoveryHandler(context.Background(), input)
+	assertConfirmAccountRecoveryFailedClosed(t, resp, err)
+}
+
 // --- GenerateCLITokenHandler mock tests ---
 
 func TestGenerateCLITokenHandler_Success(t *testing.T) {
@@ -2648,6 +3159,11 @@ func TestGenerateCLITokenHandler_Success(t *testing.T) {
 	}
 }
 
+// TestGenerateCLITokenHandler_TokenFails asserts that a JWT-service failure
+// at the CLI-token mint step propagates as a 5xx rather than the prior
+// silent HTTP-200 SERVICE_UNAVAILABLE downgrade. Locks in the fail-closed
+// convention so an unexpected backend defect surfaces in monitoring instead
+// of being read by the CLI client as the canonical body shape.
 func TestGenerateCLITokenHandler_TokenFails(t *testing.T) {
 	h := authHandler(func(ah *AuthHandler) {
 		ah.jwtService = &testhelpers.MockJWTService{
@@ -2659,14 +3175,25 @@ func TestGenerateCLITokenHandler_TokenFails(t *testing.T) {
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 
 	resp, err := h.GenerateCLITokenHandler(ctx, &struct{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 
@@ -2797,6 +3324,11 @@ func TestUpdateProfileHandler_DuplicateUsername(t *testing.T) {
 	}
 }
 
+// TestUpdateProfileHandler_ServiceError asserts that a raw (non-AuthError)
+// service-call failure propagates as a 5xx via the apperror wrapper rather
+// than the prior silent HTTP-200 SERVICE_UNAVAILABLE downgrade. Locks in the
+// fail-closed outer fallback so unexpected backend defects surface in
+// monitoring instead of being read by the client as a canonical sad-path body.
 func TestUpdateProfileHandler_ServiceError(t *testing.T) {
 	mock := &testhelpers.MockUserService{
 		UpdateUserFn: func(_ uint, _ map[string]any) (*authm.User, error) {
@@ -2809,10 +3341,55 @@ func TestUpdateProfileHandler_ServiceError(t *testing.T) {
 	req.Body.FirstName = strPtr("Jane")
 
 	resp, err := h.UpdateProfileHandler(ctx, req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
 	}
 	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
 		t.Errorf("expected service-unavailable failure, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestUpdateProfileHandler_UnknownAuthCodeFailsClosed asserts that an
+// AuthError whose Code is not explicitly handled by the UpdateProfileHandler
+// switch propagates as a 5xx instead of falling through to the silent
+// SERVICE_UNAVAILABLE downgrade. Locks in the convention so a new AuthError
+// code added without a dedicated handler case must surface as 5xx — code
+// review forces a UX decision per code.
+func TestUpdateProfileHandler_UnknownAuthCodeFailsClosed(t *testing.T) {
+	unknownErr := &autherrors.AuthError{Code: autherrors.CodeUnknown, Message: "unrouted auth code"}
+	mock := &testhelpers.MockUserService{
+		UpdateUserFn: func(_ uint, _ map[string]any) (*authm.User, error) {
+			return nil, unknownErr
+		},
+	}
+	h := NewAuthHandler(nil, nil, mock, nil, nil, nil, testConfig())
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.FirstName = strPtr("Jane")
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }


### PR DESCRIPTION
## Summary
- Applies PSY-864's fail-closed convention to 10 of the 11 silent-downgrade auth handlers surfaced by the PSY-865 audit, across 4 fix-shape categories (mechanical / missing-default / mixed UX/silent / custom byte-body).
- RegisterHandler (category 5) is explicitly deferred pending the email-enumeration design lock for the registration path — an inline code comment documents the coordination so the gap is visible.
- Single PR (not split) — production-code change is ~190 net lines, test additions ~625 net lines, all mechanical and following a uniform regression-shape pattern. Reviewer benefit of seeing the convention applied uniformly outweighs the split overhead.

## Per-handler outcomes

| Handler | Category | Outcome | Regression tests |
| --- | --- | --- | --- |
| GetProfileHandler | 1 mechanical | Fixed (nil-authService + GetUserProfile both fail-closed) | NilAuthServiceReturnsServerError, ServiceError |
| SendVerificationEmailHandler | 1 mechanical | Fixed (CreateVerificationToken + SendVerificationEmail both fail-closed) | TokenFails, EmailSendFailsClosed |
| GetDeletionSummaryHandler | 1 mechanical | Fixed | ServiceError |
| GenerateCLITokenHandler | 1 mechanical | Fixed | TokenFails |
| ChangePasswordHandler | 2 missing-default | Fixed (extended switch + outer non-AuthError fallback) | UnknownAuthCodeFailsClosed, NonAuthErrorFailsClosed |
| UpdateProfileHandler | 2 missing-default | Fixed (promoted `if` to switch with `default:` + outer fallback) | ServiceError, UnknownAuthCodeFailsClosed |
| ConfirmVerificationHandler | 3 mixed | Fixed silent path (SetEmailVerified) only; intentional UX shapes preserved | SetVerifiedFailsClosed, AlreadyVerifiedStillSucceeds |
| ConfirmAccountRecoveryHandler | 3 mixed | Fixed 3 silent paths (RestoreAccount / GetUserByID / CreateToken); intentional UX shapes preserved | RestoreFailsClosed, FetchFailsClosed, TokenFailsClosed |
| ExportDataHandler | 4 custom byte-body | Fixed (5xx via apperror wrapper; byte-body shape preserved for no-user-context branch) | ServiceErrorFailsClosed, NoUserContextPreservesByteBodyShape |
| RecoverAccountHandler | 4 custom shape | Fixed 3 silent post-success-eligibility paths; PSY-774 enumeration-safe closure preserved for pre-success branches | RestoreFailsClosed, FetchFailsClosed, TokenFailsClosed |
| RegisterHandler | 5 coordinated | UNCHANGED — inline code comment documents the deferred coordination pending the registration enumeration-safety design lock | none (skipped per umbrella) |

## Test plan
- [x] `cd backend && go build ./...` — passes
- [x] `cd backend && go test ./internal/api/handlers/auth/... ./internal/errors/...` — passes
- [x] `cd backend && go test ./...` — all 32 packages pass (12 new regression tests + 9 updated existing tests)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues

## Manual repro

12 new regression tests + 9 updated existing tests cover the categories:
- Category 1 mechanical (4 handlers): UnknownAuthCode-equivalent (raw fmt.Errorf returned from service) → 5xx via `apperrors.ErrServiceUnavailable`, response body matches canonical SERVICE_UNAVAILABLE shape.
- Category 2 missing-default (2 handlers): both `UnknownAuthCode` (untracked AuthError sub-code) + `NonAuthError` (raw fmt.Errorf) paths assert 5xx + structured body.
- Category 3 mixed (2 handlers): silent-path 5xx assertions + intentional-UX-shape preservation guards (AlreadyVerified stays HTTP 200 with success=true; ACCOUNT_ACTIVE / ACCOUNT_NOT_RECOVERABLE paths unchanged).
- Category 4 custom-shape (2 handlers): ExportData asserts empty resp.Body (Huma builds from error) + byte-body preservation on no-user-context path; RecoverAccount asserts 5xx on each of the 3 post-success-eligibility branches while the PSY-774 enumeration test (`TestRecoverAccountHandler_ResponseIdenticalAcrossAccountStates`) still passes unchanged — locks both safety invariants simultaneously.

All assertions PASSED.

## Follow-up tickets filed

None — single PR covers all 10 in-scope handlers. RegisterHandler stays deferred to the coordinated email-enumeration design work.

## Code review

Inline 3-lens pass per `pattern_subagent_inline_code_review.md`:
- **Reuse**: declined to factor the `apperrors.ErrServiceUnavailable + ToExternalMessage + return resp, authErr` boilerplate into a helper — PSY-864 / PSY-883 kept the inline shape so each handler's WHY-comment can name its specific service-call domain. Premature abstraction here would obscure intent.
- **Quality**: verified the `*AuthError → error` conversion for the return slot (PSY-864 uses the same pattern), and the case-arm split in ChangePassword / UpdateProfile (moving from collapsed `if errors.As && Code==X` to outer-`errors.As` + inner-`switch`) preserves behavior under all existing test scenarios. ExportData's zero-value `ContentType / Body` on the failed return is verified by `TestExportDataHandler_ServiceErrorFailsClosed` asserting `len(resp.Body) == 0` (Huma builds the canonical JSON 5xx body from the returned error).
- **Efficiency**: no concerns — one `*AuthError` allocation per failed call is well below the cost-of-failure threshold; `ToExternalMessage(CodeServiceUnavailable)` is a tiny switch the optimizer inlines.

Closes PSY-873