### PR TITLE
PSY-904: seed festival fixture row for content-detail e2e

### DIFF
--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -109,6 +109,30 @@ VALUES
   ('Sundressed EP', 'sundressed-ep', 'ep', 2014, NOW(), NOW())
 ON CONFLICT DO NOTHING;
 
+-- Festival fixture (PSY-904): the festivals table is a real DB-stored entity
+-- (migration 000039), unlike blog/dj-sets (local MDX) and scenes (derived from
+-- venue/show/artist aggregates). The /festivals/[slug] detail page fetches
+-- /festivals/<slug> (backend GetFestivalHandler falls back to GetFestivalBySlug
+-- for a non-numeric path), so a deterministic slug here gives content-detail.spec
+-- a stable festival URL to assert H1 + canonical + JSON-LD against. NOT NULL
+-- columns per the migration: name, slug, series_slug, edition_year, start_date,
+-- end_date. City/state = Phoenix, AZ matches the rest of the seed (and increments
+-- the phoenix-az scene's festival_count — a harmless side benefit, not relied on).
+INSERT INTO festivals (
+  name, slug, series_slug, edition_year,
+  description, city, state, country,
+  start_date, end_date, status,
+  created_at, updated_at
+)
+VALUES (
+  'E2E Test Fest 2026', 'e2e-test-fest-2026', 'e2e-test-fest', 2026,
+  'Seeded festival fixture for content-detail E2E coverage (PSY-904).',
+  'Phoenix', 'AZ', 'US',
+  '2026-09-18', '2026-09-20', 'confirmed',
+  NOW(), NOW()
+)
+ON CONFLICT DO NOTHING;
+
 -- Link artists to releases (artist_releases junction)
 DO $$
 DECLARE


### PR DESCRIPTION
## Summary

Seeds a single **festival** row in the E2E fixture (`frontend/e2e/setup-db.sh`) so `content-detail.spec.ts` (PSY-723) can be extended to cover the `/festivals/[slug]` detail page. The other three "uncovered" content types named in the ticket — **blog**, **dj-sets**, **scenes** — turned out to be **non-seedable by design** and are already navigable in the E2E environment without any DB rows, so this PR does NOT add INSERTs for them.

## Premise correction (verified against current code)

The ticket assumed all four types (blog / festival / scene / dj-set) are DB-stored rows that can be seeded into `setup-db.sh`. That is wrong for three of them. Verified per type:

| Type | Data model | Source of truth | Seed needed? |
| --- | --- | --- | --- |
| **festival** | **DB table** | `festivals` (migration `000039`); `/festivals/[slug]` page fetches `/festivals/<slug>`, backend `GetFestivalHandler` falls back to `GetFestivalBySlug` for a non-numeric path | **YES — added one row** |
| **blog** | **Local MDX** | `frontend/content/blog/*.md` via `getBlogPost`/`getBlogSlugs` (`fs.readdirSync`) — 4 posts ship in the repo | No — already navigable |
| **dj-sets** | **Local MDX** | `frontend/content/mixes/*.md` via `getMix`/`getMixSlugs` (`fs.readdirSync`) — 1 mix ships in the repo | No — already navigable |
| **scenes** | **Derived (no table)** | computed from `venues`+`shows`+`artists`; `/scenes/<slug>` → `SceneService.GetSceneDetail`; qualifies at ≥2 verified venues + ≥3 approved shows. The existing seed's `phoenix-az` (3 verified Phoenix venues + 55 approved shows) already qualifies | No — already navigable |

So the genuine, missing, DB-stored content type was **festival only**. Adding INSERTs for blog/dj-sets/scenes would target tables that don't exist (blog/dj-sets) or aggregates that aren't rows (scenes).

**Navigable existing slugs (no seeding) for the follow-up spec to use:**
- blog → `/blog/2025-02-16-psychic-homily-dot-com-is-now-live` (H1 "PsychicHomily.com is now live!")
- dj-sets → `/dj-sets/2025-03-31-vinyl-mix-what-the-hell-is-vibe-coding-2-10-25`
- scenes → `/scenes/phoenix-az`

The seeded festival slug is `e2e-test-fest-2026` (name "E2E Test Fest 2026", H1 via `EntityHeader title={festival.name}`).

## Test plan

- [x] `bash -n setup-db.sh` — bash syntax valid.
- [x] Festival INSERT columns cross-checked against migration `000039` NOT NULL set (`name`, `slug`, `series_slug`, `edition_year`, `start_date`, `end_date`); migration `000048` only ADDs nullable provenance columns (untouched).
- [x] Isolated dev stack (`stack-up.sh --mode=isolated`) seeds via this exact `setup-db.sh` → migrate + seed completed with no SQL error; backend compiled and passed `/health`.
- [ ] Folding the four extra cases into `content-detail.spec.ts` is a small follow-up (per the ticket's AC, "OR do it in a small follow-up") — left out of this seed-only PR to keep the diff tight.

## Manual repro (isolated stack — per-type)

Seed log: labels `INSERT 0 3`, releases `INSERT 0 5`, **festival `INSERT 0 1`** — no errors; `==> E2E database setup complete!`.

| Surface | URL | Status |
| --- | --- | --- |
| festival (DB, seeded) — backend by slug | `/festivals/e2e-test-fest-2026` | **200** + full body (name/slug/status/city/state/dates) |
| festival (DB, seeded) — frontend detail | `/festivals/e2e-test-fest-2026` | **200**, H1 "E2E Test Fest 2026" |
| scene (derived, no seed) — backend | `/scenes/phoenix-az` | **200** (7 venues, 7 artists, 43 upcoming, festival_count 1) |
| scene (derived, no seed) — frontend | `/scenes/phoenix-az` | **200** |
| blog (MDX, no seed) — frontend | `/blog/2025-02-16-psychic-homily-dot-com-is-now-live` | **200** |
| dj-set (MDX, no seed) — frontend | `/dj-sets/2025-03-31-vinyl-mix-what-the-hell-is-vibe-coding-2-10-25` | **200** |

DB row confirmed directly: `SELECT ... FROM festivals` → 1 row (`e2e-test-fest-2026`, Phoenix/AZ, confirmed, 2026-09-18..20).

## Code review

`/code-review` run inline (sub-agent has no Agent tool in a worktree — three lenses applied to the diff directly):
- **Correctness**: clean. All NOT NULL columns covered (verified against `information_schema` + migration `000039`); `ON CONFLICT DO NOTHING` matches the adjacent labels/releases idempotency contract; `UNIQUE(series_slug, edition_year)` satisfied; slug `e2e-test-fest-2026` cannot collide with `not-found.spec.ts`'s nonce slug (`psy721-${Date.now()}-…`) or any seeded row.
- **Reuse / simplification**: mirrors the existing labels/releases seed style exactly; no duplication, nothing to extract for a single fixture row.
- **Efficiency**: single INSERT inside the existing `psql` heredoc — no extra round-trip, no new `psql` invocation.

No changes required.

## Notes

- No overlap with PSY-899 (radio seed): that work lives in `backend/internal/seeddata/radio.go`; this PR touches only `frontend/e2e/setup-db.sh` and adds a festival INSERT in the labels/releases block.
- The JSON-LD observation from PSY-723 (releases/labels lack page-specific JSON-LD) is a separate SEO concern, out of scope here, already flagged on the ticket.

Closes PSY-904
