### PR TITLE
PSY-868: dynamic-import ForceGraphView off /explore initial JS

### DIFF
--- a/frontend/features/explore/components/InlineGraph.tsx
+++ b/frontend/features/explore/components/InlineGraph.tsx
@@ -23,9 +23,9 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { ForceGraphView } from '@/components/graph/ForceGraphView'
 import type { GraphNode } from '@/components/graph/ForceGraphView'
 import { useShow } from '@/features/shows'
 import { useArtistGraph } from '@/features/artists/hooks/useArtistGraph'
@@ -33,6 +33,34 @@ import { useArtistGraph } from '@/features/artists/hooks/useArtistGraph'
 const GRAPH_BREAKPOINT_PX = 640
 const GRAPH_HEIGHT_PX = 480
 const INTERSECTION_ROOT_MARGIN = '200px'
+
+// Placeholder reserving the graph's natural height (CLS budget). Reused
+// as the dynamic-import loading fallback AND the pre-mount / data-loading
+// skeleton below, so the two can't drift apart.
+function GraphSkeleton() {
+  return (
+    <div
+      className="aspect-[16/9] w-full rounded-lg border border-border/50 bg-muted/10 animate-pulse"
+      style={{ minHeight: GRAPH_HEIGHT_PX }}
+      aria-hidden="true"
+    />
+  )
+}
+
+// ForceGraphView is /explore's only static reach into the shared graph
+// chunk: a static import keeps it (and that chunk) in /explore's initial
+// JS even though the graph is below the fold and IntersectionObserver-
+// gated. dynamic(ssr:false) splits the wrapper into its own async chunk
+// fetched only when the graph mounts; the heavy renderer underneath
+// (react-force-graph-2d) is already lazy. The canvas never renders
+// server-side, so ssr:false costs nothing. See PSY-868.
+const ForceGraphView = dynamic(
+  () =>
+    import('@/components/graph/ForceGraphView').then(m => ({
+      default: m.ForceGraphView,
+    })),
+  { ssr: false, loading: () => <GraphSkeleton /> },
+)
 
 interface InlineGraphProps {
   /** Featured bill slug — drives the show-detail fetch for lineup. */
@@ -127,15 +155,10 @@ export function InlineGraph({ billSlug, billTitle, billHref }: InlineGraphProps)
     </div>
   )
 
-  // Skeleton placeholder — reserves the graph's natural height so the
-  // section below doesn't shift when the canvas mounts (CLS budget).
-  const skeleton = (
-    <div
-      className="aspect-[16/9] w-full rounded-lg border border-border/50 bg-muted/10 animate-pulse"
-      style={{ minHeight: GRAPH_HEIGHT_PX }}
-      aria-hidden="true"
-    />
-  )
+  // Reserves the graph's natural height so the section below doesn't
+  // shift when the canvas mounts (CLS budget). Same element the dynamic
+  // import shows while the ForceGraphView chunk loads.
+  const skeleton = <GraphSkeleton />
 
   return (
     <div ref={containerRef} className="w-full">

--- a/frontend/features/explore/components/InlineGraph.tsx
+++ b/frontend/features/explore/components/InlineGraph.tsx
@@ -47,6 +47,35 @@ function GraphSkeleton() {
   )
 }
 
+// Visible, announced fallback for when the ForceGraphView chunk fails to
+// load. next/dynamic does NOT throw a failed chunk fetch to an error
+// boundary — it re-invokes `loading` with `error` set — so without this
+// the user would sit on the aria-hidden skeleton forever. The graph is an
+// optional below-the-fold section, so a failure must be perceivable but
+// must not take down the rest of /explore.
+function GraphLoadError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="aspect-[16/9] w-full rounded-lg border border-border/50 bg-muted/10 flex flex-col items-center justify-center gap-3 text-center p-6"
+      style={{ minHeight: GRAPH_HEIGHT_PX }}
+    >
+      <p className="text-sm text-muted-foreground">
+        The lineup graph couldn&apos;t load.
+      </p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="text-sm text-primary hover:underline underline-offset-4"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  )
+}
+
 // ForceGraphView is /explore's only static reach into the shared graph
 // chunk: a static import keeps it (and that chunk) in /explore's initial
 // JS even though the graph is below the fold and IntersectionObserver-
