### PR TITLE
PSY-915: add lightweight entity existence probe

### DIFF
--- a/backend/internal/api/handlers/catalog/entity_existence.go
+++ b/backend/internal/api/handlers/catalog/entity_existence.go
@@ -1,0 +1,37 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type entityExistenceService interface {
+	Exists(entityType, idOrSlug string) (bool, error)
+}
+
+type EntityExistenceHandler struct {
+	entityExistenceService entityExistenceService
+}
+
+func NewEntityExistenceHandler(entityExistenceService entityExistenceService) *EntityExistenceHandler {
+	return &EntityExistenceHandler{entityExistenceService: entityExistenceService}
+}
+
+type EntityExistsRequest struct {
+	EntityType string `path:"entity_type" validate:"required" doc:"Entity prefix (shows, venues, artists, releases, labels, festivals, tags, scenes)"`
+	EntityID   string `path:"entity_id" validate:"required" doc:"Entity ID or slug"`
+}
+
+type EntityExistsResponse struct{}
+
+func (h *EntityExistenceHandler) EntityExistsHandler(ctx context.Context, req *EntityExistsRequest) (*EntityExistsResponse, error) {
+	exists, err := h.entityExistenceService.Exists(req.EntityType, req.EntityID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to check entity existence", err)
+	}
+	if !exists {
+		return nil, huma.Error404NotFound("Entity not found")
+	}
+	return &EntityExistsResponse{}, nil
+}

