### PR TITLE
chore(skills): wire /adversarial-review into psy-solo + psy-dispatch

### DIFF
--- a/.claude/skills/psy-solo/SKILL.md
+++ b/.claude/skills/psy-solo/SKILL.md
@@ -122,6 +122,18 @@ Invoke `Skill` with `skill: "code-review"`. The code-review skill spawns 3 paral
 
 If `/code-review` produced code changes, re-run the relevant test commands from phase 4.
 
+### Phase 5.5: /adversarial-review (gate — required before PR)
+
+Invoke `Skill` with `skill: "adversarial-review"`. It spawns a fresh panel of sub-agents (Saboteur / Future-Maintainer / Security / Completeness) with NONE of this session's context — they see only the branch diff + a one-line intent and attack it. This is distinct from `/code-review`: `/code-review` polishes; `/adversarial-review` tries to break the polished result and asks "what did we miss?".
+
+- **Order matters:** run this AFTER `/code-review` (phase 5) and BEFORE `/psy-self-review` (phase 7.6). The chain is `/code-review` → `/adversarial-review` → (separate commit) → `/psy-self-review` → push.
+- **Fixes go in their own commit** (`PSY-{N}: adversarial-review fixes`), separate from the implementation, so the pass is auditable in history.
+- **Re-run if the diff changes** after the marker is written — the pass-marker is per-branch (existence check), so its honesty depends on you re-running when you push something different from what the panel saw.
+- **Put the findings + fixes in the PR body** under a `## Adversarial review` section (the skill emits a ready-to-paste block). This is a standing requirement — reviewers audit the adversarial pass from the PR alone.
+- **Enforcement:** the `PreToolUse(Bash)` hook blocks `gh pr create` in any repo until the marker exists for repo+branch. Genuine docs/config-only bypass: `ADVERSARIAL_REVIEW_SKIP=1 gh pr create …`.
+
+If `/adversarial-review` produced code changes, re-run the relevant test commands from phase 4 before proceeding.
+
 ### Phase 6: Screenshots (UI tickets only)
 
 Skip this phase entirely for backend-only / docs-only / config-only tickets — note `"no UI surface, screenshots skipped"` in the test plan.


### PR DESCRIPTION
## Summary

Wires the `/adversarial-review` gate into the two PSY workflow skills that open PRs. The `adversarial-review` skill and its `PreToolUse` hook (which blocks `gh pr create` until a per-branch pass-marker exists) already *assumed* `psy-solo` and `psy-dispatch` invoke it — but neither skill documented it, so the gate fired by surprise mid-ticket (during PSY-909). This closes that doc-vs-reality gap.

Docs-only (two `SKILL.md` files). No code paths touched.

## What changed

**`psy-solo`**
- Non-negotiable #5 reframed from "`/code-review` before PR" to **"Review gates before PR"** — covers `/code-review` *and* `/adversarial-review`, and states the hook enforces the latter.
- New **`### Phase 5.5: /adversarial-review`** between Phase 5 (`/code-review`) and Phase 7.6 (`/psy-self-review`): states the order (`/code-review` → `/adversarial-review` → separate commit → `/psy-self-review` → push), the separate-commit rule, the `## Adversarial review` PR-body requirement, and the hook + `ADVERSARIAL_REVIEW_SKIP=1` bypass.

**`psy-dispatch`**
- New per-agent **step 7.5** (between step 7 File-follow-ups and step 8 Open PR). Dispatched sub-agents lack the Agent tool, so they run the lenses **inline** — same fallback convention the existing step 6 (`/code-review`) already documents.

**Cross-reference fix (user-level, not in this diff):** the authoritative `adversarial-review` skill said "psy-dispatch step 8.5"; 8.5 would land *after* Open PR (step 8), which is wrong. Corrected its reference to "step 7.5, before the Open-PR step" so the source of truth matches this wiring.

## Test plan

- [x] No code — docs only; nothing to typecheck/test/lint.
- [x] Cross-checked every factual claim against the authoritative `adversarial-review` skill + the `require-adversarial-review.sh` hook (block scope = only `gh pr create`; bypass = `ADVERSARIAL_REVIEW_SKIP=1`; order; separate-commit; per-branch marker; inline fallback) — all accurate.
- [x] Verified the `Phase 7.6` and step-numbering cross-references resolve to real anchors.

## Adversarial review

`/adversarial-review` — ran one fresh docs-accuracy reviewer (proportionate to a 2-file prose change; the full break-it-in-prod panel doesn't apply to markdown). Reviewer had no prior session context, diff + intent only. Verdict: **CONCERNS** (no HIGH/CRITICAL); both items addressed:

- **[LOW] Verify the `Phase 7.6` cross-ref resolves.** → Confirmed: psy-solo line 238 has `### Phase 7.6: /psy-self-review`. No change needed.
- **[MEDIUM] The authoritative skill still said "step 8.5", contradicting this wiring's "7.5".** → Fixed at the source: updated the `adversarial-review` skill's reference to "step 7.5, before the Open-PR step" (user-level file, outside this repo diff).

Reviewer confirmed all six factual claims about the hook + skill are accurate and the new step/phase placements are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
