### PR TITLE
PSY-914: e2e OAuth faux google provider behind env guard

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -62,6 +62,16 @@ func main() {
 		log.Fatalf("PSY-475 auth-rate-limit misconfiguration: %v", err)
 	}
 
+	// PSY-914: keystone guard for the faux OAuth "google" provider. Refuses
+	// to boot if ENABLE_OAUTH_TEST_PROVIDER=1 outside {test, ci, development}.
+	// Without this, the fake provider (which mints a session as a fixed email)
+	// could be a critical auth bypass in production. SetupGoth also re-checks,
+	// but the registration only matters if the process starts — this is the
+	// real safety net.
+	if err := auth.ValidateOAuthTestProviderEnvironment(os.Getenv); err != nil {
+		log.Fatalf("PSY-914 oauth-test-provider misconfiguration: %v", err)
+	}
+
 	// Initialize structured logger
 	// Use JSON format in production, text format with debug in development
 	isProduction := environment == config.EnvProduction

--- a/backend/internal/api/handlers/admin/test_fixtures.go
+++ b/backend/internal/api/handlers/admin/test_fixtures.go
@@ -15,27 +15,22 @@ import (
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	communitym "psychic-homily-backend/internal/models/community"
 	engagementm "psychic-homily-backend/internal/models/engagement"
+	"psychic-homily-backend/internal/testenv"
 )
 
-// Env flag + allowed environment list for the test-fixtures reset endpoint.
-// See PSY-432 for the layered-defense rationale. The check is default-deny:
-// `ENABLE_TEST_FIXTURES=1` is only honored when ENVIRONMENT is one of the
-// allowed values. Unset and unknown values both refuse.
+// Env flag for the test-fixtures reset endpoint. See PSY-432 for the
+// layered-defense rationale. The check is default-deny: `ENABLE_TEST_FIXTURES=1`
+// is only honored when ENVIRONMENT is in the shared allow-list
+// (internal/testenv.AllowedEnvironments: test, ci, development). Unset and
+// unknown values both refuse. PSY-914 moved the allow-list + boot guard into
+// internal/testenv (shared with DISABLE_AUTH_RATE_LIMITS and
+// ENABLE_OAUTH_TEST_PROVIDER); these wrappers keep a flag-specific name.
 const (
 	EnableTestFixturesEnvVar           = "ENABLE_TEST_FIXTURES"
 	TestFixturesHeader                 = "X-Test-Fixtures"
 	TestUserEmailSuffix                = "@test.local"
 	ReservedWorkerCollectionSlugPrefix = "e2e-worker-collection-"
 )
-
-// TestFixturesAllowedEnvironments is the whitelist of ENVIRONMENT values that
-// may set ENABLE_TEST_FIXTURES=1. Blacklisting "production" would miss
-// staging/preview and other envs that host real data, so allow-list instead.
-var TestFixturesAllowedEnvironments = map[string]bool{
-	"test":        true,
-	"ci":          true,
-	"development": true,
-}
 
 // testFixtureScope is the subset of a delete query that varies per allowlisted
 // "table" (some entries map to a logical scope, e.g. pending shows, rather
