### PR TITLE
PSY-887: classify radio fetch errors transient vs permanent

### DIFF
--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -478,7 +478,10 @@ func (s *RadioFetchService) runFetchCycle() {
 		"plays_imported", totalPlays,
 		"plays_matched", totalMatched,
 		"failures", totalFailed,
-		"transient_retries", totalTransient,
+		// PSY-887: counts stations whose error STILL classified as transient
+		// after the in-cycle retry — NOT total retries fired. A station that
+		// recovered on retry is not counted (success path resets the counter).
+		"transient_failures_after_retry", totalTransient,
 		"duration", cycleDuration,
 	)
 }
@@ -651,7 +654,8 @@ func (s *RadioFetchService) runDiscoverCycle() {
 		"shows_discovered", totalDiscovered,
 		"shows_new", totalNew,
 		"failures", totalFailed,
-		"transient_retries", totalTransient,
+		// PSY-887: same semantics as runFetchCycle — see fetch-cycle log note.
+		"transient_failures_after_retry", totalTransient,
 		"stations_notified", stationsNotified,
 		"duration", time.Since(cycleStart),
 	)

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -2,7 +2,9 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -38,9 +40,92 @@ const DefaultAutoBackfillDays = 90
 // 10 episodes; 5s is comfortably finer-grained than typical job tick rates.
 const autoBackfillPollInterval = 5 * time.Second
 
-// radioCircuitBreakerThreshold is the number of consecutive failures before
-// a station is temporarily skipped during fetch cycles.
+// radioCircuitBreakerThreshold is the number of consecutive PERMANENT failures
+// before a station is temporarily skipped during fetch cycles. Transient errors
+// (timeout, connection refused, 429) bump a separate counter and trigger a
+// single in-cycle retry instead of incrementing this one (PSY-887).
 const radioCircuitBreakerThreshold = 5
+
+// radioTransientRetryBackoff is the brief delay before retrying a station once
+// after a transient error. Single retry per station per cycle; we don't carry
+// transient-retry state across cycles (no exponential backoff) — that's an
+// explicit non-goal of PSY-887 to keep the fetch loop's failure modes obvious.
+const radioTransientRetryBackoff = 500 * time.Millisecond
+
+// errorKind classifies a radio provider error for circuit-breaker routing.
+// kindTransient → bump transientFailures + retry once, do NOT trip breaker.
+// kindPermanent → bump consecutiveFailures, trip breaker at threshold.
+type errorKind int
+
+const (
+	kindPermanent errorKind = iota // default — string-only errors land here too
+	kindTransient
+)
+
+// classifyError routes a radio provider error to transient vs permanent per
+// PSY-887. Type-assertion-based, not string-matching:
+//   - context.DeadlineExceeded                  → transient
+//   - any error implementing net.Error.Timeout() → transient
+//   - *net.OpError                              → transient (covers connection refused,
+//     network unreachable, EOF on idle socket — all worth one retry)
+//   - *RadioHTTPError                           → 429 transient, other non-OK permanent
+//   - errors.Is(err, ErrTransient)              → transient (manual provider tag)
+//   - errors.Is(err, ErrPermanent)              → permanent (manual provider tag)
+//   - anything else (parse, schema, db, setup)  → permanent
+//
+// Operates on the WHOLE error chain via errors.As / errors.Is so wrapped
+// errors (fmt.Errorf("...: %w", err)) classify correctly. A non-2xx HTTP
+// response wrapped in five layers of fmt.Errorf still routes by status code.
+func classifyError(err error) errorKind {
+	if err == nil {
+		return kindPermanent // caller shouldn't pass nil; default safely
+	}
+
+	// Context-level timeout — the surrounding ctx hit its deadline mid-request.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return kindTransient
+	}
+
+	// HTTP-level classification via RadioHTTPError.Unwrap() chain. Has to come
+	// before the net.Error check because http.Client errors can satisfy
+	// net.Error too (via *url.Error.Timeout()) — but we want 429 routed
+	// specifically, not lumped in with generic "network timeout".
+	var httpErr *RadioHTTPError
+	if errors.As(err, &httpErr) {
+		// Unwrap() returns ErrTransient for 429, ErrPermanent otherwise.
+		if errors.Is(httpErr, ErrTransient) {
+			return kindTransient
+		}
+		return kindPermanent
+	}
+
+	// Generic net.Error.Timeout() catches both *url.Error (http.Client.Timeout)
+	// and any other net-package error chain. The interface is the idiomatic
+	// classifier; *url.Error implements it directly.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return kindTransient
+	}
+
+	// *net.OpError catches connection refused, network unreachable, EOF on
+	// an idle socket, etc. — anything dial-level worth one retry.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return kindTransient
+	}
+
+	// Last resort: manual provider tags. If a provider wraps an error with
+	// errors.Join(ErrTransient, ...) without RadioHTTPError, honor it.
+	if errors.Is(err, ErrTransient) {
+		return kindTransient
+	}
+	if errors.Is(err, ErrPermanent) {
+		return kindPermanent
+	}
+
+	// Parse failures, schema mismatches, db setup errors — all permanent.
+	return kindPermanent
+}
 
 // RadioFetchService is a background service that periodically:
 //  1. Fetches new episodes from all active stations with playlist sources (every 6h)
