### PR TITLE
PSY-890: notify requester in-app when a fulfillment is proposed

### DIFF
--- a/backend/internal/api/handlers/community/request.go
+++ b/backend/internal/api/handlers/community/request.go
@@ -424,6 +424,16 @@ func (h *RequestHandler) FulfillRequestHandler(ctx context.Context, req *Fulfill
 		})
 	}
 
+	// Notify the requester (in-app, fire-and-forget) that a fulfillment now
+	// awaits their approval. No-op on self-fulfill or when requesterID didn't
+	// resolve above; never blocks the fulfillment response. PSY-890.
+	shared.GoSafe(ctx, "request_fulfillment_notify", func() {
+		if notifyErr := h.requestService.NotifyRequesterFulfillmentProposed(uint(id), requesterID, user.ID); notifyErr != nil {
+			logger.FromContext(ctx).Warn("request_fulfillment_notify_failed",
+				"request_id", id, "error", notifyErr.Error())
+		}
+	})
+
 	return nil, nil
 }
 

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -2698,18 +2698,19 @@ func (m *MockReleaseService) RemoveExternalLink(linkID uint) error {
 // ============================================================================
 
 type MockRequestService struct {
-	CreateRequestFn      func(uint, string, string, string, *uint) (*communitym.Request, error)
-	GetRequestFn         func(uint) (*communitym.Request, error)
-	ListRequestsFn       func(string, string, string, int, int) ([]communitym.Request, int64, error)
-	UpdateRequestFn      func(uint, uint, *string, *string) (*communitym.Request, error)
-	DeleteRequestFn      func(uint, uint, bool) error
-	VoteFn               func(uint, uint, bool) error
-	RemoveVoteFn         func(uint, uint) error
-	FulfillRequestFn     func(uint, uint, *uint) error
-	ApproveFulfillmentFn func(uint, uint, bool) error
-	RejectFulfillmentFn  func(uint, uint, bool) error
-	CloseRequestFn       func(uint, uint, bool) error
-	GetUserVoteFn        func(uint, uint) (*communitym.RequestVote, error)
+	CreateRequestFn                      func(uint, string, string, string, *uint) (*communitym.Request, error)
+	GetRequestFn                         func(uint) (*communitym.Request, error)
+	ListRequestsFn                       func(string, string, string, int, int) ([]communitym.Request, int64, error)
+	UpdateRequestFn                      func(uint, uint, *string, *string) (*communitym.Request, error)
+	DeleteRequestFn                      func(uint, uint, bool) error
+	VoteFn                               func(uint, uint, bool) error
+	RemoveVoteFn                         func(uint, uint) error
+	FulfillRequestFn                     func(uint, uint, *uint) error
+	ApproveFulfillmentFn                 func(uint, uint, bool) error
+	RejectFulfillmentFn                  func(uint, uint, bool) error
+	NotifyRequesterFulfillmentProposedFn func(uint, uint, uint) error
+	CloseRequestFn                       func(uint, uint, bool) error
+	GetUserVoteFn                        func(uint, uint) (*communitym.RequestVote, error)
 }
 
 func (m *MockRequestService) CreateRequest(userID uint, title string, description string, entityType string, requestedEntityID *uint) (*communitym.Request, error) {
@@ -2786,6 +2787,12 @@ func (m *MockRequestService) ApproveFulfillment(requestID uint, userID uint, isA
 func (m *MockRequestService) RejectFulfillment(requestID uint, userID uint, isAdmin bool) error {
 	if m.RejectFulfillmentFn != nil {
 		return m.RejectFulfillmentFn(requestID, userID, isAdmin)
+	}
+	return nil
+}
+func (m *MockRequestService) NotifyRequesterFulfillmentProposed(requestID uint, requesterID uint, fulfillerID uint) error {
+	if m.NotifyRequesterFulfillmentProposedFn != nil {
+		return m.NotifyRequesterFulfillmentProposedFn(requestID, requesterID, fulfillerID)
 	}
 	return nil
 }

--- a/backend/internal/models/notification/notification_filter.go
+++ b/backend/internal/models/notification/notification_filter.go
@@ -60,3 +60,23 @@ type NotificationLog struct {
 func (NotificationLog) TableName() string {
 	return "notification_log"
 }
+
+// In-app notification_log discriminators shared across domain services that
+// write rows and the notification read service that enriches them. Kept here
+// (next to the NotificationLog model) so a domain service can mint a row
+// without importing another service package. The comment-driven channel +
+// entity-type constants predate this and live in the engagement package
+// (engagement.NotificationChannelInApp / NotificationEntityCommentReply); the
+// channel value is identical by design.
+const (
+	// NotificationChannelInApp is the channel value for in-app notification_log
+	// rows surfaced by the bell/inbox (vs the "email" channel used by the
+	// show-filter matcher).
+	NotificationChannelInApp = "in_app"
+
+	// NotificationEntityRequestFulfillmentProposed marks a notification_log row
+	// created when someone proposes a fulfillment for a community request (the
+	// request enters pending_fulfillment). entity_id holds the request_id; the
+	// requester is notified so they can approve or reject. PSY-890.
+	NotificationEntityRequestFulfillmentProposed = "request_fulfillment_proposed"
+)

--- a/backend/internal/services/community/request.go
+++ b/backend/internal/services/community/request.go
@@ -10,6 +10,7 @@ import (
 	"psychic-homily-backend/db"
 	apperrors "psychic-homily-backend/internal/errors"
 	communitym "psychic-homily-backend/internal/models/community"
+	notificationm "psychic-homily-backend/internal/models/notification"
 )
 
 // requestEntityTables maps a request's declared entity_type to the
@@ -466,6 +467,41 @@ func (s *RequestService) RejectFulfillment(requestID, userID uint, isAdmin bool)
 		return fmt.Errorf("failed to reject fulfillment: %w", err)
 	}
 
+	return nil
+}
+
+// NotifyRequesterFulfillmentProposed writes an in-app notification_log row to
+// the request's owner letting them know a fulfillment was proposed and is
+// awaiting their approval. Surfaces in the bell/inbox built for PSY-595.
+//
+// No-op when requesterID is 0 (the handler couldn't resolve it) or when the
+// fulfiller IS the requester (self-fulfill — they already know). Fire-and-
+// forget: the caller invokes this via shared.GoSafe; the returned error is for
+// logging only and never blocks the fulfillment response. PSY-890.
+func (s *RequestService) NotifyRequesterFulfillmentProposed(requestID, requesterID, fulfillerID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	if requesterID == 0 || requesterID == fulfillerID {
+		return nil
+	}
+
+	entry := notificationm.NotificationLog{
+		UserID:     requesterID,
+		EntityType: notificationm.NotificationEntityRequestFulfillmentProposed,
+		EntityID:   requestID,
+		Channel:    notificationm.NotificationChannelInApp,
+		SentAt:     time.Now().UTC(),
+	}
+	// Plain insert — one row per proposal. FulfillRequest only succeeds on a
+	// pending/in_progress → pending_fulfillment transition and the handler
+	// fires this exactly once per success, so no dedup clause is needed. (A
+	// re-proposal after a reject is a genuinely new event and SHOULD produce a
+	// fresh notification; an ON CONFLICT clause would be a no-op here anyway
+	// because filter_id is NULL and Postgres treats NULLs as distinct.)
+	if err := s.db.Create(&entry).Error; err != nil {
+		return fmt.Errorf("failed to write request-fulfillment notification: %w", err)
+	}
 	return nil
 }
 

--- a/backend/internal/services/community/request_test.go
+++ b/backend/internal/services/community/request_test.go
@@ -12,6 +12,7 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	communitym "psychic-homily-backend/internal/models/community"
+	notificationm "psychic-homily-backend/internal/models/notification"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -72,6 +73,7 @@ func (suite *RequestServiceIntegrationTestSuite) SetupTest() {
 	_, _ = sqlDB.Exec("DELETE FROM requests")
 	_, _ = sqlDB.Exec("DELETE FROM artists")
 	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM notification_log")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 
@@ -927,6 +929,64 @@ func (suite *RequestServiceIntegrationTestSuite) TestWilsonScore_Computed() {
 	wilsonScore := request.WilsonScore()
 	suite.Assert().Greater(wilsonScore, 0.0)
 	suite.Assert().LessOrEqual(wilsonScore, 1.0)
+}
+
+// ============================================================================
+// Test: NotifyRequesterFulfillmentProposed (PSY-890)
+// ============================================================================
+
+// countRequestFulfillmentNotifications returns how many in-app
+// request_fulfillment_proposed notification_log rows exist for (userID, requestID).
+func (suite *RequestServiceIntegrationTestSuite) countRequestFulfillmentNotifications(userID, requestID uint) int64 {
+	var n int64
+	err := suite.db.Model(&notificationm.NotificationLog{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND channel = ?",
+			userID, notificationm.NotificationEntityRequestFulfillmentProposed, requestID,
+			notificationm.NotificationChannelInApp).
+		Count(&n).Error
+	suite.Require().NoError(err)
+	return n
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestNotifyRequesterFulfillmentProposed_WritesInAppRow() {
+	requester := suite.createTestUser("requester")
+	fulfiller := suite.createTestUser("fulfiller")
+	created, _ := suite.requestService.CreateRequest(requester.ID, "Notify Me", "desc", "artist", nil)
+
+	err := suite.requestService.NotifyRequesterFulfillmentProposed(created.ID, requester.ID, fulfiller.ID)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(int64(1), suite.countRequestFulfillmentNotifications(requester.ID, created.ID),
+		"requester should have one in-app fulfillment-proposed notification")
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestNotifyRequesterFulfillmentProposed_SkipsSelfFulfill() {
+	requester := suite.createTestUser("requester")
+	created, _ := suite.requestService.CreateRequest(requester.ID, "Self Fulfill", "desc", "artist", nil)
+
+	// Fulfiller IS the requester — they already know, so no self-notify.
+	err := suite.requestService.NotifyRequesterFulfillmentProposed(created.ID, requester.ID, requester.ID)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(int64(0), suite.countRequestFulfillmentNotifications(requester.ID, created.ID),
+		"self-fulfillment should not notify the requester")
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestNotifyRequesterFulfillmentProposed_SkipsZeroRequester() {
+	fulfiller := suite.createTestUser("fulfiller")
+	created, _ := suite.requestService.CreateRequest(fulfiller.ID, "Unresolved Requester", "desc", "artist", nil)
+
+	// requesterID 0 simulates the handler failing to resolve the request owner;
+	// the notification must be skipped rather than writing a row for user 0.
+	err := suite.requestService.NotifyRequesterFulfillmentProposed(created.ID, 0, fulfiller.ID)
+	suite.Require().NoError(err)
+
+	var n int64
+	suite.Require().NoError(suite.db.Model(&notificationm.NotificationLog{}).
+		Where("entity_type = ? AND entity_id = ?",
+			notificationm.NotificationEntityRequestFulfillmentProposed, created.ID).
+		Count(&n).Error)
+	suite.Assert().Equal(int64(0), n, "zero requesterID should not write a notification row")
 }
 
 // ============================================================================

--- a/backend/internal/services/contracts/notification_filter.go
+++ b/backend/internal/services/contracts/notification_filter.go
@@ -96,6 +96,12 @@ type NotificationLogEntry struct {
 	CommentEntityType string `json:"comment_entity_type,omitempty"`
 	CommentEntityID   uint   `json:"comment_entity_id,omitempty"`
 	CommentEntityName string `json:"comment_entity_name,omitempty"`
+
+	// Request-driven enrichment fields (populated only for
+	// request_fulfillment_proposed rows; entity_id holds the request_id). The
+	// requester is notified that a fulfillment awaits their approval. PSY-890.
+	RequestTitle string `json:"request_title,omitempty"`
+	RequestURL   string `json:"request_url,omitempty"`
 }
 
 // NotificationFilterServiceInterface defines the contract for notification filter operations.

--- a/backend/internal/services/contracts/request.go
+++ b/backend/internal/services/contracts/request.go
@@ -67,6 +67,11 @@ type RequestServiceInterface interface {
 	// clearing the fulfiller and proposed entity link. Only the original
 	// requester or an admin may reject.
 	RejectFulfillment(requestID, userID uint, isAdmin bool) error
+	// NotifyRequesterFulfillmentProposed writes an in-app notification to the
+	// request's owner that a fulfillment has been proposed and awaits their
+	// approval. No-op when the fulfiller IS the requester (self-fulfill) or
+	// when requesterID is 0. Fire-and-forget: the error is for logging only.
+	NotifyRequesterFulfillmentProposed(requestID, requesterID, fulfillerID uint) error
 	CloseRequest(requestID, userID uint, isAdmin bool) error
 	GetUserVote(requestID, userID uint) (*communitym.RequestVote, error)
 }

--- a/backend/internal/services/notification/filter_service.go
+++ b/backend/internal/services/notification/filter_service.go
@@ -653,9 +653,66 @@ func (s *NotificationFilterService) GetUserNotifications(userID uint, limit, off
 		}
 	}
 
-	// Enrich comment-driven rows in a single batched pass.
+	// Enrich comment-driven + request-driven rows in batched passes.
 	s.enrichCommentNotifications(entries)
+	s.enrichRequestNotifications(entries)
 	return entries, nil
+}
+
+// enrichRequestNotifications populates request_title + request_url on
+// request_fulfillment_proposed rows (entity_id holds the request_id) via a
+// single batched lookup against the requests table. Missing requests (deleted
+// after the row was minted) leave the fields empty so the UI degrades to a
+// plain "fulfillment proposed" line. PSY-890.
+func (s *NotificationFilterService) enrichRequestNotifications(entries []contracts.NotificationLogEntry) {
+	if len(entries) == 0 {
+		return
+	}
+
+	ids := make([]uint, 0, len(entries))
+	seen := make(map[uint]struct{}, len(entries))
+	for _, e := range entries {
+		if e.EntityType != notificationm.NotificationEntityRequestFulfillmentProposed {
+			continue
+		}
+		if _, dup := seen[e.EntityID]; dup {
+			continue
+		}
+		seen[e.EntityID] = struct{}{}
+		ids = append(ids, e.EntityID)
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	var rows []struct {
+		ID    uint
+		Title string
+	}
+	if err := s.db.Table("requests").
+		Select("id, title").
+		Where("id IN ?", ids).
+		Scan(&rows).Error; err != nil {
+		log.Printf("warning: failed to load requests for inbox enrichment: %v", err)
+		return
+	}
+	titleByID := make(map[uint]string, len(rows))
+	for _, r := range rows {
+		titleByID[r.ID] = r.Title
+	}
+
+	for i := range entries {
+		e := &entries[i]
+		if e.EntityType != notificationm.NotificationEntityRequestFulfillmentProposed {
+			continue
+		}
+		title, found := titleByID[e.EntityID]
+		if !found {
+			continue // request deleted — leave fields empty; UI degrades gracefully
+		}
+		e.RequestTitle = title
+		e.RequestURL = fmt.Sprintf("%s/requests/%d", s.frontendURL, e.EntityID)
+	}
 }
 
 // commentInboxExcerptMaxRunes is the rune cap for the bell/inbox excerpt.

--- a/backend/internal/services/notification/filter_service_test.go
+++ b/backend/internal/services/notification/filter_service_test.go
@@ -13,6 +13,7 @@ import (
 
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
 	notificationm "psychic-homily-backend/internal/models/notification"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
@@ -744,6 +745,64 @@ func (s *NotificationFilterSuite) TestGetUserNotifications() {
 	entries, err := s.svc.GetUserNotifications(userID, 10, 0)
 	s.Require().NoError(err)
 	s.Assert().Len(entries, 3)
+}
+
+// TestGetUserNotifications_EnrichesRequestFulfillment verifies request-driven
+// rows (entity_type=request_fulfillment_proposed, entity_id=request_id) get
+// their request_title + request_url populated for the bell/inbox UI. PSY-890.
+func (s *NotificationFilterSuite) TestGetUserNotifications_EnrichesRequestFulfillment() {
+	userID := s.createTestUser()
+
+	req := communitym.Request{
+		Title:       "Add Local Band XYZ",
+		EntityType:  "artist",
+		Status:      communitym.RequestStatusPendingFulfillment,
+		RequesterID: userID,
+	}
+	s.Require().NoError(s.db.Create(&req).Error)
+
+	s.Require().NoError(s.db.Create(&notificationm.NotificationLog{
+		UserID:     userID,
+		EntityType: notificationm.NotificationEntityRequestFulfillmentProposed,
+		EntityID:   req.ID,
+		Channel:    notificationm.NotificationChannelInApp,
+		SentAt:     time.Now().UTC(),
+	}).Error)
+
+	entries, err := s.svc.GetUserNotifications(userID, 10, 0)
+	s.Require().NoError(err)
+	s.Require().Len(entries, 1)
+
+	e := entries[0]
+	s.Assert().Equal(notificationm.NotificationEntityRequestFulfillmentProposed, e.EntityType)
+	s.Assert().Equal("Add Local Band XYZ", e.RequestTitle)
+	s.Assert().Equal(fmt.Sprintf("http://localhost:3000/requests/%d", req.ID), e.RequestURL)
+}
+
+// TestGetUserNotifications_RequestFulfillment_DeletedRequest verifies a
+// request_fulfillment_proposed row whose underlying request no longer exists
+// enriches to empty fields with NO error — the inbox degrades to a plain line
+// rather than crashing the request. PSY-890.
+func (s *NotificationFilterSuite) TestGetUserNotifications_RequestFulfillment_DeletedRequest() {
+	userID := s.createTestUser()
+
+	// notification_log row pointing at a request_id that does not exist.
+	s.Require().NoError(s.db.Create(&notificationm.NotificationLog{
+		UserID:     userID,
+		EntityType: notificationm.NotificationEntityRequestFulfillmentProposed,
+		EntityID:   999999, // no such request
+		Channel:    notificationm.NotificationChannelInApp,
+		SentAt:     time.Now().UTC(),
+	}).Error)
+
+	entries, err := s.svc.GetUserNotifications(userID, 10, 0)
+	s.Require().NoError(err)
+	s.Require().Len(entries, 1)
+
+	e := entries[0]
+	s.Assert().Equal(notificationm.NotificationEntityRequestFulfillmentProposed, e.EntityType)
+	s.Assert().Empty(e.RequestTitle, "deleted request leaves title empty")
+	s.Assert().Empty(e.RequestURL, "deleted request leaves url empty")
 }
 
 func (s *NotificationFilterSuite) TestGetUnreadCount() {

--- a/frontend/features/notifications/components/NotificationList.test.tsx
+++ b/frontend/features/notifications/components/NotificationList.test.tsx
@@ -49,6 +49,20 @@ function showFilter(overrides: Partial<NotificationLogEntry> = {}): Notification
   }
 }
 
+function requestFulfillment(overrides: Partial<NotificationLogEntry> = {}): NotificationLogEntry {
+  return {
+    id: 5,
+    entity_type: 'request_fulfillment_proposed',
+    entity_id: 300,
+    channel: 'in_app',
+    sent_at: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    read_at: null,
+    request_title: 'Add Local Band XYZ',
+    request_url: 'https://example.com/requests/300',
+    ...overrides,
+  }
+}
+
 describe('NotificationList', () => {
   it('renders empty state when no entries', () => {
     render(<NotificationList entries={[]} />)
@@ -85,6 +99,31 @@ describe('NotificationList', () => {
     render(<NotificationList entries={[showFilter()]} />)
     expect(screen.getByText('My Filter')).toBeInTheDocument()
     expect(screen.getByText(/new match for/i)).toBeInTheDocument()
+  })
+
+  it('renders a request_fulfillment_proposed row with title + approve/reject prompt', () => {
+    render(<NotificationList entries={[requestFulfillment()]} />)
+    expect(screen.getByText(/a fulfillment was proposed for/i)).toBeInTheDocument()
+    expect(screen.getByText('Add Local Band XYZ')).toBeInTheDocument()
+    expect(screen.getByText(/review it to approve or reject/i)).toBeInTheDocument()
+  })
+
+  it('uses request_url as the deep-link target for request rows', () => {
+    render(<NotificationList entries={[requestFulfillment()]} />)
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      'https://example.com/requests/300'
+    )
+  })
+
+  it('falls back to "your request" + /requests when request fields are missing', () => {
+    render(
+      <NotificationList
+        entries={[requestFulfillment({ request_title: undefined, request_url: undefined })]}
+      />
+    )
+    expect(screen.getByText('your request')).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/requests')
   })
 
   it('marks unread rows visually (Unread label) and read rows without', () => {

--- a/frontend/features/notifications/components/NotificationList.tsx
+++ b/frontend/features/notifications/components/NotificationList.tsx
@@ -7,11 +7,12 @@
  */
 
 import Link from 'next/link'
-import { MessageCircle, AtSign, Calendar, BellRing, ExternalLink } from 'lucide-react'
+import { MessageCircle, AtSign, Calendar, BellRing, ExternalLink, PackageCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   formatTimeAgo,
   isCommentNotification,
+  isRequestNotification,
   NOTIFICATION_ENTITY_COMMENT_MENTION,
 } from '../types'
 import type { NotificationLogEntry } from '../types'
@@ -109,6 +110,49 @@ function NotificationRow({ entry, variant, onItemClick }: RowProps) {
                 {entry.comment_excerpt}
               </p>
             )}
+            <p className="mt-1 text-[11px] uppercase tracking-wide text-muted-foreground/70">
+              {formatTimeAgo(entry.sent_at)}
+            </p>
+          </div>
+          {unread && (
+            <span
+              className="mt-2 h-2 w-2 shrink-0 rounded-full bg-primary"
+              aria-label="Unread"
+            />
+          )}
+        </Link>
+      </li>
+    )
+  }
+
+  if (isRequestNotification(entry)) {
+    const href = entry.request_url ?? '/requests'
+    const requestTitle = entry.request_title || 'your request'
+    return (
+      <li>
+        <Link
+          href={href}
+          onClick={() => onItemClick?.(entry)}
+          className={cn(
+            'flex items-start gap-3 transition-colors hover:bg-accent/40',
+            padding,
+            unread && 'bg-accent/20'
+          )}
+        >
+          <div
+            className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary"
+            aria-hidden
+          >
+            <PackageCheck className="h-3.5 w-3.5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm leading-snug">
+              <span className="text-muted-foreground">A fulfillment was proposed for</span>{' '}
+              <span className="font-medium">{requestTitle}</span>
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Review it to approve or reject.
+            </p>
             <p className="mt-1 text-[11px] uppercase tracking-wide text-muted-foreground/70">
               {formatTimeAgo(entry.sent_at)}
             </p>

--- a/frontend/features/notifications/types.test.ts
+++ b/frontend/features/notifications/types.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   NOTIFICATION_ENTITY_COMMENT_REPLY,
   NOTIFICATION_ENTITY_COMMENT_MENTION,
+  NOTIFICATION_ENTITY_REQUEST_FULFILLMENT_PROPOSED,
   isCommentNotification,
+  isRequestNotification,
   NOTIFY_ENTITY_TYPES,
   formatTimeAgo,
   getFilterSummary,
@@ -42,6 +44,12 @@ describe('notification entity constants', () => {
     expect(NOTIFICATION_ENTITY_COMMENT_MENTION).toBe('comment_mention')
   })
 
+  it('exposes the PSY-890 request-fulfillment row type', () => {
+    expect(NOTIFICATION_ENTITY_REQUEST_FULFILLMENT_PROPOSED).toBe(
+      'request_fulfillment_proposed'
+    )
+  })
+
   it('lists the quick-create entity types', () => {
     expect(NOTIFY_ENTITY_TYPES).toEqual(['artist', 'venue', 'label', 'tag'])
   })
@@ -68,6 +76,34 @@ describe('isCommentNotification', () => {
     expect(isCommentNotification(logEntry({ entity_type: 'venue' }))).toBe(
       false
     )
+  })
+
+  it('returns false for a request-fulfillment row', () => {
+    expect(
+      isCommentNotification(
+        logEntry({ entity_type: 'request_fulfillment_proposed' })
+      )
+    ).toBe(false)
+  })
+})
+
+describe('isRequestNotification', () => {
+  it('returns true for a request_fulfillment_proposed row', () => {
+    expect(
+      isRequestNotification(
+        logEntry({ entity_type: 'request_fulfillment_proposed' })
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for a comment row', () => {
+    expect(
+      isRequestNotification(logEntry({ entity_type: 'comment_reply' }))
+    ).toBe(false)
+  })
+
+  it('returns false for a show-filter row', () => {
+    expect(isRequestNotification(logEntry({ entity_type: 'show' }))).toBe(false)
   })
 })
 

--- a/frontend/features/notifications/types.ts
+++ b/frontend/features/notifications/types.ts
@@ -37,6 +37,10 @@ export interface NotificationLogEntry {
   comment_entity_type?: string
   comment_entity_id?: number
   comment_entity_name?: string
+  // Request-driven enrichment (PSY-890): entity_id holds the request_id; the
+  // backend populates request_title + request_url for the inbox row + link.
+  request_title?: string
+  request_url?: string
 }
 
 /** GET /me/notifications response shape */
@@ -59,12 +63,25 @@ export interface MarkReadResponse {
 export const NOTIFICATION_ENTITY_COMMENT_REPLY = 'comment_reply' as const
 export const NOTIFICATION_ENTITY_COMMENT_MENTION = 'comment_mention' as const
 
+/**
+ * Backend notification_log entity_type for the PSY-890 request-fulfillment
+ * in-app row. Must stay in sync with
+ * models/notification.NotificationEntityRequestFulfillmentProposed.
+ */
+export const NOTIFICATION_ENTITY_REQUEST_FULFILLMENT_PROPOSED =
+  'request_fulfillment_proposed' as const
+
 /** isCommentNotification returns true for the PSY-595 comment row types. */
 export function isCommentNotification(entry: NotificationLogEntry): boolean {
   return (
     entry.entity_type === NOTIFICATION_ENTITY_COMMENT_REPLY ||
     entry.entity_type === NOTIFICATION_ENTITY_COMMENT_MENTION
   )
+}
+
+/** isRequestNotification returns true for the PSY-890 request-fulfillment row. */
+export function isRequestNotification(entry: NotificationLogEntry): boolean {
+  return entry.entity_type === NOTIFICATION_ENTITY_REQUEST_FULFILLMENT_PROPOSED
 }
 
 /** Notification filter response from the API */


### PR DESCRIPTION
Closes PSY-890.

## Summary

Notifies a community-request owner, in-app, when someone proposes a fulfillment for their request (the request enters `pending_fulfillment` and awaits their approve/reject). Reuses the existing PSY-595 bell + inbox — **no migration** (`notification_log.entity_type` / `channel` are unconstrained strings).

- **New discriminators** in `models/notification`: `NotificationEntityRequestFulfillmentProposed = "request_fulfillment_proposed"` + `NotificationChannelInApp` (leaf package so any domain service can mint a row without a cross-service import).
- **Fire point**: `FulfillRequestHandler` fires `RequestService.NotifyRequesterFulfillmentProposed(requestID, requesterID, fulfillerID)` via `shared.GoSafe` after the fulfillment succeeds — mirroring the audit-log fire right beside it. Skips when `fulfiller == requester` (self-fulfill) or when the requester didn't resolve.
- **Read enrichment**: `NotificationFilterService.enrichRequestNotifications` batch-loads the `requests` row → populates `request_title` + a `/requests/{id}` `request_url` (parallel to `enrichCommentNotifications`). Deleted requests degrade to empty fields.
- **Frontend**: a new `NotificationList` render branch for the request type (icon + "A fulfillment was proposed for **\<title\>** — Review it to approve or reject." + deep-link), plus `isRequestNotification` + contract fields.

Design locked from the PSY-890 spike (in-product-only · submit-only · no pref · admins not pinged · self-fulfill skip).

## Deferred by design (no ticket — revisit only if email is added)

- **Email channel + digest batching** — in-product-only this round; the bell is low-friction.
- **`notify_on_request_activity` opt-out preference + settings toggle** — only warranted once email is in scope (an in-app bell needs no mute). If email lands later, the opt-out pref ships with it.
- **Close-the-loop notification on approve/reject** (to the fulfiller) — a separable enhancement; the ticket's ask is "notify the requester on a proposal."

## Heads up from `/code-review`

Three parallel reviewers (correctness / cross-file+contract / quality). Correctness + contract: clean. One fix applied: **removed a `clause.OnConflict{DoNothing}` I'd added to the write — it's a no-op here** (`filter_id` is NULL, so Postgres treats rows as distinct and it can't dedup) and the comment overstated it; now a plain `Create` with an accurate comment (one row per proposal; a re-proposal after a reject is intentionally a fresh notification).

Noted, not chased (would expand scope into PSY-595 code or are deliberate forks):
- `enrichRequestNotifications`' dedup-collect loop mirrors `uniqueCommentIDs`; left inline rather than extracting a generic helper that touches PSY-595 code.
- The in-app write mirrors `engagement.writeInAppNotification`; a shared `notificationm` writer could collapse them if a 3rd in-app writer ever appears.
- `NotificationChannelInApp` is duplicated across `engagement` + `models/notification` (intentional, documented — avoids an `engagement→notificationm` import; identical value).
- Firing via a public interface method + handler `GoSafe` (vs PSY-595's injected-notifier-inside-service) is deliberate per the spike: `RequestService` is a bare `*gorm.DB` with no notifier injected, and this mirrors the adjacent audit-log `GoSafe`.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/services/community/... ./internal/services/notification/... ./internal/api/handlers/community/...` — all pass
- [x] New backend tests: `TestNotifyRequesterFulfillmentProposed_{WritesInAppRow,SkipsSelfFulfill,SkipsZeroRequester}` + `TestGetUserNotifications_{EnrichesRequestFulfillment,RequestFulfillment_DeletedRequest}` — pass (the deleted-request case locks the degrade-to-empty-fields path the self-review flagged)
- [x] `cd backend && ~/go/bin/golangci-lint run -c .golangci.yml ./...` — 0 issues
- [x] `go generate ./...` — mocks regenerated (Mocks Generator Drift clean)
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:run features/notifications` — 111 passing (incl. 3 new `NotificationList` request-row tests + 4 new `isRequestNotification` / const tests)
- [x] `/code-review` — 1 fix applied (above), re-ran backend tests after
- [x] Manual repro against local dev stack (below)

## Manual repro

Full end-to-end against the local dev stack (real API, not seeded rows):

1. Logged in as user A (`asdf@admin.com`) and user B (`asdfTwo@admin.com`).
2. A `POST /requests` → created request #2 "Add Local Band XYZ".
3. B `POST /requests/2/fulfill` → **HTTP 204** (fires my notification to A).
4. A `GET /me/notifications` returned the row, **enriched**:
   ```json
   { "entity_type": "request_fulfillment_proposed", "entity_id": 2,
     "channel": "in_app", "request_title": "Add Local Band XYZ",
     "request_url": "http://localhost:3000/requests/2" }
   ```
   (`unread_count: 1`)
5. Logged into the browser as A → both surfaces render the branch; the row links to `/requests/2`.

This exercises the whole path: fire → write → read-enrichment → API → render.

## Screenshots

Inbox (`/notifications`, `page` variant):

![inbox](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-f01773f5aa777ac8b8d3/psy890-inbox.png)

Bell popover (`popover` variant):

![bell popover](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-f01773f5aa777ac8b8d3/psy890-bell-popover.png)

## Coverage gaps

- **The fulfillment-proposal UI** that triggers this (RequestDetail approve/reject) isn't wired on the frontend yet — that's **PSY-891**. I triggered the fulfillment via the API to produce a genuine notification; the screenshots show the authenticated requester's rendered inbox + bell, and the backend fire is covered by the integration tests above.
- **Approve/reject and email** notifications are out of scope by design (see Deferred).
- Browser repro covered the **authenticated requester** path (the only one that renders this row); the self-fulfill-skip + zero-requester-skip paths are covered by integration tests, not the screenshot.
