### PR TITLE
PSY-738: bound catalog pagination query params

### DIFF
--- a/backend/internal/api/handlers/catalog/artist_relationship.go
+++ b/backend/internal/api/handlers/catalog/artist_relationship.go
@@ -134,7 +134,7 @@ func splitAndTrim(s string) []string {
 type GetRelatedArtistsRequest struct {
 	ArtistID string `path:"artist_id" doc:"Artist ID" example:"1"`
 	Type     string `query:"type" required:"false" doc:"Filter by relationship type (similar, shared_bills, shared_label, side_project, member_of)"`
-	Limit    int    `query:"limit" required:"false" doc:"Max results (default 30)" example:"30"`
+	Limit    int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 30)" example:"30"`
 }
 
 type GetRelatedArtistsResponse struct {

--- a/backend/internal/api/handlers/catalog/charts.go
+++ b/backend/internal/api/handlers/catalog/charts.go
@@ -28,7 +28,7 @@ func NewChartsHandler(
 
 // GetTrendingShowsRequest is the Huma request for GET /charts/trending-shows
 type GetTrendingShowsRequest struct {
-	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+	Limit int `query:"limit" required:"false" minimum:"1" maximum:"50" doc:"Number of results (default 20, max 50)"`
 }
 
 // TrendingShowResponse is a single trending show in the response.
@@ -87,7 +87,7 @@ func (h *ChartsHandler) GetTrendingShowsHandler(ctx context.Context, req *GetTre
 
 // GetPopularArtistsRequest is the Huma request for GET /charts/popular-artists
 type GetPopularArtistsRequest struct {
-	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+	Limit int `query:"limit" required:"false" minimum:"1" maximum:"50" doc:"Number of results (default 20, max 50)"`
 }
 
 // PopularArtistResponse is a single popular artist in the response.
@@ -138,7 +138,7 @@ func (h *ChartsHandler) GetPopularArtistsHandler(ctx context.Context, req *GetPo
 
 // GetActiveVenuesRequest is the Huma request for GET /charts/active-venues
 type GetActiveVenuesRequest struct {
-	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+	Limit int `query:"limit" required:"false" minimum:"1" maximum:"50" doc:"Number of results (default 20, max 50)"`
 }
 
 // ActiveVenueResponse is a single active venue in the response.
@@ -191,7 +191,7 @@ func (h *ChartsHandler) GetActiveVenuesHandler(ctx context.Context, req *GetActi
 
 // GetHotReleasesRequest is the Huma request for GET /charts/hot-releases
 type GetHotReleasesRequest struct {
-	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+	Limit int `query:"limit" required:"false" minimum:"1" maximum:"50" doc:"Number of results (default 20, max 50)"`
 }
 
 // HotReleaseResponse is a single hot release in the response.

--- a/backend/internal/api/handlers/catalog/festival_intelligence.go
+++ b/backend/internal/api/handlers/catalog/festival_intelligence.go
@@ -37,7 +37,7 @@ func NewFestivalIntelligenceHandler(
 
 type GetSimilarFestivalsRequest struct {
 	FestivalID string `path:"festival_id" doc:"Festival ID or slug" example:"m3f-2026"`
-	Limit      int    `query:"limit" required:"false" doc:"Maximum number of similar festivals to return" example:"10"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Maximum number of similar festivals to return" example:"10"`
 }
 
 // GetSimilarFestivalsResponse keeps a bespoke struct because the body wraps

--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -275,8 +275,8 @@ func (h *RadioHandler) GetRadioShowHandler(ctx context.Context, req *GetRadioSho
 // GetRadioShowEpisodesRequest represents the request for listing episodes of a show.
 type GetRadioShowEpisodesRequest struct {
 	Slug   string `path:"slug" doc:"Radio show slug or numeric ID" example:"morning-show"`
-	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
-	Offset int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
+	Offset int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 // GetRadioShowEpisodesResponse represents the response for listing episodes.
@@ -361,7 +361,7 @@ func (h *RadioHandler) GetRadioEpisodeByDateHandler(ctx context.Context, req *Ge
 type GetRadioShowTopArtistsRequest struct {
 	Slug   string `path:"slug" doc:"Radio show slug or numeric ID" example:"morning-show"`
 	Period int    `query:"period" required:"false" doc:"Period in days (default 90)" example:"90"`
-	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
 }
 
 // GetRadioShowTopArtistsResponse represents the response for top artists.
@@ -409,7 +409,7 @@ func (h *RadioHandler) GetRadioShowTopArtistsHandler(ctx context.Context, req *G
 type GetRadioShowTopLabelsRequest struct {
 	Slug   string `path:"slug" doc:"Radio show slug or numeric ID" example:"morning-show"`
 	Period int    `query:"period" required:"false" doc:"Period in days (default 90)" example:"90"`
-	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
 }
 
 // GetRadioShowTopLabelsResponse represents the response for top labels.
@@ -530,7 +530,7 @@ func (h *RadioHandler) GetReleaseRadioPlaysHandler(ctx context.Context, req *Get
 // GetRadioNewReleaseRadarRequest represents the request for new release radar.
 type GetRadioNewReleaseRadarRequest struct {
 	StationID uint `query:"station_id" required:"false" doc:"Filter by station ID (0 for all)" example:"1"`
-	Limit     int  `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
+	Limit     int  `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
 }
 
 // GetRadioNewReleaseRadarResponse represents the response for new release radar.

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -255,7 +255,7 @@ type GetShowsResponse struct {
 type GetUpcomingShowsRequest struct {
 	Timezone string `query:"timezone" default:"UTC" doc:"IANA timezone (e.g., 'America/Phoenix', 'America/New_York'). Defaults to UTC."`
 	Cursor   string `query:"cursor" doc:"Pagination cursor from previous response. Omit for first page."`
-	Limit    int    `query:"limit" default:"50" doc:"Number of shows per page (max 200). Defaults to 50."`
+	Limit    int    `query:"limit" default:"50" minimum:"1" maximum:"200" doc:"Number of shows per page (max 200). Defaults to 50."`
 	City     string `query:"city" doc:"Filter by city name (exact match). Legacy — prefer 'cities' param."`
 	State    string `query:"state" doc:"Filter by state code (exact match, e.g., 'AZ'). Legacy — prefer 'cities' param."`
 	Cities   string `query:"cities" doc:"Filter by multiple cities. Pipe-delimited pairs: 'Phoenix,AZ|Mesa,AZ|Tucson,AZ'. Max 10 cities."`
@@ -1405,8 +1405,8 @@ func (h *ShowHandler) ExportShowHandler(ctx context.Context, req *ExportShowRequ
 
 // GetMySubmissionsRequest represents the HTTP request for getting user's submitted shows
 type GetMySubmissionsRequest struct {
-	Limit  int `query:"limit" default:"50" doc:"Maximum number of shows to return"`
-	Offset int `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Maximum number of shows to return"`
+	Offset int `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetMySubmissionsResponse represents the HTTP response for user's submitted shows

--- a/backend/internal/api/handlers/catalog/tag.go
+++ b/backend/internal/api/handlers/catalog/tag.go
@@ -147,8 +147,8 @@ func (h *TagHandler) GetTagDetailHandler(ctx context.Context, req *GetTagDetailR
 type ListTagEntitiesRequest struct {
 	TagID      string `path:"tag_id" doc:"Tag ID or slug" example:"post-punk"`
 	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, release, label, show, venue, festival)"`
-	Limit      int    `query:"limit" required:"false" doc:"Max results (default 50)" example:"50"`
-	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 50)" example:"50"`
+	Offset     int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 type ListTagEntitiesResponse struct {
@@ -846,8 +846,8 @@ func (h *TagHandler) BulkImportAliasesHandler(ctx context.Context, req *BulkImpo
 // ============================================================================
 
 type ListLowQualityTagsRequest struct {
-	Limit  int `query:"limit" required:"false" doc:"Max results (default 20, max 100)" example:"20"`
-	Offset int `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit  int `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)" example:"20"`
+	Offset int `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 type ListLowQualityTagsResponse struct {


### PR DESCRIPTION
Closes PSY-738.

## Summary
- Added Huma `minimum`/`maximum` schema bounds to the cited catalog `limit` query params across charts, shows, radio, tags, festival intelligence, and artist relationships.
- Added `minimum:"0"` to the cited catalog `offset` query params, preserving local tag ordering conventions.

## Test plan
- [x] `cd backend && go build ./...`
- [x] `cd backend && go test ./internal/api/handlers/catalog/...`

## Manual repro
Backend-only schema validation change; no dev stack or migration needed. Manual repro is covered by the focused backend build and catalog handler package tests passing locally.

## Code review
Inline code review completed because no `/code-review` command/tool is available in this dispatched worktree. Checked correctness, missed catalog `limit`/`offset` query sites, peer tag ordering, and test coverage; no findings.

## Adversarial review
`/adversarial-review` inline fallback completed with Saboteur, Future-Maintainer, Security, and Completeness lenses. Verdict: CLEAN, no findings.
