### PR TITLE
PSY-888: radio importPlays — ON CONFLICT DO NOTHING + unique index

### DIFF
--- a/backend/db/migrations/20260528172125_radio_plays_unique_index.down.sql
+++ b/backend/db/migrations/20260528172125_radio_plays_unique_index.down.sql
@@ -1,0 +1,3 @@
+-- PSY-888: Drop the radio_plays dedup unique index.
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_radio_plays_unique;

--- a/backend/db/migrations/20260528172125_radio_plays_unique_index.up.sql
+++ b/backend/db/migrations/20260528172125_radio_plays_unique_index.up.sql
@@ -1,0 +1,31 @@
+-- PSY-888: Unique index for radio_plays dedup so importPlays can use
+-- ON CONFLICT DO NOTHING on re-imports.
+--
+-- Re-running a radio playlist fetch (chronic during dev / scheduled re-fetches)
+-- previously rolled back the entire 100-row batch insert on any duplicate row.
+--
+-- Dedup key shape: (episode_id, position, air_timestamp, artist_name,
+-- track_title). Including `position` is necessary because:
+--   * `position` is non-nullable; the other three are nullable/NULL across
+--     providers (NTS never sets air_timestamp).
+--   * Real radio episodes legitimately play the same artist multiple
+--     times in one episode (different tracks, same artist). Without
+--     position in the key, two such plays would collide and one would be
+--     silently lost on re-import.
+--   * Providers assign `position` deterministically from the parsed
+--     playlist index, so identical re-fetches produce identical
+--     positions, making this a stable dedup key for the re-import case.
+--
+-- NULLS NOT DISTINCT (Postgres 15+) is still required because for the
+-- common case (same row re-inserted with NULL air_timestamp / NULL
+-- track_title), Postgres' default NULL-is-distinct semantics would treat
+-- the new row as non-conflicting and insert it.
+--
+-- CONCURRENTLY is safe here because this file contains a single statement;
+-- golang-migrate v4 wraps multi-statement .up.sql files in a transaction
+-- which is incompatible with CREATE INDEX CONCURRENTLY. See the
+-- 20260528160326 unaccent migration for the multi-statement case where
+-- CONCURRENTLY was intentionally dropped.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_radio_plays_unique
+  ON radio_plays (episode_id, position, air_timestamp, artist_name, track_title)
+  NULLS NOT DISTINCT;

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
@@ -617,12 +618,31 @@ func (s *RadioService) importPlays(episodeID uint, plays []RadioPlayImport) (int
 		return 0, summary, nil
 	}
 
-	// Batch insert. Records are pre-validated, so a constraint failure here
-	// is a hard infrastructural error (FK gone, conn lost) — bubble it up.
-	if err := s.db.CreateInBatches(records, 100).Error; err != nil {
+	// Batch insert with ON CONFLICT DO NOTHING so duplicate rows (re-imports
+	// of the same playlist; chronic during dev / scheduled re-fetches) are
+	// silently skipped rather than rolling back the entire 100-row batch.
+	// Dedup is enforced by the idx_radio_plays_unique UNIQUE index on
+	// (episode_id, position, air_timestamp, artist_name, track_title) NULLS
+	// NOT DISTINCT (PSY-888 migration). Records are pre-validated (PSY-885), so
+	// a non-UNIQUE constraint violation here (FK gone, NOT NULL) is a hard
+	// infrastructural error — bubble it up.
+	result := s.db.Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(records, 100)
+	if err := result.Error; err != nil {
 		return 0, summary, fmt.Errorf("batch inserting plays: %w", err)
 	}
 
+	if skipped := len(records) - int(result.RowsAffected); skipped > 0 {
+		slog.Info("radio import: skipped duplicate plays",
+			"episode_id", episodeID,
+			"skipped", skipped,
+			"total", len(records),
+		)
+	}
+
+	// Return len(records) (attempted) rather than RowsAffected (newly
+	// inserted) so callers like importEpisode keep using it to set
+	// play_count on the episode without regressing on re-imports where
+	// most rows are duplicates. summary carries the PSY-885 drop aggregate.
 	return len(records), summary, nil
 }
 

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -1618,6 +1618,106 @@ func (suite *RadioImportIntegrationTestSuite) TestImportPlays_MixedBatch() {
 	suite.Equal("Sonic Youth", dbPlays[3].ArtistName)
 }
 
