### PR TITLE
PSY-918: wire /adversarial-review into psy-solo + psy-dispatch

### DIFF
--- a/.claude/skills/psy-dispatch/SKILL.md
+++ b/.claude/skills/psy-dispatch/SKILL.md
@@ -39,7 +39,7 @@ These are the non-negotiables. They are encoded in the per-agent prompt template
 
 1. **Resolve ambiguity BEFORE dispatch.** If any ticket has an explicit design fork ("Option A or B", "pick one and document", taxonomy/threshold/UX choice not already decided), the orchestrator MUST surface those forks via `AskUserQuestion` in a single batched call before spawning any agents. See `feedback_no_speculative_implementation.md` and `feedback_plan_mode_questions_first.md`.
 2. **Move tickets to In Progress on dispatch.** Before spawning agents, transition every dispatched ticket to the team's "In Progress" state. The state transition is the canonical signal to other humans/agents that work has started.
-3. **Both `/code-review` AND relevant local tests run before every PR opens; failure blocks push.** No exceptions. The code-review pass lands as a SEPARATE commit if it produced edits. Local tests must be the relevant suite for what the PR touches (backend test packages, frontend unit + typecheck, plus the E2E spec if a file under `frontend/e2e/` was modified). If ANY test fails — even one the agent believes is pre-existing on main — the agent must STOP, leave the branch unpushed, and report the failure for orchestrator-level escalation. The judgment "this is pre-existing, safe to push" is NOT the agent's call to make unilaterally; pushing first and triaging via GitHub CI wastes cycles, masks the diff's true signal, and fails the engineering bar. See `feedback_code_review_before_pr.md`.
+3. **`/code-review`, `/adversarial-review`, AND relevant local tests run before every PR opens; failure blocks push.** No exceptions. The code-review pass lands as a SEPARATE commit if it produced edits; the adversarial-review fixes land as their OWN separate commit (`PSY-{N}: adversarial-review fixes`), referenced in the PR body's `## Adversarial review` section. A BLOCK verdict (surviving CRITICAL/HIGH finding) the agent can't clear is a STOP-and-escalate, exactly like a failing test. Local tests must be the relevant suite for what the PR touches (backend test packages, frontend unit + typecheck, plus the E2E spec if a file under `frontend/e2e/` was modified). If ANY test fails — even one the agent believes is pre-existing on main — the agent must STOP, leave the branch unpushed, and report the failure for orchestrator-level escalation. The judgment "this is pre-existing, safe to push" is NOT the agent's call to make unilaterally; pushing first and triaging via GitHub CI wastes cycles, masks the diff's true signal, and fails the engineering bar. See `feedback_code_review_before_pr.md`.
 4. **One ticket = one PR.** Never bundle multiple PSY tickets into a single PR.
 5. **Agents never mark Done.** Linear ticket transitions to Done happen on PR merge (which is a human call). Agents leave the ticket In Progress.
 6. **Agents never merge their own PRs.** PR creation is the agent's last step; merging is the user's.
@@ -377,6 +377,11 @@ Fix PSY-{N}: {ticket title}.
    - Continue from your worktree.
 7. Commit the implementation.
 8. Run `/code-review` (Skill tool, skill: "code-review"). If it edited files, commit them as a SEPARATE commit `PSY-{N}: code-review pass`. **Re-run the relevant local tests from step 4** if code-review changed anything substantive. Re-run the manual repro from step 5 only if code-review edited a file you exercised in step 5.
