### PR TITLE
PSY-741: bound community pagination query params

### DIFF
--- a/backend/internal/api/handlers/community/artist_report.go
+++ b/backend/internal/api/handlers/community/artist_report.go
@@ -175,8 +175,8 @@ func (h *ArtistReportHandler) GetMyArtistReportHandler(ctx context.Context, req 
 
 // GetPendingArtistReportsRequest represents the HTTP request for listing pending artist reports
 type GetPendingArtistReportsRequest struct {
-	Limit  int `query:"limit" default:"50" doc:"Number of reports to return (max 100)"`
-	Offset int `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of reports to return (max 100)"`
+	Offset int `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetPendingArtistReportsResponse represents the HTTP response for listing pending artist reports

--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -874,7 +874,7 @@ func (h *CollectionHandler) GetUserCollectionsContainingHandler(ctx context.Cont
 type GetEntityCollectionsHandlerRequest struct {
 	EntityType string `path:"entity_type" doc:"Entity type (artist, release, label, show, venue, festival)" example:"artist"`
 	EntityID   string `path:"entity_id" doc:"Entity ID" example:"42"`
-	Limit      int    `query:"limit" required:"false" doc:"Max results (default 10)" example:"10"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 10)" example:"10"`
 }
 
 // GetEntityCollectionsHandlerResponse represents the response for entity collections
@@ -930,8 +930,8 @@ func (h *CollectionHandler) GetEntityCollectionsHandler(ctx context.Context, req
 // GetUserPublicCollectionsHandlerRequest represents the request for getting a user's public collections
 type GetUserPublicCollectionsHandlerRequest struct {
 	Username string `path:"username" doc:"Username" example:"johndoe"`
-	Limit    int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
-	Offset   int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit    int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
+	Offset   int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 // GetUserPublicCollectionsHandlerResponse represents the response for user public collections

--- a/backend/internal/api/handlers/community/contribute.go
+++ b/backend/internal/api/handlers/community/contribute.go
@@ -69,8 +69,8 @@ func (h *ContributeHandler) GetOpportunitiesHandler(ctx context.Context, _ *GetO
 // GetOpportunityCategoryRequest is the Huma request for GET /contribute/opportunities/{category}
 type GetOpportunityCategoryRequest struct {
 	Category string `path:"category" doc:"Contribution opportunity category key"`
-	Limit    int    `query:"limit" required:"false" doc:"Max results (default 20, max 200)"`
-	Offset   int    `query:"offset" required:"false" doc:"Offset for pagination"`
+	Limit    int    `query:"limit" required:"false" minimum:"1" maximum:"200" doc:"Max results (default 20, max 200)"`
+	Offset   int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetOpportunityCategoryResponse is the Huma response for GET /contribute/opportunities/{category}

--- a/backend/internal/api/handlers/community/contributor_profile.go
+++ b/backend/internal/api/handlers/community/contributor_profile.go
@@ -43,8 +43,8 @@ type GetPublicProfileResponse struct {
 
 type GetContributionHistoryRequest struct {
 	Username   string `path:"username" doc:"Username of the contributor"`
-	Limit      int    `query:"limit" default:"20" doc:"Number of contributions per page (max 100)"`
-	Offset     int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit      int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of contributions per page (max 100)"`
+	Offset     int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 	EntityType string `query:"entity_type" default:"" doc:"Filter by entity type (show, venue, artist, release, label, festival)"`
 }
 
@@ -62,8 +62,8 @@ type GetOwnProfileResponse struct {
 }
 
 type GetOwnContributionsRequest struct {
-	Limit      int    `query:"limit" default:"20" doc:"Number of contributions per page (max 100)"`
-	Offset     int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit      int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of contributions per page (max 100)"`
+	Offset     int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 	EntityType string `query:"entity_type" default:"" doc:"Filter by entity type"`
 }
 

--- a/backend/internal/api/handlers/community/entity_report.go
+++ b/backend/internal/api/handlers/community/entity_report.go
@@ -144,8 +144,8 @@ func (h *EntityReportHandler) reportEntity(ctx context.Context, entityType strin
 type AdminListEntityReportsRequest struct {
 	Status     string `query:"status" required:"false" doc:"Filter by status (pending, resolved, dismissed)"`
 	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, venue, festival, show)"`
-	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
-	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`
+	Offset     int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
 // AdminListEntityReportsResponse is the Huma response for GET /admin/entity-reports

--- a/backend/internal/api/handlers/community/leaderboard.go
+++ b/backend/internal/api/handlers/community/leaderboard.go
@@ -31,7 +31,7 @@ func NewLeaderboardHandler(
 type GetLeaderboardRequest struct {
 	Dimension string `query:"dimension" required:"false" doc:"Leaderboard dimension: overall, shows, venues, tags, edits, requests (default: overall)"`
 	Period    string `query:"period" required:"false" doc:"Time period: all_time, month, week (default: all_time)"`
-	Limit     int    `query:"limit" required:"false" doc:"Number of results (default 25, max 100)"`
+	Limit     int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Number of results (default 25, max 100)"`
 }
 
 // LeaderboardEntryResponse is a single entry in the leaderboard response.

--- a/backend/internal/api/handlers/community/request.go
+++ b/backend/internal/api/handlers/community/request.go
@@ -102,8 +102,8 @@ type ListRequestsHandlerRequest struct {
 	Status     string `query:"status" required:"false" doc:"Filter by status (pending, in_progress, pending_fulfillment, fulfilled, rejected, cancelled)"`
 	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, release, label, show, venue, festival)"`
 	Sort       string `query:"sort" required:"false" doc:"Sort by: newest, votes, oldest (default: votes)" example:"votes"`
-	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
-	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
+	Offset     int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 // ListRequestsHandlerResponse represents the response for listing requests

--- a/backend/internal/api/handlers/community/show_report.go
+++ b/backend/internal/api/handlers/community/show_report.go
@@ -175,8 +175,8 @@ func (h *ShowReportHandler) GetMyReportHandler(ctx context.Context, req *GetMyRe
 
 // GetPendingReportsRequest represents the HTTP request for listing pending reports
 type GetPendingReportsRequest struct {
-	Limit  int `query:"limit" default:"50" doc:"Number of reports to return (max 100)"`
-	Offset int `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of reports to return (max 100)"`
+	Offset int `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetPendingReportsResponse represents the HTTP response for listing pending reports


### PR DESCRIPTION
## Summary
- Adds Huma schema bounds to the community handler pagination query params cited by PSY-741.
- Uses each local doc max where present (`100`, except contribution opportunities at `200`) and `100` for collection/request params without a doc max.

## Test plan
- [x] `pwd && git rev-parse --show-toplevel && git branch --show-current && git status --short` - confirmed isolated worktree and branch.
- [x] `go build ./... && go test ./internal/api/handlers/community/...` - backend build ran before focused community handler tests; tests passed.

## Manual repro
Backend-only schema metadata change; no migration or dev stack needed. Manual repro is the passing backend build plus focused community handler package test run above.

## Code review
Inline `/code-review` fallback - CLEAN. Reviewed correctness of bounds, missed cited call sites, tag ordering (`query -> required/default -> minimum/maximum -> doc -> example`), and local verification.

## Adversarial review
Inline `/adversarial-review` fallback - CLEAN, no findings and no fix commit needed.
Panel: Saboteur · Future-Maintainer · Security · Completeness.

Closes PSY-741
