### PR TITLE
PSY-723: add e2e for content detail pages (release + label)

### DIFF
--- a/frontend/e2e/pages/content-detail.spec.ts
+++ b/frontend/e2e/pages/content-detail.spec.ts
@@ -1,0 +1,121 @@
+import { test } from '../fixtures/error-detection'
+import { expect } from '@playwright/test'
+
+/**
+ * PSY-723: SEO/render coverage for content detail pages.
+ *
+ * Each content detail route is a Next.js server component with a
+ * `generateMetadata` (title + canonical) plus a JSON-LD `<script>` and a
+ * level-1 heading. These are silent-regression surfaces: a broken
+ * `generateMetadata`, a dropped canonical, or a missing JSON-LD block hurts
+ * SEO and browsing without throwing a visible error. This spec asserts, per
+ * covered content type:
+ *   1. the page loads and its H1 (entity name) is visible;
+ *   2. a `<link rel="canonical">` is present in <head> and points at the
+ *      page's own URL;
+ *   3. a `<script type="application/ld+json">` is present and parses.
+ *
+ * The `error-detection` fixture (no auth needed — these are public,
+ * read-only pages) auto-fails the test on any console.error / failed
+ * request / 5xx, so each assertion lands on real content rather than an
+ * error state.
+ *
+ * Selectors prefer `getByRole`/`getByText` over class selectors (PSY-859
+ * anti-false-coverage guidance). The success-state H1 is rendered by the
+ * shared `EntityHeader` (components/shared/EntityHeader.tsx) as
+ * `<h1>{title}</h1>` — for releases the release title, for labels the label
+ * name. (Two other `<h1>`s exist in *Detail.tsx but only on the error/404
+ * branch, which we never hit for a seeded slug.)
+ *
+ * ── SEED SCOPE (verified against frontend/e2e/setup-db.sh) ───────────────
+ * Of the six content detail routes
+ *   /blog/[slug]  /releases/[slug]  /festivals/[slug]
+ *   /scenes/[slug]  /labels/[slug]  /dj-sets/[slug]
+ * the E2E seed only INSERTs into `releases` and `labels`. There are no
+ * seeded rows for blog_posts, festivals, scenes, or dj-sets/playlists, so
+ * those four routes have NO stable slug to navigate to. Per PSY-722's
+ * precedent (and PSY-859's anti-false-coverage rule) we cover ONLY the two
+ * seeded types here and disclose the gap in the PR's scope-deviation note
+ * rather than fabricating fixtures or writing `.skip`/Not-Found placeholders.
+ * Recommended follow-up: a seed ticket adding one row per uncovered type so
+ * the remaining four can be covered the same way.
+ *
+ * ── JSON-LD NOTE ─────────────────────────────────────────────────────────
+ * The release/label *page* components do not emit a page-specific JSON-LD
+ * block (unlike artists/shows/venues/blog/dj-sets). However the root layout
+ * (app/layout.tsx) renders a global Organization schema
+ * `<script type="application/ld+json">` (via generateOrganizationSchema) in
+ * <head> on EVERY page. So the presence assertion below is satisfied by that
+ * global block — which is the SEO signal these pages actually ship. The test
+ * asserts presence + valid JSON + a `@type`, not a release/label-specific
+ * schema, to avoid claiming coverage the page doesn't provide.
+ *
+ * Stable seeded slugs used below (from setup-db.sh):
+ *   - release "Futures"               -> /releases/futures
+ *   - label   "Run For Cover Records" -> /labels/run-for-cover-records
+ */
+
+interface CoveredType {
+  /** Human label for the test title. */
+  label: string
+  /** Route path including the seeded slug. */
+  path: string
+  /** Exact H1 text the success-state EntityHeader renders. */
+  heading: string
+  /** Absolute canonical href set by the route's generateMetadata. */
+  canonical: string
+}
+
+const COVERED_TYPES: CoveredType[] = [
+  {
+    label: 'release',
+    path: '/releases/futures',
+    heading: 'Futures',
+    canonical: 'https://psychichomily.com/releases/futures',
+  },
+  {
+    label: 'label',
+    path: '/labels/run-for-cover-records',
+    heading: 'Run For Cover Records',
+    canonical: 'https://psychichomily.com/labels/run-for-cover-records',
+  },
+]
+
+test.describe('Content detail pages — SEO + render', () => {
+  for (const ct of COVERED_TYPES) {
+    test(`${ct.label} detail: loads, canonical + JSON-LD present`, async ({
+      page,
+    }) => {
+      await page.goto(ct.path)
+
+      // 1. Page loaded: the entity-name H1 (EntityHeader) is visible. We scope
+      //    to the page <main> so the persistent sidebar/topbar can't satisfy
+      //    the query, and target level 1 to skip section sub-headings.
+      await expect(
+        page
+          .getByRole('main')
+          .getByRole('heading', { name: ct.heading, level: 1 })
+      ).toBeVisible({ timeout: 10_000 })
+
+      // 2. Canonical <link> in <head> points at this page's own URL. Next.js
+      //    resolves `alternates.canonical` against metadataBase
+      //    (https://psychichomily.com), so the rendered href is the absolute
+      //    production URL — NOT the localhost test origin. `<link>` is not an
+      //    ARIA role, so query the DOM attribute directly.
+      const canonical = page.locator('link[rel="canonical"]')
+      await expect(canonical).toHaveCount(1)
+      await expect(canonical).toHaveAttribute('href', ct.canonical)
+
+      // 3. JSON-LD structured-data block is present and parses. (Satisfied by
+      //    the global Organization schema in app/layout.tsx — see file header.)
+      const ldScripts = page.locator('script[type="application/ld+json"]')
+      const ldCount = await ldScripts.count()
+      expect(ldCount).toBeGreaterThan(0)
+
+      const firstLd = await ldScripts.first().textContent()
+      expect(firstLd, 'JSON-LD script should have content').toBeTruthy()
+      const parsed = JSON.parse(firstLd ?? '{}')
+      expect(parsed['@type'], 'JSON-LD should declare an @type').toBeTruthy()
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- Adds `frontend/e2e/pages/content-detail.spec.ts` covering content detail SEO/render for the two seeded content types: **release** (`/releases/futures`) and **label** (`/labels/run-for-cover-records`).
- Per covered type asserts: entity-name H1 visible (rendered by shared `EntityHeader`), `<link rel="canonical">` in `<head>` matches the page URL, and a `<script type="application/ld+json">` is present and parses with an `@type`.
- Uses the `error-detection` fixture (no auth — public read-only pages) so assertions land on real content, not error states. Selectors prefer `getByRole`/`getByText` (PSY-859).

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:e2e -- e2e/pages/content-detail.spec.ts` — passed (2 runs: 2/2 in 28.0s, then 2/2 in 17.3s)

## Manual repro
The e2e spec is the manual repro. Observed for both covered types:
- **release** `/releases/futures` — H1 "Futures" visible; canonical `<link href="https://psychichomily.com/releases/futures">` (1 match); JSON-LD `<script>` present + parses with `@type`.
- **label** `/labels/run-for-cover-records` — H1 "Run For Cover Records" visible; canonical `<link href="https://psychichomily.com/labels/run-for-cover-records">` (1 match); JSON-LD `<script>` present + parses with `@type`.

Note: the canonical href is the absolute production URL (Next resolves `alternates.canonical` against `metadataBase = https://psychichomily.com`), not the localhost test origin. The JSON-LD presence is satisfied by the global Organization schema rendered in `app/layout.tsx` (`generateOrganizationSchema`) on every page — the release/label *page* components don't emit a page-specific block (unlike artists/shows/venues/blog/dj-sets). The test asserts presence + valid JSON + `@type`, not a type-specific schema, to avoid claiming coverage the page doesn't provide.

## Scope deviation
Of the six content detail routes (`/blog`, `/releases`, `/festivals`, `/scenes`, `/labels`, `/dj-sets` `[slug]`), the E2E seed (`frontend/e2e/setup-db.sh`) only `INSERT`s into the `releases` and `labels` tables. There are no seeded rows for `blog_posts`, `festivals`, `scenes`, or `dj_sets`/`playlists`, so those four routes have no stable slug to navigate to. Per PSY-722's precedent (PR #880 shipped 3/5 cases + filed seed follow-up PSY-899) and PSY-859's anti-false-coverage rule, the four unseeded types are **omitted** (not `.skip`'d or asserted as Not-Found, which would be false coverage) and disclosed here.

**Recommended follow-up:** a seed ticket adding one row per uncovered content type (blog post, festival, scene, dj-set) to `setup-db.sh` so the remaining four routes can be covered the same way.

## Code review
`/code-review` run inline (sub-agent worktree, no Agent tool — per `pattern_subagent_inline_code_review.md`): reuse / quality / efficiency / correctness lenses against the diff — no findings.

Closes PSY-723