### PR TITLE
PSY-885: validate radio import plays at the boundary

### DIFF
--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -607,7 +607,11 @@ func (s *RadioService) importPlays(episodeID uint, plays []RadioPlayImport) (int
 		records = append(records, record)
 	}
 
-	summary := summarizeDrops(truncatedRows, missingArtistRows)
+	// droppedRows is computed from the actual delta so new sanitize-drop
+	// reasons (added later without a matching per-class counter) still get
+	// reflected in the N total — only the per-class breakdown will lag.
+	droppedRows := len(plays) - len(records)
+	summary := summarizeDrops(droppedRows, truncatedRows, missingArtistRows)
 
 	if len(records) == 0 {
 		return 0, summary, nil
@@ -712,12 +716,18 @@ func truncateOptionalRunes(s *string, max int) *string {
 //
 //	dropped N plays: X over-length titles truncated, Y missing artist_name
 //
-// N is the total count of rows the sanitize step touched (truncated +
-// rejected). Breakdown clauses describe the per-action subset. "Dropped"
-// reads loosely here — truncated rows are kept, just with shortened text —
-// but per-class breakdown lets admins distinguish salvage from data loss.
-func summarizeDrops(truncatedCount, missingArtistCount int) string {
-	total := truncatedCount + missingArtistCount
+// N is droppedCount + truncatedCount — the total count of rows the sanitize
+// step touched. "Dropped" reads loosely here: truncated rows are kept (just
+// with shortened text), but grouping under one number gives admins a single
+// "needed attention" magnitude. The per-class breakdown clauses distinguish
+// salvage (truncated) from data loss (missing artist_name).
+//
+// droppedCount is taken as the authoritative drop count from the caller (not
+// re-derived from missingArtistCount) so future sanitize-drop classes added
+// without a matching counter still appear in N — the breakdown will lag the
+// total in that case, surfacing the omission rather than hiding it.
+func summarizeDrops(droppedCount, truncatedCount, missingArtistCount int) string {
+	total := droppedCount + truncatedCount
 	if total == 0 {
 		return ""
 	}

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -3,7 +3,10 @@ package catalog
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"gorm.io/gorm"
 
@@ -11,6 +14,12 @@ import (
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/utils"
 )
+
+// PSY-885: VARCHAR(500) limit on radio_plays text columns (artist_name,
+// track_title, album_title, label_name). Counted in runes (not bytes) so
+// truncation respects multi-byte boundaries — matches the Postgres semantics
+// for varchar length, which is character-count, not byte-count.
+const radioPlayVarcharMaxRunes = 500
 
 // getProvider returns the appropriate RadioPlaylistProvider for a station's playlist_source.
 func (s *RadioService) getProvider(source string) (RadioPlaylistProvider, error) {
@@ -85,6 +94,9 @@ func (s *RadioService) ImportStation(stationID uint, backfillDays int) (*contrac
 			result.EpisodesImported++
 			result.PlaysImported += epResult.PlaysImported
 			result.PlaysMatched += epResult.PlaysMatched
+			if epResult.DropSummary != "" {
+				result.Errors = append(result.Errors, fmt.Sprintf("episode %s: %s", ep.ExternalID, epResult.DropSummary))
+			}
 		}
 	}
 
@@ -150,6 +162,9 @@ func (s *RadioService) FetchNewEpisodes(stationID uint) (*contracts.RadioImportR
 			result.EpisodesImported++
 			result.PlaysImported += epResult.PlaysImported
 			result.PlaysMatched += epResult.PlaysMatched
+			if epResult.DropSummary != "" {
+				result.Errors = append(result.Errors, fmt.Sprintf("episode %s: %s", ep.ExternalID, epResult.DropSummary))
+			}
 		}
 	}
 
@@ -195,7 +210,7 @@ func (s *RadioService) ImportEpisodePlaylist(showID uint, episodeExternalID stri
 		return nil, fmt.Errorf("fetching playlist: %w", err)
 	}
 
-	imported, err := s.importPlays(episode.ID, plays)
+	imported, dropSummary, err := s.importPlays(episode.ID, plays)
 	if err != nil {
 		return nil, fmt.Errorf("importing plays: %w", err)
 	}
@@ -204,12 +219,13 @@ func (s *RadioService) ImportEpisodePlaylist(showID uint, episodeExternalID stri
 	matcher := NewRadioMatchingEngine(s.db)
 	matchResult, err := matcher.MatchPlaysForEpisode(episode.ID)
 	if err != nil {
-		return &contracts.EpisodeImportResult{PlaysImported: imported}, nil
+		return &contracts.EpisodeImportResult{PlaysImported: imported, DropSummary: dropSummary}, nil
 	}
 
 	return &contracts.EpisodeImportResult{
 		PlaysImported: imported,
 		PlaysMatched:  matchResult.Matched,
+		DropSummary:   dropSummary,
 	}, nil
 }
 
@@ -351,6 +367,9 @@ func (s *RadioService) importShowEpisodesWithProgress(
 			result.EpisodesImported++
 			result.PlaysImported += epResult.PlaysImported
 			result.PlaysMatched += epResult.PlaysMatched
+			if epResult.DropSummary != "" {
+				result.Errors = append(result.Errors, fmt.Sprintf("episode %s: %s", ep.ExternalID, epResult.DropSummary))
+			}
 		}
 
 		if progressFn != nil {
@@ -522,9 +541,9 @@ func (s *RadioService) importEpisode(showID uint, ep RadioEpisodeImport, provide
 		return &contracts.EpisodeImportResult{}, nil // non-fatal: episode created but no plays
 	}
 
-	imported, err := s.importPlays(episode.ID, plays)
+	imported, dropSummary, err := s.importPlays(episode.ID, plays)
 	if err != nil {
-		return &contracts.EpisodeImportResult{PlaysImported: imported}, nil
+		return &contracts.EpisodeImportResult{PlaysImported: imported, DropSummary: dropSummary}, nil
 	}
 
 	// Update play count on episode
@@ -534,50 +553,182 @@ func (s *RadioService) importEpisode(showID uint, ep RadioEpisodeImport, provide
 	matcher := NewRadioMatchingEngine(s.db)
 	matchResult, err := matcher.MatchPlaysForEpisode(episode.ID)
 	if err != nil {
-		return &contracts.EpisodeImportResult{PlaysImported: imported}, nil
+		return &contracts.EpisodeImportResult{PlaysImported: imported, DropSummary: dropSummary}, nil
 	}
 
 	return &contracts.EpisodeImportResult{
 		PlaysImported: imported,
 		PlaysMatched:  matchResult.Matched,
+		DropSummary:   dropSummary,
 	}, nil
 }
 
 // importPlays batch-creates play records for an episode.
-func (s *RadioService) importPlays(episodeID uint, plays []RadioPlayImport) (int, error) {
+//
+// PSY-885: validate-at-the-boundary semantics. Each provider-returned play is
+// passed through sanitizePlay BEFORE the batch insert so a single malformed
+// row (NULL artist_name, over-length VARCHAR field) can no longer poison its
+// 100-row CreateInBatches batch and silently drop all 99 sibling rows. CLAUDE.md:
+// "defensive programming at boundaries, trust internally".
+//
+// Returns (rowsCommitted, summary, err). rowsCommitted is the count of rows
+// actually written to the database — rejected rows are excluded; truncated
+// rows ARE included (they were salvaged with shortened text). summary is a
+// human-readable per-episode aggregate of "dropped N plays: ..." or "" when
+// no intervention was needed; callers append it to RadioImportResult.Errors
+// so the outcome is visible in admin job logs without per-row noise.
+func (s *RadioService) importPlays(episodeID uint, plays []RadioPlayImport) (int, string, error) {
 	if len(plays) == 0 {
-		return 0, nil
+		return 0, "", nil
 	}
 
 	records := make([]catalogm.RadioPlay, 0, len(plays))
+	truncatedRows := 0
+	missingArtistRows := 0
+
 	for _, p := range plays {
-		record := catalogm.RadioPlay{
-			EpisodeID:              episodeID,
-			Position:               p.Position,
-			ArtistName:             p.ArtistName,
-			TrackTitle:             p.TrackTitle,
-			AlbumTitle:             p.AlbumTitle,
-			LabelName:              p.LabelName,
-			ReleaseYear:            p.ReleaseYear,
-			IsNew:                  p.IsNew,
-			RotationStatus:         p.RotationStatus,
-			DJComment:              p.DJComment,
-			IsLivePerformance:      p.IsLivePerformance,
-			IsRequest:              p.IsRequest,
-			MusicBrainzArtistID:    p.MusicBrainzArtistID,
-			MusicBrainzRecordingID: p.MusicBrainzRecordingID,
-			MusicBrainzReleaseID:   p.MusicBrainzReleaseID,
-			AirTimestamp:           p.AirTimestamp,
+		record, err := sanitizePlay(episodeID, p)
+		if err != nil {
+			// Per-row diagnostic at WARN — surfaces the actual culprit in logs
+			// while the per-episode summary stays compact.
+			slog.Warn("radio import: dropping play row",
+				"episode_id", episodeID,
+				"position", p.Position,
+				"reason", err.Error(),
+			)
+			if errors.Is(err, errMissingArtistName) {
+				missingArtistRows++
+			}
+			continue
+		}
+		if playNeededTruncation(p) {
+			truncatedRows++
 		}
 		records = append(records, record)
 	}
 
-	// Batch insert
-	if err := s.db.CreateInBatches(records, 100).Error; err != nil {
-		return 0, fmt.Errorf("batch inserting plays: %w", err)
+	summary := summarizeDrops(truncatedRows, missingArtistRows)
+
+	if len(records) == 0 {
+		return 0, summary, nil
 	}
 
-	return len(records), nil
+	// Batch insert. Records are pre-validated, so a constraint failure here
+	// is a hard infrastructural error (FK gone, conn lost) — bubble it up.
+	if err := s.db.CreateInBatches(records, 100).Error; err != nil {
+		return 0, summary, fmt.Errorf("batch inserting plays: %w", err)
+	}
+
+	return len(records), summary, nil
+}
+
+// errMissingArtistName flags a play with no artist_name. radio_plays.artist_name
+// is NOT NULL in the schema — we can't make up an artist, so the row is dropped.
+var errMissingArtistName = errors.New("missing artist_name")
+
+// sanitizePlay validates and normalizes a provider-returned play DTO for safe
+// insertion into radio_plays. It is the single boundary checkpoint where bad
+// provider data is rejected (NULL artist_name) or salvaged (truncate
+// over-length VARCHAR fields to the column's 500-rune width). All downstream
+// code can then trust that any RadioPlay it sees is schema-valid.
+//
+// Returns the sanitized record on success, or an error explaining why the row
+// must be dropped. Truncation does NOT produce an error — it's a non-fatal
+// repair, surfaced via playNeededTruncation for the caller's per-episode
+// summary counter.
+func sanitizePlay(episodeID uint, p RadioPlayImport) (catalogm.RadioPlay, error) {
+	// artist_name is NOT NULL in the schema. Trimmed empty / whitespace-only
+	// names can't be salvaged — drop the row.
+	if strings.TrimSpace(p.ArtistName) == "" {
+		return catalogm.RadioPlay{}, errMissingArtistName
+	}
+
+	return catalogm.RadioPlay{
+		EpisodeID:              episodeID,
+		Position:               p.Position,
+		ArtistName:             truncateRunes(p.ArtistName, radioPlayVarcharMaxRunes),
+		TrackTitle:             truncateOptionalRunes(p.TrackTitle, radioPlayVarcharMaxRunes),
+		AlbumTitle:             truncateOptionalRunes(p.AlbumTitle, radioPlayVarcharMaxRunes),
+		LabelName:              truncateOptionalRunes(p.LabelName, radioPlayVarcharMaxRunes),
+		ReleaseYear:            p.ReleaseYear,
+		IsNew:                  p.IsNew,
+		RotationStatus:         p.RotationStatus,
+		DJComment:              p.DJComment, // TEXT column, no length cap
+		IsLivePerformance:      p.IsLivePerformance,
+		IsRequest:              p.IsRequest,
+		MusicBrainzArtistID:    p.MusicBrainzArtistID,
+		MusicBrainzRecordingID: p.MusicBrainzRecordingID,
+		MusicBrainzReleaseID:   p.MusicBrainzReleaseID,
+		AirTimestamp:           p.AirTimestamp,
+	}, nil
+}
+
+// playNeededTruncation reports whether sanitizePlay had to shorten any of the
+// four VARCHAR(500) text fields on p. Used by importPlays to count
+// truncated-row count for the per-episode summary without re-running the
+// sanitize logic.
+func playNeededTruncation(p RadioPlayImport) bool {
+	if utf8.RuneCountInString(p.ArtistName) > radioPlayVarcharMaxRunes {
+		return true
+	}
+	if p.TrackTitle != nil && utf8.RuneCountInString(*p.TrackTitle) > radioPlayVarcharMaxRunes {
+		return true
+	}
+	if p.AlbumTitle != nil && utf8.RuneCountInString(*p.AlbumTitle) > radioPlayVarcharMaxRunes {
+		return true
+	}
+	if p.LabelName != nil && utf8.RuneCountInString(*p.LabelName) > radioPlayVarcharMaxRunes {
+		return true
+	}
+	return false
+}
+
+// truncateRunes shortens s to at most max runes, respecting rune boundaries
+// (no split multi-byte sequences). Returns s unchanged when within budget.
+func truncateRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:max])
+}
+
+// truncateOptionalRunes is the *string variant of truncateRunes, preserving
+// nil semantics for Huma-style optional pointers.
+func truncateOptionalRunes(s *string, max int) *string {
+	if s == nil {
+		return nil
+	}
+	if utf8.RuneCountInString(*s) <= max {
+		return s
+	}
+	truncated := truncateRunes(*s, max)
+	return &truncated
+}
+
+// summarizeDrops formats a single-line per-episode aggregate of plays that
+// required boundary intervention (PSY-885). Returns "" when nothing needed
+// intervention. Format is stable for log scraping:
+//
+//	dropped N plays: X over-length titles truncated, Y missing artist_name
+//
+// N is the total count of rows the sanitize step touched (truncated +
+// rejected). Breakdown clauses describe the per-action subset. "Dropped"
+// reads loosely here — truncated rows are kept, just with shortened text —
+// but per-class breakdown lets admins distinguish salvage from data loss.
+func summarizeDrops(truncatedCount, missingArtistCount int) string {
+	total := truncatedCount + missingArtistCount
+	if total == 0 {
+		return ""
+	}
+	var parts []string
+	if truncatedCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d over-length titles truncated", truncatedCount))
+	}
+	if missingArtistCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d missing artist_name", missingArtistCount))
+	}
+	return fmt.Sprintf("dropped %d plays: %s", total, strings.Join(parts, ", "))
 }
 
 // closeProvider closes a provider if it implements a Close method.

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1442,10 +1444,11 @@ func (suite *RadioImportIntegrationTestSuite) TestImportPlays_BatchInsert() {
 		{Position: 2, ArtistName: "Sonic Youth"},
 	}
 
-	count, err := suite.radioService.importPlays(ep.ID, plays)
+	count, dropSummary, err := suite.radioService.importPlays(ep.ID, plays)
 
 	suite.Require().NoError(err)
 	suite.Equal(3, count)
+	suite.Empty(dropSummary, "clean batch should produce no drop summary")
 
 	// Verify plays in DB
 	var dbPlays []catalogm.RadioPlay
@@ -1463,10 +1466,156 @@ func (suite *RadioImportIntegrationTestSuite) TestImportPlays_Empty() {
 	show := suite.createShow(station.ID, "Morning Show")
 	ep := suite.createEpisode(show.ID, "2026-01-15")
 
-	count, err := suite.radioService.importPlays(ep.ID, []RadioPlayImport{})
+	count, dropSummary, err := suite.radioService.importPlays(ep.ID, []RadioPlayImport{})
 
 	suite.Require().NoError(err)
 	suite.Equal(0, count)
+	suite.Empty(dropSummary)
+}
+
+// PSY-885: validate-at-boundary tests for importPlays. Cover the four cases
+// enumerated in the ticket:
+//   - clean batch       → full count, empty summary
+//   - over-length title → truncated to 500 runes, summary records "truncated"
+//   - NULL artist_name  → row dropped, summary records "missing artist_name"
+//   - mixed batch       → only valid rows committed, summary reflects both
+//
+// Returned count is rows COMMITTED — drops are excluded.
+
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_TruncatesOverLengthArtistName() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	// 600-char artist name (overflows VARCHAR(500))
+	overLength := strings.Repeat("a", 600)
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: overLength},
+	}
+
+	count, dropSummary, err := suite.radioService.importPlays(ep.ID, plays)
+	suite.Require().NoError(err)
+	suite.Equal(1, count, "truncated row should still be committed")
+	// Summary counts truncated rows in N (per PSY-885 format spec) — "dropped"
+	// is used loosely to mean "required boundary intervention", with the
+	// per-class breakdown distinguishing salvage from data loss.
+	suite.Contains(dropSummary, "dropped 1 plays")
+	suite.Contains(dropSummary, "1 over-length titles truncated")
+
+	var dbPlays []catalogm.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).Find(&dbPlays)
+	suite.Len(dbPlays, 1)
+	suite.Equal(strings.Repeat("a", 500), dbPlays[0].ArtistName, "artist_name should be trimmed to 500 runes")
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_TruncatesOverLengthOptionalFields() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	overTitle := strings.Repeat("b", 600)
+	overAlbum := strings.Repeat("c", 700)
+	overLabel := strings.Repeat("d", 501)
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: "Boundary Band", TrackTitle: &overTitle, AlbumTitle: &overAlbum, LabelName: &overLabel},
+	}
+
+	count, dropSummary, err := suite.radioService.importPlays(ep.ID, plays)
+	suite.Require().NoError(err)
+	suite.Equal(1, count)
+	suite.Contains(dropSummary, "1 over-length titles truncated", "a single row with multiple over-length fields counts once")
+
+	var dbPlays []catalogm.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).Find(&dbPlays)
+	suite.Len(dbPlays, 1)
+	suite.Equal("Boundary Band", dbPlays[0].ArtistName)
+	suite.Require().NotNil(dbPlays[0].TrackTitle)
+	suite.Len([]rune(*dbPlays[0].TrackTitle), 500)
+	suite.Require().NotNil(dbPlays[0].AlbumTitle)
+	suite.Len([]rune(*dbPlays[0].AlbumTitle), 500)
+	suite.Require().NotNil(dbPlays[0].LabelName)
+	suite.Len([]rune(*dbPlays[0].LabelName), 500)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_TruncatesMultiByteRunesAtBoundary() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	// Each "é" is 2 UTF-8 bytes but 1 rune. 600 runes overflows.
+	overLength := strings.Repeat("é", 600)
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: overLength},
+	}
+
+	count, _, err := suite.radioService.importPlays(ep.ID, plays)
+	suite.Require().NoError(err, "truncation must respect rune boundaries, not split a multi-byte char")
+	suite.Equal(1, count)
+
+	var dbPlays []catalogm.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).Find(&dbPlays)
+	suite.Len(dbPlays, 1)
+	// Postgres counts characters (runes), not bytes — should fit 500 "é"s exactly.
+	suite.Equal(500, len([]rune(dbPlays[0].ArtistName)), "trimmed to 500 runes")
+	suite.True(utf8.ValidString(dbPlays[0].ArtistName), "trimmed string must remain valid UTF-8")
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_DropsMissingArtistName() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: ""},
+		{Position: 1, ArtistName: "   "}, // whitespace-only also dropped
+	}
+
+	count, dropSummary, err := suite.radioService.importPlays(ep.ID, plays)
+	suite.Require().NoError(err)
+	suite.Equal(0, count, "rows with NULL/blank artist_name must be dropped")
+	suite.Contains(dropSummary, "dropped 2 plays")
+	suite.Contains(dropSummary, "2 missing artist_name")
+
+	var playCount int64
+	suite.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", ep.ID).Count(&playCount)
+	suite.Equal(int64(0), playCount)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_MixedBatch() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	overLength := strings.Repeat("x", 600)
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: "Radiohead"},          // clean
+		{Position: 1, ArtistName: ""},                   // dropped: blank artist
+		{Position: 2, ArtistName: overLength},           // truncated
+		{Position: 3, ArtistName: "Deerhunter"},         // clean
+		{Position: 4, ArtistName: "Sonic Youth"},        // clean
+		{Position: 5, ArtistName: "  \t  "},             // dropped: whitespace-only
+	}
+
+	count, dropSummary, err := suite.radioService.importPlays(ep.ID, plays)
+	suite.Require().NoError(err)
+	// 4 rows commit: Radiohead, Deerhunter, Sonic Youth, truncated overLength row.
+	// 2 rows drop: the two blank artist_name rows.
+	suite.Equal(4, count, "return value must reflect rows COMMITTED, not rows received")
+
+	// Summary covers BOTH classes in one line, no per-play entries. The
+	// PSY-885 format counts truncated + missing as the leading N: 1 + 2 = 3.
+	suite.Contains(dropSummary, "dropped 3 plays")
+	suite.Contains(dropSummary, "1 over-length titles truncated")
+	suite.Contains(dropSummary, "2 missing artist_name")
+	suite.Equal(1, strings.Count(dropSummary, "\n")+1, "summary must be a single line")
+
+	var dbPlays []catalogm.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).Order("position ASC").Find(&dbPlays)
+	suite.Len(dbPlays, 4)
+	suite.Equal("Radiohead", dbPlays[0].ArtistName)
+	suite.Equal(strings.Repeat("x", 500), dbPlays[1].ArtistName, "truncated row preserved at its position")
+	suite.Equal("Deerhunter", dbPlays[2].ArtistName)
+	suite.Equal("Sonic Youth", dbPlays[3].ArtistName)
 }
 
 func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_LabelCaseInsensitive() {

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -353,9 +353,17 @@ type RadioDiscoverResult struct {
 }
 
 // EpisodeImportResult summarizes the result of importing a single episode's playlist.
+//
+// DropSummary, when non-empty, is a single-line per-episode aggregate of plays
+// that were dropped or truncated at the import boundary (PSY-885). Format:
+// "dropped N plays: X over-length titles truncated, Y missing artist_name".
+// The summary is also bubbled up to RadioImportResult.Errors by the batch
+// orchestrators so partial-import outcomes are visible in admin job logs
+// without ballooning the field with per-play entries.
 type EpisodeImportResult struct {
-	PlaysImported int `json:"plays_imported"`
-	PlaysMatched  int `json:"plays_matched"`
+	PlaysImported int    `json:"plays_imported"`
+	PlaysMatched  int    `json:"plays_matched"`
+	DropSummary   string `json:"drop_summary,omitempty"`
 }
 
 // MatchResult summarizes the result of running the matching engine.


### PR DESCRIPTION
## Summary
- `importPlays` now passes every provider-returned `RadioPlayImport` through a `sanitizePlay` boundary checkpoint before `CreateInBatches`, so one malformed row (NULL artist_name, VARCHAR(500) overflow) no longer poisons its 100-row GORM batch transaction and silently drops 99 sibling rows.
- Return value now reflects rows COMMITTED (not rows received). Per-episode summary `dropped N plays: X over-length titles truncated, Y missing artist_name` bubbles up via new `EpisodeImportResult.DropSummary` field into `RadioImportResult.Errors` at all three batch orchestrators (`ImportStation`, `FetchNewEpisodes`, `importShowEpisodesWithProgress`), so partial-import outcomes show up in admin job logs without per-play ballooning.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/catalog/...` — passed (2 consecutive runs, 30.2s + 30.8s post-review-fix)

## Manual repro
Stack mode: `--mode=none` (backend-only, no migration). Per the `--mode=none` carveout (PSY-592 canonical), the seven new integration tests in `TestRadioImportIntegrationTestSuite` serve as the manual repro. They drive the real Postgres testcontainer through the validate-at-boundary path and assert per-class outcomes:

| Test | Outcome |
| --- | --- |
| `TestImportPlays_BatchInsert` (clean batch) | 3 of 3 commit; `DropSummary == ""` |
| `TestImportPlays_TruncatesOverLengthArtistName` | 1 of 1 commits with 500-rune artist_name; summary `dropped 1 plays: 1 over-length titles truncated` |
| `TestImportPlays_TruncatesOverLengthOptionalFields` | 1 row with all four VARCHAR(500) fields overflown commits with each trimmed to 500 runes; summary counts the row once (not four times) |
| `TestImportPlays_TruncatesMultiByteRunesAtBoundary` | 600× `é` → 500× `é`, output remains valid UTF-8 (no split multi-byte sequence) |
| `TestImportPlays_DropsMissingArtistName` | empty + whitespace-only both drop; 0 commit; summary `dropped 2 plays: 2 missing artist_name` |
| `TestImportPlays_MixedBatch` | 6 rows in, 4 commit, 2 drop, 1 truncated row preserved at its position; summary `dropped 3 plays: 1 over-length titles truncated, 2 missing artist_name` on a single line |
| `TestImportPlays_Empty` | 0 in / 0 out / `""` summary |

## Code review
Inline 3-lens self-review (sub-agents unavailable from worktree per `pattern_subagent_inline_code_review.md`). Surfaced one latent-defect class: a future-added `sanitizePlay` error type without a matching per-class counter would silently undercount `dropped N`. Fixed in commit `5cda43af` by computing droppedCount from `len(plays) - len(records)` (authoritative delta) instead of summing per-class counters. No other findings.

Closes PSY-885