### PR TITLE
PSY-882: RefreshToken typed user-not-found → 401

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
+
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/config"
 	autherrors "psychic-homily-backend/internal/errors"
@@ -323,20 +325,45 @@ func (h *AuthHandler) RefreshTokenHandler(ctx context.Context, input *struct{}) 
 	)
 
 	// Fetch fresh user data and generate new token.
-	// Fail-closed: an unexpected DB/service failure here propagates as a 5xx so
-	// the HTTP layer cannot hand callers (or monitoring) a misleading HTTP 200
-	// SERVICE_UNAVAILABLE body. The response body shape is unchanged; only the
-	// transport-level status flips from 200 to 5xx.
+	//
+	// Two discriminated outcomes:
+	//   - Typed CodeUserNotFound  → HTTP 401 + CodeUnauthorized. The session
+	//     principal was hard- or soft-deleted between token issuance and this
+	//     refresh. The token itself is still cryptographically valid, but the
+	//     account it represents no longer exists, so the right transport
+	//     status is 401 (not 5xx) — the client clears the session and routes
+	//     the user back to login. A 5xx would tell the client "backend is
+	//     broken; retry", but retrying with the same token is futile.
+	//   - Any other error      → HTTP 5xx + CodeServiceUnavailable. Real
+	//     backend defect (DB outage, etc.); fail-closed so monitoring sees
+	//     the incident with the same uniform shape and the client retries.
 	user, err := h.authService.GetUserProfile(contextUser.ID)
 	if err != nil {
-		authErr := autherrors.ErrServiceUnavailable("refresh_token_profile", err)
+		var authErr *autherrors.AuthError
+		if errors.As(err, &authErr) && authErr.Code == autherrors.CodeUserNotFound {
+			logger.AuthWarn(ctx, "refresh_token_user_deleted",
+				"user_id", contextUser.ID,
+			)
+			resp.Body.Success = false
+			resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeUnauthorized)
+			resp.Body.ErrorCode = autherrors.CodeUnauthorized
+			return resp, huma.Error401Unauthorized(
+				autherrors.ToExternalMessage(autherrors.CodeUnauthorized),
+				authErr,
+			)
+		}
+
+		// Fail-closed for non-typed failures so the HTTP layer cannot hand
+		// callers (or monitoring) a misleading HTTP 200 SERVICE_UNAVAILABLE
+		// body.
+		svcErr := autherrors.ErrServiceUnavailable("refresh_token_profile", err)
 		logger.AuthError(ctx, "refresh_token_profile_failed", err,
 			"user_id", contextUser.ID,
 		)
 		resp.Body.Success = false
 		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
 		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
-		return resp, authErr
+		return resp, svcErr
 	}
 
 	// Generate new JWT token using the JWT service.

