### PR TITLE
PSY-879: audit rejected featured-slot attempts

### DIFF
--- a/backend/internal/services/admin/featured_slot.go
+++ b/backend/internal/services/admin/featured_slot.go
@@ -54,8 +54,9 @@ var (
 // happens at the rendering boundary, mirroring how CollectionService
 // treats Collection.Description.
 type FeaturedSlotService struct {
-	db *gorm.DB
-	md *utils.MarkdownRenderer
+	db       *gorm.DB
+	md       *utils.MarkdownRenderer
+	auditLog *AuditLogService
 }
 
 // NewFeaturedSlotService creates a new featured-slot service. The DB
@@ -66,8 +67,9 @@ func NewFeaturedSlotService(database *gorm.DB) *FeaturedSlotService {
 		database = db.GetDB()
 	}
 	return &FeaturedSlotService{
-		db: database,
-		md: utils.NewMarkdownRenderer(),
+		db:       database,
+		md:       utils.NewMarkdownRenderer(),
+		auditLog: NewAuditLogService(database),
 	}
 }
 
@@ -149,6 +151,7 @@ func (s *FeaturedSlotService) SetActiveSlot(slotType string, entityID uint, cura
 	}
 
 	if err := s.validateReferent(slotType, entityID); err != nil {
+		s.logRejectedSetActiveSlot(slotType, entityID, userID, featuredSlotReferentRejectionReason(err))
 		return nil, err
 	}
 
@@ -182,6 +185,31 @@ func (s *FeaturedSlotService) SetActiveSlot(slotType string, entityID uint, cura
 	// Re-fetch with Creator preloaded so the response carries the same
 	// shape as GetActiveSlot.
 	return s.GetActiveSlot(slotType)
+}
+
+func (s *FeaturedSlotService) logRejectedSetActiveSlot(slotType string, entityID uint, userID uint, reason string) {
+	if s.auditLog == nil {
+		s.auditLog = NewAuditLogService(s.db)
+	}
+	s.auditLog.LogAction(userID, "set_featured_slot_rejected", "featured_slot", entityID, map[string]interface{}{
+		"user_id":   userID,
+		"slot_type": slotType,
+		"entity_id": entityID,
+		"reason":    reason,
+	})
+}
+
+func featuredSlotReferentRejectionReason(err error) string {
+	switch {
+	case errors.Is(err, ErrFeaturedSlotReferentNotFound):
+		return "not_found"
+	case errors.Is(err, ErrFeaturedSlotReferentNotApproved):
+		return "not_approved"
+	case errors.Is(err, ErrFeaturedSlotReferentNotPublic):
+		return "not_public"
+	default:
+		return "validation_error"
+	}
 }
 
 // validateReferent confirms the entity_id points at a row the /explore

--- a/backend/internal/services/admin/featured_slot_test.go
+++ b/backend/internal/services/admin/featured_slot_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -40,6 +41,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TearDownSuite() {
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TearDownTest() {
 	sqlDB, err := suite.db.DB()
 	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM audit_logs")
 	_, _ = sqlDB.Exec("DELETE FROM featured_slots")
 	// Referent-validation tests seed shows + collections; tear them
 	// down so each case starts from a clean slate.
@@ -102,6 +104,27 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) createCollection(creatorID
 	return coll
 }
 
+func (suite *FeaturedSlotServiceIntegrationTestSuite) assertRejectedSetActiveSlotAuditLog(userID uint, slotType string, entityID uint, reason string) {
+	var logs []adminm.AuditLog
+	suite.Require().NoError(suite.db.Order("created_at ASC").Find(&logs).Error)
+	suite.Require().Len(logs, 1, "rejected SetActiveSlot attempt should write exactly one audit row")
+
+	log := logs[0]
+	suite.Require().NotNil(log.ActorID)
+	suite.Equal(userID, *log.ActorID)
+	suite.Equal("set_featured_slot_rejected", log.Action)
+	suite.Equal("featured_slot", log.EntityType)
+	suite.Equal(entityID, log.EntityID)
+	suite.Require().NotNil(log.Metadata)
+
+	var metadata map[string]interface{}
+	suite.Require().NoError(json.Unmarshal(*log.Metadata, &metadata))
+	suite.Equal(float64(userID), metadata["user_id"])
+	suite.Equal(slotType, metadata["slot_type"])
+	suite.Equal(float64(entityID), metadata["entity_id"])
+	suite.Equal(reason, metadata["reason"])
+}
+
 // =============================================================================
 // GetActiveSlot
 // =============================================================================
@@ -150,6 +173,10 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_FirstPic
 	suite.Equal("Killer bill", *slot.CuratorNote)
 	suite.Nil(slot.ActiveUntil, "first active row must have NULL active_until")
 	suite.Equal(admin.ID, slot.CreatedBy)
+
+	var auditCount int64
+	suite.db.Model(&adminm.AuditLog{}).Count(&auditCount)
+	suite.Equal(int64(0), auditCount, "service success path audit behavior remains handler-owned")
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_ReplacesPriorAtomically() {
@@ -426,6 +453,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillReje
 	var count int64
 	suite.db.Model(&adminm.FeaturedSlot{}).Count(&count)
 	suite.Equal(int64(0), count)
+	suite.assertRejectedSetActiveSlotAuditLog(admin.ID, adminm.FeaturedSlotTypeBill, pending.ID, "not_approved")
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillRejectsRejectedShow() {
@@ -435,6 +463,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillReje
 	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, rejected.ID, nil, admin.ID)
 	suite.Require().Error(err)
 	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotApproved))
