### PR TITLE
PSY-913: proxy.ts RESERVED_SEGMENTS — stop 404ing /shows/submit + /shows/saved

### DIFF
--- a/frontend/e2e/pages/not-found.spec.ts
+++ b/frontend/e2e/pages/not-found.spec.ts
@@ -165,4 +165,65 @@ test.describe('Not-found pages — HTTP 404 status', () => {
       ).toBeVisible({ timeout: 10_000 })
     })
   }
+
+  /**
+   * PSY-913 over-404 guard for RESERVED static routes under a proxied prefix.
+   *
+   * `proxy.ts`'s `/shows/:path*` matcher intercepts `/shows/submit` and
+   * `/shows/saved` — both are REAL Next routes (`app/shows/submit/page.tsx`,
+   * `app/shows/saved/page.tsx`), NOT entity slugs. PSY-897's shows phase made
+   * the proxy existence-check `submit`/`saved` as if they were slugs → backend
+   * 404 → rewrote the genuine page to a 404, breaking the full E2E suite on
+   * main (`submit-show.spec.ts`). `RESERVED_SEGMENTS` excludes them. These tests
+   * pin that the proxy lets each real page through. (Distinct from the seeded-
+   * slug guard above: a slug-existence backend call would 404 these; the
+   * exclusion is what saves them.)
+   */
+  test.describe('Reserved static routes under proxied prefixes (PSY-913)', () => {
+    test('/shows/submit is NOT 404-ed by proxy (real route renders, anon → client-redirect to /auth)', async ({
+      page,
+    }) => {
+      // `/shows/submit` is a client component with no server `notFound()`, so the
+      // INITIAL document is HTTP 200 (pre-fix the proxy rewrote it to the
+      // synthetic no-route path → 404). The page then client-redirects anon
+      // visitors to `/auth` (verified: app/shows/submit/page.tsx useEffect
+      // router.push('/auth?returnTo=%2Fshows%2Fsubmit')). Both assertions
+      // together prove the proxy let the real page render+hydrate, not 404.
+      const response = await page.goto('/shows/submit')
+      expect(
+        response?.status(),
+        '/shows/submit must return 200 — proxy.ts must not existence-check this static route (PSY-913)'
+      ).toBe(200)
+
+      // The anon client-redirect only fires if the real page hydrated. A 404
+      // body would never reach this useEffect.
+      await page.waitForURL(/\/auth/, { timeout: 10_000 })
+      await expect(
+        page.getByText('Sign in to your account')
+      ).toBeVisible({ timeout: 5_000 })
+    })
+
+    test('/shows/saved is NOT 404-ed by proxy (server-redirects to /library → anon lands on /auth)', async ({
+      page,
+    }) => {
+      // `/shows/saved` is a server component that unconditionally
+      // `redirect('/library')` (no auth gate — verified app/shows/saved/page.tsx).
+      // `page.goto` follows the server redirect; the final document is the
+      // `/library` 200 (its own client-side anon-redirect to /auth fires after).
+      // Pre-fix the proxy rewrote `/shows/saved` to the synthetic no-route path
+      // → 404, so the redirect chain never ran. The 200 below is the load-bearing
+      // proof the exclusion let the real route through (PSY-913).
+      const response = await page.goto('/shows/saved')
+      expect(
+        response?.status(),
+        '/shows/saved must resolve to 200 (server redirect to /library) — proxy.ts must not existence-check this static route (PSY-913)'
+      ).toBe(200)
+
+      // Settle point: /library is a client component that redirects anon
+      // visitors to /auth (verified app/library/page.tsx LibraryContent). A
+      // 404 body would never reach that redirect, so landing on /auth confirms
+      // the real route rendered.
+      await page.waitForURL(/\/auth/, { timeout: 10_000 })
+    })
+  })
 })

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -87,6 +87,24 @@ const ENTITY_CHECKS: Record<string, (slug: string) => string> = {
 }
 
 /**
+ * Static (non-`[slug]`) routes that live UNDER a proxied entity prefix. These
+ * are real Next routes — e.g. `app/shows/submit/page.tsx` (the show-submission
+ * form) and `app/shows/saved/page.tsx` (a server redirect to `/library`) — NOT
+ * entity slugs. The `config.matcher`'s `/shows/:path*` source intercepts them,
+ * and the `/<entity>/<slug>` shape guard below would otherwise existence-check
+ * `GET ${API_BASE_URL}/shows/submit` → backend 404 → rewrite the real page to a
+ * 404 (PSY-913, regressed by PSY-897's shows phase). Excluding these segments
+ * lets the genuine page render.
+ *
+ * Today only `shows` has static sub-routes; the other six proxied prefixes
+ * (venues/artists/releases/labels/festivals/tags) have only `[slug]`. When
+ * adding a NEW static route under ANY proxied prefix, add its segment here.
+ */
+const RESERVED_SEGMENTS: Record<string, ReadonlySet<string>> = {
+  shows: new Set(['submit', 'saved']),
+}
+
+/**
  * Returns the global 404 rewrite response (status 404 + render
  * `app/not-found.tsx` via the unmatched synthetic path).
  */
