### PR TITLE
PSY-891: surface pending-fulfillment state + approve/reject UI

### DIFF
--- a/frontend/features/requests/components/RequestDetail.test.tsx
+++ b/frontend/features/requests/components/RequestDetail.test.tsx
@@ -72,6 +72,8 @@ const mockDeleteMutate = vi.fn()
 const mockVoteMutate = vi.fn()
 const mockRemoveVoteMutate = vi.fn()
 const mockFulfillMutate = vi.fn()
+const mockApproveMutate = vi.fn()
+const mockRejectMutate = vi.fn()
 const mockCloseMutate = vi.fn()
 const mockUpdateMutate = vi.fn()
 
@@ -97,6 +99,16 @@ const mockFulfillMutation = vi.fn<() => MutationStub>(() => ({
   mutate: mockFulfillMutate,
   isPending: false,
 }))
+const mockApproveMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockApproveMutate,
+  isPending: false,
+  error: null,
+}))
+const mockRejectMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockRejectMutate,
+  isPending: false,
+  error: null,
+}))
 const mockCloseMutation = vi.fn<() => MutationStub>(() => ({
   mutate: mockCloseMutate,
   isPending: false,
@@ -114,6 +126,8 @@ vi.mock('../hooks', () => ({
   useVoteRequest: () => mockVoteMutation(),
   useRemoveVoteRequest: () => mockRemoveVoteMutation(),
   useFulfillRequest: () => mockFulfillMutation(),
+  useApproveFulfillment: () => mockApproveMutation(),
+  useRejectFulfillment: () => mockRejectMutation(),
   useCloseRequest: () => mockCloseMutation(),
 }))
 
@@ -178,6 +192,16 @@ describe('RequestDetail', () => {
     mockFulfillMutation.mockReturnValue({
       mutate: mockFulfillMutate,
       isPending: false,
+    })
+    mockApproveMutation.mockReturnValue({
+      mutate: mockApproveMutate,
+      isPending: false,
+      error: null,
+    })
+    mockRejectMutation.mockReturnValue({
+      mutate: mockRejectMutate,
+      isPending: false,
+      error: null,
     })
     mockCloseMutation.mockReturnValue({
       mutate: mockCloseMutate,
@@ -325,9 +349,12 @@ describe('RequestDetail', () => {
         screen.getByRole('button', { name: /Edit/i })
       ).toBeInTheDocument()
       expect(getDeleteButton()).toBeInTheDocument()
-      // Fulfill/Close are admin-only and must stay hidden for a plain requester.
+      // Close is admin-only and must stay hidden for a plain requester. (Note:
+      // "Propose a fulfillment" DOES show for the requester on an open request
+      // — submit is open to any authed user post-PSY-748 — so we assert on
+      // Close, the genuinely admin-only action, rather than /Fulfill/i.)
       expect(
-        screen.queryByRole('button', { name: /Fulfill/i })
+        screen.queryByRole('button', { name: /Close/i })
       ).not.toBeInTheDocument()
     })
 

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -19,6 +19,14 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Breadcrumb, UserAttribution } from '@/components/shared'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import {
@@ -28,6 +36,8 @@ import {
   useVoteRequest,
   useRemoveVoteRequest,
   useFulfillRequest,
+  useApproveFulfillment,
+  useRejectFulfillment,
   useCloseRequest,
 } from '../hooks'
 import {
@@ -52,9 +62,12 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
   const voteMutation = useVoteRequest()
   const removeVoteMutation = useRemoveVoteRequest()
   const fulfillMutation = useFulfillRequest()
+  const approveMutation = useApproveFulfillment()
+  const rejectMutation = useRejectFulfillment()
   const closeMutation = useCloseRequest()
 
   const [isEditing, setIsEditing] = useState(false)
+  const [isRejectModalOpen, setIsRejectModalOpen] = useState(false)
 
   if (isLoading) {
     return (
@@ -110,7 +123,16 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
   const isAdmin = user?.is_admin === true
   const canEdit = isRequester || isAdmin
   const canDelete = isRequester || isAdmin
-  const canFulfill = isAdmin && request.status !== 'fulfilled'
+  // PSY-748/PSY-891: submitting a fulfillment is open to ANY authenticated
+  // user (it proposes, not finalizes — the requester/admin then approves).
+  // Available only while the request is open for proposals.
+  const canSubmitFulfillment =
+    isAuthenticated &&
+    (request.status === 'pending' || request.status === 'in_progress')
+  // PSY-891: approving/rejecting a proposed fulfillment is gated to the
+  // original requester or an admin, and only when one is pending review.
+  const canReviewFulfillment =
+    request.status === 'pending_fulfillment' && (isRequester || isAdmin)
   const canClose = isAdmin && request.status !== 'cancelled' && request.status !== 'fulfilled'
 
   const userVote = request.user_vote ?? 0
@@ -149,6 +171,17 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
 
   const handleFulfill = () => {
     fulfillMutation.mutate({ requestId: request.id })
+  }
+
+  const handleApprove = () => {
+    approveMutation.mutate({ requestId: request.id })
+  }
+
+  const handleReject = () => {
+    rejectMutation.mutate(
+      { requestId: request.id },
+      { onSuccess: () => setIsRejectModalOpen(false) }
+    )
   }
 
   const handleClose = () => {
@@ -304,6 +337,102 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                       )}
                     </div>
                   )}
+
+                  {/* PSY-891: pending-fulfillment review panel (requester/admin) */}
+                  {canReviewFulfillment && (
+                    <div className="mt-4 rounded-lg border border-primary/60 p-4">
+                      <p className="text-sm font-semibold text-primary">
+                        A fulfillment is awaiting your approval
+                      </p>
+                      {request.fulfiller_name && (
+                        <p className="mt-1 text-sm text-foreground">
+                          <UserAttribution
+                            name={request.fulfiller_name}
+                            username={request.fulfiller_username}
+                            className="text-foreground"
+                          />{' '}
+                          proposed a fulfillment
+                          {request.updated_at &&
+                            ` · ${formatTimeAgo(request.updated_at)}`}
+                        </p>
+                      )}
+                      {request.requested_entity_id && (
+                        <Link
+                          href={getEntityUrl(
+                            request.entity_type,
+                            request.requested_entity_id
+                          )}
+                          className="mt-1 inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                          View proposed{' '}
+                          {getEntityTypeLabel(request.entity_type).toLowerCase()}
+                        </Link>
+                      )}
+                      <div className="mt-3 flex items-center gap-2">
+                        <Button
+                          size="sm"
+                          onClick={handleApprove}
+                          disabled={
+                            approveMutation.isPending || rejectMutation.isPending
+                          }
+                        >
+                          {approveMutation.isPending && (
+                            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                          )}
+                          Approve fulfillment
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setIsRejectModalOpen(true)}
+                          disabled={
+                            approveMutation.isPending || rejectMutation.isPending
+                          }
+                        >
+                          Reject
+                        </Button>
+                      </div>
+                      {approveMutation.error && (
+                        <p className="mt-2 text-sm text-destructive">
+                          {approveMutation.error instanceof Error
+                            ? approveMutation.error.message
+                            : 'Failed to approve fulfillment'}
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  {/* PSY-891: pending-fulfillment, viewer is NOT requester/admin */}
+                  {request.status === 'pending_fulfillment' &&
+                    !canReviewFulfillment && (
+                      <p className="mt-4 text-sm text-muted-foreground">
+                        A fulfillment has been proposed — awaiting the
+                        requester&apos;s approval.
+                      </p>
+                    )}
+
+                  {/* PSY-748/PSY-891: any authed user can propose a fulfillment */}
+                  {canSubmitFulfillment && (
+                    <div className="mt-4">
+                      <p className="mb-2 text-sm text-muted-foreground">
+                        Found the{' '}
+                        {getEntityTypeLabel(request.entity_type).toLowerCase()} in
+                        the graph? Propose it — the requester reviews and
+                        approves.
+                      </p>
+                      <Button
+                        size="sm"
+                        onClick={handleFulfill}
+                        disabled={fulfillMutation.isPending}
+                      >
+                        {fulfillMutation.isPending && (
+                          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                        )}
+                        Propose a fulfillment
+                      </Button>
+                    </div>
+                  )}
                 </div>
               </div>
 
@@ -317,19 +446,6 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                   >
                     <Pencil className="h-4 w-4 mr-1.5" />
                     Edit
-                  </Button>
-                )}
-
-                {canFulfill && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleFulfill}
-                    disabled={fulfillMutation.isPending}
-                    className="text-green-700 hover:text-green-700 dark:text-green-400 dark:hover:text-green-400"
-                  >
-                    <CheckCircle className="h-4 w-4 mr-1.5" />
-                    Fulfill
                   </Button>
                 )}
 
@@ -362,6 +478,46 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
           </div>
         )}
       </header>
+
+      {/* PSY-891: reject-fulfillment confirm modal (no required reason) */}
+      <Dialog open={isRejectModalOpen} onOpenChange={setIsRejectModalOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reject this fulfillment?</DialogTitle>
+            <DialogDescription>
+              The request will reopen so anyone can propose a fulfillment, and
+              the contributor will be notified. You can approve a different
+              proposal later.
+            </DialogDescription>
+          </DialogHeader>
+          {rejectMutation.error && (
+            <p className="text-sm text-destructive">
+              {rejectMutation.error instanceof Error
+                ? rejectMutation.error.message
+                : 'Failed to reject fulfillment'}
+            </p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsRejectModalOpen(false)}
+              disabled={rejectMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleReject}
+              disabled={rejectMutation.isPending}
+            >
+              {rejectMutation.isPending && (
+                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              )}
+              Reject fulfillment
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -356,19 +356,14 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                             ` · ${formatTimeAgo(request.updated_at)}`}
                         </p>
                       )}
-                      {request.requested_entity_id && (
-                        <Link
-                          href={getEntityUrl(
-                            request.entity_type,
-                            request.requested_entity_id
-                          )}
-                          className="mt-1 inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
-                        >
-                          <ExternalLink className="h-3.5 w-3.5" />
-                          View proposed{' '}
-                          {getEntityTypeLabel(request.entity_type).toLowerCase()}
-                        </Link>
-                      )}
+                      {/*
+                        PSY-891: no "view proposed entity" link here yet — the
+                        current "Propose a fulfillment" flow doesn't capture a
+                        distinct entity (it submits without fulfilled_entity_id),
+                        so request.requested_entity_id holds the ORIGINAL request
+                        target, not what the fulfiller proposed. A propose-with-
+                        entity-picker flow is the follow-up (see PSY-891 comment).
+                      */}
                       <div className="mt-3 flex items-center gap-2">
                         <Button
                           size="sm"

--- a/frontend/features/requests/hooks/index.test.tsx
+++ b/frontend/features/requests/hooks/index.test.tsx
@@ -13,6 +13,10 @@ vi.mock('@/lib/api', () => ({
       GET: (id: string | number) => `/requests/${id}`,
       VOTE: (id: string | number) => `/requests/${id}/vote`,
       FULFILL: (id: string | number) => `/requests/${id}/fulfill`,
+      APPROVE_FULFILLMENT: (id: string | number) =>
+        `/requests/${id}/approve-fulfillment`,
+      REJECT_FULFILLMENT: (id: string | number) =>
+        `/requests/${id}/reject-fulfillment`,
       CLOSE: (id: string | number) => `/requests/${id}/close`,
     },
   },
@@ -38,6 +42,8 @@ import {
   useVoteRequest,
   useRemoveVoteRequest,
   useFulfillRequest,
+  useApproveFulfillment,
+  useRejectFulfillment,
   useCloseRequest,
 } from './index'
 

--- a/frontend/features/requests/hooks/index.ts
+++ b/frontend/features/requests/hooks/index.ts
@@ -286,6 +286,48 @@ export function useFulfillRequest() {
   })
 }
 
+/**
+ * Approve a proposed fulfillment (requester or admin) — PSY-891.
+ * Transitions pending_fulfillment → fulfilled. Backend gates to the original
+ * requester or an admin (403 otherwise).
+ */
+export function useApproveFulfillment() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ requestId }: { requestId: number }) =>
+      apiRequest<void>(API_ENDPOINTS.REQUESTS.APPROVE_FULFILLMENT(requestId), {
+        method: 'POST',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.detail(variables.requestId),
+      })
+    },
+  })
+}
+
+/**
+ * Reject a proposed fulfillment (requester or admin) — PSY-891.
+ * Transitions pending_fulfillment → pending (clears fulfiller + proposed
+ * entity), reopening the request. Backend gates to requester or admin.
+ */
+export function useRejectFulfillment() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ requestId }: { requestId: number }) =>
+      apiRequest<void>(API_ENDPOINTS.REQUESTS.REJECT_FULFILLMENT(requestId), {
+        method: 'POST',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.detail(variables.requestId),
+      })
+    },
+  })
+}
+
 /** Close a request (admin) */
 export function useCloseRequest() {
   const queryClient = useQueryClient()

--- a/frontend/features/requests/types.test.ts
+++ b/frontend/features/requests/types.test.ts
@@ -24,10 +24,11 @@ describe('request type constants', () => {
     ])
   })
 
