### PR TITLE
PSY-720: add e2e for admin role-based access guard

### DIFF
--- a/frontend/e2e/admin/admin-guard.spec.ts
+++ b/frontend/e2e/admin/admin-guard.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '../fixtures'
+
+/**
+ * PSY-720: end-to-end coverage for the role-based admin route guard.
+ *
+ * AdminGuard lives at `app/admin/admin-guard.tsx` and is wired into every
+ * admin route via `app/admin/layout.tsx`. Vitest covers the component in
+ * isolation (`admin-guard.test.tsx`); this spec is the integration guard
+ * that catches regressions in the routing wiring itself — e.g. if the
+ * layout-level guard were ever removed or wired only to a subset of
+ * sub-routes, the unit test would still pass while the redirect contract
+ * silently broke.
+ *
+ * The contract under test (from admin-guard.tsx):
+ * - unauthenticated → `/auth?returnTo=%2Fadmin`
+ * - authenticated non-admin → `/` (intermediate "Access Denied" card)
+ * - authenticated admin → children render
+ *
+ * Sub-routes asserted: /admin/dashboard, /admin/reports, /admin/users
+ * (all three confirmed to exist as standalone routes under `app/admin/`
+ * with their own page.tsx). The /admin root itself is intentionally
+ * excluded — its page.tsx carries its own redundant redirect that races
+ * with AdminGuard and complicates the contract.
+ */
+
+const AUTH_URL_REGEX = /\/auth(\?|$)/
+const ADMIN_RETURN_TO = 'returnTo=%2Fadmin'
+const ADMIN_SUBROUTES = ['/admin/dashboard', '/admin/reports', '/admin/users']
+
+test.describe('AdminGuard: unauthenticated access', () => {
+  for (const route of ADMIN_SUBROUTES) {
+    test(`unauthenticated visitor at ${route} is redirected to /auth with returnTo`, async ({
+      page,
+    }) => {
+      await page.goto(route)
+
+      // Redirects to /auth
+      await page.waitForURL(AUTH_URL_REGEX, { timeout: 10_000 })
+
+      // returnTo query param preserves the original admin path so post-login
+      // navigation can resume where the user intended.
+      expect(page.url()).toContain(ADMIN_RETURN_TO)
+
+      // Auth page rendered (sanity that we landed on the real auth surface,
+      // not an error boundary).
+      await expect(
+        page.getByRole('heading', { name: /welcome to psychic homily/i })
+      ).toBeVisible({ timeout: 5_000 })
+    })
+  }
+})
+
+test.describe('AdminGuard: authenticated non-admin access', () => {
+  for (const route of ADMIN_SUBROUTES) {
+    test(`authenticated non-admin user at ${route} is redirected to /`, async ({
+      authenticatedPage,
+    }) => {
+      await authenticatedPage.goto(route)
+
+      // Redirect destination is the home page (NOT /auth — they're already
+      // signed in; the guard demotes them to home).
+      await authenticatedPage.waitForURL(
+        (url) => url.pathname === '/',
+        { timeout: 10_000 }
+      )
+
+      // Home page rendered (the "upcoming shows" heading is the same marker
+      // home.spec.ts uses).
+      await expect(
+        authenticatedPage.getByRole('heading', { name: /upcoming shows/i })
+      ).toBeVisible({ timeout: 10_000 })
+    })
+  }
+})
+
+test.describe('AdminGuard: authenticated admin access', () => {
+  for (const route of ADMIN_SUBROUTES) {
+    test(`admin user at ${route} sees the page without redirect`, async ({
+      adminPage,
+    }) => {
+      await adminPage.goto(route)
+
+      // No redirect away from the requested admin route.
+      await expect(adminPage).toHaveURL(new RegExp(`${route}(\\?|$)`), {
+        timeout: 10_000,
+      })
+
+      // The page rendered something — the loader spinner from AdminGuard
+      // resolved into actual content. We don't assert page-specific markers
+      // here because that would couple this guard test to each sub-page's
+      // implementation; the per-page specs (admin/pending-shows.spec.ts,
+      // admin/verify-venue.spec.ts) cover that. What we DO assert is that
+      // the AdminGuard "Access Denied" card is NOT showing — the only
+      // state that proves the guard let us through.
+      await expect(
+        adminPage.getByRole('heading', { name: 'Access Denied' })
+      ).not.toBeVisible({ timeout: 10_000 })
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- Adds `frontend/e2e/admin/admin-guard.spec.ts`: 3 redirect scenarios × 3 representative sub-routes (`/admin/dashboard`, `/admin/reports`, `/admin/users`) = 9 tests.
- Asserts: unauthenticated → `/auth?returnTo=%2Fadmin` (with returnTo preserved); non-admin authenticated → `/`; admin → no redirect, no "Access Denied" card.
- Reuses existing `page` / `authenticatedPage` / `adminPage` fixtures; no new test users seeded.
- `/admin` root intentionally excluded — its `page.tsx` carries its own redundant redirect that races with AdminGuard; testing it would conflate two guards.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:e2e -- admin-guard` — passed twice consecutively (run 1: 9 passed / 22.7s; run 2: 9 passed / 27.2s)

## Manual repro
The Playwright spec IS the manual repro for this ticket — it drives the same browser flow a real user would. The 9 tests collectively exercise every redirect scenario × every representative sub-route. No separate browser-MCP screenshot was needed.

Observed:
- Unauthenticated `/admin/{dashboard,reports,users}` → redirects to `/auth?returnTo=%2Fadmin` (auth heading "Welcome to Psychic Homily" rendered).
- Non-admin authenticated `/admin/{dashboard,reports,users}` → redirects to `/` (home "Upcoming Shows" heading rendered).
- Admin `/admin/{dashboard,reports,users}` → no redirect, AdminGuard "Access Denied" card NOT visible.

## Code review
Ran inline (sub-agent doesn't have Agent tool access for the 3-reviewer parallel pattern per `pattern_subagent_inline_code_review.md`). 1 PLAUSIBLE finding surfaced, shipped as-is with disclosure:

> **Admin-positive tests use only negative assertions.** `not.toBeVisible('Access Denied')` passes even if AdminGuard is stuck on its loading spinner — a stuck-spinner regression would not be caught. PSY-720's stated AC is "routing wiring regressions" which IS covered (URL assertion proves no redirect happened); the stuck-spinner concern is a separate test-strength hardening opportunity.

Recommendation: file follow-up if stronger coverage is wanted. Two paths considered:
1. Add `data-testid="admin-content"` to AdminGuard's children-render path + positive assertion. Requires touching AdminGuard source — broadens this PR's scope.
2. Couple to per-page markers (admin/dashboard heading, etc.). Agent's spec comment argues against — would couple this guard test to each sub-page's implementation and duplicate per-page spec coverage.

Neither fits this PR's scope. Surface to follow-up if desired.

## Orchestrator takeover (psy-dispatch stall carveout)
Agent stalled post-`/code-review` before reaching the push + PR step (canonical pattern per psy-dispatch SKILL.md "stall-takeover carveout" — agent's task-completion notification returned only the truncated `/code-review` JSON, no structured report). Orchestrator re-verified tests locally per `feedback_local_test_before_push.md`: typecheck clean, e2e spec passed twice consecutively. First re-verify attempt hit a cold-compile flake at `captureAuthState` (canonical PSY-834-class issue at global-setup; the spec itself wasn't reached); retry + run #2 both passed cleanly.

Closes PSY-720
