### PR TITLE
PSY-739: bound admin pagination query params

### DIFF
--- a/backend/internal/api/handlers/admin/admin_data.go
+++ b/backend/internal/api/handlers/admin/admin_data.go
@@ -32,8 +32,8 @@ func NewAdminDataHandler(
 
 // ExportShowsRequest represents the HTTP request for exporting shows
 type ExportShowsRequest struct {
-	Limit    int    `query:"limit" default:"50" doc:"Number of shows to return (max 200)"`
-	Offset   int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit    int    `query:"limit" default:"50" minimum:"1" maximum:"200" doc:"Number of shows to return (max 200)"`
+	Offset   int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 	Status   string `query:"status" doc:"Filter by status: approved, pending, rejected, all"`
 	FromDate string `query:"from_date" doc:"Filter shows from this date (YYYY-MM-DD)"`
 	City     string `query:"city" doc:"Filter by city"`

--- a/backend/internal/api/handlers/admin/admin_shows.go
+++ b/backend/internal/api/handlers/admin/admin_shows.go
@@ -47,8 +47,8 @@ func NewAdminShowHandler(
 
 // GetPendingShowsRequest represents the HTTP request for listing pending shows
 type GetPendingShowsRequest struct {
-	Limit   int    `query:"limit" default:"50" doc:"Number of shows to return (max 100)"`
-	Offset  int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit   int    `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of shows to return (max 100)"`
+	Offset  int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 	VenueID uint   `query:"venue_id" required:"false" doc:"Filter by venue ID (0 = no filter)"`
 	Source  string `query:"source" required:"false" doc:"Filter by source (discovery or user)"`
 }
@@ -603,8 +603,8 @@ func (h *AdminShowHandler) ImportShowConfirmHandler(ctx context.Context, req *Im
 
 // GetAdminShowsRequest represents the HTTP request for listing all shows (admin)
 type GetAdminShowsRequest struct {
-	Limit    int    `query:"limit" default:"50" doc:"Number of shows to return (max 100)"`
-	Offset   int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit    int    `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of shows to return (max 100)"`
+	Offset   int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 	Status   string `query:"status" doc:"Filter by status (pending, approved, rejected, private)"`
 	FromDate string `query:"from_date" doc:"Filter shows from this date (RFC3339 format)"`
 	ToDate   string `query:"to_date" doc:"Filter shows until this date (RFC3339 format)"`

--- a/backend/internal/api/handlers/admin/admin_venues.go
+++ b/backend/internal/api/handlers/admin/admin_venues.go
@@ -41,8 +41,8 @@ type VerifyVenueResponse struct {
 
 // GetUnverifiedVenuesRequest represents the HTTP request for listing unverified venues
 type GetUnverifiedVenuesRequest struct {
-	Limit  int `query:"limit" default:"50" doc:"Number of venues to return (max 100)"`
-	Offset int `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit  int `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of venues to return (max 100)"`
+	Offset int `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetUnverifiedVenuesResponse represents the HTTP response for listing unverified venues

--- a/backend/internal/api/handlers/admin/audit_log.go
+++ b/backend/internal/api/handlers/admin/audit_log.go
@@ -24,8 +24,8 @@ func NewAuditLogHandler(auditLogService contracts.AuditLogServiceInterface) *Aud
 
 // GetAuditLogsRequest represents the HTTP request for listing audit logs
 type GetAuditLogsRequest struct {
-	Limit      int    `query:"limit" default:"50" doc:"Number of logs to return (max 100)"`
-	Offset     int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	Limit      int    `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of logs to return (max 100)"`
+	Offset     int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 	EntityType string `query:"entity_type" doc:"Filter by entity type (show, venue, venue_edit, show_report)"`
 	Action     string `query:"action" doc:"Filter by action (approve_show, reject_show, etc.)"`
 }

--- a/backend/internal/api/handlers/admin/data_quality.go
+++ b/backend/internal/api/handlers/admin/data_quality.go
@@ -77,8 +77,8 @@ func (h *DataQualityHandler) GetDataQualitySummaryHandler(ctx context.Context, _
 // GetDataQualityCategoryRequest is the Huma request for GET /admin/data-quality/{category}
 type GetDataQualityCategoryRequest struct {
 	Category string `path:"category" doc:"Data quality category key"`
-	Limit    int    `query:"limit" required:"false" doc:"Max results (default 50, max 200)"`
-	Offset   int    `query:"offset" required:"false" doc:"Offset for pagination"`
+	Limit    int    `query:"limit" required:"false" minimum:"1" maximum:"200" doc:"Max results (default 50, max 200)"`
+	Offset   int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
 // DataQualityItemResponse is the response format for a data quality item.

--- a/backend/internal/api/handlers/admin/pagination_tags_test.go
+++ b/backend/internal/api/handlers/admin/pagination_tags_test.go
@@ -1,0 +1,98 @@
+package admin
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAdminPaginationQueryTagsAreBounded(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   any
+		limitTag  string
+		offsetTag string
+	}{
+		{
+			name:      "pending shows",
+			request:   GetPendingShowsRequest{},
+			limitTag:  `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of shows to return (max 100)"`,
+			offsetTag: `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "admin shows",
+			request:   GetAdminShowsRequest{},
+			limitTag:  `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of shows to return (max 100)"`,
+			offsetTag: `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "unverified venues",
+			request:   GetUnverifiedVenuesRequest{},
+			limitTag:  `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of venues to return (max 100)"`,
+			offsetTag: `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "entity revision history",
+			request:   GetEntityHistoryRequest{},
+			limitTag:  `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`,
+			offsetTag: `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "user revisions",
+			request:   GetUserRevisionsRequest{},
+			limitTag:  `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`,
+			offsetTag: `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "data quality category",
+			request:   GetDataQualityCategoryRequest{},
+			limitTag:  `query:"limit" required:"false" minimum:"1" maximum:"200" doc:"Max results (default 50, max 200)"`,
+			offsetTag: `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "audit logs",
+			request:   GetAuditLogsRequest{},
+			limitTag:  `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of logs to return (max 100)"`,
+			offsetTag: `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "export shows",
+			request:   ExportShowsRequest{},
+			limitTag:  `query:"limit" default:"50" minimum:"1" maximum:"200" doc:"Number of shows to return (max 200)"`,
+			offsetTag: `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "my pending edits",
+			request:   GetMyPendingEditsRequest{},
+			limitTag:  `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`,
+			offsetTag: `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`,
+		},
+		{
+			name:      "admin pending edits",
+			request:   AdminListPendingEditsRequest{},
+			limitTag:  `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`,
+			offsetTag: `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestType := reflect.TypeOf(tt.request)
+
+			limitField, ok := requestType.FieldByName("Limit")
+			if !ok {
+				t.Fatalf("%s is missing Limit field", requestType.Name())
+			}
+			if got := string(limitField.Tag); got != tt.limitTag {
+				t.Fatalf("Limit tag mismatch:\ngot:  %s\nwant: %s", got, tt.limitTag)
+			}
+
+			offsetField, ok := requestType.FieldByName("Offset")
+			if !ok {
+				t.Fatalf("%s is missing Offset field", requestType.Name())
+			}
+			if got := string(offsetField.Tag); got != tt.offsetTag {
+				t.Fatalf("Offset tag mismatch:\ngot:  %s\nwant: %s", got, tt.offsetTag)
+			}
+		})
+	}
+}

--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -219,8 +219,8 @@ func (h *PendingEditHandler) suggestEdit(ctx context.Context, entityType string,
 
 // GetMyPendingEditsRequest is the Huma request for GET /my/pending-edits
 type GetMyPendingEditsRequest struct {
-	Limit  int `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
-	Offset int `query:"offset" required:"false" doc:"Offset for pagination"`
+	Limit  int `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`
+	Offset int `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetMyPendingEditsResponse is the Huma response for GET /my/pending-edits
@@ -302,8 +302,8 @@ func (h *PendingEditHandler) CancelMyPendingEditHandler(ctx context.Context, req
 type AdminListPendingEditsRequest struct {
 	Status     string `query:"status" required:"false" doc:"Filter by status (pending, approved, rejected)"`
 	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, venue, festival, release, label)"`
-	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
-	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`
+	Offset     int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
 // AdminListPendingEditsResponse is the Huma response for GET /admin/pending-edits

--- a/backend/internal/api/handlers/admin/revision.go
+++ b/backend/internal/api/handlers/admin/revision.go
@@ -145,8 +145,8 @@ func mapRevisionToResponse(r adminm.Revision) RevisionResponseItem {
 type GetEntityHistoryRequest struct {
 	EntityType string `path:"entity_type" doc:"Entity type (artist, venue, show, release, label, festival)"`
 	EntityID   string `path:"entity_id" doc:"Entity ID"`
-	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
-	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination"`
+	Limit      int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`
+	Offset     int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetEntityHistoryResponse is the Huma response for GET /revisions/{entity_type}/{entity_id}
@@ -235,8 +235,8 @@ func (h *RevisionHandler) GetRevisionHandler(ctx context.Context, req *GetRevisi
 // GetUserRevisionsRequest is the Huma request for GET /users/{user_id}/revisions
 type GetUserRevisionsRequest struct {
 	UserID string `path:"user_id" doc:"User ID"`
-	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
-	Offset int    `query:"offset" required:"false" doc:"Offset for pagination"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`
+	Offset int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
 // GetUserRevisionsResponse is the Huma response for GET /users/{user_id}/revisions


### PR DESCRIPTION
## Summary
- Bound the remaining PSY-739 admin handler pagination schema tags so Huma rejects `limit < 1`, over-doc-limit `limit`, and `offset < 0` before handlers run.
- Added a focused reflection test that asserts the exact `Limit`/`Offset` tags and ordering for every PSY-739 request struct.

## Test plan
- [x] `go build ./...` from `backend`
- [x] `go test ./internal/api/handlers/admin/...` from `backend`

## Manual repro
- Backend-only schema validation change; no stack or migration required.
- Manual repro is the focused admin handler package test. `TestAdminPaginationQueryTagsAreBounded` asserts each PSY-739 request struct has `minimum:"1" maximum:"<doc-bound>"` on `Limit` and `minimum:"0"` on `Offset` with the required tag ordering.

## Code review
- Inline review completed because no `/code-review` command/tool is available in this dispatched subagent.
- Checked correctness, missed admin pagination call sites, peer tag ordering, and tests. No findings.

## Adversarial review
- Inline four-lens review completed because this dispatched subagent cannot spawn review agents.
- Saboteur: no bypass found in cited request structs; all relevant admin pagination tags are bounded.
- Future-Maintainer: exact-tag regression test covers bounds and ordering for the PSY-739 structs.
- Security: caps now apply at request schema level before handler/service pagination can be abused.
- Completeness: verified every cited file and admin pagination tag scan; no high/critical findings.

Closes PSY-739