+// PSY-888: Re-importing the same playlist must succeed without error and
+// without inserting duplicate rows. Before the ON CONFLICT DO NOTHING +
+// idx_radio_plays_unique migration, the second call rolled back the whole
+// 100-row batch and returned an error.
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_DedupOnReimport() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	track1 := "Karma Police"
+	track2 := "Cover Me"
+	ts1 := time.Date(2026, 1, 15, 9, 5, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 1, 15, 9, 10, 0, 0, time.UTC)
+
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: "Radiohead", TrackTitle: &track1, AirTimestamp: &ts1},
+		{Position: 1, ArtistName: "Deerhunter", TrackTitle: &track2, AirTimestamp: &ts2},
+		// NULL track + NULL air_timestamp — covers the NTS-style case where
+		// NULLS NOT DISTINCT must engage for dedup to work.
+		{Position: 2, ArtistName: "Sonic Youth"},
+	}
+
+	// First import — all three rows inserted.
+	count, _, err := suite.radioService.importPlays(ep.ID, plays)
+	suite.Require().NoError(err)
+	suite.Equal(3, count)
+
+	var dbCount int64
+	suite.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", ep.ID).Count(&dbCount)
+	suite.Equal(int64(3), dbCount, "first import should insert all 3 rows")
+
+	// Second import (re-fetch) — same playlist, no new rows, no error.
+	count2, _, err := suite.radioService.importPlays(ep.ID, plays)
+	suite.Require().NoError(err, "re-importing duplicates must not error")
+	suite.Equal(3, count2, "importPlays returns attempted count for play_count stability")
+
+	suite.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", ep.ID).Count(&dbCount)
+	suite.Equal(int64(3), dbCount, "re-import must not insert duplicate rows")
+}
+
+// PSY-888: A mixed batch (some duplicates of prior rows + some genuinely
+// new rows) should insert ONLY the new rows and not fail. This is the
+// real-world re-fetch-with-new-songs case.
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_PartialOverlapInsertsNewOnly() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	track1 := "Karma Police"
+	track2 := "Cover Me"
+	track3 := "Mountain"
+	ts1 := time.Date(2026, 1, 15, 9, 5, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 1, 15, 9, 10, 0, 0, time.UTC)
+	ts3 := time.Date(2026, 1, 15, 9, 15, 0, 0, time.UTC)
+
+	firstBatch := []RadioPlayImport{
+		{Position: 0, ArtistName: "Radiohead", TrackTitle: &track1, AirTimestamp: &ts1},
+		{Position: 1, ArtistName: "Deerhunter", TrackTitle: &track2, AirTimestamp: &ts2},
+	}
+	_, _, err := suite.radioService.importPlays(ep.ID, firstBatch)
+	suite.Require().NoError(err)
+
+	// Second fetch — first two are dupes, third is new.
+	secondBatch := []RadioPlayImport{
+		{Position: 0, ArtistName: "Radiohead", TrackTitle: &track1, AirTimestamp: &ts1},
+		{Position: 1, ArtistName: "Deerhunter", TrackTitle: &track2, AirTimestamp: &ts2},
+		{Position: 2, ArtistName: "Cocteau Twins", TrackTitle: &track3, AirTimestamp: &ts3},
+	}
+	_, _, err = suite.radioService.importPlays(ep.ID, secondBatch)
+	suite.Require().NoError(err, "partial overlap must not roll back the batch")
+
+	var dbCount int64
+	suite.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", ep.ID).Count(&dbCount)
+	suite.Equal(int64(3), dbCount, "must end with 3 rows (2 original + 1 new)")
+}
+
+// PSY-888: ON CONFLICT DO NOTHING only masks UNIQUE violations. Other
+// constraint failures (e.g. NOT NULL or FK) must still surface as errors
+// to the caller — they indicate a genuine data bug, not a re-import
+// collision. AC explicitly calls this out.
+//
+// Real-world plays always carry a non-empty ArtistName (providers skip
+// blank artists), so we use a FK violation instead — a play with a
+// non-existent episode_id triggers the FK to radio_episodes. FK is a
+// different constraint kind than UNIQUE, so ON CONFLICT DO NOTHING does
+// NOT swallow it.
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_NonUniqueConstraintViolationErrors() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: "Radiohead"},
+	}
+
+	// Use a non-existent episode ID so the FK to radio_episodes fires.
+	_, _, err := suite.radioService.importPlays(ep.ID+99999, plays)
+	suite.Require().Error(err, "non-UNIQUE constraint failures must still surface as errors")
+}
+
 func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_LabelCaseInsensitive() {
 	station := suite.createStation("KEXP")
 	show := suite.createShow(station.ID, "Morning Show")

--- a/backend/internal/services/catalog/radio_unmatched_test.go
+++ b/backend/internal/services/catalog/radio_unmatched_test.go
@@ -115,13 +115,19 @@ func (s *RadioUnmatchedSuite) createTestEpisode(showID uint, airDate string) *ca
 	return ep
 }
 