+8.5. Run `/adversarial-review` (Skill tool, skill: "adversarial-review") — the hostile pre-PR gate; the change must EARN a clean verdict, not get the benefit of the doubt. **You are a dispatched sub-agent WITHOUT the Agent tool, so you cannot spawn the parallel panel — run the four lenses INLINE** (Saboteur / Future-Maintainer / Security / Completeness) against your branch diff, applying the skill's finding bar. This is expected, not an error (same inline fallback as `/code-review` from a worktree — see `pattern_subagent_inline_code_review.md`). Verdict handling:
+   - **BLOCK** (any surviving CRITICAL/HIGH): fix the findings (or reject a wrong one with a concrete technical counter-argument), then re-run the lenses; cap 3 rounds. If you cannot clear the BLOCK, STOP and report — do NOT push (rule 3).
+   - **CONCERNS** (MEDIUM only): fix what's cheap; disclose any deferral in the PR body.
+   - **CLEAN**: proceed.
+   Commit the review's fixes as a SEPARATE commit `PSY-{N}: adversarial-review fixes`, and re-run the relevant step-4 tests if it changed anything substantive. The skill writes the branch pass-marker on a passing verdict — this is REQUIRED: the `PreToolUse` hook blocks your `gh pr create` in step 10 without it (bypass only for a genuine docs-only PR via `ADVERSARIAL_REVIEW_SKIP=1`). Record findings + dispositions for the PR body's `## Adversarial review` section.
 9. Push branch with `-u origin <branch>`.
 10. Open PR with `gh pr create`. Body template:
     ```
@@ -387,12 +392,16 @@ Fix PSY-{N}: {ticket title}.
     ## Test plan
     - [x] <command you ran locally> — passed
     - [x] <command you ran locally> — passed
+    - [x] `/adversarial-review` — CLEAN (or CONCERNS addressed; fixes in separate commit)
 
     ## Manual repro
     <Frontend: link to screenshot at `dogfood-output/PSY-{N}/screenshots/<name>.png` + one-sentence description of what the screenshot shows. Backend: exact `curl` command + response body verbatim, OR test name + relevant assertion output. State what you exercised — the canonical failing path from the ticket — and what you saw. "docs-only, no manual repro applicable" is the only valid placeholder.>
 
     ## Code review
     <one-line outcome: "no changes" OR "edited N files, -M net lines, <one-phrase summary>". Post-code-review retest commands belong in the Test plan above with [x].>
+
+    ## Adversarial review
+    <verdict; findings + how each was resolved; fixes in separate commit `<sha>`. Panel run inline — no Agent tool in a worktree.>
 
     Closes PSY-{N}
     ```
@@ -447,6 +456,7 @@ These supplement the ironclad rules with tactical guidance from observed batch f
 - **`psy-ticket`** — ticket *creation* (this skill is for ticket *execution*).
 - **`linear-reference`** — workspace-agnostic `linear` CLI reference. Drop down to it when you need a command shape outside `psy-ticket`'s ticket-creation focus — `linear issue update --state` flags, posting comments on dispatched tickets (`linear issue comment add` rejects `--no-interactive`), project-update posts, milestone / document ops.
 - **`code-review`** — invoked by every dispatched agent before opening its PR.
+- **`/adversarial-review`** — invoked per-agent in step 8.5 (after `/code-review`, before push); the hostile "earn the pass" gate. Runs its lenses inline in a worktree (no Agent tool); fixes ship in a separate commit referenced in the PR body; the `PreToolUse` hook blocks `gh pr create` until it passes. User-level skill at `~/.claude/skills/adversarial-review/SKILL.md`.
 - `feedback_code_review_before_pr.md` — `/code-review` AND relevant local tests run before every PR (single-ticket or batched); failure blocks push, escalate to orchestrator instead of pushing past it.
 - `feedback_no_speculative_implementation.md` — when a ticket is ambiguous about WHAT to build, STOP and ask.
 - `feedback_plan_mode_questions_first.md` — surface forks via `AskUserQuestion` before exiting plan mode / dispatching.

--- a/.claude/skills/psy-dispatch/SKILL.md
+++ b/.claude/skills/psy-dispatch/SKILL.md
@@ -381,7 +381,7 @@ Fix PSY-{N}: {ticket title}.
    - **BLOCK** (any surviving CRITICAL/HIGH): fix the findings (or reject a wrong one with a concrete technical counter-argument), then re-run the lenses; cap 3 rounds. If you cannot clear the BLOCK, STOP and report — do NOT push (rule 3).
    - **CONCERNS** (MEDIUM only): fix what's cheap; disclose any deferral in the PR body.
    - **CLEAN**: proceed.