@@ -133,10 +128,10 @@ func testFixtureScopeByName(name string) (testFixtureScope, bool) {
 // Callers should also invoke ValidateTestFixturesEnvironment at startup to
 // panic if the flag is combined with a non-allowed ENVIRONMENT.
 func IsTestFixturesEnabled(getenv func(string) string) bool {
-	return getenv(EnableTestFixturesEnvVar) == "1"
+	return testenv.IsFlagEnabled(EnableTestFixturesEnvVar, getenv)
 }
 
-// ValidateTestFixturesEnvironment panics unless the combination of
+// ValidateTestFixturesEnvironment returns an error unless the combination of
 // ENABLE_TEST_FIXTURES and ENVIRONMENT is safe. Rules:
 //   - ENABLE_TEST_FIXTURES=0 (or unset): always safe, returns nil.
 //   - ENABLE_TEST_FIXTURES=1 AND ENVIRONMENT in {test, ci, development}: safe.
@@ -145,21 +140,7 @@ func IsTestFixturesEnabled(getenv func(string) string) bool {
 // Call this from cmd/server/main.go before route setup. A returned error
 // should cause the server to refuse to boot.
 func ValidateTestFixturesEnvironment(getenv func(string) string) error {
-	if !IsTestFixturesEnabled(getenv) {
-		return nil
-	}
-	env := getenv("ENVIRONMENT")
-	if !TestFixturesAllowedEnvironments[env] {
-		allowed := make([]string, 0, len(TestFixturesAllowedEnvironments))
-		for k := range TestFixturesAllowedEnvironments {
-			allowed = append(allowed, k)
-		}
-		return fmt.Errorf(
-			"%s=1 requires ENVIRONMENT to be one of %v (got %q); refusing to boot",
-			EnableTestFixturesEnvVar, allowed, env,
-		)
-	}
-	return nil
+	return testenv.ValidateFlagEnvironment(EnableTestFixturesEnvVar, getenv)
 }
 
 // TestFixtureHandler serves the admin-only, test-env-only reset endpoint.

--- a/backend/internal/api/routes/auth_rate_limit.go
+++ b/backend/internal/api/routes/auth_rate_limit.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
-	"fmt"
 	"net/http"
+
+	"psychic-homily-backend/internal/testenv"
 )
 
 // PSY-475: env-flagged skip of the IP-scoped auth/passkey rate limiters
@@ -13,27 +14,18 @@ import (
 // allowlisted; default-deny at startup refuses to boot in prod/staging/
 // preview/unset with the flag on.
 //
-// Not combined with PSY-432's TestFixturesAllowedEnvironments enum on
-// purpose — separating the two flags lets them be audited / flipped
-// independently. Factor out into a shared `testenv` helper when a third
-// flag lands with the same shape.
+// PSY-914: the {test,ci,development} allowlist + default-deny boot check
+// are now shared in internal/testenv (third flag of this shape landed —
+// ENABLE_OAUTH_TEST_PROVIDER). These thin wrappers stay so callers/tests
+// keep a flag-specific name; the policy lives in one place.
 const DisableAuthRateLimitsEnvVar = "DISABLE_AUTH_RATE_LIMITS"
-
-// authRateLimitAllowedEnvironments mirrors the PSY-432 allowed list:
-// test, ci, development. Production / stage / preview / unset all
-// refuse when the flag is on.
-var authRateLimitAllowedEnvironments = map[string]bool{
-	"test":        true,
-	"ci":          true,
-	"development": true,
-}
 
 // IsAuthRateLimitDisabled reports whether the auth + passkey rate
 // limiters should be replaced with no-ops. ValidateAuthRateLimitEnvironment
 // is the safety gate — callers should invoke it at startup before relying
 // on this value for route setup.
 func IsAuthRateLimitDisabled(getenv func(string) string) bool {
-	return getenv(DisableAuthRateLimitsEnvVar) == "1"
+	return testenv.IsFlagEnabled(DisableAuthRateLimitsEnvVar, getenv)
 }
 
 // ValidateAuthRateLimitEnvironment returns an error if the disable flag is
@@ -41,21 +33,7 @@ func IsAuthRateLimitDisabled(getenv func(string) string) bool {
 // before route setup; a returned error should cause the server to refuse
 // to boot.
 func ValidateAuthRateLimitEnvironment(getenv func(string) string) error {
-	if !IsAuthRateLimitDisabled(getenv) {
-		return nil
-	}
-	env := getenv("ENVIRONMENT")
-	if !authRateLimitAllowedEnvironments[env] {
-		allowed := make([]string, 0, len(authRateLimitAllowedEnvironments))
-		for k := range authRateLimitAllowedEnvironments {
-			allowed = append(allowed, k)
-		}
-		return fmt.Errorf(
-			"%s=1 requires ENVIRONMENT to be one of %v (got %q); refusing to boot",
-			DisableAuthRateLimitsEnvVar, allowed, env,
-		)
-	}
-	return nil
+	return testenv.ValidateFlagEnvironment(DisableAuthRateLimitsEnvVar, getenv)
 }
 
 // noopRateLimiter returns a pass-through middleware. Used in place of

--- a/backend/internal/auth/goth.go
+++ b/backend/internal/auth/goth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
@@ -66,6 +67,22 @@ func SetupGoth(cfg *config.Config) error {
 		)
 		providers = append(providers, githubProvider)
 		log.Printf("DEBUG: GitHub provider configured with callback URL: %s", cfg.OAuth.GitHubCallbackURL)
+	}
+
+	// PSY-914: E2E-only faux "google" provider. Double-gated for safety:
+	// the flag must be set AND ValidateOAuthTestProviderEnvironment must pass
+	// (ENVIRONMENT in {test,ci,development}). Re-validating here — not just
+	// checking the flag — means the faux provider can never register in
+	// production even if a future caller skips the main.go boot guard. When
+	// registered, it appends as "google" and (because UseProviders keys on
+	// Name() and "last wins") shadows any real google.New provider; in E2E
+	// there is no GOOGLE_CLIENT_ID so the real one never gets added anyway.
+	if IsOAuthTestProviderEnabled(os.Getenv) {
+		if err := ValidateOAuthTestProviderEnvironment(os.Getenv); err != nil {
+			return err
+		}
+		providers = append(providers, newTestProvider())
+		log.Printf("DEBUG: PSY-914 faux OAuth test provider registered as %q (ENABLE_OAUTH_TEST_PROVIDER=1)", TestProviderName)
 	}
 
 	// Register providers with Goth

--- a/backend/internal/auth/oauth_test_provider.go
+++ b/backend/internal/auth/oauth_test_provider.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/faux"
+
+	"psychic-homily-backend/internal/testenv"
+)
+
+// PSY-914: a FAKE OAuth provider that answers as "google", used to exercise
+// the real OAuth login -> callback -> session flow in E2E without a live
+// Google IdP.
+//
+// SECURITY: if this provider were ever registered in production it would be a
+// CRITICAL auth bypass — anyone hitting /auth/login/google could mint a session
+// as TestProviderEmail. Registration is therefore double-gated:
+//
+//  1. SetupGoth only appends it when ENABLE_OAUTH_TEST_PROVIDER=1, AND
+//  2. main.go calls ValidateOAuthTestProviderEnvironment at boot, which
+//     (via internal/testenv) refuses to start the server if the flag is set in
+//     any ENVIRONMENT outside {test, ci, development}. Production / stage /
+//     preview / unset all fail closed.
+//
+// Mirrors the default-deny shape of ENABLE_TEST_FIXTURES (PSY-432) and
+// DISABLE_AUTH_RATE_LIMITS (PSY-475).
+const EnableOAuthTestProviderEnvVar = "ENABLE_OAUTH_TEST_PROVIDER"
+
+// TestProviderName is the provider key the faux clone registers under. It must
+// be a real provider the frontend can initiate ("google"), so the existing
+// /auth/login/google button and /auth/callback/google route drive it unchanged.
+const TestProviderName = "google"
+
+// TestProviderEmail is the deterministic email the faux clone always returns.
+// The E2E seed pre-creates a user with this email so the first faux login
+// resolves to an EXISTING user (a login, via linkOAuthAccount), not a brand-new
+// signup (which would trigger the terms/consent flow). Stock goth/faux returns
+// an EMPTY email, which would make FindOrCreateUserWithConsent key on "" and
+// create a degenerate account — hence the clone.
+const TestProviderEmail = "e2e-oauth@test.local"
+
+// TestProviderUserID is the deterministic provider_user_id the faux clone
+// returns. Fixed so repeat logins resolve to the same oauth_accounts row.
+const TestProviderUserID = "e2e-oauth-faux-user-id"
+
+// testProvider wraps goth's faux provider so it (a) registers/resolves under
+// the name "google" and (b) returns a deterministic, non-empty user. Every
+// method other than Name/FetchUser delegates to the embedded faux provider, so
+// the state-token round-trip (BeginAuth -> AuthURL -> Authorize -> session) is
+// the real goth machinery — only the identity surface is faked.
+type testProvider struct {
+	*faux.Provider
+}
+
+// newTestProvider builds the faux clone. The embedded faux.Provider supplies
+// BeginAuth (state nonce + http://example.com/auth AuthURL), UnmarshalSession,
+// RefreshToken, etc.
+func newTestProvider() *testProvider {
+	return &testProvider{Provider: &faux.Provider{}}
+}
+
+// Name returns "google". goth.UseProviders keys the registry on Name(), and
+// gothic.CompleteUserAuth looks the provider up by the request's "provider"
+// query param ("google"). Both must agree, so this override — not faux's
+// SetName — is what makes the clone resolve as Google.
+func (p *testProvider) Name() string {
+	return TestProviderName
+}
+
+// FetchUser delegates to faux for the AccessToken-gating round-trip (faux
+// errors until the session has been Authorize()d, exactly as a real provider
+// would before the token exchange), then overwrites the identity fields with
+// the deterministic test values. The empty-email problem in stock faux is
+// fixed here.
+func (p *testProvider) FetchUser(session goth.Session) (goth.User, error) {
+	user, err := p.Provider.FetchUser(session)
+	if err != nil {
+		return user, err
+	}
+	user.Provider = TestProviderName
+	user.UserID = TestProviderUserID
+	user.Email = TestProviderEmail
+	user.Name = "E2E OAuth User"
+	return user, nil
+}
+
+// IsOAuthTestProviderEnabled reports whether the faux "google" provider should
+// be registered. ValidateOAuthTestProviderEnvironment is the safety gate —
+// callers MUST invoke it at startup before relying on this for registration.
+func IsOAuthTestProviderEnabled(getenv func(string) string) bool {
+	return testenv.IsFlagEnabled(EnableOAuthTestProviderEnvVar, getenv)
+}
+
+// ValidateOAuthTestProviderEnvironment returns an error if the faux-provider
+// flag is set in a non-allowlisted ENVIRONMENT. Call from cmd/server/main.go
+// before SetupGoth; a returned error MUST cause the server to refuse to boot.
+// This is the keystone defense against the faux provider ever going live.
+func ValidateOAuthTestProviderEnvironment(getenv func(string) string) error {
+	return testenv.ValidateFlagEnvironment(EnableOAuthTestProviderEnvVar, getenv)
+}

--- a/backend/internal/auth/oauth_test_provider_test.go
+++ b/backend/internal/auth/oauth_test_provider_test.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/markbates/goth"
+)
+
+func envFromMap(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestIsOAuthTestProviderEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"unset", map[string]string{}, false},
+		{"empty", map[string]string{EnableOAuthTestProviderEnvVar: ""}, false},
+		{"zero", map[string]string{EnableOAuthTestProviderEnvVar: "0"}, false},
+		{"truthy-but-not-1", map[string]string{EnableOAuthTestProviderEnvVar: "true"}, false},
+		{"exactly-1", map[string]string{EnableOAuthTestProviderEnvVar: "1"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsOAuthTestProviderEnabled(envFromMap(tc.env)); got != tc.want {
+				t.Errorf("want %v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestValidateOAuthTestProviderEnvironment is the security contract for the
+// faux "google" provider: the flag may only be honored in {test, ci,
+// development}. Anywhere else — production, stage, preview, or unset — the
+// guard MUST return an error so cmd/server/main.go refuses to boot. A
+// regression here would let the fake provider go live and mint sessions as
+// TestProviderEmail (critical auth bypass).
+func TestValidateOAuthTestProviderEnvironment(t *testing.T) {
+	cases := []struct {
+		name        string
+		env         map[string]string
+		wantError   bool
+		errContains string
+	}{
+		// Flag off = always safe.
+		{"flag-off / env-unset", map[string]string{}, false, ""},
+		{"flag-off / env-production", map[string]string{"ENVIRONMENT": "production"}, false, ""},
+		{"flag-0 / env-production", map[string]string{EnableOAuthTestProviderEnvVar: "0", "ENVIRONMENT": "production"}, false, ""},
+
+		// Flag on + allowed env = safe.
+		{"flag-on / env-test", map[string]string{EnableOAuthTestProviderEnvVar: "1", "ENVIRONMENT": "test"}, false, ""},
+		{"flag-on / env-ci", map[string]string{EnableOAuthTestProviderEnvVar: "1", "ENVIRONMENT": "ci"}, false, ""},
+		{"flag-on / env-development", map[string]string{EnableOAuthTestProviderEnvVar: "1", "ENVIRONMENT": "development"}, false, ""},
+
+		// Flag on + non-allowed env = refuse to boot (the security-critical rows).
+		{"flag-on / env-production", map[string]string{EnableOAuthTestProviderEnvVar: "1", "ENVIRONMENT": "production"}, true, "production"},
+		{"flag-on / env-stage", map[string]string{EnableOAuthTestProviderEnvVar: "1", "ENVIRONMENT": "stage"}, true, "stage"},
+		{"flag-on / env-preview", map[string]string{EnableOAuthTestProviderEnvVar: "1", "ENVIRONMENT": "preview"}, true, "preview"},
+		{"flag-on / env-unset", map[string]string{EnableOAuthTestProviderEnvVar: "1"}, true, ""},
+		{"flag-on / env-casing", map[string]string{EnableOAuthTestProviderEnvVar: "1", "ENVIRONMENT": "Test"}, true, "Test"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOAuthTestProviderEnvironment(envFromMap(tc.env))
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("want error got nil — faux provider would be allowed to register!")
+				}
+				if !strings.Contains(err.Error(), EnableOAuthTestProviderEnvVar) {
+					t.Errorf("error %q should name the flag", err.Error())
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q missing %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Errorf("want no error got %v", err)
+			}
+		})
+	}
+}
+
+// TestTestProvider_Name asserts the clone registers/resolves as "google",
+// not faux's default "faux" — UseProviders keys the registry on Name() and
+// gothic looks it up by the "google" request param, so they must match.
+func TestTestProvider_Name(t *testing.T) {
+	p := newTestProvider()
+	if got := p.Name(); got != TestProviderName {
+		t.Errorf("Name() = %q, want %q", got, TestProviderName)
+	}
+	if TestProviderName != "google" {
+		t.Errorf("TestProviderName = %q, want \"google\" (frontend initiates /auth/login/google)", TestProviderName)
+	}
+}
+
+// TestTestProvider_FetchUser_FixedIdentity asserts the clone returns a
+// deterministic, NON-EMPTY identity (the whole reason for cloning faux, whose
+// FetchUser returns an empty email). The full begin->authorize->callback round
+// trip is exercised by the e2e spec; here we drive FetchUser directly via an
+// already-authorized faux session.
+func TestTestProvider_FetchUser_FixedIdentity(t *testing.T) {
+	p := newTestProvider()
+
+	// faux.FetchUser errors unless the session carries an AccessToken (mirrors
+	// a real provider pre-token-exchange). Begin then Authorize to get one,
+	// exactly as gothic.CompleteUserAuth does.
+	sess, err := p.BeginAuth("test-state")
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+	if _, err := sess.Authorize(p, goth.Params(nil)); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+
+	user, err := p.FetchUser(sess)
+	if err != nil {
+		t.Fatalf("FetchUser: %v", err)
+	}
+	if user.Email != TestProviderEmail {
+		t.Errorf("Email = %q, want %q (empty email would break FindOrCreateUserWithConsent)", user.Email, TestProviderEmail)
+	}
+	if user.Email == "" {
+		t.Error("Email is empty — the clone exists precisely to avoid faux's empty email")
+	}
+	if user.UserID != TestProviderUserID {
+		t.Errorf("UserID = %q, want %q", user.UserID, TestProviderUserID)
+	}
+	if user.Provider != TestProviderName {
+		t.Errorf("Provider = %q, want %q", user.Provider, TestProviderName)
+	}
+}
+
+// TestTestProvider_FetchUser_RequiresAccessToken confirms the clone still
+// honors faux's pre-authorize gate: FetchUser must fail before the session is
+// Authorized. This keeps the e2e flow faithful to the real two-FetchUser dance
+// in gothic.CompleteUserAuth.
+func TestTestProvider_FetchUser_RequiresAccessToken(t *testing.T) {
+	p := newTestProvider()
+	sess, err := p.BeginAuth("test-state")
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+	// No Authorize() -> no AccessToken -> FetchUser should error.
+	if _, err := p.FetchUser(sess); err == nil {
+		t.Error("FetchUser succeeded before Authorize; expected the faux access-token gate to fail")
+	}
+}

--- a/backend/internal/testenv/testenv.go
+++ b/backend/internal/testenv/testenv.go
@@ -1,0 +1,85 @@
+// Package testenv centralizes the "test-only feature flag" safety pattern
+// shared by every flag that unlocks an E2E/test affordance the server must
+// NEVER expose in production.
+//
+// The pattern, introduced piecemeal by PSY-432 (ENABLE_TEST_FIXTURES) and
+// PSY-475 (DISABLE_AUTH_RATE_LIMITS), is default-deny:
+//
+//   - The flag is only honored when set to exactly "1".
+//   - Even when set, it is only safe in an allow-listed ENVIRONMENT
+//     ({test, ci, development}). In any other ENVIRONMENT — production,
+//     stage, preview, or unset — the server must refuse to boot.
+//
+// Allow-listing (rather than black-listing "production") is deliberate:
+// staging/preview and any future real-data environment must fail closed if
+// someone forgets to add them to a blacklist. Forgetting to add a *new*
+// safe environment to the allowlist only costs a failed boot in that one
+// environment — a loud, safe failure — never a silent prod auth bypass.
+//
+// PSY-914 is the third flag of this exact shape (ENABLE_OAUTH_TEST_PROVIDER,
+// which registers a fake OAuth provider answering as "google"), so the
+// shape is factored here per the TODO left in auth_rate_limit.go. Both the
+// pre-existing guards and the new OAuth guard delegate to this package.
+package testenv
+
+import "fmt"
+
+// AllowedEnvironments is the set of ENVIRONMENT values in which a test-only
+// feature flag may safely be enabled. Production, stage, preview, and unset
+// are intentionally absent: any flag of this shape must fail closed there.
+//
+// Exposed (read-only by convention) so callers can echo the list in their
+// own docs/errors; do NOT mutate it.
+var AllowedEnvironments = map[string]bool{
+	"test":        true,
+	"ci":          true,
+	"development": true,
+}
+
+// IsAllowedEnvironment reports whether env is one in which test-only flags
+// may be enabled. Matching is exact and case-sensitive — "Test" is rejected,
+// matching how ENVIRONMENT is compared elsewhere in the codebase.
+func IsAllowedEnvironment(env string) bool {
+	return AllowedEnvironments[env]
+}
+
+// IsFlagEnabled reports whether the named env var is set to exactly "1".
+// Anything else ("", "0", "true", unset) reads as disabled — the flag must
+// be opted into explicitly and unambiguously.
+func IsFlagEnabled(flagName string, getenv func(string) string) bool {
+	return getenv(flagName) == "1"
+}
+
+// ValidateFlagEnvironment is the keystone default-deny guard. It returns an
+// error if flagName is enabled (=="1") while ENVIRONMENT is not allow-listed.
+// A nil return means either the flag is off (always safe) or it is on in a
+// safe environment.
+//
+// Call this at startup (cmd/server/main.go) for every test-only flag; a
+// returned error must cause the server to refuse to boot. The route/registration
+// guard (IsFlagEnabled) only helps if the process actually starts, so this
+// boot-time check is the real safety net.
+func ValidateFlagEnvironment(flagName string, getenv func(string) string) error {
+	if !IsFlagEnabled(flagName, getenv) {
+		return nil
+	}
+	env := getenv("ENVIRONMENT")
+	if !IsAllowedEnvironment(env) {
+		return fmt.Errorf(
+			"%s=1 requires ENVIRONMENT to be one of %v (got %q); refusing to boot",
+			flagName, allowedList(), env,
+		)
+	}
+	return nil
+}
+
+// allowedList returns the allow-listed environments as a slice for error
+// messages. Order is not guaranteed (map iteration); callers use it only for
+// human-readable diagnostics, never for logic.
+func allowedList() []string {
+	allowed := make([]string, 0, len(AllowedEnvironments))
+	for k := range AllowedEnvironments {
+		allowed = append(allowed, k)
+	}
+	return allowed
+}

--- a/backend/internal/testenv/testenv_test.go
+++ b/backend/internal/testenv/testenv_test.go
@@ -1,0 +1,101 @@
+package testenv
+
+import (
+	"strings"
+	"testing"
+)
+
+func envFromMap(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestIsFlagEnabled(t *testing.T) {
+	const flag = "SOME_FLAG"
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"unset", map[string]string{}, false},
+		{"empty", map[string]string{flag: ""}, false},
+		{"zero", map[string]string{flag: "0"}, false},
+		{"truthy-but-not-1", map[string]string{flag: "true"}, false},
+		{"exactly-1", map[string]string{flag: "1"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsFlagEnabled(flag, envFromMap(tc.env)); got != tc.want {
+				t.Errorf("want %v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIsAllowedEnvironment(t *testing.T) {
+	cases := []struct {
+		env  string
+		want bool
+	}{
+		{"test", true},
+		{"ci", true},
+		{"development", true},
+		{"production", false},
+		{"stage", false},
+		{"preview", false},
+		{"", false},
+		{"Test", false}, // case-sensitive
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			if got := IsAllowedEnvironment(tc.env); got != tc.want {
+				t.Errorf("env %q: want %v got %v", tc.env, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestValidateFlagEnvironment(t *testing.T) {
+	const flag = "SOME_FLAG"
+	cases := []struct {
+		name        string
+		env         map[string]string
+		wantError   bool
+		errContains string
+	}{
+		// Flag off = always safe, regardless of ENVIRONMENT.
+		{"flag-off / env-unset", map[string]string{}, false, ""},
+		{"flag-off / env-production", map[string]string{"ENVIRONMENT": "production"}, false, ""},
+		{"flag-0 / env-production", map[string]string{flag: "0", "ENVIRONMENT": "production"}, false, ""},
+
+		// Flag on + allowed env = safe.
+		{"flag-on / env-test", map[string]string{flag: "1", "ENVIRONMENT": "test"}, false, ""},
+		{"flag-on / env-ci", map[string]string{flag: "1", "ENVIRONMENT": "ci"}, false, ""},
+		{"flag-on / env-development", map[string]string{flag: "1", "ENVIRONMENT": "development"}, false, ""},
+
+		// Flag on + non-allowed env = refuse to boot.
+		{"flag-on / env-production", map[string]string{flag: "1", "ENVIRONMENT": "production"}, true, "production"},
+		{"flag-on / env-stage", map[string]string{flag: "1", "ENVIRONMENT": "stage"}, true, "stage"},
+		{"flag-on / env-preview", map[string]string{flag: "1", "ENVIRONMENT": "preview"}, true, "preview"},
+		{"flag-on / env-unset", map[string]string{flag: "1"}, true, ""},
+		{"flag-on / env-casing", map[string]string{flag: "1", "ENVIRONMENT": "Test"}, true, "Test"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateFlagEnvironment(flag, envFromMap(tc.env))
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("want error got nil")
+				}
+				// The error must name the offending flag so misconfig is debuggable.
+				if !strings.Contains(err.Error(), flag) {
+					t.Errorf("error %q missing flag name %q", err.Error(), flag)
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q missing %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Errorf("want no error got %v", err)
+			}
+		})
+	}
+}

--- a/frontend/e2e/auth/oauth-google.spec.ts
+++ b/frontend/e2e/auth/oauth-google.spec.ts
@@ -1,35 +1,77 @@
 import { test } from '../fixtures/error-detection'
 import { expect } from '@playwright/test'
 
-// PSY-719: Google OAuth login.
+// PSY-914: Google OAuth login, end-to-end through a faux "google" provider.
 //
-// The E2E harness cannot complete a real Google OAuth handshake:
-//   1. The Google provider is only registered when GOOGLE_CLIENT_ID *and*
-//      GOOGLE_CLIENT_SECRET are set (backend/internal/auth/goth.go
-//      SetupGoth). The E2E backend env (frontend/e2e/global-setup.ts) sets
-//      neither, so goth has no "google" provider and BeginAuthHandler errors.
-//      OAUTH_SECRET_KEY in that env is only the Gorilla session-store key —
-//      not a callback mock.
-//   2. Even with a provider registered, completing the flow requires a real
-//      redirect to Google's consent screen and a valid authorization code
-//      from Google — impossible without an external mock IdP, which does not
-//      exist anywhere in backend/ or frontend/e2e/.
+// The E2E harness cannot complete a REAL Google handshake (no client ID/secret,
+// no live consent screen). Instead the backend registers a faux clone of goth's
+// test provider under the name "google", gated behind ENABLE_OAUTH_TEST_PROVIDER
+// (set in global-setup.ts) plus a default-deny ENVIRONMENT guard that refuses to
+// boot the server with the flag on outside {test,ci,development}. See
+// backend/internal/auth/oauth_test_provider.go.
 //
-// Per the ticket, this spec is skipped rather than fabricating a mock. A
-// follow-up OAuth-harness spike (a fake OAuth2 IdP + test-only provider
-// registration) is needed before this flow can be exercised end-to-end.
-test.describe('Google OAuth', () => {
-  test.skip(
-    true,
-    'requires an OAuth IdP mock + test-only provider registration — see PSY-719 follow-up spike'
-  )
+// What this exercises (~95% of the real path): the button does a full-page nav
+// to the backend's /auth/login/google, which runs the genuine
+// gothic.BeginAuthHandler — it mints the _gothic_session cookie (carrying the
+// state nonce) and 307s to the faux AuthURL http://example.com/auth?state=<nonce>.
+// We let the browser follow that 307 natively so it actually stores the session
+// cookie, capture the state nonce off the example.com request, then drive the
+// browser straight to the real backend callback
+// /auth/callback/google?state=<nonce>&code=... — echoing the state, the real
+// OAuth contract. The callback runs the genuine gothic.CompleteUserAuth ->
+// FindOrCreateUserWithConsent -> CreateToken -> auth_token cookie -> redirect to
+// the frontend. Only the identity (a fixed e2e-oauth@test.local user) is faked.
+//
+// Why capture-then-navigate rather than page.route intercept: Playwright only
+// re-applies route handlers to a redirect hop if the *initiating* request was
+// itself intercepted, and example.com is a real reachable page, so routing it
+// directly does nothing. Observing the redirect request and re-navigating is the
+// robust path and keeps the genuine cookie-setting begin-auth leg intact.
+//
+// The fixed email matches a pre-seeded user (setup-db.sh), so the first faux
+// login resolves to an EXISTING user (a login via linkOAuthAccount), NOT a new
+// signup — keeping this spec off the terms/consent path. The signup-consent
+// flow is a separate follow-up.
 
-  test('logs in via the Google button', async ({ page }) => {
+const BACKEND_ORIGIN = 'http://localhost:8080'
+
+test.describe('Google OAuth', () => {
+  test('logs in via the faux Google provider', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/auth')
+
+    // The faux AuthURL host. Capturing this request gives us the state nonce
+    // goth generated; the _gothic_session cookie is set on the 307 that points
+    // here, so by the time this fires the browser already holds it.
+    const fauxRedirect = page.waitForRequest(
+      (req) => new URL(req.url()).hostname === 'example.com',
+      { timeout: 20_000 }
+    )
+
     await page.getByRole('button', { name: /continue with google/i }).click()
-    // Would assert the post-callback logged-in state once a mock IdP exists.
+
+    const fauxReq = await fauxRedirect
+    const state = new URL(fauxReq.url()).searchParams.get('state')
+    expect(state, 'goth should have produced a state nonce on the faux AuthURL').toBeTruthy()
+
+    // Complete the handshake: hit the real callback with the state echoed back
+    // plus an arbitrary code. The _gothic_session cookie (host-scoped to
+    // localhost, port-agnostic) rides along, so CompleteUserAuth validates the
+    // state, the faux provider returns the fixed user, and the real
+    // login + token + auth cookie path runs. The callback 307s to the frontend.
+    const callbackUrl = new URL(`${BACKEND_ORIGIN}/auth/callback/google`)
+    callbackUrl.searchParams.set('state', state!)
+    callbackUrl.searchParams.set('code', 'e2e-faux-auth-code')
+    await page.goto(callbackUrl.toString())
+
+    // Lands back on the frontend, off the /auth page.
+    await page.waitForURL((url) => !url.pathname.startsWith('/auth'), {
+      timeout: 20_000,
+    })
+
+    // Logged-in marker present, login link gone — mirrors login.spec.ts.
     await expect(
       page.getByRole('button', { name: 'User menu' })
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('link', { name: /login/i })).not.toBeVisible()
   })
 })

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -156,6 +156,13 @@ function startBackend(): ChildProcess {
       // ENABLE_TEST_FIXTURES — the server refuses to boot if the flag is
       // set in anything other than test/ci/development.
       DISABLE_AUTH_RATE_LIMITS: '1',
+      // PSY-914: register the faux "google" OAuth provider so
+      // oauth-google.spec.ts can exercise the real login -> callback ->
+      // session flow without a live Google IdP. Same default-deny ENVIRONMENT
+      // guard as the two flags above — the server refuses to boot if this is
+      // set outside {test, ci, development}, so the fake provider can never
+      // reach production.
+      ENABLE_OAUTH_TEST_PROVIDER: '1',
     },
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,

--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -494,12 +494,24 @@ INSERT INTO users (email, password_hash, first_name, last_name, is_active, is_ad
 VALUES ('e2e-recovery@test.local', '${BCRYPT_HASH}', 'Test', 'Recovery', false, false, true, NOW(), 'e2e recovery fixture', NOW(), NOW())
 ON CONFLICT (email) DO NOTHING;
 
--- Create user_preferences for all seeded test users (regular worker users + admin + unverified + recovery)
+-- OAuth login fixture (PSY-914). The faux "google" provider
+-- (ENABLE_OAUTH_TEST_PROVIDER=1, backend/internal/auth/oauth_test_provider.go)
+-- always returns email e2e-oauth@test.local. Pre-seeding that user means the
+-- first faux login resolves to an EXISTING user (linkOAuthAccount = a login),
+-- NOT a new signup — so oauth-google.spec.ts never hits the terms/consent flow.
+-- Dedicated user (not a worker login) so linking an oauth_accounts row to it
+-- can't disturb the parallel worker auth state. No password login is expected
+-- (OAuth only); the shared hash is set just for parity with the other fixtures.
+INSERT INTO users (email, password_hash, first_name, last_name, is_active, is_admin, email_verified, user_tier, created_at, updated_at)
+VALUES ('e2e-oauth@test.local', '${BCRYPT_HASH}', 'Test', 'OAuth', true, false, true, 'contributor', NOW(), NOW())
+ON CONFLICT (email) DO NOTHING;
+
+-- Create user_preferences for all seeded test users (regular worker users + admin + unverified + recovery + oauth)
 INSERT INTO user_preferences (user_id, notification_email, notification_push, show_reminders, theme, timezone, language, created_at, updated_at)
 SELECT id, true, false, false, 'system', 'America/Phoenix', 'en', NOW(), NOW()
 FROM users
 WHERE email LIKE 'e2e-user%@test.local'
-   OR email IN ('e2e-admin@test.local', 'e2e-unverified@test.local', 'e2e-recovery@test.local')
+   OR email IN ('e2e-admin@test.local', 'e2e-unverified@test.local', 'e2e-recovery@test.local', 'e2e-oauth@test.local')
 ON CONFLICT (user_id) DO NOTHING;
 SQL
 


### PR DESCRIPTION
## Summary

Registers a **faux clone** of goth's test provider under the name `"google"` so `oauth-google.spec.ts` can exercise the real OAuth login → callback → session flow end-to-end without a live Google IdP, and un-skips that spec.

- **Faux clone** (`backend/internal/auth/oauth_test_provider.go`): wraps `goth/providers/faux`, overriding `Name()` → `"google"` (`goth.UseProviders` keys the registry on `Name()`, so `SetName` alone is insufficient) and `FetchUser()` → a deterministic, non-empty identity (`e2e-oauth@test.local` + fixed UserID). Stock faux returns an **empty** email, which would make `FindOrCreateUserWithConsent` key on `""` and create a degenerate account — the clone exists to avoid that.
- **Login-existing-user path**: the fixed email is pre-seeded (`setup-db.sh`), so the first faux login resolves to an **existing** user via `linkOAuthAccount` (a login), **not** a new signup — keeping this spec off the terms/consent flow. The signup-consent path is an explicit out-of-scope follow-up.
- **Shared `testenv` helper**: this is the third env flag of the `{test,ci,development}` default-deny shape (after `ENABLE_TEST_FIXTURES`/PSY-432 and `DISABLE_AUTH_RATE_LIMITS`/PSY-475), so per the TODO in `auth_rate_limit.go` the allowlist + boot guard are extracted into `internal/testenv`, and both pre-existing guards now delegate to it — **no behavior change** to those guards.
- **Playwright interception**: the spec lets the browser follow the backend's 307 to the faux `example.com` AuthURL natively (so the genuine `_gothic_session` cookie is stored), captures the `state` nonce off that request, then drives the browser straight to the real `/auth/callback/google?state=…&code=…`. `page.route`-ing `example.com` directly does nothing because Playwright only re-applies routes to a redirect hop if the *initiating* request was intercepted, and `example.com` is a real reachable page.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./...` — full suite green (incl. `admin`, `auth`, `routes` — the helper extraction touches a shared path)
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:e2e -- e2e/auth/oauth-google.spec.ts` — **1 passed** (verified twice; backend log shows `OAuth callback successful for user ID: 9`, the pre-seeded user resolved as a login)

## Manual repro

The passing `oauth-google.spec.ts` run **is** the manual repro: it exercises the real `/auth/login/google` → faux begin-auth → `/auth/callback/google` → `gothic.CompleteUserAuth` → `FindOrCreateUserWithConsent` → `CreateToken` → auth cookie → frontend redirect, then asserts the logged-in `User menu`.

Security-guard repro: `TestValidateOAuthTestProviderEnvironment` (`backend/internal/auth/oauth_test_provider_test.go`) asserts the guard **returns an error** (server refuses to boot) for `ENABLE_OAUTH_TEST_PROVIDER=1` in `env-production`, `env-stage`, `env-preview`, and `env-unset`, and passes only in `{test,ci,development}`.

## Code review

Ran `/code-review` inline (sub-agent, no Agent tool) across all 9 finder angles + sweep, with explicit scrutiny of the guard's fail-closed behavior and the faux-wrapper method routing. **No confirmed or plausible defects.** No fix-up commit needed.

## Security note

The faux provider would be a **critical auth bypass** if it ever went live (anyone could mint a session as the fixed email). Default-deny is the keystone:

1. `SetupGoth` only appends the clone when `ENABLE_OAUTH_TEST_PROVIDER=1`, **and** re-runs `ValidateOAuthTestProviderEnvironment` before appending (defense in depth — it can't register in prod even if a future caller skips the boot guard).
2. `cmd/server/main.go` calls `ValidateOAuthTestProviderEnvironment` at boot (next to the two existing guards); it **refuses to boot** if the flag is set in any `ENVIRONMENT` outside `{test,ci,development}`.

No production auth path is modified: the real `google.New` provider still registers only when `GOOGLE_CLIENT_ID`/`SECRET` are set, and the `OAuthLoginHTTPHandler`/`OAuthCallbackHTTPHandler`/`FindOrCreateUserWithConsent`/`CreateToken` chain is unchanged.

## Adversarial review
`/adversarial-review` — **CLEAN**, no code changes needed. Panel ran inline (dispatched sub-agent, no Agent tool) against the branch diff with no prior session context: Saboteur · Future-Maintainer · Security · Completeness.
- **Security (the keystone):** attacked the default-deny guard from every direction — flag-on with `ENVIRONMENT` unset, wrong-casing (`Production`/`Test`), `production`/`stage`/`preview` — all fail **closed** (server refuses to boot; can never fail open to enable the faux provider). Defense-in-depth confirmed at both the `main.go` boot guard and the `SetupGoth` re-validation; the faux type is unexported and only reachable via the gated registration. `validateState`/CSRF unchanged.
- **Completeness:** all ticket requirements met; signup-consent correctly left out of scope.
- **Disclosed (LOW, author's discretion):** the `goth.go` registration branch (flag-on → provider appended) has no dedicated Go unit test — it's covered by the passing e2e spec plus unit tests of its constituents (`IsOAuthTestProviderEnabled`, `ValidateOAuthTestProviderEnvironment`, `newTestProvider().Name()`). A `SetupGoth`-level unit test would require manipulating process env + goth's global registry for marginal value; the security-critical validator is already unit-tested.

Closes PSY-914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
