### PR TITLE
PSY-866: typed ACCOUNT_INACTIVE error for deactivated accounts

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -115,6 +115,20 @@ func (h *AuthHandler) LoginHandler(ctx context.Context, input *LoginRequest) (*L
 				resp.Body.Message = authErr.UserMessage()
 				resp.Body.ErrorCode = autherrors.ToExternalCode(autherrors.CodeInvalidCredentials)
 				return resp, nil
+			case autherrors.CodeAccountInactive:
+				// Deactivated account (is_active = false). The account exists in
+				// a known state and the service is healthy, so this is NOT a
+				// fail-closed 5xx — return HTTP 200 with the distinct
+				// ACCOUNT_INACTIVE code so the frontend can show contact-support
+				// copy. The password check already ran (no extra enumeration
+				// signal); the user-facing message stays intentionally vague.
+				logger.AuthWarn(ctx, "login_account_inactive",
+					"email_hash", logger.HashEmail(input.Body.Email),
+				)
+				resp.Body.Success = false
+				resp.Body.Message = authErr.UserMessage()
+				resp.Body.ErrorCode = autherrors.CodeAccountInactive
+				return resp, nil
 			case autherrors.CodeServiceUnavailable:
 				// Fail-closed surface from AuthenticateUserWithPassword: the
 				// lockout-counter write failed, so we cannot let the request

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -856,6 +856,51 @@ func TestLoginHandler_AccountLocked(t *testing.T) {
 	}
 }
 
+// TestLoginHandler_AccountInactive asserts the PSY-866 contract: when
+// AuthenticateUserWithPassword returns a CodeAccountInactive AuthError
+// (deactivated account, is_active = false), the handler returns HTTP 200
+// (nil error) with Success=false, the distinct ACCOUNT_INACTIVE code, and the
+// chosen contact-support message — NOT a fail-closed 5xx via the default arm.
+func TestLoginHandler_AccountInactive(t *testing.T) {
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			AuthenticateUserWithPasswordFn: func(email, password string) (*authm.User, error) {
+				return nil, autherrors.ErrAccountInactive()
+			},
+		}
+	})
+
+	input := &LoginRequest{}
+	input.Body.Email = "inactive@example.com"
+	input.Body.Password = "CorrectPassword1!"
+
+	resp, err := h.LoginHandler(context.Background(), input)
+
+	// HTTP 200: the account state is known and the service is healthy, so the
+	// handler must NOT return an error (which would push Huma into the 5xx band).
+	if err != nil {
+		t.Fatalf("expected nil error (HTTP 200), got %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeAccountInactive {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeAccountInactive, resp.Body.ErrorCode)
+	}
+	if resp.Body.Message != "Account unavailable. Please contact support." {
+		t.Errorf("expected contact-support message, got %q", resp.Body.Message)
+	}
+	// Regression guard: an inactive account must NOT be downgraded to the
+	// fail-closed SERVICE_UNAVAILABLE shape (the default-arm behavior before
+	// the explicit case was added).
+	if resp.Body.ErrorCode == autherrors.CodeServiceUnavailable {
+		t.Error("regression: ACCOUNT_INACTIVE must not be downgraded to SERVICE_UNAVAILABLE")
+	}
+}
+
 // TestLoginHandler_ServiceUnavailable asserts that a CodeServiceUnavailable
 // AuthError from AuthenticateUserWithPassword (the PSY-861 fail-closed signal
 // emitted when IncrementFailedAttempts errors) propagates as a real error to

--- a/backend/internal/errors/auth.go
+++ b/backend/internal/errors/auth.go
@@ -29,6 +29,11 @@ const (
 	CodeUnknown = "UNKNOWN"
 	// CodeAccountLocked indicates the account is locked due to too many failed attempts
 	CodeAccountLocked = "ACCOUNT_LOCKED"
+	// CodeAccountInactive indicates the account exists but has been deactivated
+	// (is_active = false). Distinct from CodeInvalidCredentials so the frontend
+	// can special-case the copy; the password check still ran, so this is not an
+	// enumeration oracle beyond what login already exposes.
+	CodeAccountInactive = "ACCOUNT_INACTIVE"
 	// CodeNoPasswordSet indicates the user has no password (OAuth-only account)
 	CodeNoPasswordSet = "NO_PASSWORD_SET"
 	// CodeTermsAcceptanceRequired indicates an OAuth signup arrived without the
@@ -159,6 +164,18 @@ func ErrAccountLockedWithMinutes(minutes int) *AuthError {
 	}
 }
 