@@ -54,12 +83,25 @@ function GraphSkeleton() {
 // fetched only when the graph mounts; the heavy renderer underneath
 // (react-force-graph-2d) is already lazy. The canvas never renders
 // server-side, so ssr:false costs nothing. See PSY-868.
+//
+// Peer ForceGraphView consumers (Scene / Venue / Collection graphs) keep
+// the static import on purpose: there the graph IS the page's primary
+// content, not a below-the-fold widget on a perf-budgeted landing page,
+// so the split would only add a chunk round-trip. The divergence is
+// intentional and scoped to /explore.
 const ForceGraphView = dynamic(
   () =>
     import('@/components/graph/ForceGraphView').then(m => ({
       default: m.ForceGraphView,
     })),
-  { ssr: false, loading: () => <GraphSkeleton /> },
+  {
+    ssr: false,
+    // Happy path: the height-reserving skeleton while the chunk downloads.
+    // Error path (e.g. a deploy rotated the hashed chunk while the page
+    // was open): a perceivable, recoverable state, not an infinite skeleton.
+    loading: ({ error, retry }) =>
+      error ? <GraphLoadError onRetry={retry} /> : <GraphSkeleton />,
+  },
 )
 
 interface InlineGraphProps {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -31,7 +31,7 @@
           { "maxNumericValue": 2000, "aggregationMethod": "median" }
         ],
         "interactive": [
-          "warn",
+          "error",
           { "maxNumericValue": 2500, "aggregationMethod": "median" }
         ],
         "cumulative-layout-shift": [


### PR DESCRIPTION
Closes PSY-868.

## Summary
- `features/explore/components/InlineGraph.tsx`: replace the **static** `import { ForceGraphView }` with a `next/dynamic` (`ssr: false`) import, splitting the graph wrapper into its own async chunk fetched only when the below-the-fold, IntersectionObserver-gated graph actually mounts.
- Goal: cut `/explore` Time-To-Interactive (measured **7666 ms** median on the Vercel preview, mobile 4× CPU + slow-4G; budget **2500 ms**) by removing `/explore`'s static dependency on the shared graph chunk.

## Investigation (refutes the ticket's original suspect)
Full doc: `docs/research/psy-868-explore-tti-investigation.md` (gitignored, agent-only). Headlines:

- **The graph renderer is already lazy.** `react-force-graph-2d` + `force-graph` + all d3 sim deps live in their own chunk (172 KB / 54 KB gz), already behind a `dynamic()` *inside* `ForceGraphView.tsx`. It is **not** in `/explore`'s initial JS. So the ticket's framing ("ForceGraphView bundle is shipped + parsed in the initial payload") is inaccurate — it's already deferred.
- **The real mechanism:** `/explore`'s page chunk is tiny (13.7 KB). Under the bundler's chunk grouping, `ForceGraphView.tsx` (the ~590-line wrapper, 5.6 KB) lands in a **555 KB shared chunk** full of *other routes'* components (CollectionDetail, ArtistDetail, ShowCard, ShowForm…). `/explore` imports **nothing** from that chunk except `ForceGraphView` via InlineGraph's static import — so that one static edge plausibly drags the whole shared chunk into `/explore`'s first load. Dynamic-importing severs that edge.
- **Tooling caveats (why this is directional, not proven, locally):** the original Lighthouse report expired; the throttled gap doesn't reproduce locally (local prod-build TTI = 469 ms); and the bundle analyzer only runs under **webpack** (`next build --webpack`) while production + the Vercel preview build with **Turbopack**, which groups chunks differently. The only authoritative measurement is the `lighthouse-explore.yml` lhci run on this PR's preview.

## Gate promoted to `error` (budget met)
`lighthouserc.json` `interactive` is flipped from `warn` back to **`error`** (commit `0365af01`). The Vercel-preview lhci run on this PR measured **median TTI = 2011 ms** (3 runs: 8952 ms cold-lambda / 2011 / 1933; median-of-3 discards the cold outlier) — under the 2500 ms budget, **down from the pre-fix 7666 ms**. `assertion-results.json` was empty (no violations); LCP (median 1296 ms) and CLS (0.000) also pass.

**Residual flake note (not introduced by this change):** run 1 was a cold-lambda outlier (TTI 8952 ms, LCP 2512 ms). Median-of-3 tolerates one cold run, but a future PR hitting cold starts on ≥2 of 3 runs could flake the gate red — the same exposure the already-`error` LCP gate carries on this serverless preview. Flagged for awareness.

## Adversarial review
`/adversarial-review` — CONCERNS; findings addressed in commit `fd71ab52`. Panel: Saboteur · Future-Maintainer · Completeness (no Security surface — client-side dynamic import, no auth/data/input change).
- [HIGH] **Chunk-load failure stranded the user on an infinite `aria-hidden` skeleton.** `next/dynamic` re-invokes `loading` with `error`/`retry` on a failed chunk fetch (e.g. a deploy rotates the hashed chunk mid-session) rather than throwing to an error boundary. → Added `GraphLoadError` (a `role="alert"`, retryable fallback) on the error path; happy path unchanged (`fd71ab52`). Note: the inner ForceGraphView `dynamic()` has the same pre-existing gap app-wide — not expanded here.
- [MEDIUM] **Peer-divergence undocumented** (Scene/Venue/Collection graphs static-import ForceGraphView). → Added a comment: the divergence is intentional and route-scoped (only `/explore` is a perf-budgeted landing page with a below-fold graph) (`fd71ab52`).
- [HIGH, Completeness] **Gate not flipped / TTI unmeasured.** → By design (measure-then-promote, above); resolved after the lhci run, not in this diff.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/explore/components/InlineGraph.test.tsx` — 2/2 passing
- [x] `bun run build` (Turbopack, the production bundler) — compiled clean, 89/89 pages
- [x] `/code-review` — 2 cleanups fixed (DRY the skeleton into a shared `GraphSkeleton`; drop a point-in-time KB figure from the comment); no correctness bugs
- [x] `/adversarial-review` — CONCERNS; fixes in separate commit `fd71ab52`
- [x] **TTI median 2011 ms < 2500 ms on Vercel preview** (3 runs: 8952 cold / 2011 / 1933, median-of-3) — measured on this PR's `lighthouse-explore.yml` run; gate flipped to `error` (`0365af01`) and re-run to confirm the hard gate passes
- [x] No rendered-output change **by construction** (not visually re-verified — screenshots skipped): the `ForceGraphView` component is unchanged, only its import mechanism; the loading fallback reuses the same height-reserving skeleton element (no CLS), and the graph renders identically once its chunk loads.

## Coverage gaps (honest disclosure)
- **The dynamic-loaded graph mount + loading/error fallbacks are not unit-tested.** The existing `InlineGraph.test.tsx` mocks `ForceGraphView` by module path and asserts the pre-mount skeleton + the headliner-id wiring; it does not exercise the dynamic boundary. The re-export contract (`m.ForceGraphView`) IS protected by `tsc` (it would error if ForceGraphView became a default export), so the highest-risk break is caught — but the loading/error rendering paths are unexercised. Adding that test requires faking the `containerWidth ≥ 640` gate (ResizeObserver) + non-empty graph data; deferred as disproportionate for this perf change.
- **The TTI improvement was unverifiable locally** (see caveats: webpack analyzer ≠ Turbopack chunking; local TTI = 469 ms) — now **confirmed on the Vercel preview** (median 2011 ms). The local↔preview gap is a property of the throttled serverless environment, not this change.