--- a/backend/internal/api/handlers/auth/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth/auth_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/suite"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
@@ -284,16 +285,18 @@ func (s *AuthHandlerIntegrationSuite) TestRefreshToken_UserDeletedFromDB() {
 
 	resp, err := h.RefreshTokenHandler(ctx, &struct{}{})
 
-	// Fail-closed: profile fetch against a deleted user surfaces as a 5xx so
-	// the HTTP layer does not hand callers an HTTP 200 with a sad-path body.
-	// The body shape still carries SERVICE_UNAVAILABLE for the structured
-	// error-code branch on clients; only the transport status flips.
+	// Deleted-user-during-refresh is the canonical 401 case: the token is
+	// cryptographically valid but the principal it represents no longer
+	// exists, so the right transport status is 401 (client clears session +
+	// redirects to login). A 5xx would (incorrectly) tell the client
+	// "backend is broken; retry". Generic backend failures stay on the 5xx
+	// fail-closed path (covered by TestRefreshTokenHandler_ProfileFails).
 	s.Require().Error(err)
-	var authErr *autherrors.AuthError
-	s.Require().True(errors.As(err, &authErr), "expected returned error to wrap *AuthError")
-	s.Equal(autherrors.CodeServiceUnavailable, authErr.Code)
+	var statusErr huma.StatusError
+	s.Require().True(errors.As(err, &statusErr), "expected returned error to satisfy huma.StatusError")
+	s.Equal(401, statusErr.GetStatus())
 	s.False(resp.Body.Success)
-	s.Equal(autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	s.Equal(autherrors.CodeUnauthorized, resp.Body.ErrorCode)
 }
 
 // --- SendVerificationEmailHandler ---

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/danielgtaylor/huma/v2"
+
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
 	"psychic-homily-backend/internal/config"
 	autherrors "psychic-homily-backend/internal/errors"
@@ -1316,6 +1318,59 @@ func TestRefreshTokenHandler_ProfileFails(t *testing.T) {
 	// callers do not see "Failed to refresh token" as an internal-step leak.
 	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
 		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
+	}
+}
+
+// TestRefreshTokenHandler_DeletedUserReturns401 asserts the typed
+// CodeUserNotFound path: when GetUserProfile reports the principal was
+// deleted between token issuance and this refresh, the handler routes to
+// HTTP 401 + CodeUnauthorized rather than the fail-closed 5xx +
+// CodeServiceUnavailable reserved for generic backend failures.
+//
+// The 5xx contract for non-typed errors stays covered by
+// TestRefreshTokenHandler_ProfileFails. Both directions must remain
+// asserted to prevent a future fail-closed pass from collapsing the 401
+// discrimination back into the generic 5xx bucket.
+func TestRefreshTokenHandler_DeletedUserReturns401(t *testing.T) {
+	notFoundErr := autherrors.ErrUserNotFoundByID(1, fmt.Errorf("record not found"))
+	h := authHandler(func(ah *AuthHandler) {
+		ah.authService = &testhelpers.MockAuthService{
+			GetUserProfileFn: func(userID uint) (*authm.User, error) {
+				return nil, notFoundErr
+			},
+		}
+	})
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	resp, err := h.RefreshTokenHandler(ctx, &struct{}{})
+
+	// Handler MUST return a non-nil StatusError so Huma emits HTTP 401.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits HTTP 401")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	var statusErr huma.StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("expected returned error to satisfy huma.StatusError, got %T (%v)", err, err)
+	}
+	if got := statusErr.GetStatus(); got != 401 {
+		t.Errorf("expected HTTP status 401, got %d", got)
+	}
+	// Body shape carries the canonical CodeUnauthorized envelope. Huma drops
+	// the resp body when the handler returns a non-nil error, but the body
+	// fields are still asserted here so a downstream change that switches
+	// to a body-preserving error-emit (e.g. embedding the resp shape in a
+	// custom StatusError) cannot quietly drop the discriminator.
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeUnauthorized {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeUnauthorized, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeUnauthorized) {
+		t.Errorf("expected canonical UNAUTHORIZED message, got %q", resp.Body.Message)
 	}
 }
 

--- a/backend/internal/errors/auth.go
+++ b/backend/internal/errors/auth.go
@@ -100,6 +100,21 @@ func ErrUserNotFound(email string) *AuthError {
 	return NewAuthError(CodeUserNotFound, "User not found", fmt.Errorf("no user with email: %s", email))
 }
 
+// ErrUserNotFoundByID creates a user-not-found error for the by-ID lookup
+// case (session refresh after the principal was hard- or soft-deleted).
+//
+// Distinct from ErrUserNotFound(email) because the by-ID lookup does NOT have
+// the enumeration-safety concern that maps CodeUserNotFound to
+// CodeInvalidCredentials externally — the user already proved possession of
+// a token signed for this userID, so there is no email-enumeration oracle to
+// protect. Routes that need "this session principal is gone" semantics
+// (RefreshTokenHandler, eventually GetProfileHandler) inspect the typed
+// AuthError and emit HTTP 401 + CodeUnauthorized so the client clears the
+// session and redirects to login rather than retrying against a 5xx.
+func ErrUserNotFoundByID(userID uint, internal error) *AuthError {
+	return NewAuthError(CodeUserNotFound, "User not found", fmt.Errorf("no user with id %d: %w", userID, internal))
+}
+
 // ErrTokenExpired creates a token expired error.
 func ErrTokenExpired(internal error) *AuthError {
 	return NewAuthError(CodeTokenExpired, "Your session has expired. Please log in again.", internal)

--- a/backend/internal/services/auth/oauth.go
+++ b/backend/internal/services/auth/oauth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/config"
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -120,9 +122,24 @@ func (s *AuthService) oauthCallbackInternal(
 	return user, token, nil
 }
 
-// GetUserProfile retrieves user profile using the user service
+// GetUserProfile retrieves user profile using the user service.
+//
+// Discriminates the not-found case (the principal was hard- or soft-deleted
+// between token issuance and this lookup) from generic backend failures by
+// returning a typed *AuthError{Code: CodeUserNotFound}. Callers that need
+// session-invalidation semantics (RefreshTokenHandler) route the typed
+// error to HTTP 401 + CodeUnauthorized so the client clears the session and
+// redirects to login. Generic backend errors (DB outage, etc.) keep flowing
+// through as wrapped errors so handlers' fail-closed branches emit 5xx.
 func (s *AuthService) GetUserProfile(userID uint) (*authm.User, error) {
-	return s.userService.GetUserByID(userID)
+	user, err := s.userService.GetUserByID(userID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrUserNotFoundByID(userID, err)
+		}
+		return nil, err
+	}
+	return user, nil
 }
 
 // RefreshUserToken generates a new JWT token for the user