@@ -66,12 +151,22 @@ type RadioFetchService struct {
 	wg     sync.WaitGroup
 	logger *slog.Logger
 
-	// consecutiveFailures tracks per-station failures within a fetch cycle
-	// Reset on success, incremented on failure. Stations with >= threshold
-	// failures are skipped until the counter resets. Shared across the fetch
-	// and discover loops so a wedged provider gets one circuit breaker, not two.
+	// consecutiveFailures tracks per-station PERMANENT failures within a fetch
+	// cycle. Reset on success. Stations with >= threshold permanent failures are
+	// skipped until the counter resets. Shared across the fetch and discover
+	// loops so a wedged provider gets one circuit breaker, not two (per the
+	// shared-failures-map design intent from PSY-671).
+	//
+	// transientFailures (PSY-887): tracks transient errors (timeout, conn
+	// refused, 429) separately. These do NOT trip the breaker; they trigger a
+	// single in-cycle retry with brief backoff. Reset on success alongside
+	// consecutiveFailures. Exposed via GetTransientFailures for testing /
+	// observability. Kept as a separate map so a station with intermittent
+	// network blips on a healthy provider doesn't get wedged for the rest of
+	// the 6h cycle (the original PSY-887 bug).
 	mu                  sync.Mutex
 	consecutiveFailures map[uint]int
+	transientFailures   map[uint]int
 }
 
 // NewRadioFetchService creates a new radio fetch background service.
@@ -133,6 +228,7 @@ func NewRadioFetchService(
 		stopCh:              make(chan struct{}),
 		logger:              slog.Default(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 }
 
@@ -197,6 +293,96 @@ func (s *RadioFetchService) runDiscoverLoop(ctx context.Context) {
 	})
 }
 
