### PR TITLE
PSY-897: proxy.ts real HTTP 404 for unknown /shows/<slug> (Phase 1, shows-only)

### DIFF
--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { API_BASE_URL } from '@/lib/api-base'
+
+/**
+ * Slug-existence proxy — real HTTP 404 for unknown entity slug pages (PSY-897).
+ *
+ * Why this file exists
+ * --------------------
+ * Under Next 16's `cacheComponents: true` (PPR, see `next.config.ts`), entity
+ * slug pages that call `notFound()` render the global `app/not-found.tsx` UI
+ * but commit **HTTP 200**, not 404. The root cause is the root layout
+ * (`app/layout.tsx`): every page's `{children}` is wrapped in a `<Suspense>`
+ * around the async, cookie-reading `<AuthHydrator>`. That boundary flushes the
+ * static shell — committing the 200 status header — before any page's
+ * `await getShow()` → `notFound()` resolves. Next's own docs describe this
+ * exactly ("a `200` status code will be returned [...] the status code of the
+ * response cannot be updated [after streaming starts]") and prescribe the fix:
+ *
+ *   "If you need a 404 status [...] ensure the resource exists before the
+ *    response body is streamed [...] run this check in `proxy` to rewrite
+ *    missing slugs to a not-found route, or produce a 404 response. Keep proxy
+ *    checks fast, and avoid fetching full content there."
+ *   — Next.js v16 loading.js "Status Codes" docs
+ *
+ * Proxy runs BEFORE the route renders/streams, so a 404 produced here sets the
+ * status header before the streaming trap can commit a 200. This is Option C
+ * from the PSY-897 architecture spike (Options A and B were rejected — A is
+ * impossible because the trapping Suspense is the root-layout ancestor of every
+ * page, and B regresses the PSY-797/PSY-841 PPR/ISR architecture).
+ *
+ * Phase 1 scope: SHOWS ONLY (proof-of-approach). Venues/artists/releases/
+ * labels/festivals/tags are Phase 2 — adding one is a single `ENTITY_CHECKS`
+ * entry. Collections (auth-gated), blog/dj-sets (local MDX), and scenes
+ * (separate soft-404) are Phase 3 and have distinct semantics.
+ *
+ * How the 404 is produced
+ * ------------------------
+ * We `rewrite` to a synthetic path that matches NO route. Next's routing layer
+ * returns HTTP 404 for an unmatched path and renders `app/not-found.tsx` — the
+ * SAME mechanism that already correctly 404s for `/this-route-does-not-exist`
+ * (a no-route-match 404 is resolved before any render/stream, so it is NOT
+ * subject to the streaming-commits-200 trap that breaks page-level
+ * `notFound()`). We also pass `{ status: 404 }` to `rewrite` as belt-and-
+ * suspenders for Next versions that honor a rewrite status override. The
+ * synthetic target lives OUTSIDE this proxy's matcher (which only intercepts
+ * `/shows/...`), so the rewrite cannot re-trigger the proxy — no loop.
+ */
+
+/**
+ * Path Next rewrites unknown slugs to. Deliberately matches no route segment
+ * AND is not matched by `config.matcher` below (matcher only intercepts
+ * `/shows/...`), guaranteeing no rewrite loop. The leading-underscore segment
+ * also signals "framework-internal, not a user route".
+ */
+const NOT_FOUND_REWRITE_PATH = '/_psy-not-found'
+
+/**
+ * Per-entity existence check. Phase 1 maps only `shows`. The `endpoint`
+ * function returns the backend URL whose non-2xx response means "slug does not
+ * exist". `shows` reuses the SAME `GET ${API_BASE_URL}/shows/<slug>` the page
+ * itself calls (`app/shows/[slug]/page.tsx`). The spike flagged that a backend
+ * HEAD / `/exists` endpoint would be cheaper than a full GET; using the
+ * existing GET is acceptable for Phase 1 (latency noted as a follow-up). Adding
+ * an entity in Phase 2 is one entry here (e.g. tags → `/tags/<slug>/detail`).
+ */
+const ENTITY_CHECKS: Record<string, (slug: string) => string> = {
+  shows: (slug) => `${API_BASE_URL}/shows/${encodeURIComponent(slug)}`,
+}
+
+/**
+ * Returns the global 404 rewrite response (status 404 + render
+ * `app/not-found.tsx` via the unmatched synthetic path).
+ */
+function notFoundResponse(request: NextRequest): NextResponse {
+  return NextResponse.rewrite(new URL(NOT_FOUND_REWRITE_PATH, request.url), {
+    status: 404,
+  })
+}
+
+export async function proxy(request: NextRequest): Promise<NextResponse> {
+  const { pathname } = request.nextUrl
+
+  // pathname is `/shows/<slug>` (matcher guarantees the `/shows/` prefix).
+  // Split into ["", "shows", "<slug>", ...optional sub-segments].
+  const segments = pathname.split('/')
+  const entityType = segments[1]
+  const slug = segments[2]
+
+  const buildCheckUrl = ENTITY_CHECKS[entityType]
+
+  // Not a Phase-1 entity, or a sub-route like `/shows/<slug>/edit`, or the
+  // bare `/shows` list (no slug): leave untouched. Only the exact
+  // `/<entity>/<slug>` detail shape is existence-checked.
+  if (!buildCheckUrl || !slug || segments.length !== 3) {
+    return NextResponse.next()
+  }
+
+  try {
+    const res = await fetch(buildCheckUrl(slug), {
+      // `next: { revalidate }` has NO effect inside proxy (per Next docs), so
+      // we don't set it. `redirect: 'manual'` keeps the check cheap and avoids
+      // following any backend redirect chain. A 2xx/3xx means the slug
+      // resolves; only a hard non-ok (4xx/5xx) is treated as "missing".
+      redirect: 'manual',
+    })
+
+    // Backend reachable and slug resolves → let the page render normally
+    // (ISR / hydration path untouched).
+    if (res.ok) {
+      return NextResponse.next()
+    }
+
+    // 404 from the backend = slug genuinely does not exist → real 404.
+    if (res.status === 404) {
+      return notFoundResponse(request)
+    }
+
+    // Any other non-ok (5xx, 403, 429, opaqueredirect, …): fail OPEN — let the
+    // page render and apply its own handling (the page's `getShow` reports 5xx
+    // to Sentry, renders its own not-found on null, etc.). Producing a 404 here
+    // on a transient backend blip would mask real outages as "not found".
+    return NextResponse.next()
+  } catch {
+    // Network error reaching the backend: fail OPEN. The proxy must never take
+    // the whole route down when the existence check itself fails.
+    return NextResponse.next()
+  }
+}
+
+export const config = {
+  /**
+   * Intercept ONLY `/shows/...` (Phase 1). Excludes everything else — the
+   * homepage, other entity routes (`/venues/...` etc.), and crucially
+   * `api`, `_next/static`, `_next/image`, and metadata files — so the proxy
+   * cannot block CSS/JS/images or re-intercept its own rewrite target. The
+   * negative-lookahead guards `_next`-prefixed and metadata paths even though
+   * the `/shows/` prefix already scopes the match, matching Next's documented
+   * exclusion pattern for defense-in-depth.
+   *
+   * `missing` excludes RSC prefetch requests (`next-router-prefetch` /
+   * `purpose: prefetch` headers) so client-side route prefetches don't fire a
+   * backend existence lookup on every hovered link.
+   */
+  matcher: [
+    {
+      source:
+        '/shows/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+}

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -130,13 +130,15 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 
 export const config = {
   /**
-   * Intercept ONLY `/shows/...` (Phase 1). Excludes everything else — the
-   * homepage, other entity routes (`/venues/...` etc.), and crucially
-   * `api`, `_next/static`, `_next/image`, and metadata files — so the proxy
-   * cannot block CSS/JS/images or re-intercept its own rewrite target. The
-   * negative-lookahead guards `_next`-prefixed and metadata paths even though
-   * the `/shows/` prefix already scopes the match, matching Next's documented
-   * exclusion pattern for defense-in-depth.
+   * Intercept ONLY `/shows/...` (Phase 1). The `/shows/` prefix already scopes
+   * the match away from everything else — the homepage, other entity routes
+   * (`/venues/...`), `api`, `_next/static`, `_next/image`, metadata files, and
+   * the `/_psy-not-found` rewrite target — so none of those can be blocked or
+   * re-intercepted. (A root-level matcher would need a negative-lookahead to
+   * exclude `api`/`_next`/metadata; scoping to `/shows/` makes that
+   * unnecessary.) The `proxy()` body further narrows to the exact
+   * `/shows/<slug>` detail shape — bare `/shows` and `/shows/<slug>/<sub>` pass
+   * through untouched.
    *
    * `missing` excludes RSC prefetch requests (`next-router-prefetch` /
    * `purpose: prefetch` headers) so client-side route prefetches don't fire a
@@ -144,8 +146,7 @@ export const config = {
    */
   matcher: [
     {
-      source:
-        '/shows/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+      source: '/shows/:path*',
       missing: [
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' },


### PR DESCRIPTION
## Summary
- Phase 1 of PSY-897: `frontend/proxy.ts` returns a real HTTP 404 for unknown `/shows/<slug>` (Option C from the spike). Shows-only; venues/artists/releases/labels/festivals/tags are Phase 2.
- Root cause: under `cacheComponents: true`, the root layout's `AuthHydrator` `<Suspense>` flushes the static shell (committing HTTP 200) before a page's `await getShow()` → `notFound()` resolves, so page-level `notFound()` renders the 404 UI but commits 200 (soft-404). Proxy runs **before** the route streams, so the 404 status header is set before the streaming trap can commit 200. Next's own `loading.js`/`not-found.js` docs prescribe exactly this ("ensure the resource exists before the response body is streamed... run this check in `proxy`").
- Mechanism: lightweight existence check via the existing `GET ${API_BASE_URL}/shows/<slug>` (reusing `lib/api-base.ts`); on a backend 404, `NextResponse.rewrite` to a synthetic no-route-match path (`/_psy-not-found`) which Next resolves as a routing-layer 404 + renders the global `app/not-found.tsx`. Fails **open** on 5xx/network error so a transient backend blip never masks as 404. No page/layout/`next.config` change.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] Local (isolated stack) curl: `/shows/<invalid>` → 404; `/shows/<valid>` → 200 + real show page; `/`, `/venues/*`, static assets, bare `/shows` list all unaffected (pass-through); RSC prefetch requests excluded
- [x] `app/not-found.test.tsx` — 3 tests pass (no regression)

## Manual repro
Local isolated stack (seeded e2e fixture), valid slug `e2e-collection-saved-show`:

| Request | Result |
| --- | --- |
| `/shows/definitely-not-a-real-slug-psy897` | **404** ✓ (renders global not-found UI — visible `>404<` heading present) |
| `/shows/e2e-collection-saved-show` | **200** ✓ (renders real show — `<title>Calexico at …`, ShowDetail content; NO visible 404 heading) |
| `/` (homepage) | 200 ✓ pass-through |
| `/venues/not-real-psy897` | 200 ✓ pass-through (Phase 1 = shows-only; venues keep current behavior) |
| `/_next/static/.../*.js` (asset) | 200 ✓ NOT intercepted |
| `/_psy-not-found` (rewrite target) | 404 ✓ no loop |
| `/shows` (bare list) | 200 ✓ pass-through |
| `/shows/<invalid>` + `next-router-prefetch: 1` | 200 ✓ prefetch excluded by `missing` matcher |

Next dev request log confirmed proxy latency (warm): `proxy.ts: 6–27ms` per request; first (cold) request 39ms. No proxy errors/warnings in the dev log.

**Vercel-preview validation REQUIRED before merge — not yet run at time of writing.** The spike flagged that local `bun run dev` streaming can diverge from Vercel; the preview is the authoritative gate. See the status comment below / ask the orchestrator to curl the preview's `/shows/<invalid>` (expect 404) and `/shows/<valid>` (expect 200).

## Blast-radius guard
- Valid show loads **fully** (200 + real ShowDetail content + correct `<title>`, ISR/hydration intact) — confirmed via content grep, not just status.
- Homepage + a non-shows entity route (`/venues/*`) + static assets all pass through untouched (Phase 1 matcher scopes to `/shows/` only).
- No rewrite loop: synthetic target `/_psy-not-found` is outside the matcher (`/shows/:path*`), so it can never re-trigger the proxy; direct hit returns 404 without hanging.
- Fails open (4 paths: backend 5xx, 403, 429, opaque-redirect, and network error all `NextResponse.next()`), so the proxy can never take the route down.

## Code review
Ran the review inline (sub-agent — no Agent-tool access) across reuse/quality/efficiency + correctness/matcher/loop angles. One cleanup applied: simplified the matcher from a redundant negative-lookahead regex to `/shows/:path*` (the `/shows/` anchor already excludes `api`/`_next`/metadata). No correctness bugs found; re-validated after the change.

Part of PSY-897 (Phase 1: shows). Does NOT close the ticket — Phase 2 (roll out venues/artists/releases/labels/festivals/tags) + Phase 3 (collections/blog/dj-sets/scenes special cases) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### ⚠️ Vercel-preview validation — REQUIRED before merge, NOT yet run

The preview deploy is gated by **Vercel Deployment Protection (SSO)** — unauthenticated `curl` returns HTTP 401 (`set-cookie: _vercel_sso_nonce=…`, `server: Vercel`), i.e. Vercel's auth layer, not the app. I (dispatched agent) have no bypass token / authenticated session, so I could not complete the preview curl. **This is the authoritative gate per the spike (local `bun run dev` streaming can diverge from Vercel) and still needs to be run by someone with Vercel access.**

Preview URL: `https://psychic-homily-web-git-psy-897-p-4974f0-matts-projects-722d5204.vercel.app`

Run (with a protection-bypass token or while signed into Vercel):
```
BASE="https://psychic-homily-web-git-psy-897-p-4974f0-matts-projects-722d5204.vercel.app"
# If using a bypass token: append  -H "x-vercel-protection-bypass: <TOKEN>"
curl -s -o /dev/null -w "invalid -> %{http_code}\n" "$BASE/shows/this-slug-does-not-exist-psy897"   # expect 404
curl -s -o /dev/null -w "valid   -> %{http_code}\n" "$BASE/shows/<a-real-seeded-or-prod-show-slug>" # expect 200
```
Expected: invalid → **404**, valid → **200** + real show page. If the preview's invalid-slug returns 200, the streaming behavior differs on Vercel and the rewrite mechanism needs revisiting before merge.
