### PR TITLE
PSY-636: document E2E seed show_artists denorm-cols carveout

### DIFF
--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -588,6 +588,19 @@ BEGIN
     )
     RETURNING id INTO s_id;
     INSERT INTO show_venues (show_id, venue_id) VALUES (s_id, v_id);
+    -- PSY-636 / PSY-576 carveout — DO NOT naively populate this row's denorm
+    -- cols. PSY-576 added denormalized event_date + venue_id to show_artists
+    -- plus a partial unique index on (artist_id, venue_id, event_date)
+    -- `WHERE event_date IS NOT NULL AND venue_id IS NOT NULL`. This seed leaves
+    -- those denorm cols NULL on every show_artists row, so the partial index
+    -- excludes them and they pass straight through. That is INTENTIONAL here:
+    -- every iteration of this loop inserts one distinct show per worker-user
+    -- but reuses the SAME (artist_id=a_id, venue_id=v_id, event_date=NOW()+85d)
+    -- triple, so populating the denorm cols would make all of these rows
+    -- collide on the unique index and fail the seed. If a future change needs
+    -- the denorm cols populated, first give each iteration a DISTINCT
+    -- event_date (e.g. stagger by minute) on both the shows row above and this
+    -- show_artists row. See PSY-636 (and PSY-628 for the partial-index design).
     INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (s_id, a_id, 0, 'headliner');
   END LOOP;
 


### PR DESCRIPTION
Closes PSY-636.

## Summary

Documents the PSY-576 denorm-column carveout in the E2E seed — a latent footgun, not a current bug. The seed inserts `show_artists` rows via raw SQL **without** PSY-576's denormalized `event_date` / `venue_id` columns; today this works because PSY-576's partial unique index on `(artist_id, venue_id, event_date)` is `WHERE event_date IS NOT NULL AND venue_id IS NOT NULL`, so the NULL-denorm seed rows pass straight through.

The risk: the "E2E My Submitted Show" loop seeds one **distinct** show per worker-user (for `my-submissions.spec.ts`, PSY-431) that all reuse the **same** `(artist_id, venue_id, event_date)` triple. A future engineer who naively populates the denorm cols would make those rows collide on the unique index and break the seed with a confusing violation.

Per the ticket's "pick one," chose **Option 2 (document the carveout)** — the rows are distinct shows that share a triple incidentally (not "the same logical show"), the seed works as-is, and an inline comment is the lowest-risk way to prevent the future-confusion footgun. The comment explains *why* the denorm cols are NULL and gives the fix path (stagger each iteration's `event_date`) if they ever need populating.

No production code changed; this is a comment-only edit to `frontend/e2e/setup-db.sh`.

## Test plan

- [x] `bash -n frontend/e2e/setup-db.sh` — shell + heredoc syntax valid (the comment didn't break the heredoc'd SQL)
- [x] Ran the seed against a freshly-migrated e2e DB (`docker compose -p e2e -f docker-compose.e2e.yml up -d` → `bash frontend/e2e/setup-db.sh`) — **exit 0**, "E2E database setup complete!", no errors/violations. This is the real check: the seed completes against a schema that HAS PSY-576's denorm cols + partial unique index, so the index behaves correctly with the seed (AC).
- [x] Verified the 5 "E2E My Submitted Show" rows seeded, and their `show_artists.event_date` / `venue_id` are **NULL** — exactly the carveout the comment documents
- [x] `/simplify` — clean (comment-only diff; no code-quality surface)
- [x] No UI surface — screenshots skipped

## Manual repro

```
$ DATABASE_URL=postgres://e2euser:e2epassword@localhost:5433/e2edb bash frontend/e2e/setup-db.sh
...
==> E2E database setup complete!
seed exit code: 0

-- 5 distinct submitted-show rows, denorm cols NULL (partial index skips them):
SELECT sa.event_date, sa.venue_id FROM show_artists sa
  JOIN shows s ON s.id=sa.show_id WHERE s.title LIKE 'E2E My Submitted Show%';
 event_date | venue_id
------------+----------
            |          (×5)
```

## Coverage gaps

- The full Playwright E2E suite was **not** re-run — the change is an inert SQL `--` comment with no behavior change, and the seed (the file's actual purpose) was verified to execute clean against the migrated schema. Running the full suite for a comment would be disproportionate.