@@ -112,6 +130,13 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   // bare `/<entity>` list (no slug): leave untouched. Only the exact
   // `/<entity>/<slug>` detail shape is existence-checked.
   if (!buildCheckUrl || !slug || segments.length !== 3) {
+    return NextResponse.next()
+  }
+
+  // `/<entity>/<segment>` where <segment> is a real static route (e.g.
+  // `/shows/submit`, `/shows/saved`), not an entity slug — never existence-check
+  // it, or we'd 404 a genuine page (PSY-913).
+  if (RESERVED_SEGMENTS[entityType]?.has(slug)) {
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Summary
- Fix PSY-897 regression: `proxy.ts` no longer 404s the static routes `/shows/submit` + `/shows/saved` (RESERVED_SEGMENTS exclusion). Restores the full E2E suite on main.
- Root cause: PSY-897's shows phase added a `/shows/:path*` matcher that existence-checked `submit`/`saved` as if they were show slugs → backend 404 → rewrote the real page to `/_psy-not-found` → HTTP 404, breaking `submit-show.spec.ts` on the full sharded suite (runs on main, not PR-level Smoke — why it slipped through).
- Fix is a declarative `RESERVED_SEGMENTS` map (`shows → {submit, saved}`) checked right after the existing `/<entity>/<slug>` shape guard. Verified exhaustively: of the 7 proxied prefixes, only `shows` has static sub-routes today; the other 6 have only `[slug]`.
- Regression guard added to `not-found.spec.ts` (the PSY-721 spec): `/shows/submit` → 200, `/shows/saved` → 200.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:e2e -- submit-show` — passed, 3/3 (was FAILING on main pre-fix)
- [x] `cd frontend && bun run test:e2e -- not-found` — passed, 13/13 (2 consecutive runs), incl. new static-route guards + invalid-slug-still-404 for all 7 types

## Manual repro
The e2e runs are the repro (local full-stack harness: ephemeral postgres :5433 + Go backend :8080 + Next dev :3000).
- **submit-show** (the previously-failing spec): 3/3 passed (13.1s warm) — `displays submission form for verified user`, `can submit a show with existing venue`, `redirects unauthenticated user to login`. This is the spec the proxy regression broke on main.
- **not-found**: 13/13 passed, run 1 (31.6s) and run 2 (26.7s).
  - New PSY-913 guards: `/shows/submit` → HTTP 200 + anon client-redirect to `/auth` (real client page rendered, not a 404 body); `/shows/saved` → HTTP 200 (server-redirects to `/library` → anon settles on `/auth`).
  - No PSY-897 regression: invalid slug on all 7 types (`/shows`, `/venues`, `/artists`, `/releases`, `/labels`, `/festivals`, `/tags`) still → HTTP 404; generic no-route → 404; valid seeded show/venue → 200 (proxy does not over-404 real slugs).

## Code review
`/code-review` (max effort, 9 angles + sweep, run inline per the dispatched-sub-agent fallback) against the 86-line diff: **no findings (`[]`)**. Verified the `RESERVED_SEGMENTS[entityType]?.has(slug)` early-return is correctly placed after the `segments.length !== 3` shape guard, short-circuits safely for non-`shows` prefixes (undefined → falsy), adds no widening of the existence-check surface, and removes no guard. Separately confirmed via exhaustive `find` that the exclusion set is complete — no other static sub-routes exist under any proxied prefix.

Closes PSY-913