-   Commit the review's fixes as a SEPARATE commit `PSY-{N}: adversarial-review fixes`, and re-run the relevant step-4 tests if it changed anything substantive. The skill writes the branch pass-marker on a passing verdict — this is REQUIRED: the `PreToolUse` hook blocks your `gh pr create` in step 10 without it (bypass only for a genuine docs-only PR via `ADVERSARIAL_REVIEW_SKIP=1`). Record findings + dispositions for the PR body's `## Adversarial review` section.
+   Commit the review's fixes as a SEPARATE commit `PSY-{N}: adversarial-review fixes`, and re-run the relevant step-4 tests if it changed anything substantive. The skill writes the branch pass-marker on a passing verdict. If you cannot reach a passing verdict, STOP and report to the orchestrator — do NOT bypass the gate (any bypass is a human-only escape hatch documented in the skill itself, never something a dispatched agent invokes to self-clear a BLOCK). Record findings + dispositions for the PR body's `## Adversarial review` section.
 9. Push branch with `-u origin <branch>`.
 10. Open PR with `gh pr create`. Body template:
     ```
@@ -401,7 +401,10 @@ Fix PSY-{N}: {ticket title}.
     <one-line outcome: "no changes" OR "edited N files, -M net lines, <one-phrase summary>". Post-code-review retest commands belong in the Test plan above with [x].>
 
     ## Adversarial review
-    <verdict; findings + how each was resolved; fixes in separate commit `<sha>`. Panel run inline — no Agent tool in a worktree.>
+    `/adversarial-review` — <CLEAN, no findings | N findings addressed in separate commit `<sha>`>.
+    - [HIGH] <finding> → fixed in `<short-sha>` (<one line>)
+    - [MEDIUM] <finding> → <fixed | deferred: reason>
+    Panel: Saboteur · Future-Maintainer · Security · Completeness — run inline (no Agent tool in a worktree).
 
     Closes PSY-{N}
     ```

--- a/.claude/skills/psy-solo/SKILL.md
+++ b/.claude/skills/psy-solo/SKILL.md
@@ -127,14 +127,14 @@ If `/code-review` produced code changes, re-run the relevant test commands from 
 
 The hostile pre-PR gate — distinct from `/code-review` (balanced quality) and `/psy-self-review` (evidence audit). It spawns a panel of **fresh sub-agents with none of this session's context**, each attacking the diff from a different lens (Saboteur / Future-Maintainer / Security / Completeness) and competing to find the most *real* problems. The change must EARN a clean verdict — it does not get the benefit of the doubt. See `~/.claude/skills/adversarial-review/SKILL.md`.
 
-Because the review's fixes must land in a **separate commit** (non-negotiable 9), commit the implementation first:
+Because the review's fixes must land in a **separate commit** (non-negotiable 9), **commit the implementation first** — this commit always happens, even when the review comes back CLEAN with no fixes:
 
 ```bash
 # 1. Commit implementation + /code-review fixes as the implementation commit
 git -C <repo> add <impl files>                       # specific paths, never `git add .`
 git -C <repo> commit -m "PSY-{N}: <imperative summary>
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ```
 
 Then invoke `Skill` with `skill: "adversarial-review"`. As the orchestrator you have the Agent tool, so it spawns the panel in parallel. Aggregate the verdict:
@@ -149,7 +149,7 @@ Commit the fixes the review produced as their own commit, and re-run the relevan
 git -C <repo> add <files the review fixed>
 git -C <repo> commit -m "PSY-{N}: adversarial-review fixes
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ```
 
 The skill writes the branch pass-marker on a passing verdict (CLEAN, or fixed/disclosed CONCERNS) — this is what unblocks `gh pr create` at phase 8. Capture the findings + dispositions for the PR body's `## Adversarial review` section (phase 7.5). If the verdict was CLEAN with no fixes, there's no second commit — note "CLEAN, no findings" in the section.
@@ -287,9 +287,10 @@ Born out of the May 16–17 retro: PSY-658 shipped with an unverified `[x]` clai
 The PR body is the file you wrote in phase 7.5 and refined in phase 7.6 — use `--body-file`, not an inline heredoc.
 
 ```bash
-# Implementation + adversarial-review fixes were already committed in phases 5 / 5.5.
-git -C <repo> status                               # confirm nothing unexpected is uncommitted
-# (commit any stragglers with specific paths — never `git add .`)
+# Implementation (phase 5.5) + any adversarial-review fixes should already be committed.
+# If ANY code changed after Phase 5.5 (e.g. a Phase 6 screenshot-driven fix), re-run
+# /adversarial-review first so the pass-marker reflects exactly what you're pushing.
+git -C <repo> status                               # if this shows uncommitted implementation, COMMIT it now (specific paths) before pushing — never `git add .`
 git -C <repo> push -u origin PSY-{N}/<branch>
 gh pr create --title "PSY-{N}: <under-70-char summary>" --body-file /tmp/psy-{N}-pr-body.md   # hook checks the /adversarial-review pass-marker
 ```