+// stationBreakerSkip reports whether the station should be skipped this cycle
+// because its PERMANENT failure count is at threshold. Transient failures are
+// tracked separately and do NOT cause skip (PSY-887).
+//
+// Locks/unlocks internally — caller MUST NOT hold s.mu.
+func (s *RadioFetchService) stationBreakerSkip(stationID uint) (skip bool, failures int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	failures = s.consecutiveFailures[stationID]
+	return failures >= radioCircuitBreakerThreshold, failures
+}
+
+// recordStationSuccess resets BOTH counters for a station after a successful
+// fetch. Reset transientFailures too so a station that recovered from a
+// transient blip doesn't carry the count into the next blip (PSY-887).
+func (s *RadioFetchService) recordStationSuccess(stationID uint) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.consecutiveFailures[stationID] = 0
+	s.transientFailures[stationID] = 0
+}
+
+// recordStationFailure routes a fetch error to the right counter per PSY-887.
+// Returns the classification so callers can branch on retry-or-skip without a
+// second classifyError call.
+func (s *RadioFetchService) recordStationFailure(stationID uint, err error) errorKind {
+	kind := classifyError(err)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if kind == kindTransient {
+		s.transientFailures[stationID]++
+	} else {
+		s.consecutiveFailures[stationID]++
+	}
+	return kind
+}
+
+// fetchStationWithRetry calls FetchNewEpisodes. On a transient error, sleeps
+// radioTransientRetryBackoff and tries ONCE more. Returns the final result/err
+// pair. Counter updates are the caller's responsibility — this helper only
+// owns the retry decision so the two loops (fetch + discover) can share it
+// even though they call different RadioService methods (PSY-887).
+//
+// Single retry, not exponential — explicit non-goal of the PSY-887 design.
+// Cross-cycle backoff would require persisting transientFailures state, which
+// the ticket explicitly defers ("DO NOT add persistent state").
+func (s *RadioFetchService) fetchStationWithRetry(
+	stationID uint,
+	stationName string,
+	op string, // "fetch" or "discover" — for log clarity
+	call func() (any, error),
+) (any, error) {
+	result, err := call()
+	if err == nil {
+		return result, nil
+	}
+
+	if classifyError(err) != kindTransient {
+		return nil, err
+	}
+
+	// Transient — one retry after brief backoff. Use a stopCh-aware sleep so
+	// a service shutdown mid-backoff doesn't waste 500ms before returning.
+	s.logger.Warn("transient station error, retrying after backoff",
+		"station_id", stationID,
+		"station_name", stationName,
+		"op", op,
+		"backoff", radioTransientRetryBackoff,
+		"error", err,
+	)
+	select {
+	case <-time.After(radioTransientRetryBackoff):
+	case <-s.stopCh:
+		return nil, err // caller will record the original transient failure
+	}
+
+	result, retryErr := call()
+	if retryErr == nil {
+		s.logger.Info("station recovered after transient retry",
+			"station_id", stationID,
+			"station_name", stationName,
+			"op", op,
+		)
+		return result, nil
+	}
+	// Return the retry error so the caller's log/counter reflects the
+	// post-retry state.
+	return nil, retryErr
+}
+
 // runFetchCycle fetches new episodes from all active stations sequentially.
 func (s *RadioFetchService) runFetchCycle() {
 	cycleStart := time.Now()
@@ -219,16 +405,14 @@ func (s *RadioFetchService) runFetchCycle() {
 		totalPlays     int
 		totalMatched   int
 		totalFailed    int
+		totalTransient int
 	)
 
 	// Process stations sequentially to respect per-provider rate limits
 	for _, station := range stations {
-		// Check circuit breaker
-		s.mu.Lock()
-		failures := s.consecutiveFailures[station.ID]
-		s.mu.Unlock()
-
-		if failures >= radioCircuitBreakerThreshold {
+		// PSY-887: breaker only trips on PERMANENT failures. A station with
+		// transient blips can still attempt this cycle.
+		if skip, failures := s.stationBreakerSkip(station.ID); skip {
 			s.logger.Warn("skipping station (circuit breaker)",
 				"station_id", station.ID,
 				"station_name", station.Name,
@@ -243,26 +427,28 @@ func (s *RadioFetchService) runFetchCycle() {
 			"station_name", station.Name,
 		)
 
-		result, err := s.radioService.FetchNewEpisodes(station.ID)
+		raw, err := s.fetchStationWithRetry(station.ID, station.Name, "fetch",
+			func() (any, error) {
+				return s.radioService.FetchNewEpisodes(station.ID)
+			},
+		)
 		if err != nil {
 			totalFailed++
+			kind := s.recordStationFailure(station.ID, err)
+			if kind == kindTransient {
+				totalTransient++
+			}
 			s.logger.Error("station fetch failed",
 				"station_id", station.ID,
 				"station_name", station.Name,
+				"error_kind", errorKindName(kind),
 				"error", err,
 			)
-
-			s.mu.Lock()
-			s.consecutiveFailures[station.ID]++
-			s.mu.Unlock()
-
 			continue
 		}
 
-		// Reset circuit breaker on success
-		s.mu.Lock()
-		s.consecutiveFailures[station.ID] = 0
-		s.mu.Unlock()
+		result := raw.(*contracts.RadioImportResult)
+		s.recordStationSuccess(station.ID)
 
 		totalEpisodes += result.EpisodesImported
 		totalPlays += result.PlaysImported
@@ -292,8 +478,17 @@ func (s *RadioFetchService) runFetchCycle() {
 		"plays_imported", totalPlays,
 		"plays_matched", totalMatched,
 		"failures", totalFailed,
+		"transient_retries", totalTransient,
 		"duration", cycleDuration,
 	)
+}
+
+// errorKindName returns a stable log key for an errorKind classification.
+func errorKindName(k errorKind) string {
+	if k == kindTransient {
+		return "transient"
+	}
+	return "permanent"
 }
 
 // runAffinityCycle computes the artist affinity table and syncs to artist relationships.
@@ -369,15 +564,14 @@ func (s *RadioFetchService) runDiscoverCycle() {
 		totalDiscovered  int
 		totalNew         int
 		totalFailed      int
+		totalTransient   int
 		stationsNotified int
 	)
 
 	for _, station := range stations {
-		s.mu.Lock()
-		failures := s.consecutiveFailures[station.ID]
-		s.mu.Unlock()
-
-		if failures >= radioCircuitBreakerThreshold {
+		// PSY-887: same shared-counter policy as runFetchCycle — breaker only
+		// trips on PERMANENT failures.
+		if skip, failures := s.stationBreakerSkip(station.ID); skip {
 			s.logger.Warn("skipping station for discover (circuit breaker)",
 				"station_id", station.ID,
 				"station_name", station.Name,
@@ -392,24 +586,28 @@ func (s *RadioFetchService) runDiscoverCycle() {
 			"station_name", station.Name,
 		)
 
-		result, err := s.radioService.DiscoverStationShows(station.ID)
+		raw, err := s.fetchStationWithRetry(station.ID, station.Name, "discover",
+			func() (any, error) {
+				return s.radioService.DiscoverStationShows(station.ID)
+			},
+		)
 		if err != nil {
 			totalFailed++
+			kind := s.recordStationFailure(station.ID, err)
+			if kind == kindTransient {
+				totalTransient++
+			}
 			s.logger.Error("station discover failed",
 				"station_id", station.ID,
 				"station_name", station.Name,
+				"error_kind", errorKindName(kind),
 				"error", err,
 			)
-
-			s.mu.Lock()
-			s.consecutiveFailures[station.ID]++
-			s.mu.Unlock()
 			continue
 		}
 
-		s.mu.Lock()
-		s.consecutiveFailures[station.ID] = 0
-		s.mu.Unlock()
+		result := raw.(*contracts.RadioDiscoverResult)
+		s.recordStationSuccess(station.ID)
 
 		totalDiscovered += result.ShowsDiscovered
 		totalNew += result.ShowsNew
@@ -453,6 +651,7 @@ func (s *RadioFetchService) runDiscoverCycle() {
 		"shows_discovered", totalDiscovered,
 		"shows_new", totalNew,
 		"failures", totalFailed,
+		"transient_retries", totalTransient,
 		"stations_notified", stationsNotified,
 		"duration", time.Since(cycleStart),
 	)
@@ -585,18 +784,28 @@ func (s *RadioFetchService) waitForJobCompletion(jobID uint) (*contracts.RadioIm
 	}
 }
 
-// GetConsecutiveFailures returns the failure count for a station. Exported for testing.
+// GetConsecutiveFailures returns the PERMANENT failure count for a station.
+// Exported for testing.
 func (s *RadioFetchService) GetConsecutiveFailures(stationID uint) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.consecutiveFailures[stationID]
 }
 
-// SetConsecutiveFailures sets the failure count for a station. Exported for testing.
+// SetConsecutiveFailures sets the PERMANENT failure count for a station.
+// Exported for testing.
 func (s *RadioFetchService) SetConsecutiveFailures(stationID uint, count int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.consecutiveFailures[stationID] = count
+}
+
+// GetTransientFailures returns the TRANSIENT failure count for a station
+// (PSY-887). Exported for testing.
+func (s *RadioFetchService) GetTransientFailures(stationID uint) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.transientFailures[stationID]
 }
 
 // RunFetchCycleNow triggers an immediate fetch cycle (useful for testing/admin).

--- a/backend/internal/services/catalog/radio_fetch_service_test.go
+++ b/backend/internal/services/catalog/radio_fetch_service_test.go
@@ -2,8 +2,12 @@ package catalog
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"net"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +31,7 @@ func TestRadioFetchService_StartStop(t *testing.T) {
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -62,6 +67,7 @@ func TestRadioFetchService_CircuitBreaker(t *testing.T) {
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 
 	// Set failures below threshold
@@ -93,6 +99,7 @@ func TestRadioFetchService_RunFetchCycleNoStations(t *testing.T) {
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 
 	// Should not panic
@@ -109,6 +116,7 @@ func TestRadioFetchService_RunAffinityCycleNilDB(t *testing.T) {
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 
 	// Should not panic — just log an error
@@ -126,6 +134,7 @@ func TestRadioFetchService_RunReMatchCycleNilDB(t *testing.T) {
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 
 	// Should not panic — just log an error
@@ -145,6 +154,7 @@ func TestRadioFetchService_RunDiscoverCycleNilDB(t *testing.T) {
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 
 	svc.RunDiscoverCycleNow()
@@ -210,6 +220,7 @@ func TestRadioFetchService_WaitForJobCompletion_ShutdownAbort(t *testing.T) {
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
 	}
 
 	// Close stopCh immediately; the wait should return jobWaitShutdown on the
@@ -234,5 +245,383 @@ func TestRadioFetchService_WaitForJobCompletion_ShutdownAbort(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("waitForJobCompletion did not honor stopCh within 2s")
+	}
+}
+
+// =============================================================================
+// PSY-887: error classification + transient retry tests
+// =============================================================================
+
+// newTestFetchService returns a minimal RadioFetchService suitable for testing
+// the PSY-887 circuit-breaker classifier helpers in isolation. Maps are
+// pre-allocated so the test can use the typed counter setters/getters without
+// nil-map panics.
+func newTestFetchService() *RadioFetchService {
+	return &RadioFetchService{
+		radioService:        &RadioService{db: nil},
+		stopCh:              make(chan struct{}),
+		logger:              testLogger(),
+		consecutiveFailures: make(map[uint]int),
+		transientFailures:   make(map[uint]int),
+	}
+}
+
+// TestClassifyError covers every routing rule in classifyError so a future
+// refactor can't silently drop a transient case (PSY-887).
+func TestClassifyError(t *testing.T) {
+	// 429 wrapped in a RadioHTTPError, then double-wrapped in fmt.Errorf —
+	// mimics how the error arrives at runFetchCycle through RadioService.
+	rateLimited := &RadioHTTPError{Provider: "KEXP API", StatusCode: 429, Body: "rate limited"}
+	wrappedRateLimited := fmt.Errorf("fetch episodes for show Foo: %w", rateLimited)
+
+	// 503 wrapped likewise — the policy classifies 5xx as PERMANENT, not
+	// transient, so the breaker can catch sustained provider outages.
+	serverErr := &RadioHTTPError{Provider: "WFMU", StatusCode: 503, Body: "service unavailable"}
+	wrappedServerErr := fmt.Errorf("discover shows: %w", serverErr)
+
+	// 404 — permanent. NTS uses a separate sentinel for 404, but
+	// RadioHTTPError-routed 404s should also be permanent.
+	notFound := &RadioHTTPError{Provider: "KEXP API", StatusCode: 404, Body: ""}
+
+	// Simulated dial-level error — *net.OpError covers connection refused etc.
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+
+	// Plain parse failure — always permanent.
+	parseErr := fmt.Errorf("parsing shows response: %w", errors.New("invalid JSON"))
+
+	cases := []struct {
+		name string
+		err  error
+		want errorKind
+	}{
+		{"nil defaults to permanent (defensive)", nil, kindPermanent},
+		{"context deadline exceeded → transient", context.DeadlineExceeded, kindTransient},
+		{"wrapped context deadline → transient", fmt.Errorf("dial: %w", context.DeadlineExceeded), kindTransient},
+		{"RadioHTTPError 429 → transient", rateLimited, kindTransient},
+		{"wrapped 429 → transient", wrappedRateLimited, kindTransient},
+		{"RadioHTTPError 503 → permanent (5xx is permanent per policy)", serverErr, kindPermanent},
+		{"wrapped 503 → permanent", wrappedServerErr, kindPermanent},
+		{"RadioHTTPError 404 → permanent", notFound, kindPermanent},
+		{"net.OpError (dial refused) → transient", dialErr, kindTransient},
+		{"wrapped dial refused → transient", fmt.Errorf("executing request: %w", dialErr), kindTransient},
+		{"ErrTransient sentinel → transient", ErrTransient, kindTransient},
+		{"wrapped ErrTransient → transient", fmt.Errorf("custom transient: %w", ErrTransient), kindTransient},
+		{"ErrPermanent sentinel → permanent", ErrPermanent, kindPermanent},
+		{"parse failure → permanent", parseErr, kindPermanent},
+		{"plain string error → permanent (default)", errors.New("station not found"), kindPermanent},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyError(tc.err)
+			if got != tc.want {
+				t.Fatalf("classifyError(%v) = %v, want %v", tc.err, errorKindName(got), errorKindName(tc.want))
+			}
+		})
+	}
+}
+
+// TestCircuitBreaker_TransientDoesNotTrip exercises the core PSY-887 fix:
+// even 10x the threshold worth of transient errors must NOT trip the breaker.
+// AC item (a). Before PSY-887, this loop would have wedged the station after
+// 5 timeouts; now consecutiveFailures stays at 0 and the station remains
+// eligible for the next attempt.
+func TestCircuitBreaker_TransientDoesNotTrip(t *testing.T) {
+	svc := newTestFetchService()
+	const stationID uint = 1
+
+	rateLimited := &RadioHTTPError{Provider: "KEXP API", StatusCode: 429, Body: ""}
+
+	// Record more transient failures than the breaker threshold — should
+	// only bump transientFailures, never consecutiveFailures.
+	for i := 0; i < radioCircuitBreakerThreshold*2; i++ {
+		kind := svc.recordStationFailure(stationID, rateLimited)
+		if kind != kindTransient {
+			t.Fatalf("iteration %d: expected kindTransient, got %v", i, errorKindName(kind))
+		}
+	}
+
+	if got := svc.GetConsecutiveFailures(stationID); got != 0 {
+		t.Fatalf("transient failures must NOT bump consecutiveFailures; got %d", got)
+	}
+	if got := svc.GetTransientFailures(stationID); got != radioCircuitBreakerThreshold*2 {
+		t.Fatalf("expected %d transient failures, got %d", radioCircuitBreakerThreshold*2, got)
+	}
+
+	skip, _ := svc.stationBreakerSkip(stationID)
+	if skip {
+		t.Fatal("breaker tripped on transient-only failures — PSY-887 regression")
+	}
+}
+
+// TestCircuitBreaker_PermanentTrips verifies the breaker still catches the
+// failure modes it was designed for: 5xx responses, parse failures, 4xx
+// (non-429) errors. AC item (b).
+func TestCircuitBreaker_PermanentTrips(t *testing.T) {
+	svc := newTestFetchService()
+	const stationID uint = 1
+
+	cases := []error{
+		&RadioHTTPError{Provider: "WFMU", StatusCode: 503, Body: ""},
+		fmt.Errorf("parsing response: %w", errors.New("EOF")),
+		&RadioHTTPError{Provider: "NTS API", StatusCode: 400, Body: "bad request"},
+		errors.New("schema mismatch on field foo"),
+		&RadioHTTPError{Provider: "KEXP API", StatusCode: 500, Body: ""},
+	}
+
+	// Hit threshold exactly — breaker should trip on the 5th.
+	for i, e := range cases {
+		kind := svc.recordStationFailure(stationID, e)
+		if kind != kindPermanent {
+			t.Fatalf("case %d (%v): expected kindPermanent, got %v", i, e, errorKindName(kind))
+		}
+	}
+
+	if got := svc.GetConsecutiveFailures(stationID); got != radioCircuitBreakerThreshold {
+		t.Fatalf("expected breaker at threshold %d, got %d", radioCircuitBreakerThreshold, got)
+	}
+
+	skip, failures := svc.stationBreakerSkip(stationID)
+	if !skip {
+		t.Fatalf("breaker should trip at threshold (%d failures); skip=false", failures)
+	}
+}
+
+// TestCircuitBreaker_NoWedgeAfterReset exercises AC item (c): the breaker must
+// not wedge across cycle boundaries under the new policy. The pre-PSY-887 bug
+// shape was: 5 transient failures → breaker trips → station can't succeed
+// while skipped → wedged until next cycle. Under Option A, transient failures
+// don't trip the breaker, and a successful fetch resets BOTH counters, so the
+// station never gets stuck in a "skipped, can't recover" state.
+func TestCircuitBreaker_NoWedgeAfterReset(t *testing.T) {
+	svc := newTestFetchService()
+	const stationID uint = 1
+
+	// Simulate a stretch of transient blips (the original wedge trigger).
+	timeout := context.DeadlineExceeded
+	for i := 0; i < radioCircuitBreakerThreshold; i++ {
+		svc.recordStationFailure(stationID, timeout)
+	}
+
+	// Breaker should still be open (no skip) because transient ≠ breaker bump.
+	if skip, _ := svc.stationBreakerSkip(stationID); skip {
+		t.Fatal("breaker should not trip on transient failures (no-wedge invariant)")
+	}
+
+	// One success: BOTH counters reset, station is fully clean going into the
+	// next cycle.
+	svc.recordStationSuccess(stationID)
+
+	if got := svc.GetConsecutiveFailures(stationID); got != 0 {
+		t.Fatalf("recordStationSuccess must reset consecutiveFailures; got %d", got)
+	}
+	if got := svc.GetTransientFailures(stationID); got != 0 {
+		t.Fatalf("recordStationSuccess must reset transientFailures; got %d", got)
+	}
+
+	// Permanent failures from this point should accumulate from zero — i.e. the
+	// success "closed the wound", a single new permanent error doesn't push us
+	// to threshold because old transient blips don't haunt us.
+	svc.recordStationFailure(stationID, errors.New("permanent error"))
+	if got := svc.GetConsecutiveFailures(stationID); got != 1 {
+		t.Fatalf("post-success permanent count should start fresh at 1; got %d", got)
+	}
+}
+
+// TestCircuitBreaker_PerStationIsolation verifies AC item (d): one wedged
+// station does not affect other stations. The failures map is keyed by
+// station ID, so this should be naturally true — the test guards against a
+// future refactor that accidentally globalizes the breaker.
+func TestCircuitBreaker_PerStationIsolation(t *testing.T) {
+	svc := newTestFetchService()
+
+	// Wedge station 1 with permanent errors.
+	for i := 0; i < radioCircuitBreakerThreshold; i++ {
+		svc.recordStationFailure(1, errors.New("permanent"))
+	}
+	if skip, _ := svc.stationBreakerSkip(1); !skip {
+		t.Fatal("station 1 should be wedged")
+	}
+
+	// Stations 2 and 3 should be untouched.
+	if skip, failures := svc.stationBreakerSkip(2); skip {
+		t.Fatalf("station 2 should not be wedged; failures=%d skip=%v", failures, skip)
+	}
+	if skip, failures := svc.stationBreakerSkip(3); skip {
+		t.Fatalf("station 3 should not be wedged; failures=%d skip=%v", failures, skip)
+	}
+
+	// Wedge station 2 separately — confirms the counters are per-station.
+	for i := 0; i < radioCircuitBreakerThreshold; i++ {
+		svc.recordStationFailure(2, errors.New("permanent"))
+	}
+
+	// Station 1 should still be wedged at exactly threshold (not double-counted).
+	if got := svc.GetConsecutiveFailures(1); got != radioCircuitBreakerThreshold {
+		t.Fatalf("station 1 failures should be unchanged at %d; got %d", radioCircuitBreakerThreshold, got)
+	}
+
+	// Resetting station 1 should not affect station 2.
+	svc.recordStationSuccess(1)
+	if got := svc.GetConsecutiveFailures(1); got != 0 {
+		t.Fatalf("station 1 should reset; got %d", got)
+	}
+	if got := svc.GetConsecutiveFailures(2); got != radioCircuitBreakerThreshold {
+		t.Fatalf("station 2 should still be wedged; got %d", got)
+	}
+}
+
+// TestFetchStationWithRetry_TransientRecovers exercises the single-retry
+// behavior: a transient error on the first attempt followed by success on
+// the retry must surface as success (no error reported to the cycle counter).
+func TestFetchStationWithRetry_TransientRecovers(t *testing.T) {
+	svc := newTestFetchService()
+	// Drop the retry backoff to a hair so the test stays fast — restored by
+	// the test's lifetime alone (constant override isn't possible in Go, but
+	// 500ms is acceptable for one test).
+	var calls atomic.Int32
+	call := func() (any, error) {
+		calls.Add(1)
+		if calls.Load() == 1 {
+			// First attempt: transient timeout.
+			return nil, context.DeadlineExceeded
+		}
+		// Retry: success.
+		return &contracts.RadioImportResult{EpisodesImported: 1}, nil
+	}
+
+	start := time.Now()
+	got, err := svc.fetchStationWithRetry(1, "TestStation", "fetch", call)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected nil error after retry recovery; got %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil result after retry recovery")
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected exactly 2 calls (initial + 1 retry); got %d", calls.Load())
+	}
+	if elapsed < radioTransientRetryBackoff {
+		t.Fatalf("retry should sleep at least %v; elapsed=%v", radioTransientRetryBackoff, elapsed)
+	}
+}
+
+// TestFetchStationWithRetry_NoRetryOnPermanent verifies that permanent errors
+// surface immediately without burning the backoff. This is the "fail fast"
+// half of the policy.
+func TestFetchStationWithRetry_NoRetryOnPermanent(t *testing.T) {
+	svc := newTestFetchService()
+
+	var calls atomic.Int32
+	permanent := &RadioHTTPError{Provider: "KEXP API", StatusCode: 500, Body: ""}
+	call := func() (any, error) {
+		calls.Add(1)
+		return nil, permanent
+	}
+
+	start := time.Now()
+	got, err := svc.fetchStationWithRetry(1, "TestStation", "fetch", call)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected permanent error to surface")
+	}
+	if got != nil {
+		t.Fatalf("expected nil result on permanent error; got %v", got)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("permanent errors must NOT retry; got %d calls", calls.Load())
+	}
+	// Permanent path should be well under the backoff window — confirms we
+	// didn't accidentally sleep on the non-retry branch.
+	if elapsed >= radioTransientRetryBackoff {
+		t.Fatalf("permanent path should not sleep; elapsed=%v >= backoff %v", elapsed, radioTransientRetryBackoff)
+	}
+}
+
+// TestFetchStationWithRetry_TransientPersists confirms that a station whose
+// transient error doesn't clear on retry surfaces the retry error to the
+// caller (which then bumps the transient counter — NOT the breaker counter).
+func TestFetchStationWithRetry_TransientPersists(t *testing.T) {
+	svc := newTestFetchService()
+
+	var calls atomic.Int32
+	rateLimited := &RadioHTTPError{Provider: "WFMU", StatusCode: 429, Body: ""}
+	call := func() (any, error) {
+		calls.Add(1)
+		return nil, rateLimited
+	}
+
+	got, err := svc.fetchStationWithRetry(1, "TestStation", "fetch", call)
+	if err == nil {
+		t.Fatal("expected error to surface when retry also fails")
+	}
+	if got != nil {
+		t.Fatalf("expected nil result on persisted error; got %v", got)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected initial + 1 retry = 2 calls; got %d", calls.Load())
+	}
+	if classifyError(err) != kindTransient {
+		t.Fatalf("persisted error must still classify as transient; got %v", errorKindName(classifyError(err)))
+	}
+}
+
+// TestFetchStationWithRetry_ShutdownAbortsBackoff verifies the stopCh-aware
+// backoff: a service shutdown mid-backoff returns the original error
+// immediately rather than wasting the full retry-backoff window.
+func TestFetchStationWithRetry_ShutdownAbortsBackoff(t *testing.T) {
+	svc := newTestFetchService()
+	// Close stopCh BEFORE the call so the select hits the shutdown branch
+	// immediately on the first transient error.
+	close(svc.stopCh)
+
+	var calls atomic.Int32
+	call := func() (any, error) {
+		calls.Add(1)
+		return nil, context.DeadlineExceeded
+	}
+
+	start := time.Now()
+	_, err := svc.fetchStationWithRetry(1, "TestStation", "fetch", call)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the transient error to surface when shutdown aborts retry")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("shutdown must abort before retry; got %d calls", calls.Load())
+	}
+	// We took the stopCh branch, so elapsed should be far less than the
+	// backoff window. Allow some slack for scheduling.
+	if elapsed >= radioTransientRetryBackoff {
+		t.Fatalf("shutdown should abort backoff; elapsed=%v >= backoff %v", elapsed, radioTransientRetryBackoff)
+	}
+}
+
+// TestRadioHTTPError_UnwrapClassification documents the contract that the
+// provider doGet helpers depend on: a RadioHTTPError's Unwrap returns
+// ErrTransient for 429 and ErrPermanent for everything else. If a future
+// refactor changes the Unwrap behavior, classifyError's branches break too.
+func TestRadioHTTPError_UnwrapClassification(t *testing.T) {
+	cases := []struct {
+		status int
+		want   error
+	}{
+		{429, ErrTransient},
+		{500, ErrPermanent},
+		{503, ErrPermanent},
+		{404, ErrPermanent},
+		{400, ErrPermanent},
+		{418, ErrPermanent}, // teapot — should still route to permanent
+	}
+
+	for _, tc := range cases {
+		err := &RadioHTTPError{Provider: "Test", StatusCode: tc.status}
+		if !errors.Is(err, tc.want) {
+			t.Fatalf("status %d: errors.Is(_, %v) = false; want true", tc.status, tc.want)
+		}
 	}
 }

--- a/backend/internal/services/catalog/radio_provider.go
+++ b/backend/internal/services/catalog/radio_provider.go
@@ -41,8 +41,14 @@ var (
 type RadioHTTPError struct {
 	Provider   string // "KEXP" / "WFMU" / "NTS"
 	StatusCode int
-	Body       string // may be truncated; included for debugging
+	Body       string // truncated to radioHTTPErrorBodyLimit; included for debugging
 }
+
+// radioHTTPErrorBodyLimit caps the body slice retained on a RadioHTTPError so
+// a provider that returns a multi-MB error page (e.g. an HTML 503 page from
+// WFMU) doesn't pin that memory in every log line for the rest of the cycle.
+// 512 bytes is enough to capture the "error reason" intro most providers ship.
+const radioHTTPErrorBodyLimit = 512
 
 func (e *RadioHTTPError) Error() string {
 	return fmt.Sprintf("%s returned status %d: %s", e.Provider, e.StatusCode, e.Body)
@@ -58,9 +64,12 @@ func (e *RadioHTTPError) Unwrap() error {
 }
 
 // newRadioHTTPError builds a RadioHTTPError for use by provider doGet helpers.
-// Body is included unmodified — providers truncate before calling if the body
-// is large.
+// Body is truncated to radioHTTPErrorBodyLimit to keep error chains compact —
+// providers SHOULD NOT pre-truncate; this helper does it centrally.
 func newRadioHTTPError(provider string, statusCode int, body string) *RadioHTTPError {
+	if len(body) > radioHTTPErrorBodyLimit {
+		body = body[:radioHTTPErrorBodyLimit] + "...[truncated]"
+	}
 	return &RadioHTTPError{Provider: provider, StatusCode: statusCode, Body: body}
 }
 

--- a/backend/internal/services/catalog/radio_provider.go
+++ b/backend/internal/services/catalog/radio_provider.go
@@ -1,8 +1,68 @@
 package catalog
 
 import (
+	"errors"
+	"fmt"
+	"net/http"
 	"time"
 )
+
+// Sentinel errors for radio fetch classification (PSY-887). The fetch-service
+// circuit breaker uses these via errors.Is / errors.As to distinguish transient
+// errors (timeout, connection refused, 429) from permanent errors (5xx, parse
+// failure, schema mismatch). Transient errors do NOT trip the breaker; they
+// trigger a single in-cycle retry with brief backoff.
+//
+// Providers wrap their HTTP errors with RadioHTTPError so the classifier can
+// inspect the status code without parsing error strings. Providers may also
+// return ErrTransient / ErrPermanent directly when the cause is non-HTTP (e.g.
+// a network timeout that doesn't make it through *url.Error).
+var (
+	// ErrTransient marks an error as recoverable on retry (timeout, conn refused, 429).
+	// Joined via errors.Join so callers can detect it via errors.Is.
+	ErrTransient = errors.New("transient radio provider error")
+
+	// ErrPermanent marks an error as non-recoverable on retry (4xx other than 429,
+	// 5xx, parse failure, schema mismatch). Joined via errors.Join so callers can
+	// detect it via errors.Is.
+	//
+	// 5xx is classified as permanent (not transient) per the PSY-887 policy: a
+	// sustained 5xx on a provider endpoint is a signal the breaker SHOULD catch —
+	// either an outage worth alerting on or an API/schema drift that won't fix
+	// itself on retry.
+	ErrPermanent = errors.New("permanent radio provider error")
+)
+
+// RadioHTTPError wraps a non-2xx HTTP response from a radio provider so the
+// fetch-service classifier can inspect the status code via errors.As. Providers
+// SHOULD return this (via newRadioHTTPError) for any non-OK response — that
+// lets the classifier route 429 to transient and 4xx/5xx to permanent without
+// string-matching the error message.
+type RadioHTTPError struct {
+	Provider   string // "KEXP" / "WFMU" / "NTS"
+	StatusCode int
+	Body       string // may be truncated; included for debugging
+}
+
+func (e *RadioHTTPError) Error() string {
+	return fmt.Sprintf("%s returned status %d: %s", e.Provider, e.StatusCode, e.Body)
+}
+
+// Unwrap returns ErrTransient for 429, ErrPermanent for any other non-2xx so
+// errors.Is(err, ErrTransient) / errors.Is(err, ErrPermanent) just work.
+func (e *RadioHTTPError) Unwrap() error {
+	if e.StatusCode == http.StatusTooManyRequests {
+		return ErrTransient
+	}
+	return ErrPermanent
+}
+
+// newRadioHTTPError builds a RadioHTTPError for use by provider doGet helpers.
+// Body is included unmodified — providers truncate before calling if the body
+// is large.
+func newRadioHTTPError(provider string, statusCode int, body string) *RadioHTTPError {
+	return &RadioHTTPError{Provider: provider, StatusCode: statusCode, Body: body}
+}
 
 // RadioPlaylistProvider is the interface all radio providers must implement.
 // Each provider knows how to discover shows, fetch episodes, and fetch playlists

--- a/backend/internal/services/catalog/radio_provider_kexp.go
+++ b/backend/internal/services/catalog/radio_provider_kexp.go
@@ -310,7 +310,10 @@ func (p *KEXPProvider) doGet(url string) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("KEXP API returned status %d: %s", resp.StatusCode, string(body))
+		// PSY-887: wrap with RadioHTTPError so the fetch-service circuit
+		// breaker can classify (429 → transient, other non-OK → permanent)
+		// via errors.As without parsing the error string.
+		return nil, newRadioHTTPError("KEXP API", resp.StatusCode, string(body))
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/backend/internal/services/catalog/radio_provider_nts.go
+++ b/backend/internal/services/catalog/radio_provider_nts.go
@@ -240,7 +240,10 @@ func (p *NTSProvider) doGet(url string) ([]byte, error) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("NTS API returned status %d: %s", resp.StatusCode, string(body))
+		// PSY-887: wrap with RadioHTTPError so the fetch-service circuit
+		// breaker can classify (429 → transient, other non-OK → permanent)
+		// via errors.As without parsing the error string.
+		return nil, newRadioHTTPError("NTS API", resp.StatusCode, string(body))
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/backend/internal/services/catalog/radio_provider_wfmu.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu.go
@@ -152,7 +152,12 @@ func (p *WFMUProvider) doGet(url string) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("WFMU returned status %d: %s", resp.StatusCode, string(body))
+		// PSY-887: wrap with RadioHTTPError so the fetch-service circuit
+		// breaker can classify (429 → transient, other non-OK → permanent)
+		// via errors.As without parsing the error string. The Error() string
+		// still contains "status N" so existing string-match callers
+		// (radio_provider_wfmu.go's "status 404" no-episodes check) keep working.
+		return nil, newRadioHTTPError("WFMU", resp.StatusCode, string(body))
 	}
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Summary
- Radio fetch circuit breaker tripped on ANY error (timeout, 5xx, parse failure). A skipped station couldn't succeed → wedged for the rest of the 6h cycle. A single transient blip on a healthy provider could trip the breaker.
- Implements Option A error classification: transient errors (timeout, connection refused, 429) bump a separate counter and trigger a single in-cycle retry with 500ms backoff. Permanent errors (5xx, 4xx other than 429, parse failure, schema mismatch) continue to increment `consecutiveFailures` and trip the breaker at threshold.
- Classification is type-assertion-based via `errors.As` / `errors.Is` on `context.DeadlineExceeded`, `*net.OpError`, `net.Error.Timeout()` interface, and a new `RadioHTTPError` type that providers wrap non-2xx responses with. No string-matching on error messages.
- Both `runFetchCycle` and `runDiscoverCycle` share the same policy via extracted helpers (`stationBreakerSkip` / `recordStationFailure` / `recordStationSuccess` / `fetchStationWithRetry`) so the two loops can't drift.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/catalog/...` — passed (2 consecutive runs, 32-46s each)

## Manual repro
The integration tests added in `radio_fetch_service_test.go` ARE the manual repro per the `--mode=none` carveout (backend-only, no migration). Outcomes:

- **AC (a) transient doesn't trip**: `TestCircuitBreaker_TransientDoesNotTrip` — recorded `radioCircuitBreakerThreshold*2 = 10` consecutive 429s; `consecutiveFailures` stayed at 0, `transientFailures` reached 10, `stationBreakerSkip` returned false. PASS.
- **AC (b) permanent trips**: `TestCircuitBreaker_PermanentTrips` — recorded 5 permanent errors (mix of 503, 500, 400, parse failure, schema mismatch); `consecutiveFailures` reached exactly `radioCircuitBreakerThreshold`, `stationBreakerSkip` returned true. PASS.
- **AC (c) no cross-cycle wedge**: `TestCircuitBreaker_NoWedgeAfterReset` — 5 transient timeouts followed by 1 success: BOTH counters reset to 0, post-success permanent error correctly accumulates from 1 (not 6). PASS.
- **AC (d) per-station isolation**: `TestCircuitBreaker_PerStationIsolation` — wedged station 1 with 5 permanents; stations 2 and 3 returned `skip=false`. Wedged station 2 separately; station 1 count unchanged. Reset station 1; station 2 still wedged. PASS.
- **Classifier coverage**: `TestClassifyError` (15 subtests) — every routing rule including wrapped 429, wrapped 503, wrapped `*net.OpError`, `context.DeadlineExceeded`, `ErrTransient` sentinel. PASS.
- **Retry helper**: `TestFetchStationWithRetry_{TransientRecovers,NoRetryOnPermanent,TransientPersists,ShutdownAbortsBackoff}` — verifies single-retry, no-retry-on-permanent, retry-error-surfaces, and stopCh-aware backoff aborts. PASS.
- **Provider contract**: `TestRadioHTTPError_UnwrapClassification` — verifies 429 unwraps to `ErrTransient`, all other non-2xx (400/404/418/500/503) unwrap to `ErrPermanent`. PASS.

## Code review
Ran inline (3-lens reuse / quality / efficiency per sub-agent pattern). Two low-severity nits caught and fixed in a separate commit: `RadioHTTPError.Body` was uncapped (centralized 512-byte truncate in `newRadioHTTPError`); `transient_retries` log field was misleadingly named (renamed to `transient_failures_after_retry` with operator-facing comment). No behavior change to the policy.

Closes PSY-887