--- a/backend/internal/api/handlers/catalog/entity_existence_test.go
+++ b/backend/internal/api/handlers/catalog/entity_existence_test.go
@@ -1,0 +1,56 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+)
+
+type mockEntityExistenceService struct {
+	exists bool
+	err    error
+}
+
+func (m mockEntityExistenceService) Exists(entityType, idOrSlug string) (bool, error) {
+	return m.exists, m.err
+}
+
+func TestEntityExistsHandler_Success(t *testing.T) {
+	h := NewEntityExistenceHandler(mockEntityExistenceService{exists: true})
+
+	resp, err := h.EntityExistsHandler(context.Background(), &EntityExistsRequest{
+		EntityType: "shows",
+		EntityID:   "approved-show",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+}
+
+func TestEntityExistsHandler_NotFound(t *testing.T) {
+	h := NewEntityExistenceHandler(mockEntityExistenceService{exists: false})
+
+	_, err := h.EntityExistsHandler(context.Background(), &EntityExistsRequest{
+		EntityType: "tags",
+		EntityID:   "missing-tag",
+	})
+
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestEntityExistsHandler_ServiceError(t *testing.T) {
+	h := NewEntityExistenceHandler(mockEntityExistenceService{err: fmt.Errorf("database down")})
+
+	_, err := h.EntityExistsHandler(context.Background(), &EntityExistsRequest{
+		EntityType: "scenes",
+		EntityID:   "phoenix-az",
+	})
+
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/routes/entity_existence.go
+++ b/backend/internal/api/routes/entity_existence.go
@@ -1,0 +1,13 @@
+package routes
+
+import (
+	"github.com/danielgtaylor/huma/v2"
+
+	catalogh "psychic-homily-backend/internal/api/handlers/catalog"
+)
+
+func setupEntityExistenceRoutes(rc RouteContext) {
+	entityExistenceHandler := catalogh.NewEntityExistenceHandler(rc.SC.EntityExistence)
+
+	huma.Head(rc.API, "/entities/{entity_type}/{entity_id}/exists", entityExistenceHandler.EntityExistsHandler)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -82,6 +82,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupCollectionRoutes(rc)
 	setupRequestRoutes(rc)
 	setupRevisionRoutes(rc)
+	setupEntityExistenceRoutes(rc)
 	setupTagRoutes(rc)
 	setupArtistRelationshipRoutes(rc)
 	setupSceneRoutes(rc)

--- a/backend/internal/services/catalog/entity_existence.go
+++ b/backend/internal/services/catalog/entity_existence.go
@@ -1,0 +1,96 @@
+package catalog
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+)
+
+// EntityExistenceService answers lightweight public entity existence probes.
+// It intentionally avoids the detail services, which hydrate joins and response
+// bodies that the frontend proxy does not need before rendering a page.
+type EntityExistenceService struct {
+	db *gorm.DB
+}
+
+func NewEntityExistenceService(database *gorm.DB) *EntityExistenceService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &EntityExistenceService{db: database}
+}
+
+func (s *EntityExistenceService) Exists(entityType, idOrSlug string) (bool, error) {
+	if s.db == nil {
+		return false, fmt.Errorf("database not initialized")
+	}
+
+	switch entityType {
+	case "shows":
+		return s.existsByIDOrSlug(
+			&catalogm.Show{},
+			idOrSlug,
+			"status = ?",
+			catalogm.ShowStatusApproved,
+		)
+	case "venues":
+		return s.existsByIDOrSlug(&catalogm.Venue{}, idOrSlug)
+	case "artists":
+		return s.existsByIDOrSlug(&catalogm.Artist{}, idOrSlug)
+	case "releases":
+		return s.existsByIDOrSlug(&catalogm.Release{}, idOrSlug)
+	case "labels":
+		return s.existsByIDOrSlug(&catalogm.Label{}, idOrSlug)
+	case "festivals":
+		return s.existsByIDOrSlug(&catalogm.Festival{}, idOrSlug)
+	case "tags":
+		return s.existsByIDOrSlug(&catalogm.Tag{}, idOrSlug)
+	case "scenes":
+		return s.sceneExists(idOrSlug)
+	default:
+		return false, nil
+	}
+}
+
+func (s *EntityExistenceService) existsByIDOrSlug(model any, idOrSlug string, extraWhere ...any) (bool, error) {
+	query := s.db.Model(model)
+
+	if len(extraWhere) > 0 {
+		where, ok := extraWhere[0].(string)
+		if !ok {
+			return false, fmt.Errorf("extra where clause must be a string")
+		}
+		query = query.Where(where, extraWhere[1:]...)
+	}
+
+	if id, err := strconv.ParseUint(idOrSlug, 10, 32); err == nil {
+		query = query.Where("id = ?", uint(id))
+	} else {
+		query = query.Where("slug = ?", idOrSlug)
+	}
+
+	var id uint
+	if err := query.Select("id").Limit(1).Scan(&id).Error; err != nil {
+		return false, err
+	}
+	return id != 0, nil
+}
+
+func (s *EntityExistenceService) sceneExists(slug string) (bool, error) {
+	var verifiedVenueCount int64
+	err := s.db.Raw(`
+		SELECT COUNT(DISTINCT id)
+		FROM venues
+		WHERE verified = true
+		  AND LOWER(REPLACE(city, ' ', '-')) || '-' || LOWER(state) = ?
+	`, strings.ToLower(slug)).Scan(&verifiedVenueCount).Error
+	if err != nil {
+		return false, err
+	}
+	return verifiedVenueCount >= sceneMinVenues, nil
+}

--- a/backend/internal/services/catalog/entity_existence_test.go
+++ b/backend/internal/services/catalog/entity_existence_test.go
@@ -1,0 +1,156 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/testutil"
+)
+
+type EntityExistenceServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *EntityExistenceService
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.svc = NewEntityExistenceService(suite.db)
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM festival_artists")
+	_, _ = sqlDB.Exec("DELETE FROM festival_venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestEntityExistenceServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(EntityExistenceServiceIntegrationTestSuite))
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) createEntityExistenceUser() *authm.User {
+	user := &authm.User{
+		Email:         stringPtr(fmt.Sprintf("entity-existence-%d@test.com", time.Now().UnixNano())),
+		FirstName:     stringPtr("Entity"),
+		LastName:      stringPtr("Probe"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	suite.Require().NoError(suite.db.Create(user).Error)
+	return user
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) TestExists_ShowSlugUsesPublicDetailSemantics() {
+	user := suite.createEntityExistenceUser()
+	approvedSlug := "approved-show"
+	privateSlug := "private-show"
+
+	approved := &catalogm.Show{
+		Title:       "Approved Show",
+		Slug:        &approvedSlug,
+		EventDate:   time.Now().UTC().Add(24 * time.Hour),
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      catalogm.ShowStatusApproved,
+		SubmittedBy: &user.ID,
+	}
+	private := &catalogm.Show{
+		Title:       "Private Show",
+		Slug:        &privateSlug,
+		EventDate:   time.Now().UTC().Add(48 * time.Hour),
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      catalogm.ShowStatusPrivate,
+		SubmittedBy: &user.ID,
+	}
+	suite.Require().NoError(suite.db.Create(approved).Error)
+	suite.Require().NoError(suite.db.Create(private).Error)
+
+	exists, err := suite.svc.Exists("shows", approvedSlug)
+	suite.Require().NoError(err)
+	suite.True(exists)
+
+	exists, err = suite.svc.Exists("shows", fmt.Sprintf("%d", approved.ID))
+	suite.Require().NoError(err)
+	suite.True(exists)
+
+	exists, err = suite.svc.Exists("shows", privateSlug)
+	suite.Require().NoError(err)
+	suite.False(exists)
+
+	exists, err = suite.svc.Exists("shows", "missing-show")
+	suite.Require().NoError(err)
+	suite.False(exists)
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) TestExists_TagSlugAndID() {
+	tag := &catalogm.Tag{Name: "Post Punk", Slug: "post-punk", Category: catalogm.TagCategoryGenre}
+	suite.Require().NoError(suite.db.Create(tag).Error)
+
+	exists, err := suite.svc.Exists("tags", "post-punk")
+	suite.Require().NoError(err)
+	suite.True(exists)
+
+	exists, err = suite.svc.Exists("tags", fmt.Sprintf("%d", tag.ID))
+	suite.Require().NoError(err)
+	suite.True(exists)
+
+	exists, err = suite.svc.Exists("tags", "missing-tag")
+	suite.Require().NoError(err)
+	suite.False(exists)
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) TestExists_SceneSlugUsesDetailThreshold() {
+	venues := []*catalogm.Venue{
+		{Name: "Crescent Ballroom", Slug: stringPtr("crescent-ballroom"), City: "Phoenix", State: "AZ", Verified: true},
+		{Name: "Valley Bar", Slug: stringPtr("valley-bar"), City: "Phoenix", State: "AZ", Verified: true},
+		{Name: "Small Room", Slug: stringPtr("small-room"), City: "Tucson", State: "AZ", Verified: true},
+		{Name: "Unverified Room", Slug: stringPtr("unverified-room"), City: "Mesa", State: "AZ", Verified: false},
+	}
+	for _, venue := range venues {
+		suite.Require().NoError(suite.db.Create(venue).Error)
+	}
+	suite.Require().NoError(suite.db.Model(venues[3]).Update("verified", false).Error)
+
+	exists, err := suite.svc.Exists("scenes", "phoenix-az")
+	suite.Require().NoError(err)
+	suite.True(exists)
+
+	exists, err = suite.svc.Exists("scenes", "tucson-az")
+	suite.Require().NoError(err)
+	suite.False(exists)
+
+	exists, err = suite.svc.Exists("scenes", "mesa-az")
+	suite.Require().NoError(err)
+	suite.False(exists)
+}
+
+func (suite *EntityExistenceServiceIntegrationTestSuite) TestExists_UnsupportedEntityTypeIsMissing() {
+	exists, err := suite.svc.Exists("collections", "any")
+	suite.Require().NoError(err)
+	suite.False(exists)
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -36,6 +36,7 @@ type ServiceContainer struct {
 	AuditLog               *adminsvc.AuditLogService
 	FeaturedSlot           *adminsvc.FeaturedSlotService
 	Explore                *exploresvc.ExploreService
+	EntityExistence        *catalog.EntityExistenceService
 	Bookmark               *engagement.BookmarkService
 	Calendar               *engagement.CalendarService
 	Collection             *community.CollectionService
@@ -177,6 +178,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		AuditLog:               adminsvc.NewAuditLogService(database),
 		FeaturedSlot:           featuredSlotSvc,
 		Explore:                exploreService,
+		EntityExistence:        catalog.NewEntityExistenceService(database),
 		Bookmark:               engagement.NewBookmarkService(database),
 		Calendar:               engagement.NewCalendarService(database, savedShow),
 		Collection:             collectionSvc,

--- a/frontend/proxy.test.ts
+++ b/frontend/proxy.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+import { proxy } from './proxy'
+
+function requestFor(pathname: string): NextRequest {
+  return {
+    nextUrl: new URL(`http://localhost:3000${pathname}`),
+    url: `http://localhost:3000${pathname}`,
+  } as unknown as NextRequest
+}
+
+describe('proxy entity existence checks', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses the lightweight HEAD exists probe instead of the full detail GET', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }))
+
+    await proxy(requestFor('/shows/e2e-attendance-test'))
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/entities/shows/e2e-attendance-test/exists',
+      {
+        method: 'HEAD',
+        redirect: 'manual',
+      }
+    )
+  })
+
+  it('rewrites backend 404 probes to a real not-found response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 404 })
+    )
+
+    const response = await proxy(requestFor('/tags/missing-tag'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('does not existence-check reserved static show routes', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }))
+
+    await proxy(requestFor('/shows/submit'))
+    await proxy(requestFor('/shows/saved'))
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -61,39 +61,36 @@ import { API_BASE_URL } from '@/lib/api-base'
 const NOT_FOUND_REWRITE_PATH = '/_psy-not-found'
 
 /**
- * Per-entity existence check. The function returns the backend URL whose
- * non-2xx response means "slug does not exist". Each entry reuses the SAME
- * backend GET the corresponding `app/<type>/[slug]/page.tsx` already calls in
- * its server-side `cache()`'d fetch, so the proxy's notion of existence matches
- * the page's exactly (each of these pages calls `notFound()` when that fetch
- * misses — verified per type). The spike flagged that a backend HEAD /
- * `/exists` endpoint would be cheaper than a full GET; using the existing GET
- * is acceptable for now (latency noted as a follow-up). Adding an entity is one
- * entry here plus one `config.matcher` source.
+ * Per-entity existence check. The function returns the backend HEAD probe URL
+ * whose 404 response means "slug does not exist". The probe uses direct backend
+ * existence queries instead of duplicating each page's full `GET /<type>/<slug>`
+ * fetch and its response hydration. Adding an entity is one entry here plus one
+ * `config.matcher` source.
  *
- * Every type uses the uniform `/<type>/<slug>` backend shape EXCEPT `tags`,
- * whose page fetches the enriched `/tags/<slug>/detail` endpoint (the shape its
- * `useTagDetail` hook consumes) — see `app/tags/[slug]/page.tsx`. `scenes` is
- * also uniform: `GET /scenes/<slug>` is the same backend call the scene page's
- * `getScene` fetch makes, and it already 404s for an unresolvable slug or a
- * below-threshold location (≥2 verified venues). Collections (auth-gated) and
+ * The backend probe centralizes the historical non-uniform cases: tags still
+ * resolve by tag ID/slug without loading `/tags/<slug>/detail`, and scenes still
+ * resolve derived city/state slugs against the same qualifying venue threshold
+ * without loading the full computed scene detail. Collections (auth-gated) and
  * blog/dj-sets (local MDX, no backend existence endpoint) are deliberately
  * absent — they have distinct semantics.
  */
 const ENTITY_CHECKS: Record<string, (slug: string) => string> = {
-  shows: (slug) => `${API_BASE_URL}/shows/${encodeURIComponent(slug)}`,
-  venues: (slug) => `${API_BASE_URL}/venues/${encodeURIComponent(slug)}`,
-  artists: (slug) => `${API_BASE_URL}/artists/${encodeURIComponent(slug)}`,
-  releases: (slug) => `${API_BASE_URL}/releases/${encodeURIComponent(slug)}`,
-  labels: (slug) => `${API_BASE_URL}/labels/${encodeURIComponent(slug)}`,
-  festivals: (slug) => `${API_BASE_URL}/festivals/${encodeURIComponent(slug)}`,
-  // NOTE: tags is the lone non-uniform endpoint — `/tags/<slug>/detail`, not
-  // `/tags/<slug>`. Matches the tag page's getTagDetail fetch.
-  tags: (slug) => `${API_BASE_URL}/tags/${encodeURIComponent(slug)}/detail`,
-  // scenes are derived city/state aggregations; the backend resolves the slug
-  // against verified venues and 404s when it doesn't qualify (PSY-906). Matches
-  // the scene page's getScene fetch.
-  scenes: (slug) => `${API_BASE_URL}/scenes/${encodeURIComponent(slug)}`,
+  shows: slug =>
+    `${API_BASE_URL}/entities/shows/${encodeURIComponent(slug)}/exists`,
+  venues: slug =>
+    `${API_BASE_URL}/entities/venues/${encodeURIComponent(slug)}/exists`,
+  artists: slug =>
+    `${API_BASE_URL}/entities/artists/${encodeURIComponent(slug)}/exists`,
+  releases: slug =>
+    `${API_BASE_URL}/entities/releases/${encodeURIComponent(slug)}/exists`,
+  labels: slug =>
+    `${API_BASE_URL}/entities/labels/${encodeURIComponent(slug)}/exists`,
+  festivals: slug =>
+    `${API_BASE_URL}/entities/festivals/${encodeURIComponent(slug)}/exists`,
+  tags: slug =>
+    `${API_BASE_URL}/entities/tags/${encodeURIComponent(slug)}/exists`,
+  scenes: slug =>
+    `${API_BASE_URL}/entities/scenes/${encodeURIComponent(slug)}/exists`,
 }
 
 /**
@@ -152,10 +149,11 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 
   try {
     const res = await fetch(buildCheckUrl(slug), {
+      method: 'HEAD',
       // `next: { revalidate }` has NO effect inside proxy (per Next docs), so
       // we don't set it. `redirect: 'manual'` keeps the check cheap and avoids
-      // following any backend redirect chain. A 2xx/3xx means the slug
-      // resolves; only a hard non-ok (4xx/5xx) is treated as "missing".
+      // following any backend redirect chain. A 2xx means the slug resolves;
+      // only a backend 404 is treated as "missing".
       redirect: 'manual',
     })
 


### PR DESCRIPTION
Closes PSY-915.

## Summary
- Adds a backend `HEAD /entities/{entity_type}/{entity_id}/exists` probe backed by direct existence queries for shows, venues, artists, releases, labels, festivals, tags, and scenes.
- Updates `frontend/proxy.ts` to call the lightweight HEAD probe instead of duplicating full detail GETs before entity pages render.
- Preserves invalid-slug hard 404s, valid-slug 200s, public-only show semantics, and `/shows/submit` + `/shows/saved` reserved-route bypass behavior.

## Test plan
- [x] `cd backend && go test ./internal/api/handlers/catalog -run 'TestEntityExistsHandler'` — passed
- [x] `cd backend && go test ./internal/services/catalog -run 'TestEntityExistenceServiceIntegrationTestSuite'` — passed
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/api/...` — passed
- [x] `cd frontend && bun run test:run proxy.test.ts` — passed (3/3)
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:e2e -- frontend/e2e/pages/not-found.spec.ts` — passed (15/15)
- [x] `/code-review` — inline pass, no findings
- [x] `/adversarial-review` — inline CLEAN, no findings

## Manual repro
- The practical manual repro is `frontend/e2e/pages/not-found.spec.ts`, which exercises invalid slugs for all eight proxied entity types, valid seeded show/venue/scene routes, and reserved `/shows/submit` + `/shows/saved` routes. It passed locally: 15/15 in 50.2s.
- E2E backend logs confirmed the proxy now emits `HEAD /entities/<type>/<slug>/exists` probes, including invalid all-entity coverage and valid show/venue/scene checks.
- Attempted the isolated dispatch stack per ticket instructions. Direct invocation failed because the uppercase worktree basename produced an invalid Docker Compose project name; retrying through a lowercase `/tmp/psy-915-proxy-exists-probe` symlink seeded the DB and started backend/frontend, but `stack-up.sh` timed out waiting for the frontend and the native processes were not reachable afterward. `stack-down.sh` completed and removed the Docker resources. No screenshots were captured from that stack.
- Vercel preview spot-check was not performed from this worktree; reviewer should spot-check the preview for one invalid entity slug and valid seeded/entity page after deployment.

## Code review
Inline `/code-review` checked reuse, quality, and efficiency. No blockers or follow-up edits: the probe is centralized, avoids detail hydration, keeps fail-open proxy behavior for non-404/backend errors, and has focused backend + proxy coverage.

## Adversarial review
`/adversarial-review` — CLEAN, no findings.
Panel: Saboteur · Future-Maintainer · Security · Completeness. Review ran inline because this dispatched sub-agent cannot spawn fresh sub-agents.


Made with [Cursor](https://cursor.com)