--- a/.claude/skills/psy-solo/SKILL.md
+++ b/.claude/skills/psy-solo/SKILL.md
@@ -35,11 +35,12 @@ which agent-browser               # if any UI screenshots are planned
 1. **One issue = one PR.** Branch name `PSY-{N}/{kebab-description}`. PR body includes `Closes PSY-{N}`.
 2. **Pull latest main BEFORE starting.** `git -C <repo> checkout main && git pull --ff-only origin main`. Stale main inherits stale-fallout CI from anything that merged in between (see psy-dispatch anti-pattern catalog for the canonical incident).
 3. **Surface ambiguity via `AskUserQuestion` BEFORE writing code.** When the ticket has a design fork (Option A vs B, taxonomy/threshold/UX choice not already decided), batch the questions into a single `AskUserQuestion` call. See `feedback_no_speculative_implementation.md` and `feedback_plan_mode_questions_first.md`. Do not guess — file a follow-up rather than implementing speculative scope.
-4. **`/code-review` AND relevant local tests run before push; failure blocks push.** Same rule as `psy-dispatch`. Never push past a failing local test, even one you believe is pre-existing on main — escalate to the user instead of triaging via GitHub CI. See `feedback_code_review_before_pr.md`.
+4. **`/code-review`, `/adversarial-review`, AND relevant local tests run before push; failure blocks push.** Same rule as `psy-dispatch`. Never push past a failing local test, even one you believe is pre-existing on main — escalate to the user instead of triaging via GitHub CI. See `feedback_code_review_before_pr.md`. The `PreToolUse` hook (`~/.claude/hooks/require-adversarial-review.sh`) will block `gh pr create` until `/adversarial-review` has written a pass-marker for the branch.
 5. **Never mark Done in Linear.** Transition to "In Progress" on start; the user moves it to Done on merge.
 6. **Never merge the PR yourself.** Push and open the PR; the user merges.
 7. **Document deferred scope explicitly in the PR body.** If the implementation Q&A produced a "skip this and file a follow-up" decision, link the follow-up ticket(s) in a `## Deferred` section.
 8. **For UI changes: capture screenshots when feasible.** UI tickets benefit from rendered visual evidence in the PR. Use the [Screenshot workflow](#phase-6-screenshots-ui-tickets-only) — skip for backend-only / docs-only / config-only tickets (note "no UI surface" in the test plan instead).
+9. **Adversarial-review fixes ship as a SEPARATE commit, referenced in the PR body.** The implementation (incl. `/code-review` fixes) is committed first; `/adversarial-review`'s findings + fixes land in their own commit (`PSY-{N}: adversarial-review fixes`) so the adversarial pass stays visible in history. The PR body's `## Adversarial review` section names the findings and how each was resolved. See [Phase 5.5](#phase-55-adversarial-review).
 
 ## Workflow
 
@@ -121,6 +122,37 @@ bash scripts/dispatch/stack-down.sh "$(git rev-parse --show-toplevel)"
 Invoke `Skill` with `skill: "code-review"`. The code-review skill spawns 3 parallel reviewer agents (reuse / quality / efficiency) against your diff. Aggregate their findings; fix the actionable ones directly. For findings that are pre-existing peer-wide gaps (e.g. inline `<h2>` headings vs `SectionHeader` primitive when the peer pages all use inline) — note in the PR body, do NOT expand scope.
 
 If `/code-review` produced code changes, re-run the relevant test commands from phase 4.
+
+### Phase 5.5: /adversarial-review
+
+The hostile pre-PR gate — distinct from `/code-review` (balanced quality) and `/psy-self-review` (evidence audit). It spawns a panel of **fresh sub-agents with none of this session's context**, each attacking the diff from a different lens (Saboteur / Future-Maintainer / Security / Completeness) and competing to find the most *real* problems. The change must EARN a clean verdict — it does not get the benefit of the doubt. See `~/.claude/skills/adversarial-review/SKILL.md`.
+
+Because the review's fixes must land in a **separate commit** (non-negotiable 9), commit the implementation first:
+
+```bash
+# 1. Commit implementation + /code-review fixes as the implementation commit
+git -C <repo> add <impl files>                       # specific paths, never `git add .`
+git -C <repo> commit -m "PSY-{N}: <imperative summary>
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+Then invoke `Skill` with `skill: "adversarial-review"`. As the orchestrator you have the Agent tool, so it spawns the panel in parallel. Aggregate the verdict:
+
+- **BLOCK** (any CRITICAL/HIGH) — the change has not earned the pass. Fix the findings (or reject a wrong one with a concrete technical counter-argument), then re-run the panel (cap 3 rounds; if severity won't decline, STOP and surface to the user).
+- **CONCERNS** (MEDIUM only) — fix what's cheap; disclose any deferral in the PR body.
+- **CLEAN** — proceed.
+
+Commit the fixes the review produced as their own commit, and re-run the relevant phase-4 tests if it changed anything substantive:
+
+```bash
+git -C <repo> add <files the review fixed>
+git -C <repo> commit -m "PSY-{N}: adversarial-review fixes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+The skill writes the branch pass-marker on a passing verdict (CLEAN, or fixed/disclosed CONCERNS) — this is what unblocks `gh pr create` at phase 8. Capture the findings + dispositions for the PR body's `## Adversarial review` section (phase 7.5). If the verdict was CLEAN with no fixes, there's no second commit — note "CLEAN, no findings" in the section.
 
 ### Phase 6: Screenshots (UI tickets only)
 
@@ -255,12 +287,11 @@ Born out of the May 16–17 retro: PSY-658 shipped with an unverified `[x]` clai
 The PR body is the file you wrote in phase 7.5 and refined in phase 7.6 — use `--body-file`, not an inline heredoc.
 
 ```bash
-git -C <repo> add <specific files>                # NOT `git add .` — never accidentally add untracked
-git -C <repo> commit -m "PSY-{N}: <imperative summary>
-
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+# Implementation + adversarial-review fixes were already committed in phases 5 / 5.5.
+git -C <repo> status                               # confirm nothing unexpected is uncommitted
+# (commit any stragglers with specific paths — never `git add .`)
 git -C <repo> push -u origin PSY-{N}/<branch>
-gh pr create --title "PSY-{N}: <under-70-char summary>" --body-file /tmp/psy-{N}-pr-body.md
+gh pr create --title "PSY-{N}: <under-70-char summary>" --body-file /tmp/psy-{N}-pr-body.md   # hook checks the /adversarial-review pass-marker
 ```
 
 #### PR body template (use as starting point for the phase 7.5 draft)
@@ -278,10 +309,17 @@ Closes PSY-{N}.
 ## Heads up from `/code-review`
 <only include this section if /code-review surfaced a non-blocking concern worth flagging — e.g. an efficiency regression that's intrinsic to the design. Omit if /code-review was clean.>
 
+## Adversarial review
+`/adversarial-review` — <CLEAN, no findings | N findings addressed in commit `<sha>`>.
+- [HIGH] <finding> → fixed in `<short-sha>` (<one line>)
+- [MEDIUM] <finding> → <fixed | deferred: reason>
+Panel: Saboteur · Future-Maintainer · Security<· Completeness>. Reviewers ran with no prior session context against the branch diff.
+
 ## Test plan
 - [x] `bun run typecheck` — clean
 - [x] `bun run test:run features/<scope>` — N/N passing
 - [x] `/code-review` — <outcome>
+- [x] `/adversarial-review` — <CLEAN | CONCERNS addressed; fixes in separate commit `<sha>`>
 - [x] `/psy-self-review` — <outcome: clean / N findings addressed>
 - [x] Manual repro against local dev stack with <entity>: <one-sentence description of what was visually verified>
 
@@ -343,6 +381,7 @@ Do NOT delete the draft release after the PR is open — the asset URLs depend o
 - **`psy-ticket`** — ticket creation; pair with phase 7 to file the follow-ups this skill identifies.
 - **`linear-reference`** — workspace-agnostic `linear` CLI reference. Drop down to it when you need a command shape outside `psy-ticket`'s ticket-creation focus — posting status updates via `linear project-update create --health onTrack|atRisk|offTrack`, posting an issue comment via `linear issue comment add` (note: rejects `--no-interactive`), milestone / initiative-update / document ops. Pair with `psy-ticket` when PSY conventions also apply.
 - **`code-review`** — invoked in phase 5; spawns 3 parallel reviewer agents (reuse / quality / efficiency) against the diff.
+- **`/adversarial-review`** — invoked in phase 5.5 (after `/code-review`, before push); spawns a competitive panel of fresh hostile-lens sub-agents (Saboteur / Future-Maintainer / Security / Completeness) that must be convinced the change earned the pass. Fixes land in a separate commit referenced in the PR body; the `PreToolUse` hook blocks `gh pr create` until it passes. User-level skill at `~/.claude/skills/adversarial-review/SKILL.md` — available in every project on this machine.
 - **`agent-browser` CLI** — `which agent-browser` to confirm install; pre-installed in this dev environment. Reliable Chrome automation that doesn't depend on a running Chrome instance.
 - `feedback_code_review_before_pr.md` — non-negotiable rule 4 above.
 - `feedback_no_speculative_implementation.md` — non-negotiable rule 3 above (ask, don't guess).


### PR DESCRIPTION
Closes PSY-918.

## Summary
Wires the user-level `/adversarial-review` pre-PR gate into the PSY ship workflows so changes have to *earn the pass* before a PR opens. The skill spawns a fresh, hostile review panel (Saboteur / Future-Maintainer / Security / Completeness — fresh sub-agents with none of the building session's context). A `PreToolUse` hook gates `gh pr create` on a branch pass-marker.

- **psy-solo** — new Phase 5.5 (after `/code-review`, before push) + non-negotiable 9.
- **psy-dispatch** — new per-agent step 8.5 (runs the lenses inline — worktree agents have no Agent tool) + ironclad rule 3 (a BLOCK verdict is STOP-and-escalate).
- Both — a `## Adversarial review` PR-body template section; adversarial-review fixes ship as a **separate commit** referenced there.

> The skill, hook, and `~/.claude/settings.json` registration are **user-level** (every project on this machine), **outside this repo** — so this PR is the in-repo workflow wiring only.

## Provenance
Aja Hammerly's "adversarial mentor" habit (2026 Google panel: *"what did we miss? … and don't be nice"*) + the adversarial-review agents Jarred Sumner used for Bun's Rust rewrite (*"2 adversarial review agents to refute the bugfix; uncover every flaw"*).

## Adversarial review
Dogfooded on its own wiring. **4 findings, fixed in separate commit `359544bb`:**
- **[security]** step 8.5 handed the autonomous agent the `ADVERSARIAL_REVIEW_SKIP` bypass next to the STOP rule → reframed to STOP-and-report; the bypass stays a human-only escape hatch documented in the skill, not in the agent runbook.
- **[correctness]** psy-solo Phase 8 assumed the implementation was already committed → now defensive (commit any uncommitted impl before push); Phase 5.5's impl commit marked unconditional + a re-run-after-late-edits note.
- **[consistency]** psy-solo co-author template strings normalized to 4.7 (matches the sibling skill + the rest of the repo).
- **[parity]** psy-dispatch `## Adversarial review` PR template brought to parity with psy-solo's (per-finding bullets + panel byline).

*The review was completed inline against the diff (the skill's documented fallback when the parallel panel isn't available); each finding was verified against the file text before fixing.*

## Test plan
- [x] Docs/workflow-only change (two `SKILL.md` files); no `go` / `bun` / runtime code touched, so no unit tests apply.
- [x] Wiring fixes grep-confirmed in the committed files (bypass removed from the agent runbook → 0 occurrences; lifecycle note present; version strings normalized → 0 stray `4.8`; PR templates symmetric).
- [x] Anchor `[Phase 5.5](#phase-55-adversarial-review)` resolves; psy-solo and psy-dispatch insertions are symmetric.
- [x] Two commits as required: `0bb240a2` wiring + `359544bb` adversarial-review fixes.

## Notes
- The skill / hook / settings are installed user-level on this machine and are not part of this repo.
- Created from a separate worktree branched off the latest `origin/main`.
