### PR TITLE
PSY-900: RegisterHandler fail-closed for unknown service failures

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -617,33 +617,40 @@ func (h *AuthHandler) RegisterHandler(ctx context.Context, input *RegisterReques
 		},
 	)
 	if err != nil {
-		// Silent-downgrade convention intentionally preserved here pending the
-		// email-enumeration design lock for the registration path. Whether
-		// unknown service-failure codes should surface as 5xx, or stay folded
-		// into the CodeUnknown / CodeUserExists shape (to avoid leaking
-		// registered-email state via transport-status differences), is tied
-		// to that broader enumeration-safety decision — which has not landed
-		// yet. Revisit alongside the registration enumeration work; the rest
-		// of this handler family has been converted to the fail-closed
-		// pattern (see GetProfileHandler / SendVerificationEmailHandler / et al.).
-		errorCode := autherrors.CodeUnknown
-		message := "Failed to create user"
-
+		// "Account already exists" is an INTENTIONAL HTTP-200 UX response, not a
+		// fail-closed condition. PSY-775 locked the registration-enumeration
+		// decision as Option A: keep the explicit message + USER_EXISTS code so a
+		// returning user gets clear "log in instead" guidance. The transport-status
+		// enumeration oracle is accepted here. This arm MUST NOT change to a 5xx.
 		var authErr *autherrors.AuthError
 		if errors.As(err, &authErr) && authErr.Code == autherrors.CodeUserExists {
-			errorCode = autherrors.CodeUserExists
-			message = authErr.UserMessage()
+			logger.AuthWarn(ctx, "register_failed",
+				"email_hash", logger.HashEmail(input.Body.Email),
+				"error", err.Error(),
+				"error_code", autherrors.CodeUserExists,
+			)
+			resp.Body.Success = false
+			resp.Body.Message = authErr.UserMessage()
+			resp.Body.ErrorCode = autherrors.CodeUserExists
+			return resp, nil
 		}
 
-		logger.AuthWarn(ctx, "register_failed",
+		// Any other failure is an unexpected backend/service error, not a UX
+		// condition. Fail-closed (PSY-900): surface it as a 5xx so monitoring
+		// sees the same uniform shape as the rest of this handler family
+		// (GetProfileHandler / RefreshTokenHandler / SendVerificationEmailHandler
+		// et al.) instead of the prior silent HTTP-200 + CodeUnknown body. The
+		// response body stays byte-identical with the canonical SERVICE_UNAVAILABLE
+		// shape; only the transport status flips.
+		svcErr := autherrors.ErrServiceUnavailable("register_create_user", err)
+		logger.AuthError(ctx, "register_failed", err,
 			"email_hash", logger.HashEmail(input.Body.Email),
-			"error", err.Error(),
-			"error_code", errorCode,
+			"error_code", autherrors.CodeServiceUnavailable,
 		)
 		resp.Body.Success = false
-		resp.Body.Message = message
-		resp.Body.ErrorCode = errorCode
-		return resp, nil
+		resp.Body.Message = autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable)
+		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+		return resp, svcErr
 	}
 
 	// Generate JWT token for immediate authentication

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1136,6 +1136,13 @@ func TestRegisterHandler_Success(t *testing.T) {
 	}
 }
 