--- a/backend/internal/services/auth/oauth_test.go
+++ b/backend/internal/services/auth/oauth_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,8 +10,10 @@ import (
 	"github.com/markbates/goth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
+	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 )
 
@@ -166,6 +170,123 @@ func TestAuthService_RefreshUserToken(t *testing.T) {
 			assert.NotEmpty(t, token)
 		}
 	})
+}
+
+// stubUserServiceWithGetByID embeds nilDBUserService (so all unused methods
+// return the "database not initialized" sentinel) and overrides GetUserByID
+// with an injectable function. Lets GetUserProfile tests pick the exact error
+// shape the userService surfaces — gorm.ErrRecordNotFound vs a raw DB error.
+type stubUserServiceWithGetByID struct {
+	nilDBUserService
+	getByID func(userID uint) (*authm.User, error)
+}
+
+func (s *stubUserServiceWithGetByID) GetUserByID(userID uint) (*authm.User, error) {
+	return s.getByID(userID)
+}
+
+// TestAuthService_GetUserProfile_DeletedUserReturnsTyped asserts the
+// deleted-user case is discriminated as a typed *AuthError{Code:
+// CodeUserNotFound}. The handler layer relies on this typed shape to route
+// the response to HTTP 401 + CodeUnauthorized instead of the fail-closed 5xx
+// reserved for generic backend failures.
+func TestAuthService_GetUserProfile_DeletedUserReturnsTyped(t *testing.T) {
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			SecretKey: "test-secret-key-32-chars-minimum",
+			Expiry:    24,
+		},
+	}
+	userSvc := &stubUserServiceWithGetByID{
+		getByID: func(userID uint) (*authm.User, error) {
+			// Mirror UserService.GetUserByID's actual wrapping
+			// (fmt.Errorf("failed to get user: %w", result.Error))
+			// so errors.Is(err, gorm.ErrRecordNotFound) discrimination
+			// flows through %w unwrap, not raw equality.
+			return nil, fmt.Errorf("failed to get user: %w", gorm.ErrRecordNotFound)
+		},
+	}
+	authService := NewAuthService(nil, cfg, userSvc)
+
+	user, err := authService.GetUserProfile(42)
+
+	assert.Nil(t, user)
+	assert.Error(t, err)
+
+	var authErr *apperrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap *AuthError, got %T (%v)", err, err)
+	}
+	assert.Equal(t, apperrors.CodeUserNotFound, authErr.Code,
+		"deleted-user must surface as typed CodeUserNotFound so handlers route to 401")
+	// The underlying gorm sentinel must remain reachable via the standard
+	// error chain so future callers can additionally drill down if needed.
+	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound),
+		"typed AuthError must keep gorm.ErrRecordNotFound in the unwrap chain")
+}
+
+// TestAuthService_GetUserProfile_GenericErrorPassthrough asserts that any
+// non-not-found failure (DB connection lost, etc.) does NOT get wrapped in
+// the typed CodeUserNotFound shape — those continue to propagate as generic
+// errors so RefreshTokenHandler's fail-closed branch emits 5xx instead of
+// 401. Protects the dual-direction contract from a regression that
+// blanket-wraps every GetUserByID failure as not-found.
+func TestAuthService_GetUserProfile_GenericErrorPassthrough(t *testing.T) {
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			SecretKey: "test-secret-key-32-chars-minimum",
+			Expiry:    24,
+		},
+	}
+	rawErr := fmt.Errorf("connection refused: pq: server is starting up")
+	userSvc := &stubUserServiceWithGetByID{
+		getByID: func(userID uint) (*authm.User, error) {
+			return nil, rawErr
+		},
+	}
+	authService := NewAuthService(nil, cfg, userSvc)
+
+	user, err := authService.GetUserProfile(42)
+
+	assert.Nil(t, user)
+	assert.Error(t, err)
+
+	// Must NOT be a typed CodeUserNotFound. Either a non-AuthError or some
+	// other AuthError code is acceptable; the contract is "not CodeUserNotFound
+	// for non-not-found failures".
+	var authErr *apperrors.AuthError
+	if errors.As(err, &authErr) && authErr.Code == apperrors.CodeUserNotFound {
+		t.Errorf("generic error must NOT be wrapped as CodeUserNotFound (got code=%s) — handler would misroute to 401", authErr.Code)
+	}
+	// The original error must remain reachable so handler logs and the
+	// fail-closed branch can wrap it with the service-specific context.
+	assert.True(t, errors.Is(err, rawErr),
+		"original error must remain in the chain so callers can log root cause")
+}
+
+// TestAuthService_GetUserProfile_Success asserts the happy path returns the
+// user unchanged. Locks in that the typed-error wiring did not accidentally
+// drop the success-case pass-through.
+func TestAuthService_GetUserProfile_Success(t *testing.T) {
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			SecretKey: "test-secret-key-32-chars-minimum",
+			Expiry:    24,
+		},
+	}
+	expected := &authm.User{ID: 7, Email: stringPtr("ok@example.com")}
+	userSvc := &stubUserServiceWithGetByID{
+		getByID: func(userID uint) (*authm.User, error) {
+			assert.Equal(t, uint(7), userID)
+			return expected, nil
+		},
+	}
+	authService := NewAuthService(nil, cfg, userSvc)
+
+	user, err := authService.GetUserProfile(7)
+
+	assert.NoError(t, err)
+	assert.Same(t, expected, user)
 }
 
 // TestAuthService_Logout tests the Logout functionality


