### PR TITLE
PSY-742: bound notification and pipeline pagination params

### DIFF
--- a/backend/internal/api/handlers/notification/notification_filter.go
+++ b/backend/internal/api/handlers/notification/notification_filter.go
@@ -119,8 +119,8 @@ type QuickCreateFilterResponse struct {
 
 // GetNotificationsRequest is the request for GET /me/notifications
 type GetNotificationsRequest struct {
-	Limit  int `query:"limit" default:"20" doc:"Number of notifications per page"`
-	Offset int `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of notifications per page"`
+	Offset int `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetNotificationsResponse is the response for GET /me/notifications

--- a/backend/internal/api/handlers/pipeline/pipeline.go
+++ b/backend/internal/api/handlers/pipeline/pipeline.go
@@ -310,7 +310,7 @@ func (h *PipelineHandler) UpdateVenueConfigHandler(ctx context.Context, req *Upd
 // GetVenueRunsRequest is the Huma request for GET /admin/pipeline/venues/{venue_id}/runs
 type GetVenueRunsRequest struct {
 	VenueID string `path:"venue_id" validate:"required" doc:"Venue ID"`
-	Limit   int    `query:"limit" doc:"Max runs to return (default 10, max 100)"`
+	Limit   int    `query:"limit" minimum:"1" maximum:"100" doc:"Max runs to return (default 10, max 100)"`
 }
 
 // GetVenueRunsResponse is the Huma response for GET /admin/pipeline/venues/{venue_id}/runs
@@ -352,8 +352,8 @@ func (h *PipelineHandler) GetVenueRunsHandler(ctx context.Context, req *GetVenue
 
 // GetImportHistoryRequest is the Huma request for GET /admin/pipeline/imports
 type GetImportHistoryRequest struct {
-	Limit  int `query:"limit" doc:"Max entries to return (default 20, max 100)"`
-	Offset int `query:"offset" doc:"Number of entries to skip for pagination"`
+	Limit  int `query:"limit" minimum:"1" maximum:"100" doc:"Max entries to return (default 20, max 100)"`
+	Offset int `query:"offset" minimum:"0" doc:"Number of entries to skip for pagination"`
 }
 
 // GetImportHistoryResponse is the Huma response for GET /admin/pipeline/imports

--- a/backend/internal/api/handlers/pipeline/streaming_worklist.go
+++ b/backend/internal/api/handlers/pipeline/streaming_worklist.go
@@ -44,8 +44,8 @@ func NewStreamingWorklistHandler(
 // rows are excluded by definition).
 type GetStreamingWorklistRequest struct {
 	Status string `query:"status" doc:"Optional non-terminal status filter: 'unreviewed' or 'candidates_pending'. Empty means both."`
-	Limit  int    `query:"limit" default:"50" doc:"Number of artists to return (1–200; default 50)"`
-	Offset int    `query:"offset" default:"0" doc:"Pagination offset"`
+	Limit  int    `query:"limit" default:"50" minimum:"1" maximum:"200" doc:"Number of artists to return (1–200; default 50)"`
+	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Pagination offset"`
 }
 
 // GetStreamingWorklistResponse wraps the service result for OpenAPI.


### PR DESCRIPTION
## Summary
- Added Huma `minimum`/`maximum` bounds to notification pagination query params.
- Added matching bounds to pipeline venue-run, import-history, and streaming-worklist pagination params, including the `streaming_worklist.go` 1-200 limit decision.

## Test plan
- [x] `go build ./...` from `backend`
- [x] `go test ./internal/api/handlers/notification/... ./internal/api/handlers/pipeline/...` from `backend`
- [x] `git diff --check`

## Manual repro
Backend-only schema validation change; no dev stack was started. Manual repro is the passing backend build plus focused notification/pipeline handler test run, with diff review confirming the added query-param bounds.

## Code review
Inline review completed because no `/code-review` command/tool was available in this dispatched worktree. Checked correctness, missed notification/pipeline call sites, tag ordering, and test coverage; no findings.

## Adversarial review
`/adversarial-review` — CLEAN, no findings. Ran inline four-lens fallback (Saboteur, Future-Maintainer, Security, Completeness) because this dispatched worktree cannot spawn reviewer agents.

Closes PSY-742
