### PR TITLE
PSY-899: seed radio episodes + plays in e2e fixtures

### DIFF
--- a/backend/internal/seeddata/radio.go
+++ b/backend/internal/seeddata/radio.go
@@ -329,3 +329,98 @@ var RadioShows = []RadioShow{
 		ExternalID:      "anu",
 	},
 }
+
+// RadioEpisode is the canonical description of a single broadcast of a
+// RadioShow to seed. ShowSlug is the FK by slug (resolved to
+// radio_shows.id at insert time) so episodes can be defined without
+// knowing the show's autoincrement id.
+//
+// An episode is addressed in the public UI by its AirDate — the
+// /radio/{station}/{show}/{date} route segment is the air_date string and
+// GetEpisodeByShowAndDate looks it up via (show_id, air_date). There is no
+// separate episode slug column. AirDate must be a Postgres DATE literal
+// (YYYY-MM-DD).
+//
+// ExternalID participates in the episode dedup unique index
+// (idx_radio_episodes_unique on show_id, air_date, COALESCE(external_id,
+// '')), so it carries a deterministic value here rather than NULL to give
+// the ON CONFLICT target a stable expression.
+type RadioEpisode struct {
+	ShowSlug    string // resolved to radio_shows.id at insert time
+	Title       string // empty -> NULL
+	AirDate     string // Postgres DATE literal, e.g. "2025-01-15"
+	Description string // empty -> NULL
+	ArchiveURL  string // empty -> NULL
+	ExternalID  string // provider-specific episode id
+}
+
+// RadioPlay is the canonical description of a single track played in a
+// seeded RadioEpisode. EpisodeShowSlug + EpisodeAirDate together identify
+// the parent episode by its (show_id, air_date) natural key, mirroring how
+// the episode itself is addressed.
+//
+// ArtistSlug, when non-empty, resolves to artists.id and populates the
+// play's artist_id FK — this is what GetAsHeardOnForArtist joins on
+// (WHERE rp.artist_id = ?), so a seeded play MUST set ArtistSlug to a
+// real seeded artist for the artist "As Heard On" cross-link to render.
+// The raw ArtistName is always stored regardless (it's the never-
+// overwritten source metadata); leaving ArtistSlug empty models the
+// common "unmatched play" case where the matching engine found no
+// knowledge-graph artist (artist_id NULL).
+//
+// (EpisodeShowSlug, EpisodeAirDate, Position, ArtistName, TrackTitle,
+// AirTimestamp) keep each row distinct under the radio_plays dedup unique
+// index (idx_radio_plays_unique). Distinct Position values are sufficient
+// on their own.
+type RadioPlay struct {
+	EpisodeShowSlug string // parent episode's show slug
+	EpisodeAirDate  string // parent episode's air_date
+	Position        int    // 1-based play order within the episode
+	ArtistName      string // raw source metadata, always stored
+	TrackTitle      string // empty -> NULL
+	ArtistSlug      string // empty -> artist_id NULL (unmatched play)
+	AirTimestamp    string // Postgres TIMESTAMPTZ literal; empty -> NULL
+}
+
+// RadioEpisodes is the seed set of radio episodes. Currently a single
+// KEXP "The Morning Show" episode exists so the deep radio browse chain
+// (episode detail + tracklist) is E2E-reachable (PSY-899). Production
+// episodes are produced by the live fetch/import pipeline, not seeded;
+// this fixture exists solely to give the read-only browse flow a row to
+// click into.
+var RadioEpisodes = []RadioEpisode{
+	{
+		ShowSlug:    "the-morning-show",
+		Title:       "The Morning Show — January 15, 2025",
+		AirDate:     "2025-01-15",
+		Description: "Seeded fixture episode for E2E coverage of the radio episode detail + tracklist flow.",
+		ArchiveURL:  "https://www.kexp.org/shows/the-morning-show/",
+		ExternalID:  "e2e-the-morning-show-2025-01-15",
+	},
+}
+
+// RadioPlays is the seed set of radio plays. The first play links to the
+// seeded "Calexico" artist (ArtistSlug "calexico") so the artist "As Heard
+// On" cross-link (GetAsHeardOnForArtist, which joins on artist_id) renders
+// for that artist; the second is an intentionally unmatched play
+// (artist_id NULL) covering the common source-metadata-only case (PSY-899).
+var RadioPlays = []RadioPlay{
+	{
+		EpisodeShowSlug: "the-morning-show",
+		EpisodeAirDate:  "2025-01-15",
+		Position:        1,
+		ArtistName:      "Calexico",
+		TrackTitle:      "Crystal Frontier",
+		ArtistSlug:      "calexico", // matches seeded artist -> artist_id populated -> AsHeardOn renders
+		AirTimestamp:    "2025-01-15 06:05:00+00",
+	},
+	{
+		EpisodeShowSlug: "the-morning-show",
+		EpisodeAirDate:  "2025-01-15",
+		Position:        2,
+		ArtistName:      "Beach House",
+		TrackTitle:      "Space Song",
+		ArtistSlug:      "", // unmatched: no seeded artist -> artist_id NULL
+		AirTimestamp:    "2025-01-15 06:09:00+00",
+	},
+}