-// createTestPlay creates a radio play for testing.
+// createTestPlay creates a radio play for testing. Position is auto-assigned
+// based on existing plays for the episode so the PSY-888 unique index
+// (episode_id, position, air_timestamp, artist_name, track_title) NULLS NOT
+// DISTINCT is satisfied when a test inserts multiple plays for the same
+// artist in one episode — real providers always assign distinct positions.
 func (s *RadioUnmatchedSuite) createTestPlay(episodeID uint, artistName string, artistID *uint) *catalogm.RadioPlay {
+	var existing int64
+	s.Require().NoError(s.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", episodeID).Count(&existing).Error)
 	play := &catalogm.RadioPlay{
 		EpisodeID:  episodeID,
 		ArtistName: artistName,
 		ArtistID:   artistID,
-		Position:   0,
+		Position:   int(existing),
 	}
 	s.Require().NoError(s.db.Create(play).Error)
 	return play


### PR DESCRIPTION
## Summary
- Wrap `importPlays`'s `CreateInBatches` with `clause.OnConflict{DoNothing: true}` so re-imports of the same playlist (chronic during dev / scheduled re-fetches) silently skip duplicate rows instead of rolling back the entire 100-row batch. Non-UNIQUE constraint violations (FK, NOT NULL) still surface as errors.
- Add a migration creating `idx_radio_plays_unique` on `radio_plays(episode_id, position, air_timestamp, artist_name, track_title) NULLS NOT DISTINCT` so the dedup key actually fires. `position` is included to preserve the legitimate "same artist played multiple times in one episode" case; `NULLS NOT DISTINCT` (PG15+) handles providers like NTS that never populate `air_timestamp`.
- Log skipped duplicate count at `slog.Info` for visibility; return `len(records)` (not `RowsAffected`) so `importEpisode`'s `play_count = imported` write stays stable on re-import.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/catalog/... -count=1` — passed twice consecutively (33s, 32s)
- [x] Migration up→down→up round-trip via `migrate/migrate:latest` against isolated postgres:18 — clean (index appears, drops, reappears with identical definition `(episode_id, "position", air_timestamp, artist_name, track_title) NULLS NOT DISTINCT`)

## Manual repro
- `TestImportPlays_DedupOnReimport`: insert 3 plays (including one with NULL track + NULL air_timestamp covering the NTS case), call `importPlays` again with the same batch — second call returns no error, `radio_plays` row count stays at 3. Log line confirms `skipped=3 total=3`.
- `TestImportPlays_PartialOverlapInsertsNewOnly`: first batch of 2 plays, then a second batch of 3 (2 dupes + 1 new) — final row count is 3, no error.
- `TestImportPlays_NonUniqueConstraintViolationErrors`: importing into a non-existent `episode_id` triggers the FK to `radio_episodes`, which surfaces as an error (proves Option A only masks UNIQUE).

## Code review
Inline 5-angle + sweep review against the diff (sub-agent context has no Agent tool, per `pattern_subagent_inline_code_review`); zero findings — change is mechanical, scope is tight, behavior change is exactly the intended dedup.

## Notes
- The unique-index shape was tuned during implementation: the initial `(episode_id, air_timestamp, artist_name, track_title)` shape broke existing tests that insert "same artist twice in same episode" (legitimate radio behavior). Adding `position` to the key resolves it without weakening dedup, because providers (KEXP/WFMU/NTS) all assign `position` deterministically from the parsed playlist index, so identical re-fetches produce identical positions.
- `radio_unmatched_test.go`'s `createTestPlay` helper now auto-assigns position by counting existing plays per episode, matching real provider behavior (was previously hardcoded `Position: 0` which would only be valid for a single play per episode under the new index).

Closes PSY-888