### PR DESCRIPTION
## Summary
- Discriminates the deleted-user case in `authService.GetUserProfile` via a new typed `*AuthError{Code: CodeUserNotFound}` (constructor: `ErrUserNotFoundByID`, sibling to the existing email-based `ErrUserNotFound`).
- `RefreshTokenHandler` routes the typed not-found to HTTP 401 + `CodeUnauthorized` so the client clears the session and redirects to login. Non-typed errors stay on PSY-874's 5xx fail-closed path.
- `GetProfileHandler` (peer caller of `GetUserProfile`) is intentionally untouched — PSY-896 mirrors this routing there as a separate change.

## Per-direction outcomes
- Generic error → HTTP 5xx + `CodeServiceUnavailable` (PSY-874 contract preserved by `TestRefreshTokenHandler_ProfileFails`).
- Typed not-found → HTTP 401 + `CodeUnauthorized` (new; asserted by `TestRefreshTokenHandler_DeletedUserReturns401` + integration test).

## Test plan
- [x] `cd backend && go build ./...` — clean.
- [x] `cd backend && go test -short ./...` — entire backend suite green (interface change → full suite per `feedback_interface_change_full_suite.md`).
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — `0 issues.`
- [x] Integration test against real Postgres + GORM: `TestAuthHandlerIntegration/TestRefreshToken_UserDeletedFromDB` — PASSED.

## Manual repro
The new + updated test names ARE the manual repro for this typed-error promotion:

- `TestAuthService_GetUserProfile_DeletedUserReturnsTyped` — service-layer; stub returns gorm.ErrRecordNotFound (via `%w`), `GetUserProfile` surfaces `*AuthError{CodeUserNotFound}` AND keeps `gorm.ErrRecordNotFound` reachable via `errors.Is`. PASSED.
- `TestAuthService_GetUserProfile_GenericErrorPassthrough` — service-layer; stub returns raw connection error, must NOT be wrapped as `CodeUserNotFound` (dual-direction: protects against a regression that blanket-wraps all GetUserByID failures as not-found). PASSED.
- `TestAuthService_GetUserProfile_Success` — happy path unchanged. PASSED.
- `TestRefreshTokenHandler_DeletedUserReturns401` — handler-layer; mock returns typed not-found, handler returns a `huma.StatusError` with `GetStatus() == 401` + body envelope `{Success: false, ErrorCode: UNAUTHORIZED, Message: external-canonical}`. PASSED.
- `TestRefreshTokenHandler_ProfileFails` — unchanged; locks in the 5xx contract for non-typed errors (dual-direction: protects against a future fail-closed pass collapsing the 401 path back into the generic 5xx bucket). PASSED.
- `TestRefreshToken_UserDeletedFromDB` integration — flipped from asserting `CodeServiceUnavailable` to `401 + CodeUnauthorized`. Real Postgres + GORM end-to-end. PASSED.

Key contract preserved: PSY-874's 5xx-on-generic-error invariant holds; only the typed-not-found path is the behavior change.

## Code review
Inline 3-lens pass (reuse / quality / efficiency) per `pattern_subagent_inline_code_review.md`:
- Reuse — LoginHandler PSY-864 `errors.As + switch on Code` reused; `errors.Is + gorm.ErrRecordNotFound` matches existing service convention; service-test stub composes via Go embedding of `nilDBUserService` (the existing test stub).
- Quality — comments document WHY (enumeration-safety distinction, dual-direction contract), no PSY-XXX refs in code per `feedback_strip_ticket_refs_from_doc_comments.md`.
- Efficiency — added work is one `errors.As` walk per request; cheap.

No changes from the review pass.

Closes PSY-882