+	suite.assertRejectedSetActiveSlotAuditLog(admin.ID, adminm.FeaturedSlotTypeBill, rejected.ID, "not_approved")
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillRejectsPrivateShow() {
@@ -444,6 +473,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillReje
 	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, private.ID, nil, admin.ID)
 	suite.Require().Error(err)
 	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotApproved))
+	suite.assertRejectedSetActiveSlotAuditLog(admin.ID, adminm.FeaturedSlotTypeBill, private.ID, "not_approved")
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillRejectsMissingShow() {
@@ -453,6 +483,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillReje
 	suite.Require().Error(err)
 	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotFound),
 		"non-existent show must surface the not-found sentinel, got %v", err)
+	suite.assertRejectedSetActiveSlotAuditLog(admin.ID, adminm.FeaturedSlotTypeBill, 9999, "not_found")
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_BillAcceptsApprovedShow() {
@@ -476,6 +507,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_Collecti
 	var count int64
 	suite.db.Model(&adminm.FeaturedSlot{}).Count(&count)
 	suite.Equal(int64(0), count)
+	suite.assertRejectedSetActiveSlotAuditLog(admin.ID, adminm.FeaturedSlotTypeCollection, private.ID, "not_public")
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_CollectionRejectsMissing() {
@@ -484,6 +516,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_Collecti
 	_, err := suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, 9999, nil, admin.ID)
 	suite.Require().Error(err)
 	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotFound))
+	suite.assertRejectedSetActiveSlotAuditLog(admin.ID, adminm.FeaturedSlotTypeCollection, 9999, "not_found")
 }
 
 func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_CollectionAcceptsPublic() {
@@ -513,6 +546,7 @@ func (suite *FeaturedSlotServiceIntegrationTestSuite) TestSetActiveSlot_Replacem
 	_, err = suite.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, pending.ID, nil, admin.ID)
 	suite.Require().Error(err)
 	suite.True(errors.Is(err, ErrFeaturedSlotReferentNotApproved))
+	suite.assertRejectedSetActiveSlotAuditLog(admin.ID, adminm.FeaturedSlotTypeBill, pending.ID, "not_approved")
 
 	// Original row is still active.
 	active, err := suite.featuredSlotService.GetActiveSlot(adminm.FeaturedSlotTypeBill)


### PR DESCRIPTION
## Summary
- Adds service-layer audit logging for rejected `SetActiveSlot` referent validation attempts.
- Extends featured-slot integration tests to assert rejected audit rows include actor/admin user ID, slot type, entity ID, and rejection reason while keeping success audit behavior handler-owned.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/admin/...` — passed
- [x] Inline adversarial review — CLEAN

## Manual repro
Backend-only, no stack required. Integration tests `TestSetActiveSlot_BillRejectsPendingShow`, `TestSetActiveSlot_BillRejectsRejectedShow`, `TestSetActiveSlot_BillRejectsPrivateShow`, `TestSetActiveSlot_BillRejectsMissingShow`, `TestSetActiveSlot_CollectionRejectsPrivate`, `TestSetActiveSlot_CollectionRejectsMissing`, and `TestSetActiveSlot_ReplacementFailsCleanly` exercise rejected `SetActiveSlot` attempts for non-approved shows, missing shows, private collections, missing collections, and failed replacements. Assertions verify audit-log rows include actor/admin user ID, entity type/entity ID, metadata `user_id`, `slot_type`, `entity_id`, and `reason`.

## Code review
Inline focused review against `origin/main...HEAD` — no changes.

## Adversarial review
Inline adversarial review — CLEAN, no findings.
Panel: Saboteur · Future-Maintainer · Security · Completeness — run inline.

Closes PSY-879

Made with [Cursor](https://cursor.com)