### PR TITLE
PSY-722: add e2e for radio browse flow (hub → station → show)

### DIFF
--- a/frontend/e2e/pages/radio.spec.ts
+++ b/frontend/e2e/pages/radio.spec.ts
@@ -1,0 +1,166 @@
+import { test } from '../fixtures/error-detection'
+import { expect } from '@playwright/test'
+
+/**
+ * PSY-722: end-to-end coverage for the public radio browse flow.
+ *
+ * Phase 2d shipped a full provider integration (KEXP / WFMU / NTS) with no
+ * E2E signal. This spec walks the read-only navigation chain a visitor
+ * follows from the radio hub down into a single show:
+ *
+ *   /radio  →  /radio/{station-slug}  →  /radio/{station-slug}/{show-slug}
+ *
+ * Selectors prefer `getByRole`/`getByText` over class selectors (PSY-859
+ * anti-false-coverage guidance). Card titles are single outer `<Link>`s via
+ * `EntityCardTitle`, so `getByRole('link', { name })` resolves cleanly under
+ * Playwright strict mode.
+ *
+ * SCOPING NOTE: the persistent left Sidebar (components/layout/Sidebar.tsx)
+ * renders a `<Link href="/radio">Radio</Link>` that is visible at the
+ * Playwright desktop viewport (the `<aside>` is `hidden md:flex`). To keep
+ * the page-content assertions unambiguous under strict mode, link/heading
+ * queries are scoped to the page's `<main>` (`page.getByRole('main')`),
+ * which excludes the sidebar `<aside>` and the TopBar.
+ *
+ * SEED SCOPE (verified against backend/internal/seeddata/radio.go, rendered
+ * by cmd/gen-e2e-seed into frontend/e2e/setup-db.sh):
+ *   - radio_networks: 1 (wfmu)
+ *   - radio_stations: 6 (kexp, wfmu + 3 wfmu sub-channels, nts-radio)
+ *   - radio_shows:   13 (6 KEXP, 4 WFMU, 3 NTS)
+ *   - radio_episodes: 0   <-- NOT seeded
+ *   - radio_plays:    0   <-- NOT seeded
+ *
+ * Consequence: there is no episode row to click into, no tracklist to
+ * assert, and no artist with radio plays to surface an "As Heard On" link.
+ * Those two acceptance-criteria cases (episode detail + tracklist; artist
+ * "As Heard On" → station) are therefore NOT covered here — exercising them
+ * would require seeding episode + play fixtures the pipeline only produces
+ * live in prod. The show-detail test instead asserts the page renders its
+ * "Recent Episodes" section gracefully with the seeded (empty) episode set.
+ * See the PR's scope-deviation note for the recommended seed follow-up.
+ *
+ * Stable seeded slugs used below:
+ *   - station "KEXP"             -> /radio/kexp        (network-less, 1-segment URL)
+ *   - show    "The Morning Show" -> slug the-morning-show, host John Richards
+ */
+
+const KEXP_STATION_NAME = 'KEXP'
+const KEXP_SLUG = 'kexp'
+const KEXP_SHOW_NAME = 'The Morning Show'
+const KEXP_SHOW_SLUG = 'the-morning-show'
+
+test.describe('Radio browse flow', () => {
+  test('/radio loads and lists seeded stations', async ({ page }) => {
+    await page.goto('/radio')
+    const main = page.getByRole('main')
+
+    // Page-level identity heading.
+    await expect(
+      main.getByRole('heading', { name: 'Radio', level: 1 })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Station cards render as links. KEXP / WFMU / NTS are the three
+    // index-visible stations (the 3 WFMU sub-channels are hidden by
+    // isStationVisibleOnIndex per PSY-673).
+    await expect(
+      main.getByRole('link', { name: KEXP_STATION_NAME })
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(main.getByRole('link', { name: 'WFMU' })).toBeVisible()
+    await expect(main.getByRole('link', { name: 'NTS Radio' })).toBeVisible()
+  })
+
+  test('clicking a station opens station detail and lists its shows', async ({
+    page,
+  }) => {
+    await page.goto('/radio')
+
+    // Click into KEXP (network-less → 1-segment /radio/kexp URL).
+    const stationLink = page
+      .getByRole('main')
+      .getByRole('link', { name: KEXP_STATION_NAME })
+    await expect(stationLink).toBeVisible({ timeout: 10_000 })
+    await stationLink.click()
+
+    await page.waitForURL(new RegExp(`/radio/${KEXP_SLUG}(\\?|$)`), {
+      timeout: 10_000,
+    })
+
+    const main = page.getByRole('main')
+
+    // Station H1 carries the station name (network-less stations render the
+    // station name as the page H1; networked stations render the network
+    // name there instead — KEXP has no network so this holds).
+    await expect(
+      main.getByRole('heading', { name: KEXP_STATION_NAME, level: 1 })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // "Shows" section heading is rendered unconditionally on station detail.
+    await expect(main.getByRole('heading', { name: 'Shows' })).toBeVisible()
+
+    // At least one seeded show card link is present (KEXP seeds 6 shows).
+    await expect(
+      main.getByRole('link', { name: KEXP_SHOW_NAME })
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('clicking a show opens show detail with its episodes section', async ({
+    page,
+  }) => {
+    // Start at the station so the click target is the real rendered show
+    // card link (not a hand-built URL).
+    await page.goto(`/radio/${KEXP_SLUG}`)
+
+    const showLink = page
+      .getByRole('main')
+      .getByRole('link', { name: KEXP_SHOW_NAME })
+    await expect(showLink).toBeVisible({ timeout: 10_000 })
+    await showLink.click()
+
+    await page.waitForURL(
+      new RegExp(`/radio/${KEXP_SLUG}/${KEXP_SHOW_SLUG}(\\?|$)`),
+      { timeout: 10_000 }
+    )
+
+    const main = page.getByRole('main')
+
+    // Show H1 is the show name.
+    await expect(
+      main.getByRole('heading', { name: KEXP_SHOW_NAME, level: 1 })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Breadcrumb links back up the chain (Radio + the station name). The
+    // station name appears in both the breadcrumb and the "on {station}"
+    // line, so allow more than one match via `.first()`.
+    await expect(main.getByRole('link', { name: 'Radio' })).toBeVisible()
+    await expect(
+      main.getByRole('link', { name: KEXP_STATION_NAME }).first()
+    ).toBeVisible()
+
+    // "Recent Episodes" section renders. The E2E seed has no episodes, so
+    // this asserts the empty-state path resolves gracefully (the section
+    // heading shows + the "No episodes yet" copy renders) rather than
+    // erroring. The populated-episode + tracklist flow is not seedable here
+    // (see file header + PR scope note).
+    await expect(
+      main.getByRole('heading', { name: /recent episodes/i })
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(main.getByText('No episodes yet')).toBeVisible()
+  })
+
+  test('station detail breadcrumb returns to the radio hub', async ({
+    page,
+  }) => {
+    await page.goto(`/radio/${KEXP_SLUG}`)
+
+    // The in-page breadcrumb "Radio" link (scoped to <main> to avoid the
+    // sidebar's own /radio nav link).
+    const breadcrumb = page.getByRole('main').getByRole('link', { name: 'Radio' })
+    await expect(breadcrumb).toBeVisible({ timeout: 10_000 })
+    await breadcrumb.click()
+
+    await page.waitForURL(/\/radio(\?|$)/, { timeout: 10_000 })
+    await expect(
+      page.getByRole('main').getByRole('heading', { name: 'Radio', level: 1 })
+    ).toBeVisible({ timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `frontend/e2e/pages/radio.spec.ts` — first e2e coverage for the public radio browse flow (Phase 2d shipped the KEXP/WFMU/NTS integration with zero e2e signal).
- 4 cases walking the read-only chain `/radio → /radio/{station-slug} → /radio/{station-slug}/{show-slug}`:
  1. `/radio` loads + lists seeded stations (KEXP / WFMU / NTS Radio links visible)
  2. Click a station card → station detail loads, H1 = station name, "Shows" section + seeded show link present
  3. Click a show card → show detail loads, H1 = show name, breadcrumb + "Recent Episodes" section render
  4. Station-detail breadcrumb returns to the radio hub
- Selectors use `getByRole`/`getByText` (PSY-859 anti-false-coverage). Queries are scoped to the page `<main>` so the persistent sidebar's own `/radio` nav link doesn't trip Playwright strict mode.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed (clean; worktree needed `bun install` first)
- [x] `cd frontend && bun run test:e2e -- radio` — passed (2 runs: 4 passed/31.4s, 4 passed/18.9s)

## Manual repro
The e2e spec IS the manual repro — it drives the real browser against the real backend. Backend logs over the run confirmed the navigation chain hit live endpoints: `GET /radio-stations`, `/radio-stations/kexp`, `/radio-shows`, `/radio-shows/the-morning-show`, `/radio-shows/the-morning-show/episodes`. Observed:
- Hub renders the "Radio" H1 + KEXP/WFMU/NTS station cards.
- Clicking KEXP → URL `/radio/kexp`, H1 "KEXP", "Shows" heading, "The Morning Show" card link.
- Clicking the show → URL `/radio/kexp/the-morning-show`, H1 "The Morning Show", breadcrumb, "Recent Episodes" + the empty-state "No episodes yet" (seed has no episodes — see below).
- Breadcrumb "Radio" → back to `/radio`.

The `error-detection` fixture (auto-fails on any console.error / failed request / 5xx) passed on every case, confirming the assertions pass on real rendered content, not on error/empty states for the wrong reason.

## Scope deviation
The e2e seed (`backend/internal/seeddata/radio.go`, rendered by `cmd/gen-e2e-seed` into `setup-db.sh`) seeds **networks + stations + shows but NOT `radio_episodes` or `radio_plays`** — those only exist via the live fetcher pipeline in prod. Two AC cases are therefore NOT covered, because they cannot be exercised via real navigation without fabricating seed fixtures:
- **Episode detail + tracklist** — no episode row exists to click into; the episode-date route renders "Episode Not Found".
- **Artist "As Heard On" → radio station** — `AsHeardOn` self-hides when there are zero plays (`items.length === 0`), so no link renders on any artist page.

The show-detail test instead asserts the "Recent Episodes" empty-state renders gracefully. Writing `.skip`/"Not Found" assertions for the two uncovered cases would be false coverage (PSY-859), so they're omitted.

**Recommended follow-up:** file a ticket to seed a minimal episode + plays fixture (1 episode under `the-morning-show` with a few `radio_plays`, at least one play linked to a seeded artist like `jimmy-eat-world`/`ajj`) so the episode-detail/tracklist + artist "As Heard On" flows become e2e-coverable. This is a seed-data change in `seeddata/radio.go` + the SQL renderer, not a frontend change.

## Code review
`/code-review` (max effort, inline 9-angle + verify + sweep): no findings — diff is a single test-only file; the latent two-`<main>` scoping was examined and refuted (nested mains dedup to single DOM nodes; strict-mode `.click()` passed twice).

Closes PSY-722