### PR TITLE
PSY-902: guard account-recovery confirm double-fire

### DIFF
--- a/frontend/app/auth/recover/page.tsx
+++ b/frontend/app/auth/recover/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, useEffect, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { useForm } from '@tanstack/react-form'
@@ -141,11 +141,32 @@ function TokenConfirmation({ token }: { token: string }) {
   const router = useRouter()
   const confirmMutation = useConfirmAccountRecovery()
   const { setUser } = useAuthContext()
+  const attemptedTokenRef = useRef<string | null>(null)
+
   const [error, setError] = useState<string | null>(null)
+  const { mutateAsync: confirmRecovery } = confirmMutation
 
   useEffect(() => {
-    confirmMutation.mutate(token, {
-      onSuccess: data => {
+    // Confirm exactly once per token value. Without this guard, React
+    // strict-mode double-invoke (dev + E2E) re-fires the mutation: the first
+    // call restores + logs in, the redundant second hits the now-active
+    // account → "already active" banner, never completing the redirect home
+    // (PSY-902).
+    //
+    // The result is consumed through mutateAsync's returned promise — NOT the
+    // mutation's reactive state (isSuccess/isError) or a per-`.mutate()`-call
+    // onSuccess/onError. Under strict mode the guard fires the mutation on the
+    // discarded mount, and React Query then leaves the surviving mount's
+    // observer stuck on `pending` (its inline callbacks never run, isSuccess/
+    // isError never flip) — which left the page frozen on the spinner. The
+    // promise from mutateAsync settles in this effect's own closure regardless
+    // of observer lifecycle, so success/error always lands.
+    if (!token || attemptedTokenRef.current === token) {
+      return
+    }
+    attemptedTokenRef.current = token
+    confirmRecovery(token)
+      .then(data => {
         if (data.user) {
           setUser({
             id: data.user.id,
@@ -156,12 +177,11 @@ function TokenConfirmation({ token }: { token: string }) {
           })
         }
         router.push('/')
-      },
-      onError: err => {
-        setError(err.message)
-      },
-    })
-  }, [token]) // eslint-disable-line react-hooks/exhaustive-deps
+      })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : 'Account recovery failed')
+      })
+  }, [token, confirmRecovery, setUser, router])
 
   if (error) {
     return (

--- a/frontend/e2e/auth/recover.spec.ts
+++ b/frontend/e2e/auth/recover.spec.ts
@@ -109,19 +109,20 @@ test.describe('Account Recovery', () => {
     // Following the recovery link auto-fires confirmation on mount.
     await page.goto(`/auth/recover?token=${token}`)
 
-    // Completion = the recovery established a logged-in session. Assert that
-    // durable signal (the global-nav avatar dropdown, set from auth context on
-    // confirm success) rather than the post-success redirect to "/".
+    // Completion has two durable signals; assert BOTH:
+    //   1. The post-success redirect to "/" actually lands.
+    //   2. A logged-in session was established (the global-nav avatar dropdown,
+    //      set from auth context on confirm success).
     //
-    // We intentionally do NOT assert waitForURL('/'): the recover page's
-    // TokenConfirmation effect lacks the once-per-token guard that the
-    // magic-link page has (attemptedTokenRef), so under React strict mode the
-    // confirm can fire twice — the first restores + logs in, a redundant
-    // second hits the now-active account and flips the page into an
-    // "already active" banner without completing the redirect. The session
-    // (setUser) from the first confirm still persists, so the User-menu marker
-    // is the stable completion signal. Page-side guard tracked as a follow-up
-    // (see PR notes).
+    // PSY-902 added the once-per-token guard (attemptedTokenRef) the recover
+    // page previously lacked. Before that guard, React strict-mode double-invoke
+    // re-fired the confirm: the first call restored + logged in, but a redundant
+    // second hit the now-active account and flipped the page into an "already
+    // active" banner WITHOUT completing the redirect — so this test could only
+    // assert the surviving session, not the redirect. With the guard, the
+    // redirect completes deterministically, so the waitForURL assertion below is
+    // the regression that proves the double-fire is fixed.
+    await page.waitForURL('/', { timeout: 15_000 })
     await expect(
       page.getByRole('button', { name: 'User menu' })
     ).toBeVisible({ timeout: 15_000 })


### PR DESCRIPTION
## Summary

`TokenConfirmation` in `frontend/app/auth/recover/page.tsx` fired `confirmMutation.mutate(token)` in a `useEffect([token])` with **no once-per-token guard**. Under React strict-mode double-invoke (dev + E2E), the confirm fired twice — the first call restored + logged in, then the redundant second call hit the now-active account ("already active") and the redirect home never completed.

The fix has two parts:

1. **`attemptedTokenRef` guard** (mirrors `frontend/app/auth/magic-link/page.tsx`): fire confirmation exactly once per token value.
2. **Consume the result via `mutateAsync`'s returned promise** rather than the mutation's reactive state or per-`.mutate()`-call callbacks. This is the non-obvious part the magic-link mirror alone did **not** fix: under strict mode the guard fires the mutation on the discarded mount, and React Query then leaves the *surviving* mount's observer stuck on `pending` (inline `onSuccess`/`onError` never run; `isSuccess`/`isError` never flip), freezing the page on the spinner. The promise from `mutateAsync` settles in the effect's own closure regardless of observer lifecycle, so success (→ `setUser` + redirect) and error (→ banner) always land. Verified each alternative with a temporary instrumented diagnostic (`confirmMutation.status` stayed `pending` for both the reactive-state read and the per-call-callback variants; only `mutateAsync().then().catch()` settled correctly).

Also removed the now-unnecessary `eslint-disable-line react-hooks/exhaustive-deps` — the new deps `[token, confirmRecovery, setUser, router]` are exhaustive (eslint clean).

## Test plan

- [x] `bun run typecheck` — clean (`tsc --noEmit`, no errors)
- [x] `bun run test:run features/auth/hooks` — 139 passed (6 files; includes `useConfirmAccountRecovery`/`useRequestAccountRecovery` coverage in `useAuth.test.tsx`)
- [x] `bun run test:e2e -- recover` — **4 passed**, run **twice consecutively** (18.1s, then 17.1s), both deterministic
- [x] eslint on `app/auth/recover/page.tsx` — clean
- [x] Baseline comparison: confirmed the 3 token-confirmation tests **pass on baseline** (no guard, no `waitForURL`) and that the naive ref-guard-only / reactive-state variants **fail** (observer stuck `pending`) — isolating the real fix

## Manual repro

The tightened PSY-719 completion e2e in `frontend/e2e/auth/recover.spec.ts` **is** the repro. It previously routed *around* the double-fire by asserting only the surviving session and intentionally NOT asserting the redirect (the workaround comment named PSY-902 directly). This PR **strengthens** it: it now asserts `await page.waitForURL('/', { timeout: 15_000 })` (the redirect the double-fire broke) **alongside** the existing `User menu` session assertion. That assertion passes on both consecutive runs, proving the guard fixed the double-fire and the redirect completes. No coverage removed.

## Code review

Ran `/code-review` (sub-agent inline: line-by-line, removed-behavior, cross-file, language-pitfall, reuse/simplification/efficiency/altitude lenses). **No findings.** The `err instanceof Error ? err.message : 'fallback'` idiom matches 20+ existing sites; the ref-guard pattern matches the magic-link page; the one PLAUSIBLE-but-benign item (setState after a strict-mode unmount) is a no-op in React 18+ and clean across two deterministic e2e runs.

Closes PSY-902

🤖 Generated with [Claude Code](https://claude.com/claude-code)