### PR TITLE
PSY-880: predicate parity test (SetActiveSlot ↔ explore consumer)

### DIFF
--- a/backend/internal/services/admin/featured_slot.go
+++ b/backend/internal/services/admin/featured_slot.go
@@ -30,7 +30,12 @@ var ErrFeaturedSlotNotFound = errors.New("featured slot not found")
 // The predicates here MUST stay in sync with services/explore/explore.go
 // resolveFeaturedBill / resolveFeaturedCollection — those are the only
 // reason this validation exists. If the consumer's "publicly visible"
-// rule changes, change this file in the same PR.
+// rule changes, change this file in the same PR. Parity along the
+// existing predicate dimensions (show status, collection visibility,
+// referent existence) is backed by TestPredicateParity_* in
+// services/explore/predicate_parity_test.go (PSY-880); a brand-new
+// dimension added to only one side still relies on the same-PR discipline
+// above, since fixture-based tests can't see a column they don't vary.
 var (
 	// ErrFeaturedSlotReferentNotFound — the referenced show/collection
 	// does not exist. Handler maps to 404.

--- a/backend/internal/services/explore/explore.go
+++ b/backend/internal/services/explore/explore.go
@@ -297,6 +297,14 @@ func (s *ExploreService) headlinerNameByShow(showIDs []uint) map[uint]string {
 // leak a private collection's title/description through the /explore
 // landing just because someone privately featured it earlier. A new
 // admin pick or a flip back to public restores visibility.
+//
+// The "publicly visible" predicate (approved status for bills,
+// is_public=true for collections) MUST stay in sync with the write-side
+// guard in services/admin/featured_slot.go validateReferent — otherwise
+// an admin "save" succeeds but the slot never surfaces here (phantom
+// save). Parity along the existing predicate dimensions is backed by
+// TestPredicateParity_* in predicate_parity_test.go (PSY-880); a new
+// dimension added to only one side still needs the same-PR sync above.
 func (s *ExploreService) GetFeatured() (*contracts.ExploreFeaturedResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")

--- a/backend/internal/services/explore/explore.go
+++ b/backend/internal/services/explore/explore.go
@@ -288,9 +288,10 @@ func (s *ExploreService) headlinerNameByShow(showIDs []uint) map[uint]string {
 // IMPORTANT: featured_slots.entity_id is polymorphic with NO database
 // FK (the referent table varies by slot_type — shows or collections).
 // The referent may have been deleted, made private, or otherwise
-// removed from the public surface after the slot was set. We defensively
-// LEFT-JOIN here so a stale slot returns nil for that field rather
-// than 500-ing the entire response.
+// removed from the public surface after the slot was set. Each
+// resolveFeatured* re-queries the referent with the same visibility
+// predicate and maps gorm.ErrRecordNotFound to nil, so a stale slot
+// collapses to an empty field rather than 500-ing the entire response.
 //
 // Privacy rule for the collection slot: a collection that has been
 // flipped to private (is_public=false) is excluded — we don't want to

--- a/backend/internal/services/explore/explore_test.go
+++ b/backend/internal/services/explore/explore_test.go
@@ -47,6 +47,11 @@ func (s *ExploreServiceIntegrationSuite) TearDownTest() {
 	// they're referenced by show_artists/show_venues children.
 	for _, stmt := range []string{
 		"DELETE FROM featured_slots",
+		// The predicate-parity rejection tests write a rejected-attempt
+		// audit row via SetActiveSlot; clean it so any audit-counting test
+		// added to this suite later stays order-independent. actor_id is
+		// ON DELETE SET NULL so ordering vs. users below doesn't matter.
+		"DELETE FROM audit_logs",
 		"DELETE FROM show_artists",
 		"DELETE FROM show_venues",
 		"DELETE FROM shows",

--- a/backend/internal/services/explore/predicate_parity_test.go
+++ b/backend/internal/services/explore/predicate_parity_test.go
@@ -5,24 +5,32 @@ package explore
 // "publicly visible" filter in this package (resolveFeaturedBill /
 // resolveFeaturedCollection) encode the SAME predicate: a bill is
 // featurable iff its show is `approved`; a collection is featurable iff
-// it is `is_public=true`. Nothing but a source comment kept them in sync
-// before this suite.
+// it is `is_public=true`. Each side already has its own unit coverage
+// (featured_slot_test.go for the write sentinels; explore_test.go's
+// TestGetFeatured_* for the read filter); what nothing enforced before
+// this suite is that the two predicates AGREE.
 //
 // Silent-divergence risk (the bug PSY-850 closed, re-opened by drift): if
 // one side's predicate changes and the other doesn't, the admin "save"
 // succeeds but /explore hides the slot — the phantom-save UX returns,
 // only the trigger condition is different.
 //
-// Each test below exercises BOTH sides against the same fixture so the
-// suite fails if either side's predicate drifts along a dimension it
-// already exercises — show status, collection visibility, or referent
-// existence:
+// Each test below pins BOTH sides to the SAME fixture in one place — that
+// co-location is the novel guard, so the write-side sentinel assertions
+// here are DELIBERATELY redundant with featured_slot_test.go. The suite
+// fails when the two predicates disagree along a dimension the fixtures
+// vary: show status (approved vs not) and collection visibility (public
+// vs not).
 //   - write side: SetActiveSlot returns the expected rejection sentinel
 //     (or accepts, for the valid cases);
 //   - read side: GetFeatured excludes the referent (or surfaces it).
 // The read side is checked by forcing a slot at the offending referent
 // with a raw insert that bypasses write-side validation — otherwise an
-// invalid referent could never reach the read path at all.
+// invalid referent could never reach the read path at all. Note the read
+// side collapses "referent missing" and "referent present but not
+// visible" into the same nil (a single gorm.ErrRecordNotFound branch);
+// the *MissingReferent cases therefore add a distinct WRITE-side sentinel
+// (not-found vs not-approved/not-public), not a distinct read-side path.
 //
 // Scope honesty: fixture-based parity can only catch drift along the
 // dimensions the fixtures vary. A NEW predicate column added to just one
@@ -48,16 +56,32 @@ import (
 )
 
 // insertActiveSlotRaw inserts an active featured_slots row directly,
-// bypassing SetActiveSlot's referent validation. The three NOT-NULL
+// bypassing SetActiveSlot's referent validation. Only the three NOT-NULL
 // columns without a default (slot_type, entity_id, created_by) are
-// enough — active_from / created_at / updated_at default NOW() and
-// active_until defaults NULL (active). Mirrors the raw-insert bypass in
-// services/admin/featured_slot_test.go's partial-unique-index test.
+// required; active_from / created_at / updated_at default NOW() and
+// active_until defaults NULL (= active) per migration
+// 20260524214301_create_featured_slots.up.sql. Mirrors the raw-insert
+// bypass in services/admin/featured_slot_test.go's partial-unique-index
+// test.
 func (s *ExploreServiceIntegrationSuite) insertActiveSlotRaw(slotType string, entityID, createdBy uint) {
 	s.Require().NoError(s.db.Exec(
 		"INSERT INTO featured_slots (slot_type, entity_id, created_by) VALUES (?, ?, ?)",
 		slotType, entityID, createdBy,
 	).Error)
+}
+
+// requireActiveSlotLoadable asserts the active slot for slotType is the
+// one just forced in via insertActiveSlotRaw — pinning the precondition
+// that the slot actually reaches the read path. Without it, a later
+// s.Nil(resp.Bill/Collection) would also pass if GetActiveSlot silently
+// stopped returning the row (e.g. a broken active_until predicate),
+// asserting "no slot found" instead of the intended "slot found but
+// filtered out".
+func (s *ExploreServiceIntegrationSuite) requireActiveSlotLoadable(slotType string, entityID uint) {
+	active, err := s.featuredSlotService.GetActiveSlot(slotType)
+	s.Require().NoError(err)
+	s.Require().NotNil(active)
+	s.Require().Equal(entityID, active.EntityID)
 }
 
 // createShowWithStatus seeds a bare show row with the requested status.
@@ -94,8 +118,11 @@ func (s *ExploreServiceIntegrationSuite) TestPredicateParity_BillNotApproved() {
 	s.True(errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotApproved),
 		"write side must reject a non-approved bill, got %v", err)
 
-	// Read side: force a slot at the same referent, GetFeatured must hide it.
+	// Read side: force a slot at the same referent (write-side validation
+	// would never store one), confirm it really is the active slot the
+	// read path loads, then assert the visibility filter excludes it.
 	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeBill, pending.ID, admin.ID)
+	s.requireActiveSlotLoadable(adminm.FeaturedSlotTypeBill, pending.ID)
 	resp, err := s.exploreService.GetFeatured()
 	s.Require().NoError(err)
 	s.Nil(resp.Bill, "read side must exclude a non-approved bill")
@@ -111,6 +138,7 @@ func (s *ExploreServiceIntegrationSuite) TestPredicateParity_BillMissingReferent
 		"write side must reject a missing bill referent, got %v", err)
 
 	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeBill, missingID, admin.ID)
+	s.requireActiveSlotLoadable(adminm.FeaturedSlotTypeBill, missingID)
 	resp, err := s.exploreService.GetFeatured()
 	s.Require().NoError(err)
 	s.Nil(resp.Bill, "read side must exclude a missing bill referent")
@@ -126,6 +154,7 @@ func (s *ExploreServiceIntegrationSuite) TestPredicateParity_CollectionNotPublic
 		"write side must reject a private collection, got %v", err)
 
 	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeCollection, private.ID, admin.ID)
+	s.requireActiveSlotLoadable(adminm.FeaturedSlotTypeCollection, private.ID)
 	resp, err := s.exploreService.GetFeatured()
 	s.Require().NoError(err)
 	s.Nil(resp.Collection, "read side must exclude a private collection")
@@ -141,6 +170,7 @@ func (s *ExploreServiceIntegrationSuite) TestPredicateParity_CollectionMissingRe
 		"write side must reject a missing collection referent, got %v", err)
 
 	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeCollection, missingID, admin.ID)
