### PR TITLE
PSY-740: bound engagement pagination query params

### DIFF
--- a/backend/internal/api/handlers/engagement/attendance.go
+++ b/backend/internal/api/handlers/engagement/attendance.go
@@ -95,8 +95,8 @@ type BatchAttendanceResponse struct {
 // GetMyShowsRequest is the request for GET /attendance/my-shows
 type GetMyShowsRequest struct {
 	Status string `query:"status" default:"all" doc:"Filter: going, interested, or all"`
-	Limit  int    `query:"limit" default:"20" doc:"Number of shows per page"`
-	Offset int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of shows per page"`
+	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetMyShowsResponse is the response for GET /attendance/my-shows

--- a/backend/internal/api/handlers/engagement/comment.go
+++ b/backend/internal/api/handlers/engagement/comment.go
@@ -105,8 +105,8 @@ type ListCommentsRequest struct {
 	EntityType string `path:"entity_type" doc:"Entity type (artist, venue, show, release, label, festival, collection)" example:"show"`
 	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
 	Sort       string `query:"sort" required:"false" doc:"Sort order: best, new, top, controversial (default: best)" example:"best"`
-	Limit      int    `query:"limit" required:"false" doc:"Page size (default 25, max 100)" example:"25"`
-	Offset     int    `query:"offset" required:"false" doc:"Pagination offset" example:"0"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Page size (default 25, max 100)" example:"25"`
+	Offset     int    `query:"offset" required:"false" minimum:"0" doc:"Pagination offset" example:"0"`
 }
 
 // ListCommentsResponse represents the response for listing comments.

--- a/backend/internal/api/handlers/engagement/comment_admin.go
+++ b/backend/internal/api/handlers/engagement/comment_admin.go
@@ -141,8 +141,8 @@ func (h *CommentAdminHandler) AdminRestoreCommentHandler(ctx context.Context, re
 
 // AdminListPendingCommentsRequest represents the request for listing pending comments.
 type AdminListPendingCommentsRequest struct {
-	Limit  int `query:"limit" required:"false" doc:"Page size (default 20, max 100)" example:"20"`
-	Offset int `query:"offset" required:"false" doc:"Pagination offset" example:"0"`
+	Limit  int `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Page size (default 20, max 100)" example:"20"`
+	Offset int `query:"offset" required:"false" minimum:"0" doc:"Pagination offset" example:"0"`
 }
 
 // AdminListPendingCommentsResponse represents the response for listing pending comments.

--- a/backend/internal/api/handlers/engagement/favorite_venue.go
+++ b/backend/internal/api/handlers/engagement/favorite_venue.go
@@ -52,8 +52,8 @@ type UnfavoriteVenueResponse struct {
 
 // GetFavoriteVenuesRequest represents the HTTP request for listing favorite venues
 type GetFavoriteVenuesRequest struct {
-	Limit  int `query:"limit" default:"50" doc:"Number of venues per page"`
-	Offset int `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of venues per page"`
+	Offset int `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetFavoriteVenuesResponse represents the HTTP response for listing favorite venues
@@ -81,8 +81,8 @@ type CheckFavoritedResponse struct {
 // GetFavoriteVenueShowsRequest represents the HTTP request for getting shows from favorite venues
 type GetFavoriteVenueShowsRequest struct {
 	Timezone string `query:"timezone" default:"America/Phoenix" doc:"Timezone for date filtering"`
-	Limit    int    `query:"limit" default:"50" doc:"Number of shows per page"`
-	Offset   int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit    int    `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of shows per page"`
+	Offset   int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetFavoriteVenueShowsResponse represents the HTTP response for getting shows from favorite venues

--- a/backend/internal/api/handlers/engagement/field_note.go
+++ b/backend/internal/api/handlers/engagement/field_note.go
@@ -134,8 +134,8 @@ func (h *FieldNoteHandler) CreateFieldNoteHandler(ctx context.Context, req *Crea
 // ListFieldNotesRequest represents the Huma request for listing field notes on a show.
 type ListFieldNotesRequest struct {
 	ShowID string `path:"show_id" doc:"Show ID" example:"42"`
-	Limit  int    `query:"limit" required:"false" doc:"Page size (default 25, max 100)" example:"25"`
-	Offset int    `query:"offset" required:"false" doc:"Pagination offset" example:"0"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Page size (default 25, max 100)" example:"25"`
+	Offset int    `query:"offset" required:"false" minimum:"0" doc:"Pagination offset" example:"0"`
 }
 
 // ListFieldNotesResponse represents the response for listing field notes.

--- a/backend/internal/api/handlers/engagement/follow.go
+++ b/backend/internal/api/handlers/engagement/follow.go
@@ -112,8 +112,8 @@ type BatchFollowResponse struct {
 // GetMyFollowingRequest is the request for GET /me/following
 type GetMyFollowingRequest struct {
 	Type   string `query:"type" default:"all" doc:"Entity type filter: artist, venue, label, festival, or all"`
-	Limit  int    `query:"limit" default:"20" doc:"Number of items per page"`
-	Offset int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of items per page"`
+	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetMyFollowingResponse is the response for GET /me/following
@@ -130,8 +130,8 @@ type GetMyFollowingResponse struct {
 type GetFollowersListRequest struct {
 	EntityType string `path:"entity_type" doc:"Entity type (artists, venues, labels, festivals)"`
 	EntityID   string `path:"entity_id" doc:"Entity ID"`
-	Limit      int    `query:"limit" default:"20" doc:"Number of followers per page"`
-	Offset     int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit      int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of followers per page"`
+	Offset     int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetFollowersListResponse is the response for GET /{entity_type}/{entity_id}/followers/list

--- a/backend/internal/api/handlers/engagement/saved_show.go
+++ b/backend/internal/api/handlers/engagement/saved_show.go
@@ -52,8 +52,8 @@ type UnsaveShowResponse struct {
 
 // GetSavedShowsRequest represents the HTTP request for listing saved shows
 type GetSavedShowsRequest struct {
-	Limit  int `query:"limit" default:"50" doc:"Number of shows per page"`
-	Offset int `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of shows per page"`
+	Offset int `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetSavedShowsResponse represents the HTTP response for listing saved shows


### PR DESCRIPTION
## Summary
- Added Huma schema bounds to engagement pagination `Limit` fields across follow, comments, saved shows, attendance, favorite venues, and field notes.
- Added `minimum:"0"` to the corresponding engagement `Offset` fields while preserving existing defaults, docs, examples, and peer tag ordering.

## Test plan
- [x] `cd backend && go build ./...`
- [x] `cd backend && go test ./internal/api/handlers/engagement/...`

## Manual repro
Backend-only/no migration. No dispatch stack was started. Manual repro is the required backend build plus focused engagement handler package tests; schema tag coverage was also checked with `rg` over `backend/internal/api/handlers/engagement`.

## Code review
Inline review performed because no `/code-review` command/tool is available in this dispatched subagent. Checked correctness, missed call sites, peer tag ordering, and test coverage; no findings.

## Adversarial review
Inline four-lens review performed because this dispatched subagent cannot spawn agents.
- Saboteur: boundary inputs are now rejected by Huma schema tags before handler/service work; no regression found.
- Future-Maintainer: tag order matches peer bounded handlers; no new abstraction or cognitive debt.
- Security: reduces large-query resource pressure; no auth or data exposure changes.
- Completeness: all cited engagement `Limit`/`Offset` request structs are covered.

Verdict: CLEAN, no findings.

Closes PSY-740