+// TestRegisterHandler_UserExists pins the INTENTIONAL enumeration-UX arm
+// (PSY-775 Option A): an already-registered email must stay HTTP 200 (nil
+// returned error) with the explicit "account already exists" message and the
+// USER_EXISTS code. This is the dual-direction counterpart to
+// TestRegisterHandler_UnknownServiceErrorFailsClosed — it guards against a
+// future fail-closed pass accidentally flipping this arm to a 5xx, which would
+// regress the "log in instead" guidance a returning user depends on.
 func TestRegisterHandler_UserExists(t *testing.T) {
 	h := authHandler(func(ah *AuthHandler) {
 		ah.userService = &testhelpers.MockUserService{
@@ -1152,14 +1159,75 @@ func TestRegisterHandler_UserExists(t *testing.T) {
 	input.Body.TermsVersion = "2026-01-31"
 
 	resp, err := h.RegisterHandler(context.Background(), input)
+	// Option A: HTTP 200, so the handler returns a nil error. A non-nil error
+	// here would mean the arm regressed into the fail-closed 5xx path.
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected nil error (HTTP 200 enumeration-UX arm), got %v", err)
 	}
 	if resp.Body.Success {
 		t.Error("expected success=false")
 	}
 	if resp.Body.ErrorCode != autherrors.CodeUserExists {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeUserExists, resp.Body.ErrorCode)
+	}
+	// The explicit message is the user-facing guidance; it must not be replaced
+	// by the generic SERVICE_UNAVAILABLE copy.
+	if resp.Body.Message != autherrors.ErrUserExists(input.Body.Email).UserMessage() {
+		t.Errorf("expected explicit user-exists message, got %q", resp.Body.Message)
+	}
+}
+
+// TestRegisterHandler_UnknownServiceErrorFailsClosed locks in the PSY-900
+// fail-closed convention for the registration path: any CreateUser failure
+// OTHER than the intentional USER_EXISTS arm is an unexpected backend/service
+// error and MUST surface as a 5xx (non-nil returned error wrapping an
+// *AuthError of CodeServiceUnavailable) so monitoring sees the same uniform
+// shape as the rest of this handler family — not the prior silent HTTP-200 +
+// CodeUnknown body. The body stays byte-identical with the canonical
+// SERVICE_UNAVAILABLE shape; only the transport status flips.
+func TestRegisterHandler_UnknownServiceErrorFailsClosed(t *testing.T) {
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			CreateUserWithPasswordWithLegalFn: func(email, password, firstName, lastName string, acceptance contracts.LegalAcceptance) (*authm.User, error) {
+				return nil, errors.New("db connection refused")
+			},
+		}
+	})
+
+	input := &RegisterRequest{}
+	input.Body.Email = "user@example.com"
+	input.Body.Password = "a-valid-password-123"
+	input.Body.TermsAccepted = true
+	input.Body.TermsVersion = "2026-01-31"
+
+	resp, err := h.RegisterHandler(context.Background(), input)
+
+	// Handler MUST return a non-nil error so Huma emits a 5xx HTTP status.
+	if err == nil {
+		t.Fatal("expected non-nil error so Huma emits a 5xx HTTP status")
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response body")
+	}
+	// The returned error must wrap an *AuthError of CodeServiceUnavailable so
+	// the apperror mapper translates it to a 5xx with the structured body.
+	var authErr *autherrors.AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected returned error to wrap an *AuthError, got %T", err)
+	}
+	if authErr.Code != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected wrapped error code=%s, got %s", autherrors.CodeServiceUnavailable, authErr.Code)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	}
+	// External message must match the canonical SERVICE_UNAVAILABLE shape, not
+	// the prior "Failed to create user" leak.
+	if resp.Body.Message != autherrors.ToExternalMessage(autherrors.CodeServiceUnavailable) {
+		t.Errorf("expected generic SERVICE_UNAVAILABLE message, got %q", resp.Body.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `RegisterHandler`'s `if err != nil` branch previously returned **HTTP 200** for both the intentional "account exists" UX response AND genuine backend/service failures (folded into `CodeUnknown` + "Failed to create user"). The latter was the last RegisterHandler holdout from the PSY-864/873 fail-closed family — a 5xx-class failure silently returning a normal 200, invisible to monitoring.
- PSY-775 locked the registration-enumeration decision as **Option A** (keep the explicit `USER_EXISTS` message), so the deferred-decision comment is now actionable. Split the branch:
  - **`CodeUserExists`** → unchanged: HTTP 200 + `USER_EXISTS` + explicit "An account with this email already exists" message (intentional enumeration UX, Option A).
  - **Any other error** → fail-closed 5xx: non-nil `*AuthError` of `CodeServiceUnavailable`, body set to the canonical `SERVICE_UNAVAILABLE` shape. Matches `GetProfileHandler` / `RefreshTokenHandler` / `SendVerificationEmailHandler`.
- Removed the obsolete "Silent-downgrade convention intentionally preserved here pending the email-enumeration design lock" comment; replaced with intent comments citing PSY-775 + PSY-900.

## Test plan
- [x] `cd backend && go build ./...` — passed (exit 0)
- [x] `cd backend && go test ./internal/api/handlers/auth/...` — passed (exit 0; all 10 RegisterHandler unit tests + the testcontainers integration suite incl. `TestRegister_DuplicateEmail`)
- [x] golangci-lint — passed (`~/go/bin/golangci-lint run -c .golangci.yml ./...` → exit 0, "0 issues.")

## Manual repro
Dual-direction handler tests ARE the manual repro (PSY-592 pattern), run with `-run … -v`:

```
--- PASS: TestRegisterHandler_UserExists (0.00s)
--- PASS: TestRegisterHandler_UnknownServiceErrorFailsClosed (0.00s)
PASS
ok  	psychic-homily-backend/internal/api/handlers/auth	0.317s
```

**Direction 1 — unknown service failure → 5xx** (`TestRegisterHandler_UnknownServiceErrorFailsClosed`): `CreateUserWithPasswordWithLegal` returns `errors.New("db connection refused")`. Asserts:
- returned `err != nil` (so Huma emits a 5xx)
- `errors.As(err, &authErr)` and `authErr.Code == CodeServiceUnavailable`
- `resp.Body.ErrorCode == SERVICE_UNAVAILABLE`
- `resp.Body.Message == ToExternalMessage(CodeServiceUnavailable)` (no "Failed to create user" leak)

**Direction 2 — `CodeUserExists` still → 200 + `USER_EXISTS` + explicit message** (`TestRegisterHandler_UserExists`, strengthened): `CreateUser...` returns `ErrUserExists(email)`. Asserts:
- returned `err == nil` (HTTP 200; a non-nil error would mean the arm regressed into the 5xx path)
- `resp.Body.ErrorCode == USER_EXISTS`
- `resp.Body.Message == ErrUserExists(email).UserMessage()` (explicit "account already exists" guidance, not the generic SERVICE_UNAVAILABLE copy)

## Code review
Inline 3-lens review (sub-agent has no Agent-tool access, per `pattern_subagent_inline_code_review`): no correctness / reuse / simplification / efficiency / altitude findings — the diff mirrors the family's `return resp, ErrServiceUnavailable(...)` shape exactly. No changes.

Closes PSY-900