+	s.requireActiveSlotLoadable(adminm.FeaturedSlotTypeCollection, missingID)
 	resp, err := s.exploreService.GetFeatured()
 	s.Require().NoError(err)
 	s.Nil(resp.Collection, "read side must exclude a missing collection referent")

--- a/backend/internal/services/explore/predicate_parity_test.go
+++ b/backend/internal/services/explore/predicate_parity_test.go
@@ -1,0 +1,181 @@
+package explore
+
+// Predicate parity (PSY-880) — the write-side referent validation in
+// services/admin/featured_slot.go (validateReferent) and the read-side
+// "publicly visible" filter in this package (resolveFeaturedBill /
+// resolveFeaturedCollection) encode the SAME predicate: a bill is
+// featurable iff its show is `approved`; a collection is featurable iff
+// it is `is_public=true`. Nothing but a source comment kept them in sync
+// before this suite.
+//
+// Silent-divergence risk (the bug PSY-850 closed, re-opened by drift): if
+// one side's predicate changes and the other doesn't, the admin "save"
+// succeeds but /explore hides the slot — the phantom-save UX returns,
+// only the trigger condition is different.
+//
+// Each test below exercises BOTH sides against the same fixture so the
+// suite fails if either side's predicate drifts along a dimension it
+// already exercises — show status, collection visibility, or referent
+// existence:
+//   - write side: SetActiveSlot returns the expected rejection sentinel
+//     (or accepts, for the valid cases);
+//   - read side: GetFeatured excludes the referent (or surfaces it).
+// The read side is checked by forcing a slot at the offending referent
+// with a raw insert that bypasses write-side validation — otherwise an
+// invalid referent could never reach the read path at all.
+//
+// Scope honesty: fixture-based parity can only catch drift along the
+// dimensions the fixtures vary. A NEW predicate column added to just one
+// side in a future PR (say a read-side-only is_deleted filter) is
+// invisible here, because every fixture would share the same value for
+// it. Against that class the in-source "change both sides in the same PR"
+// discipline (see featured_slot.go validateReferent + explore.go
+// resolveFeatured*) stays the primary guard; this suite backs the
+// dimensions that exist today.
+//
+// These methods extend ExploreServiceIntegrationSuite (defined in
+// explore_test.go), reusing its DB, both wired services, per-test
+// cleanup, and createAdmin / createShow / createCollection helpers.
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	adminm "psychic-homily-backend/internal/models/admin"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	adminsvc "psychic-homily-backend/internal/services/admin"
+)
+
+// insertActiveSlotRaw inserts an active featured_slots row directly,
+// bypassing SetActiveSlot's referent validation. The three NOT-NULL
+// columns without a default (slot_type, entity_id, created_by) are
+// enough — active_from / created_at / updated_at default NOW() and
+// active_until defaults NULL (active). Mirrors the raw-insert bypass in
+// services/admin/featured_slot_test.go's partial-unique-index test.
+func (s *ExploreServiceIntegrationSuite) insertActiveSlotRaw(slotType string, entityID, createdBy uint) {
+	s.Require().NoError(s.db.Exec(
+		"INSERT INTO featured_slots (slot_type, entity_id, created_by) VALUES (?, ?, ?)",
+		slotType, entityID, createdBy,
+	).Error)
+}
+
+// createShowWithStatus seeds a bare show row with the requested status.
+// The suite's createShow always inserts an approved show with full
+// venue/artist joins; the parity rejection cases only need a row whose
+// status column drives the predicate, so this is the minimal variant.
+func (s *ExploreServiceIntegrationSuite) createShowWithStatus(title string, status catalogm.ShowStatus) *catalogm.Show {
+	city := "Phoenix"
+	state := "AZ"
+	slug := fmt.Sprintf("%s-%d", title, time.Now().UnixNano())
+	show := &catalogm.Show{
+		Title:     title,
+		Slug:      &slug,
+		EventDate: time.Now().UTC().AddDate(0, 0, 7),
+		City:      &city,
+		State:     &state,
+		Status:    status,
+	}
+	s.Require().NoError(s.db.Create(show).Error)
+	return show
+}
+
+// ──────────────────────────────────────────────
+// Rejection-path parity — write rejects ⇔ read excludes
+// ──────────────────────────────────────────────
+
+func (s *ExploreServiceIntegrationSuite) TestPredicateParity_BillNotApproved() {
+	admin := s.createAdmin("parity-bill-pending")
+	pending := s.createShowWithStatus("parity-pending-bill", catalogm.ShowStatusPending)
+
+	// Write side: a non-approved bill must be rejected up front.
+	_, err := s.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, pending.ID, nil, admin.ID)
+	s.Require().Error(err)
+	s.True(errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotApproved),
+		"write side must reject a non-approved bill, got %v", err)
+
+	// Read side: force a slot at the same referent, GetFeatured must hide it.
+	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeBill, pending.ID, admin.ID)
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Nil(resp.Bill, "read side must exclude a non-approved bill")
+}
+
+func (s *ExploreServiceIntegrationSuite) TestPredicateParity_BillMissingReferent() {
+	admin := s.createAdmin("parity-bill-missing")
+	const missingID = uint(999999) // entity_id has no FK — safe to point at nothing
+
+	_, err := s.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, missingID, nil, admin.ID)
+	s.Require().Error(err)
+	s.True(errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotFound),
+		"write side must reject a missing bill referent, got %v", err)
+
+	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeBill, missingID, admin.ID)
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Nil(resp.Bill, "read side must exclude a missing bill referent")
+}
+
+func (s *ExploreServiceIntegrationSuite) TestPredicateParity_CollectionNotPublic() {
+	admin := s.createAdmin("parity-coll-private")
+	private := s.createCollection(admin.ID, "parity-private-coll", false)
+
+	_, err := s.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, private.ID, nil, admin.ID)
+	s.Require().Error(err)
+	s.True(errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotPublic),
+		"write side must reject a private collection, got %v", err)
+
+	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeCollection, private.ID, admin.ID)
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Nil(resp.Collection, "read side must exclude a private collection")
+}
+
+func (s *ExploreServiceIntegrationSuite) TestPredicateParity_CollectionMissingReferent() {
+	admin := s.createAdmin("parity-coll-missing")
+	const missingID = uint(999999)
+
+	_, err := s.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, missingID, nil, admin.ID)
+	s.Require().Error(err)
+	s.True(errors.Is(err, adminsvc.ErrFeaturedSlotReferentNotFound),
+		"write side must reject a missing collection referent, got %v", err)
+
+	s.insertActiveSlotRaw(adminm.FeaturedSlotTypeCollection, missingID, admin.ID)
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Nil(resp.Collection, "read side must exclude a missing collection referent")
+}
+
+// ──────────────────────────────────────────────
+// Acceptance-path parity — write accepts ⇔ read surfaces
+// ──────────────────────────────────────────────
+//
+// The valid cases guard the opposite drift: a write side that grows
+// STRICTER than the read side (rejects something /explore would happily
+// show) is just as much a divergence as the reverse.
+
+func (s *ExploreServiceIntegrationSuite) TestPredicateParity_BillApprovedVisibleOnBothSides() {
+	admin := s.createAdmin("parity-bill-approved")
+	show, _, _ := s.createShow("parity-approved-bill", 14)
+
+	_, err := s.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeBill, show.ID, nil, admin.ID)
+	s.Require().NoError(err, "write side must accept an approved bill")
+
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.Bill, "read side must surface an approved bill the write side accepted")
+	s.Equal(show.ID, resp.Bill.ID)
+}
+
+func (s *ExploreServiceIntegrationSuite) TestPredicateParity_CollectionPublicVisibleOnBothSides() {
+	admin := s.createAdmin("parity-coll-public")
+	coll := s.createCollection(admin.ID, "parity-public-coll", true)
+
+	_, err := s.featuredSlotService.SetActiveSlot(adminm.FeaturedSlotTypeCollection, coll.ID, nil, admin.ID)
+	s.Require().NoError(err, "write side must accept a public collection")
+
+	resp, err := s.exploreService.GetFeatured()
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.Collection, "read side must surface a public collection the write side accepted")
+	s.Equal(coll.ID, resp.Collection.ID)
+}