-  it('exposes the five lifecycle statuses', () => {
+  it('exposes the six lifecycle statuses', () => {
     expect(REQUEST_STATUSES).toEqual([
       'pending',
       'in_progress',
+      'pending_fulfillment',
       'fulfilled',
       'rejected',
       'cancelled',
@@ -60,6 +61,7 @@ describe('getStatusLabel', () => {
   it.each([
     ['pending', 'Pending'],
     ['in_progress', 'In Progress'],
+    ['pending_fulfillment', 'Pending review'],
     ['fulfilled', 'Fulfilled'],
     ['rejected', 'Rejected'],
     ['cancelled', 'Cancelled'],
@@ -90,6 +92,10 @@ describe('getEntityTypeColor', () => {
 describe('getStatusColor', () => {
   it('returns a yellow class for pending', () => {
     expect(getStatusColor('pending')).toContain('yellow')
+  })
+
+  it('returns a primary class for pending_fulfillment', () => {
+    expect(getStatusColor('pending_fulfillment')).toContain('primary')
   })
 
   it('returns a green class for fulfilled', () => {

--- a/frontend/features/requests/types.ts
+++ b/frontend/features/requests/types.ts
@@ -14,6 +14,7 @@ export const REQUEST_ENTITY_TYPES = [
 export const REQUEST_STATUSES = [
   'pending',
   'in_progress',
+  'pending_fulfillment',
   'fulfilled',
   'rejected',
   'cancelled',
@@ -84,6 +85,8 @@ export function getStatusLabel(status: string): string {
       return 'Pending'
     case 'in_progress':
       return 'In Progress'
+    case 'pending_fulfillment':
+      return 'Pending review'
     case 'fulfilled':
       return 'Fulfilled'
     case 'rejected':
@@ -122,6 +125,8 @@ export function getStatusColor(status: string): string {
       return 'bg-yellow-500/15 text-yellow-700 dark:text-yellow-400'
     case 'in_progress':
       return 'bg-blue-500/15 text-blue-700 dark:text-blue-400'
+    case 'pending_fulfillment':
+      return 'bg-primary/15 text-primary'
     case 'fulfilled':
       return 'bg-green-500/15 text-green-700 dark:text-green-400'
     case 'rejected':

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -320,6 +320,10 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/requests/${requestId}/vote`,
     FULFILL: (requestId: string | number) =>
       `${API_BASE_URL}/requests/${requestId}/fulfill`,
+    APPROVE_FULFILLMENT: (requestId: string | number) =>
+      `${API_BASE_URL}/requests/${requestId}/approve-fulfillment`,
+    REJECT_FULFILLMENT: (requestId: string | number) =>
+      `${API_BASE_URL}/requests/${requestId}/reject-fulfillment`,
     CLOSE: (requestId: string | number) =>
       `${API_BASE_URL}/requests/${requestId}/close`,
   },


### PR DESCRIPTION
Closes PSY-891.

## Summary

Surfaces PSY-748's two-step fulfillment flow on the request detail UI:

- **Requester/admin review panel** on `pending_fulfillment` requests — "A fulfillment is awaiting your approval", who proposed it + when, and **Approve fulfillment** / **Reject** controls. Gated to the original requester or an admin.
- **Reject → confirm modal** (app `Dialog` primitive): "Reject this fulfillment? The request will reopen…" with Cancel + a destructive Reject-fulfillment confirm. Reopens the request (`→ pending`).
- **Other viewers** of a `pending_fulfillment` request see a muted "awaiting the requester's approval" note, no controls.
- **"Propose a fulfillment"** is now open to **any authenticated user** on open requests (fixes the stale `canFulfill = isAdmin` gate — PSY-748 made submit community-open; it proposes, doesn't finalize).
- New hooks `useApproveFulfillment` / `useRejectFulfillment` (+ `APPROVE_FULFILLMENT` / `REJECT_FULFILLMENT` endpoints), a `pending_fulfillment` → **"Pending review"** status (label + color, surfaced in list badges via the shared `getStatusLabel`/`getStatusColor` helper used by `RequestCard`), and inline error surfaces on approve + reject per the mutation-feedback convention.

Design locked on PSY-891 (Figma mock in the Product Designs file + [decisions comment](https://linear.app/psychic-homily/issue/PSY-891)). The notification path is already shipped by **PSY-890**.

## Deferred (filed as follow-up)

- **Propose-with-entity-picker** → **PSY-917**. The simple "Propose a fulfillment" button submits no `fulfilled_entity_id`, so a "View proposed entity" link in the review panel would be misleading (the field holds the *originally-requested* entity, not the proposal). The link was dropped this PR; the richer picker flow that makes it meaningful is PSY-917.

## Heads up from `/code-review`

Two parallel reviewers (correctness + quality). Correctness: clean (gating verified mutually-exclusive across all 6 states; unauthed users can't reach approve/reject; `Number(user.id)` coercion correct; hooks invalidate the right keys). Fixes applied this PR:
- **Dropped the misleading "View proposed {entity}" link** (→ PSY-917, above).
- **Added an inline approve-error surface** (reject already had one) — the review panel now surfaces both mutations' errors.
- Noted-not-changed: the `pending_fulfillment` badge uses `bg-primary/15 text-primary` (brand accent) rather than the `bg-X-500/15 text-X-700 dark:text-X-400` triad the other statuses use — intentional, matches the locked design (the orange "needs your attention" accent). The reject modal hand-rolls `<Dialog>` like every peer confirm-dialog in the app (no shared ConfirmDialog primitive exists).

## Test plan

- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:run features/requests` — **104/104 pass** (5 files; +9 new tests: requester review panel, other-viewer note, approve calls mutation, reject opens-modal→confirm-calls-mutation, propose shows-for-authed / hidden-for-anon, both new hooks' endpoints, + the `pending_fulfillment` type cases)
- [x] `/code-review` — 2 fixes applied (above)
- [x] Manual repro against the local dev stack (real backend + seeded `pending_fulfillment` request) — see Screenshots

## Manual repro

Real running app (backend :8080 + frontend :3000), against a genuinely-seeded `pending_fulfillment` request (#2: requester `asdf`, fulfiller `testuser2`) and an open request (#1):

1. Logged in as the requester (`asdf@admin.com`) → `/requests/2` → review panel renders with Approve + Reject. ✓
2. Clicked **Reject** → confirm modal opens (does not reject directly); shows the reopen-and-notify copy + Cancel / Reject-fulfillment. ✓
3. Viewed an open request (`/requests/1`) → **"Propose a fulfillment"** renders with the "Found the {entity} in the graph?" prompt. ✓

## Screenshots

Requester review panel (`pending_fulfillment`):

![review panel](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-ce58965a2f75fdd3a669/psy891-detail-requester.png)

Reject confirm modal:

![reject modal](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-ce58965a2f75fdd3a669/psy891-reject-modal.png)

Open-state "Propose a fulfillment" (any authed user):

![propose fulfillment](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-ce58965a2f75fdd3a669/psy891-propose-open.png)

## Coverage gaps

- **Approve→fulfilled and Reject→reopen transitions** were not click-completed in the browser (would consume the seeded `pending_fulfillment` fixture); both are covered by unit tests asserting the mutation fires with the right args + the hooks hit the right endpoints, and the backend transitions are PSY-748's (already shipped + tested).
- **Other-viewer muted note** (`pending_fulfillment` viewed by a non-requester non-admin) is covered by a unit test, not a screenshot — it requires a third non-admin account; the rendered string is asserted in `RequestDetail.test.tsx`.