--- a/backend/internal/seeddata/radio_sql.go
+++ b/backend/internal/seeddata/radio_sql.go
@@ -103,10 +103,97 @@ func RenderRadioSeedSQL(w io.Writer) error {
 		}
 		b.WriteString("\n")
 	}
-	b.WriteString("ON CONFLICT (slug) DO NOTHING;\n")
+	b.WriteString("ON CONFLICT (slug) DO NOTHING;\n\n")
+
+	// Radio episodes. radio_episodes has no slug; the dedup key is the
+	// idx_radio_episodes_unique expression index on
+	// (show_id, air_date, COALESCE(external_id, '')), which is the ON
+	// CONFLICT target below so re-runs are no-ops. show_id is resolved from
+	// the show slug at insert time. radio_episodes has no updated_at column.
+	b.WriteString("-- Radio episodes (generated from backend/internal/seeddata/radio.go)\n")
+	b.WriteString("INSERT INTO radio_episodes (show_id, title, air_date, description, archive_url, external_id, play_count, created_at) VALUES\n")
+	for i, e := range RadioEpisodes {
+		b.WriteString("  ((SELECT id FROM radio_shows WHERE slug = ")
+		b.WriteString(sqlString(e.ShowSlug))
+		b.WriteString("), ")
+		b.WriteString(sqlStringOrNull(e.Title))
+		b.WriteString(", ")
+		b.WriteString(sqlString(e.AirDate))
+		b.WriteString(", ")
+		b.WriteString(sqlStringOrNull(e.Description))
+		b.WriteString(", ")
+		b.WriteString(sqlStringOrNull(e.ArchiveURL))
+		b.WriteString(", ")
+		b.WriteString(sqlString(e.ExternalID))
+		// play_count is set to the number of seeded plays on this episode so
+		// the denormalized count the detail page shows matches the tracklist.
+		b.WriteString(", ")
+		b.WriteString(strconv.Itoa(countPlaysForEpisode(e.ShowSlug, e.AirDate)))
+		b.WriteString(", NOW())")
+		if i < len(RadioEpisodes)-1 {
+			b.WriteString(",")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("ON CONFLICT (show_id, air_date, COALESCE(external_id, '')) DO NOTHING;\n\n")
+
+	// Radio plays. episode_id is resolved from the parent episode's
+	// (show_id, air_date) natural key; artist_id is resolved from the
+	// (optional) artist slug — empty slug -> NULL (unmatched play). The ON
+	// CONFLICT target matches idx_radio_plays_unique
+	// (episode_id, position, air_timestamp, artist_name, track_title) so
+	// re-runs are no-ops. radio_plays has no updated_at column.
+	b.WriteString("-- Radio plays (generated from backend/internal/seeddata/radio.go)\n")
+	b.WriteString("INSERT INTO radio_plays (episode_id, position, artist_name, track_title, artist_id, air_timestamp, created_at) VALUES\n")
+	for i, p := range RadioPlays {
+		b.WriteString("  ((SELECT id FROM radio_episodes WHERE show_id = (SELECT id FROM radio_shows WHERE slug = ")
+		b.WriteString(sqlString(p.EpisodeShowSlug))
+		b.WriteString(") AND air_date = ")
+		b.WriteString(sqlString(p.EpisodeAirDate))
+		b.WriteString("), ")
+		b.WriteString(strconv.Itoa(p.Position))
+		b.WriteString(", ")
+		b.WriteString(sqlString(p.ArtistName))
+		b.WriteString(", ")
+		b.WriteString(sqlStringOrNull(p.TrackTitle))
+		b.WriteString(", ")
+		b.WriteString(sqlArtistIDFromSlug(p.ArtistSlug))
+		b.WriteString(", ")
+		b.WriteString(sqlStringOrNull(p.AirTimestamp))
+		b.WriteString(", NOW())")
+		if i < len(RadioPlays)-1 {
+			b.WriteString(",")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("ON CONFLICT (episode_id, position, air_timestamp, artist_name, track_title) DO NOTHING;\n")
 
 	_, err := io.WriteString(w, b.String())
 	return err
+}
+
+// countPlaysForEpisode returns how many seeded RadioPlays belong to the
+// episode identified by (showSlug, airDate). Used to set radio_episodes
+// .play_count so the denormalized count matches the seeded tracklist.
+func countPlaysForEpisode(showSlug, airDate string) int {
+	n := 0
+	for _, p := range RadioPlays {
+		if p.EpisodeShowSlug == showSlug && p.EpisodeAirDate == airDate {
+			n++
+		}
+	}
+	return n
+}
+
+// sqlArtistIDFromSlug returns NULL for an unmatched play (empty slug), else
+// a subquery resolving the artist slug to artists.id at insert time. This
+// is what populates radio_plays.artist_id — the column GetAsHeardOnForArtist
+// joins on — so the artist "As Heard On" cross-link renders.
+func sqlArtistIDFromSlug(slug string) string {
+	if slug == "" {
+		return "NULL"
+	}
+	return "(SELECT id FROM artists WHERE slug = " + sqlString(slug) + ")"
 }
 
 // sqlString quotes a value as an SQL string literal, escaping any embedded

--- a/backend/internal/seeddata/radio_sql_test.go
+++ b/backend/internal/seeddata/radio_sql_test.go
@@ -38,6 +38,19 @@ func TestRenderRadioSeedSQL_Shape(t *testing.T) {
 		"'wfmu-drummer'",
 		"'Rock''n''Soul Radio'",
 		"'Sheena''s Jungle Room'",
+		// PSY-899: episode + play fixtures
+		"INSERT INTO radio_episodes",
+		"INSERT INTO radio_plays",
+		// episode show_id FK resolved by show slug subquery
+		"(SELECT id FROM radio_shows WHERE slug = 'the-morning-show')",
+		// episode dedup ON CONFLICT target matches idx_radio_episodes_unique
+		"ON CONFLICT (show_id, air_date, COALESCE(external_id, '')) DO NOTHING",
+		// play episode_id FK resolved by parent episode's (show_id, air_date)
+		"AND air_date = '2025-01-15'",
+		// matched play: artist_id resolved from seeded artist slug
+		"(SELECT id FROM artists WHERE slug = 'calexico')",
+		// play dedup ON CONFLICT target matches idx_radio_plays_unique
+		"ON CONFLICT (episode_id, position, air_timestamp, artist_name, track_title) DO NOTHING",
 	}
 	for _, want := range mustContain {
 		if !strings.Contains(sql, want) {
@@ -45,9 +58,18 @@ func TestRenderRadioSeedSQL_Shape(t *testing.T) {
 		}
 	}
 
-	// Three ON CONFLICT clauses: networks + stations + shows.
-	if got := strings.Count(sql, "ON CONFLICT"); got != 3 {
-		t.Errorf("want 3 ON CONFLICT clauses (networks + stations + shows), got %d", got)
+	// Five ON CONFLICT clauses: networks + stations + shows + episodes + plays.
+	if got := strings.Count(sql, "ON CONFLICT"); got != 5 {
+		t.Errorf("want 5 ON CONFLICT clauses (networks + stations + shows + episodes + plays), got %d", got)
+	}
+
+	// PSY-899: at least one play must be unmatched (artist_id NULL) so the
+	// generator covers the common source-metadata-only case. The matched
+	// play's artist_id is a subquery, so a bare ", NULL, " in the plays
+	// VALUES list is the unmatched signal.
+	playsSection := sql[strings.Index(sql, "INSERT INTO radio_plays"):]
+	if !strings.Contains(playsSection, "'Beach House', 'Space Song', NULL,") {
+		t.Errorf("expected an unmatched play (artist_id NULL) in the plays VALUES list")
 	}
 }
 

--- a/backend/internal/seeddata/radio_sql_test.go
+++ b/backend/internal/seeddata/radio_sql_test.go
@@ -66,8 +66,15 @@ func TestRenderRadioSeedSQL_Shape(t *testing.T) {
 	// PSY-899: at least one play must be unmatched (artist_id NULL) so the
 	// generator covers the common source-metadata-only case. The matched
 	// play's artist_id is a subquery, so a bare ", NULL, " in the plays
-	// VALUES list is the unmatched signal.
-	playsSection := sql[strings.Index(sql, "INSERT INTO radio_plays"):]
+	// VALUES list is the unmatched signal. Guard the marker lookup so a
+	// missing plays INSERT fails cleanly here instead of panicking on a
+	// negative slice index (the mustContain loop above uses Errorf, not
+	// Fatalf, so execution reaches this point even when the marker is gone).
+	playsStart := strings.Index(sql, "INSERT INTO radio_plays")
+	if playsStart < 0 {
+		t.Fatalf("plays INSERT not found in generated SQL")
+	}
+	playsSection := sql[playsStart:]
 	if !strings.Contains(playsSection, "'Beach House', 'Space Song', NULL,") {
 		t.Errorf("expected an unmatched play (artist_id NULL) in the plays VALUES list")
 	}


### PR DESCRIPTION
## Summary

Phase 2d shipped the full radio provider integration (KEXP / WFMU / NTS), but the e2e seed only produced radio networks/stations/shows — **no `radio_episodes` or `radio_plays`** (documented gap in `frontend/e2e/pages/radio.spec.ts` header, surfaced by PSY-722 / #880). That left the deep radio browse chain (episode detail + tracklist, artist "As Heard On") with no e2e-reachable data.

This adds `RadioEpisode` + `RadioPlay` seed structs and slices to the single source of truth (`backend/internal/seeddata/radio.go`, per PSY-414/385) and extends `RenderRadioSeedSQL` to emit them. The data flows through `cmd/gen-e2e-seed` → `frontend/e2e/setup-db.sh` (the same pipe used for stage/local), so no drift is possible.

Seeded fixture:
- **1 episode** under KEXP `the-morning-show`, `air_date` `2025-01-15` (episodes have no slug — the `/radio/{station}/{show}/{date}` route segment is the `air_date`, looked up via `GetEpisodeByShowAndDate`).
- **2 plays:** `Calexico` (position 1) with `artist_id` resolved from the seeded `calexico` artist slug, and `Beach House` (position 2) intentionally unmatched (`artist_id` NULL, modeling the common source-metadata-only case).

The matched play's `artist_id` is the load-bearing detail: `GetAsHeardOnForArtist` joins on `rp.artist_id` (not `artist_name`), so the play must populate the FK for the artist "As Heard On" cross-link to render. The generator resolves it via a `(SELECT id FROM artists WHERE slug = ...)` subquery, mirroring the existing `sqlNetworkIDFromSlug` pattern.

`ON CONFLICT` targets match the dedup unique indexes (`idx_radio_episodes_unique`, `idx_radio_plays_unique`) so the seed stays idempotent across dispatch-stack re-ups, consistent with the existing `ON CONFLICT (slug) DO NOTHING` radio seed.

## Test plan

- [x] `cd backend && go build ./...` — clean (exit 0)
- [x] `cd backend && go test ./internal/seeddata/...` — pass (extended `TestRenderRadioSeedSQL_Shape` asserts the new episode/play SQL, the 5 `ON CONFLICT` clauses, the `calexico` artist subquery, and the unmatched-play NULL)
- [x] **Isolated dispatch stack** (`stack-up.sh --mode=isolated`, NOT the shared e2e harness) — seed ran during stack-up; queried the isolated Postgres 18 to confirm row counts.

## Manual repro (queried rows from the isolated stack DB)

Episode under `the-morning-show`:
```
 id |                title                |  air_date  |           external_id           | play_count |    show_slug
----+-------------------------------------+------------+---------------------------------+------------+------------------
  1 | The Morning Show — January 15, 2025 | 2025-01-15 | e2e-the-morning-show-2025-01-15 |          2 | the-morning-show
```

Plays on that episode:
```
 id | position | artist_name |   track_title    | artist_id | linked_artist_slug |     air_timestamp
----+----------+-------------+------------------+-----------+--------------------+------------------------
  1 |        1 | Calexico    | Crystal Frontier |         1 | calexico           | 2025-01-15 06:05:00+00
  2 |        2 | Beach House | Space Song       |    (NULL)  | (none)             | 2025-01-15 06:09:00+00
```

Row counts: `episodes=1, plays=2, plays_with_artist_id=1`.

`AsHeardOn` simulation (mirrors the `GetAsHeardOnForArtist` join `WHERE rp.artist_id = (SELECT id FROM artists WHERE slug='calexico')`):
```
 station |       show       | play_count | last_played
---------+------------------+------------+-------------
 kexp    | the-morning-show |          1 | 2025-01-15
```

**Idempotency:** re-ran `gen-e2e-seed | psql` against the already-seeded DB → all radio statements returned `INSERT 0 0`, counts unchanged (episodes=1, plays=2). Stack torn down with `stack-down.sh`.

## Code review

`/code-review` (sub-agent inline, 9 lenses + sweep). One finding fixed (medium, test-only): the new `playsSection := sql[strings.Index(...):]` could panic on a negative slice index if the plays-INSERT marker were ever absent (the preceding `mustContain` loop uses `Errorf`, not `Fatalf`, so execution continues). Guarded with an explicit `playsStart < 0 → Fatalf`. No correctness bugs in the generated SQL (verified live against Postgres 18).

Closes PSY-899

🤖 Generated with [Claude Code](https://claude.com/claude-code)