### PR DESCRIPTION
Closes PSY-880.

## Summary
- Adds `backend/internal/services/explore/predicate_parity_test.go` — a parity suite that couples the **write-side** referent validation (`admin.SetActiveSlot` → `validateReferent`) and the **read-side** `/explore` visibility filter (`explore.GetFeatured` → `resolveFeaturedBill`/`resolveFeaturedCollection`) on the **same fixtures**, so a future PR that changes one predicate without the other fails CI. This guards against silent re-opening of the phantom-save class PSY-850 closed.
- Each side already had its own unit coverage; what nothing enforced before is that the two predicates *agree*. The new tests pin write+read together in one place — that co-location is the guard.
- Updates the "MUST stay in sync" doc comments in `featured_slot.go` and `explore.go` to point at the new suite as the discoverable guard (and honestly bound what fixture-based parity can/can't catch).

## Why Option B (parity test) over Option A (shared helper)
The ticket offered both and said pick whichever fits the current shape. The consumer predicate is **GORM-side** — `resolveFeaturedBill` uses `WHERE id = ? AND status = 'approved'`, `resolveFeaturedCollection` uses `WHERE id = ? AND is_public = true` — not a Go-side predicate on a loaded struct. A shared bool helper (Option A) would require loading the full row and filtering in Go, which is the explicitly **out-of-scope** "refactor the consumer's GORM query into a Go-side filter." So Option B is the lighter-weight fit. The test lives in the `explore` package because `explore` imports `admin` (the reverse would cycle), and `explore_test.go` already wires both services on one DB.

## Coverage
All four `validateReferent` rejection sentinels, write **and** read, on the same fixture:

| Case | Write side asserts | Read side asserts |
| --- | --- | --- |
| Non-approved bill | `ErrFeaturedSlotReferentNotApproved` | `resp.Bill == nil` |
| Missing bill | `ErrFeaturedSlotReferentNotFound` | `resp.Bill == nil` |
| Private collection | `ErrFeaturedSlotReferentNotPublic` | `resp.Collection == nil` |
| Missing collection | `ErrFeaturedSlotReferentNotFound` | `resp.Collection == nil` |

Plus two acceptance-path tests (approved bill / public collection) that guard the *opposite* drift — a write side growing stricter than the read side. Each rejection test asserts the forced slot is actually loadable as the active slot before checking `GetFeatured`, so the `nil` assertion provably tests the visibility filter rather than an empty fetch.

## Adversarial review
`/adversarial-review` — CONCERNS, all findings addressed in commit `55b9c062`. Security + Completeness lenses returned CLEAN.
- [MEDIUM] Vacuous read assertion → added `requireActiveSlotLoadable` precondition so `s.Nil(resp.Bill/Collection)` provably exercises the filter (`55b9c062`).
- [MEDIUM] Header overclaimed novelty → reworded; write-half is deliberately redundant with `featured_slot_test.go`, the co-location is the novel guard (`55b9c062`).
- [MEDIUM] "referent existence" mislabeled as a read-side dimension → scoped to write-side sentinel; read side collapses missing + not-visible into one branch (`55b9c062`).
- [LOW] `audit_logs` leaked across the suite → `DELETE FROM audit_logs` added to `TearDownTest` (`55b9c062`).
- [LOW] `insertActiveSlotRaw` comment → cites the create migration (`55b9c062`).
- [LOW] Pre-existing fictional "LEFT-JOIN" wording in `GetFeatured` doc → reworded to the actual `First()` + `ErrRecordNotFound`→nil mechanism (`55b9c062`).

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/services/explore/...` — clean
- [x] `go test ./internal/services/admin/... ./internal/services/explore/...` — both packages pass (testcontainer Postgres)
- [x] All 6 `TestPredicateParity_*` pass against real Postgres
- [x] **Canary proven**: temporarily weakened the write-side predicate (accept any existing show) → `TestPredicateParity_BillNotApproved` failed as designed; reverted
- [x] `/code-review` — 1 actionable finding (comment over-promise) fixed; others assessed as intentional design
- [x] `/adversarial-review` — CONCERNS; all findings fixed in separate commit `55b9c062`
- [x] No UI surface, screenshots skipped

## Coverage gaps (honest disclosure)
- **Only `pending` is exercised for the "not-approved" sentinel**, not `rejected`/`private`. Both reviewers (Security, Completeness) confirmed this is *not* a real gap: both sides reduce non-approved to a single equality (`status = approved` / `status != approved`), so `pending` is a faithful representative of one code branch — there is no per-status divergence surface to test, and PSY-850's `featured_slot_test.go` already covers all three on the write side.
- **Fixture-based parity cannot catch a brand-new predicate dimension added to only one side** (e.g. a hypothetical read-only `is_deleted` filter) — every fixture would share the same value for an unknown column. Against that class the in-source "change both sides in the same PR" discipline remains the primary guard; this suite backs the dimensions that exist today. Documented in the suite header and both source comments.