+// ErrAccountInactive creates an error for a deactivated account (is_active = false).
+// The user-facing message is intentionally vague ("Account unavailable. Please
+// contact support.") rather than naming deactivation: the password check has
+// already run, so this carries no enumeration signal beyond what login leaks,
+// but the vaguer copy avoids confirming the deactivation reason to a guesser.
+func ErrAccountInactive() *AuthError {
+	return &AuthError{
+		Code:    CodeAccountInactive,
+		Message: "Account unavailable. Please contact support.",
+	}
+}
+
 // ErrNoPasswordSet creates an error for OAuth-only accounts that don't have a password.
 func ErrNoPasswordSet() *AuthError {
 	return NewAuthError(CodeNoPasswordSet, "Cannot change password for OAuth-only accounts", nil)
@@ -187,6 +204,11 @@ func ToExternalCode(code string) string {
 	switch code {
 	case CodeUserNotFound:
 		return CodeInvalidCredentials
+	case CodeAccountInactive:
+		// Deactivated accounts are NOT enumeration-sensitive: the password
+		// check already ran, so login already leaks existence on a correct
+		// password. Keep the code distinct so the frontend can special-case it.
+		return CodeAccountInactive
 	default:
 		return code
 	}
@@ -211,6 +233,8 @@ func ToExternalMessage(code string) string {
 		return "Validation failed"
 	case CodeAccountLocked:
 		return "Account temporarily locked. Please try again later."
+	case CodeAccountInactive:
+		return "Account unavailable. Please contact support."
 	case CodeNoPasswordSet:
 		return "Cannot change password for OAuth-only accounts"
 	default:

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -383,7 +383,7 @@ func (s *UserService) AuthenticateUserWithPassword(email, password string) (*aut
 	}
 
 	if !user.IsActive {
-		return nil, fmt.Errorf("user account is not active")
+		return nil, apperrors.ErrAccountInactive()
 	}
 
 	// Reset failed attempts on successful login. Log + continue on failure:

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -989,7 +989,40 @@ func (suite *UserServiceIntegrationTestSuite) TestAuthenticate_InactiveUser() {
 
 	suite.Require().Error(err)
 	suite.Nil(user)
-	suite.Contains(err.Error(), "user account is not active")
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr))
+	suite.Equal(apperrors.CodeAccountInactive, authErr.Code)
+}
+
+// TestAuthenticateUserWithPassword_InactiveAccountReturnsTyped asserts the
+// PSY-866 contract: a deactivated account (is_active = false) that passes the
+// password check MUST surface a typed *apperrors.AuthError with
+// CodeAccountInactive — NOT a bare fmt.Errorf. The typed error lets
+// LoginHandler return HTTP 200 + ACCOUNT_INACTIVE instead of falling through
+// the post-PSY-864 fail-closed outer fallback to a 5xx.
+func (suite *UserServiceIntegrationTestSuite) TestAuthenticateUserWithPassword_InactiveAccountReturnsTyped() {
+	_, err := suite.userService.CreateUserWithPassword(
+		"inactive-typed@example.com", "CorrectPassword1!", "Inactive", "Typed",
+	)
+	suite.Require().NoError(err)
+
+	// Deactivate the account (is_active = false) AFTER creation so the
+	// password verification still runs — exercising the !user.IsActive branch
+	// that fires only once the credentials match.
+	suite.db.Model(&authm.User{}).Where("email = ?", "inactive-typed@example.com").
+		Update("is_active", false)
+
+	user, err := suite.userService.AuthenticateUserWithPassword(
+		"inactive-typed@example.com", "CorrectPassword1!",
+	)
+
+	suite.Require().Error(err)
+	suite.Nil(user)
+
+	var authErr *apperrors.AuthError
+	suite.Require().True(errors.As(err, &authErr),
+		"expected *apperrors.AuthError, got %T", err)
+	suite.Equal(apperrors.CodeAccountInactive, authErr.Code)
 }
 
 // TestAuthenticateUserWithPassword_IncrementErrorFailsClosed asserts the


### PR DESCRIPTION
## Summary
- `AuthenticateUserWithPassword` returned a bare `fmt.Errorf` for the `!user.IsActive` branch. Post-PSY-864 that fell through `LoginHandler`'s fail-closed outer fallback → HTTP 5xx + `SERVICE_UNAVAILABLE`. Wrong UX: the account exists in a known state and the service is healthy.
- Added typed `CodeAccountInactive` (`"ACCOUNT_INACTIVE"`) + `ErrAccountInactive()` constructor in `backend/internal/errors/auth.go` (mirrors `ErrAccountLockedWithMinutes`'s struct-literal shape), plus `ToExternalCode`/`ToExternalMessage` mappings (external code == internal code — inactive accounts aren't enumeration-sensitive; the password check already ran).
- Service now returns `apperrors.ErrAccountInactive()` at the `!user.IsActive` branch.
- `LoginHandler` gets an explicit `case autherrors.CodeAccountInactive:` arm (modeled on the `CodeAccountLocked` arm) → HTTP 200, `Success=false`, `ErrorCode=ACCOUNT_INACTIVE`, `Message=authErr.UserMessage()`, with a `login_account_inactive` warn log carrying the hashed email.

**Chosen UX copy (per ticket decision):** user-facing `Message = "Account unavailable. Please contact support."` — the deliberately vaguer, enumeration-safe copy. `ErrorCode` stays the distinct `ACCOUNT_INACTIVE` so the frontend can special-case it.

**Frontend coordination (follow-up — NOT in this PR):** the frontend `AuthErrorCode` map at `frontend/lib/errors/authErrors.ts` (whose header comment says "must match backend/internal/errors/auth.go") does NOT yet have an `ACCOUNT_INACTIVE` member. The backend code still reaches the UI (the consuming `response.error_code || AuthErrorCode.UNKNOWN` only falls back when falsy), but there's no enum member or special-case copy. A follow-up should add `ACCOUNT_INACTIVE` (and ideally `ACCOUNT_LOCKED`, which is also currently absent there — pre-existing gap, out of scope) and the contact-support copy. Filed as a note for orchestrator triage.

## Test plan
- [x] `cd backend && go build ./...` — passed (whole-graph compile clean)
- [x] `cd backend && go test ./internal/services/user/... ./internal/api/handlers/auth/...` — passed (both packages `ok`)
- [x] golangci-lint (`~/go/bin/golangci-lint run -c .golangci.yml ./...`) — passed (0 issues)

**Dual-test discipline (PSY-864):** `TestLoginHandler_UnknownAuthCodeFailsClosed` was run explicitly and still PASSES — the new explicit `ACCOUNT_INACTIVE` arm does NOT weaken the fail-closed default for genuinely-unknown codes (verified: a `CodeUnknown` AuthError still propagates as 5xx via `login_unhandled_authcode`).

## Manual repro
The handler + service tests ARE the manual repro (PSY-592 pattern). Verbatim verbose output:

`TestLoginHandler_AccountInactive` — PASS:
```
msg=login_attempt email_hash=in***@example.com
msg=login_account_inactive email_hash=in***@example.com
--- PASS: TestLoginHandler_AccountInactive (0.00s)
```
Asserted response: nil handler error (HTTP 200) · `Success=false` · `ErrorCode=ACCOUNT_INACTIVE` · `Message="Account unavailable. Please contact support."` · regression guard: NOT downgraded to `SERVICE_UNAVAILABLE`.

`TestAuthenticateUserWithPassword_InactiveAccountReturnsTyped` — PASS (service layer, real Postgres via testcontainers): creates a user, flips `is_active=false`, authenticates with the correct password → returns `*apperrors.AuthError` with `Code == CodeAccountInactive`.

`TestAuthenticate_InactiveUser` (updated from string-match to typed-code assertion) — PASS.

## Code review
`/code-review` ran inline (sub-agent has no Agent-tool access — expected per dispatch note); 9 finder angles + verify + sweep → no findings. The one substantive candidate (handler using `authErr.UserMessage()` vs sibling arms' `ToExternalMessage`) was REFUTED by a scratch test confirming both return the identical string. No files changed by review.

Closes PSY-866