### PR TITLE
PSY-927: fix WFMU radio import (playlist_source + backfill date bug)

### DIFF
--- a/backend/db/migrations/20260531202754_fix_wfmu_station_playlist_source.down.sql
+++ b/backend/db/migrations/20260531202754_fix_wfmu_station_playlist_source.down.sql
@@ -1,0 +1,10 @@
+-- PSY-927: No-op (intentional).
+--
+-- This is a one-way data correction. 'wfmu_html' was an invalid value that
+-- silently broke playlist import — never a state worth restoring. The up
+-- migration only ever rewrites the broken value and is a no-op on environments
+-- that were never affected (including the fresh CI database), so there is
+-- nothing to reverse. A precise reverse is impossible anyway: once corrected,
+-- the row is indistinguishable from the legitimately-'wfmu_scrape' sub-stations.
+-- Down intentionally does nothing.
+SELECT 1;

--- a/backend/db/migrations/20260531202754_fix_wfmu_station_playlist_source.up.sql
+++ b/backend/db/migrations/20260531202754_fix_wfmu_station_playlist_source.up.sql
@@ -4,9 +4,10 @@
 -- provider handles. getProvider() returns "unsupported playlist source" for it,
 -- so episode discovery ran but every WFMU show imported 0 tracks. The seed
 -- (000068_seed_default_radio_stations) set 'wfmu_scrape'; 'wfmu_html' was
--- introduced later at runtime (an unvalidated write). Code-side hardening
--- (IsValidPlaylistSource on station create/update) prevents recurrence; this
--- corrects the existing bad row.
+-- introduced later at runtime via an unvalidated API write. API-side validation
+-- (IsValidPlaylistSource on station create/update) now rejects invalid values on
+-- that path — the realistic recurrence vector; this migration corrects the
+-- existing bad row.
 --
 -- Scoped to the exact broken value and idempotent: re-running, or running on an
 -- environment that was never broken (including the fresh CI database, where the

--- a/backend/db/migrations/20260531202754_fix_wfmu_station_playlist_source.up.sql
+++ b/backend/db/migrations/20260531202754_fix_wfmu_station_playlist_source.up.sql
@@ -1,0 +1,16 @@
+-- PSY-927: Restore the WFMU flagship station's playlist_source.
+--
+-- The station (slug 'wfmu') had playlist_source = 'wfmu_html' — a value no
+-- provider handles. getProvider() returns "unsupported playlist source" for it,
+-- so episode discovery ran but every WFMU show imported 0 tracks. The seed
+-- (000068_seed_default_radio_stations) set 'wfmu_scrape'; 'wfmu_html' was
+-- introduced later at runtime (an unvalidated write). Code-side hardening
+-- (IsValidPlaylistSource on station create/update) prevents recurrence; this
+-- corrects the existing bad row.
+--
+-- Scoped to the exact broken value and idempotent: re-running, or running on an
+-- environment that was never broken (including the fresh CI database, where the
+-- seed sets 'wfmu_scrape'), updates 0 rows.
+UPDATE radio_stations
+   SET playlist_source = 'wfmu_scrape'
+ WHERE playlist_source = 'wfmu_html';

--- a/backend/internal/models/catalog/radio.go
+++ b/backend/internal/models/catalog/radio.go
@@ -46,6 +46,34 @@ func IsValidBroadcastType(s string) bool {
 	return false
 }
 
+// PlaylistSources is the list of valid playlist sources. getProvider dispatches
+// the three scraper/API sources (kexp_api, nts_api, wfmu_scrape) to a provider;
+// "manual" is a valid value meaning hand-curated playlists with no automated
+// provider. The empty string is also accepted by IsValidPlaylistSource and
+// likewise means "no automated provider" (a link-only station not auto-imported).
+var PlaylistSources = []string{
+	PlaylistSourceKEXP,
+	PlaylistSourceNTS,
+	PlaylistSourceWFMU,
+	PlaylistSourceManual,
+}
+
+// IsValidPlaylistSource reports whether s is an accepted playlist_source. The
+// empty string is valid (no automated provider / link-only). Rejecting anything
+// else stops invalid values like "wfmu_html" from being persisted and silently
+// breaking all playlist import for the station. (PSY-927)
+func IsValidPlaylistSource(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, ps := range PlaylistSources {
+		if ps == s {
+			return true
+		}
+	}
+	return false
+}
+
 // RadioStation represents a radio station entity in the knowledge graph
 type RadioStation struct {
 	ID                  uint             `gorm:"primaryKey"`

--- a/backend/internal/models/catalog/radio_test.go
+++ b/backend/internal/models/catalog/radio_test.go
@@ -52,6 +52,23 @@ func TestIsValidBroadcastType_Invalid(t *testing.T) {
 	assert.False(t, IsValidBroadcastType("satellite"))
 }
 
+func TestIsValidPlaylistSource_Valid(t *testing.T) {
+	for _, ps := range PlaylistSources {
+		assert.True(t, IsValidPlaylistSource(ps), "expected %q to be valid", ps)
+	}
+	// Empty means "no automated provider" (link-only) and is accepted.
+	assert.True(t, IsValidPlaylistSource(""))
+}
+
+func TestIsValidPlaylistSource_Invalid(t *testing.T) {
+	// PSY-927: 'wfmu_html' was the runtime bad value that silently broke WFMU
+	// playlist import — exactly what this validation now rejects.
+	assert.False(t, IsValidPlaylistSource("wfmu_html"))
+	assert.False(t, IsValidPlaylistSource("invalid"))
+	assert.False(t, IsValidPlaylistSource("WFMU_SCRAPE")) // case-sensitive
+	assert.False(t, IsValidPlaylistSource("kexp"))
+}
+
 // =============================================================================
 // Broadcast Type Constants Tests
 // =============================================================================

--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -51,6 +51,10 @@ func (s *RadioService) CreateStation(req *contracts.CreateRadioStationRequest) (
 		return nil, fmt.Errorf("invalid broadcast type: %s", req.BroadcastType)
 	}
 
+	if req.PlaylistSource != nil && !catalogm.IsValidPlaylistSource(*req.PlaylistSource) {
+		return nil, fmt.Errorf("invalid playlist source: %s", *req.PlaylistSource)
+	}
+
 	station := &catalogm.RadioStation{
 		Name:             req.Name,
 		Slug:             slug,
@@ -282,6 +286,9 @@ func (s *RadioService) UpdateStation(stationID uint, req *contracts.UpdateRadioS
 		updates["frequency_mhz"] = *req.FrequencyMHz
 	}
 	if req.PlaylistSource != nil {
+		if !catalogm.IsValidPlaylistSource(*req.PlaylistSource) {
+			return nil, fmt.Errorf("invalid playlist source: %s", *req.PlaylistSource)
+		}
 		updates["playlist_source"] = *req.PlaylistSource
 	}
 	if req.PlaylistConfig != nil {

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -33,9 +33,10 @@ func (s *RadioService) getProvider(source string) (RadioPlaylistProvider, error)
 		return NewNTSProvider(), nil
 	case catalogm.PlaylistSourceManual:
 		// "manual" is a valid, intentional source: playlists are curated by hand,
-		// so there is no automated provider to dispatch to. Return an error (the
-		// caller skips the station) but do NOT fall into the default branch's
-		// loud alert — this is a known value, not a misconfiguration.
+		// so there is no automated provider. The scheduled cycle never reaches
+		// here for manual stations — GetActiveStationsWithPlaylistSource excludes
+		// them — so this guards the manual import-job trigger path, returning a
+		// clear error without the default branch's misconfiguration alert.
 		return nil, fmt.Errorf("playlist source %q is manual; no automated provider", source)
 	default:
 		// A truly unrecognized playlist_source silently breaks ALL playlist

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -31,9 +31,35 @@ func (s *RadioService) getProvider(source string) (RadioPlaylistProvider, error)
 		return NewWFMUProvider(), nil
 	case catalogm.PlaylistSourceNTS:
 		return NewNTSProvider(), nil
+	case catalogm.PlaylistSourceManual:
+		// "manual" is a valid, intentional source: playlists are curated by hand,
+		// so there is no automated provider to dispatch to. Return an error (the
+		// caller skips the station) but do NOT fall into the default branch's
+		// loud alert — this is a known value, not a misconfiguration.
+		return nil, fmt.Errorf("playlist source %q is manual; no automated provider", source)
 	default:
+		// A truly unrecognized playlist_source silently breaks ALL playlist
+		// import for the station — every show imports 0 tracks with no obvious
+		// cause. (PSY-927: the value "wfmu_html", which no provider handles, had
+		// been set on the WFMU station and zeroed out every show's tracks.) Log
+		// loudly with the offending value so a misconfigured station is visible
+		// rather than disappearing into a per-cycle error count.
+		slog.Default().Error("radio import: unsupported playlist source",
+			"playlist_source", source,
+			"valid", catalogm.PlaylistSources,
+		)
 		return nil, fmt.Errorf("unsupported playlist source: %s", source)
 	}
+}
+
+// parseImportDate parses an import-window bound (since/until). The value may
+// arrive date-only ("2026-03-02") from the API, or as a Postgres DATE-column
+// round-trip ("2026-03-02T00:00:00Z") when read back from a persisted import
+// job — normalizeDateString trims the time suffix so both forms parse. Without
+// it the auto-backfill job-execution path failed on every job, since
+// radio_import_job.go feeds job.Since/job.Until straight from the DB. (PSY-927)
+func parseImportDate(s string) (time.Time, error) {
+	return time.Parse("2006-01-02", normalizeDateString(s))
 }
 
 // ImportStation runs a full import: discover shows + fetch episodes for the last N days.
@@ -308,11 +334,11 @@ func (s *RadioService) importShowEpisodesWithProgress(
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	sinceTime, err := time.Parse("2006-01-02", since)
+	sinceTime, err := parseImportDate(since)
 	if err != nil {
 		return nil, fmt.Errorf("invalid since date %q: %w", since, err)
 	}
-	untilTime, err := time.Parse("2006-01-02", until)
+	untilTime, err := parseImportDate(until)
 	if err != nil {
 		return nil, fmt.Errorf("invalid until date %q: %w", until, err)
 	}

--- a/backend/internal/services/catalog/radio_import_job.go
+++ b/backend/internal/services/catalog/radio_import_job.go
@@ -218,6 +218,10 @@ func (s *RadioService) runImportJob(jobID uint) {
 		return false
 	}
 
+	// job.Since/job.Until are read straight from Postgres DATE columns and
+	// round-trip as "...T00:00:00Z"; importShowEpisodesWithProgress normalizes
+	// them via parseImportDate before parsing, so passing the raw values is safe
+	// (do NOT add a bare time.Parse here). (PSY-927)
 	result, err := s.importShowEpisodesWithProgress(job.ShowID, job.Since, job.Until, episodesFoundFn, progressFn)
 	if err != nil {
 		s.failJob(jobID, err.Error())

--- a/backend/internal/services/catalog/radio_import_job_test.go
+++ b/backend/internal/services/catalog/radio_import_job_test.go
@@ -15,6 +15,29 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
+func TestParseImportDate(t *testing.T) {
+	// Date-only (the API request form).
+	if d, err := parseImportDate("2026-03-02"); err != nil {
+		t.Fatalf("date-only should parse, got %v", err)
+	} else if got := d.Format("2006-01-02"); got != "2026-03-02" {
+		t.Fatalf("expected 2026-03-02, got %s", got)
+	}
+
+	// PSY-927: the DATE-column round-trip form, as read back from a persisted
+	// import job. This exact value previously failed every auto-backfill job
+	// with `parsing time "...": extra text "T00:00:00Z"`.
+	if d, err := parseImportDate("2026-03-02T00:00:00Z"); err != nil {
+		t.Fatalf("DATE round-trip form should parse, got %v", err)
+	} else if got := d.Format("2006-01-02"); got != "2026-03-02" {
+		t.Fatalf("expected 2026-03-02, got %s", got)
+	}
+
+	// Genuinely malformed input still errors.
+	if _, err := parseImportDate("not-a-date"); err == nil {
+		t.Fatal("expected error for invalid date, got nil")
+	}
+}
+
 func TestRadioService_NilDB_ImportJob(t *testing.T) {
 	svc := &RadioService{db: nil}
 

--- a/backend/internal/services/catalog/radio_import_job_test.go
+++ b/backend/internal/services/catalog/radio_import_job_test.go
@@ -125,6 +125,32 @@ func (suite *RadioImportJobIntegrationTestSuite) createShow(stationID uint, name
 	return show
 }
 
+// TestImportJob_PersistedDatesParse locks in the PSY-927 premise end-to-end:
+// since/until persist in Postgres DATE columns and round-trip through GORM with
+// a time component, and the value reloaded the way runImportJob reads it must
+// parse via parseImportDate. The helper-only TestParseImportDate hard-codes the
+// "T00:00:00Z" form; this catches a future driver/GORM change to that rendering
+// that the helper test would miss (which is exactly how the original bug broke
+// every auto-backfill job).
+func (suite *RadioImportJobIntegrationTestSuite) TestImportJob_PersistedDatesParse() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	job, err := suite.radioService.CreateImportJob(show.ID, "2026-03-02", "2026-03-31")
+	suite.Require().NoError(err)
+
+	var reloaded catalogm.RadioImportJob
+	suite.Require().NoError(suite.db.First(&reloaded, job.ID).Error)
+
+	since, serr := parseImportDate(reloaded.Since)
+	suite.Require().NoError(serr, "persisted Since %q must parse", reloaded.Since)
+	suite.Equal("2026-03-02", since.Format("2006-01-02"))
+
+	until, uerr := parseImportDate(reloaded.Until)
+	suite.Require().NoError(uerr, "persisted Until %q must parse", reloaded.Until)
+	suite.Equal("2026-03-31", until.Format("2006-01-02"))
+}
+
 // ─── CreateImportJob Tests ──────────────────────────────────────────────────
 
 func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_Success() {

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -1751,6 +1751,17 @@ func (suite *RadioImportIntegrationTestSuite) TestGetProvider_Unsupported() {
 	suite.Contains(err.Error(), "unsupported playlist source")
 }
 
+func (suite *RadioImportIntegrationTestSuite) TestGetProvider_Manual() {
+	// PSY-927: 'manual' is a valid source with no automated provider. It must
+	// return its own error (caller skips the station) WITHOUT folding into the
+	// loud "unsupported playlist source" default branch reserved for typos.
+	_, err := suite.radioService.getProvider(catalogm.PlaylistSourceManual)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "manual")
+	suite.Contains(err.Error(), "no automated provider")
+	suite.NotContains(err.Error(), "unsupported playlist source")
+}
+
 func (suite *RadioImportIntegrationTestSuite) TestGetProvider_KEXP() {
 	provider, err := suite.radioService.getProvider(catalogm.PlaylistSourceKEXP)
 	suite.Require().NoError(err)

--- a/backend/internal/services/catalog/radio_test.go
+++ b/backend/internal/services/catalog/radio_test.go
@@ -238,6 +238,20 @@ func (suite *RadioServiceIntegrationTestSuite) TestCreateStation_InvalidBroadcas
 	suite.Contains(err.Error(), "invalid broadcast type")
 }
 
+func (suite *RadioServiceIntegrationTestSuite) TestCreateStation_InvalidPlaylistSource() {
+	// PSY-927: reject the bad value that broke WFMU import. A valid broadcast
+	// type is supplied so the failure is attributable to playlist_source.
+	bad := "wfmu_html"
+	_, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:           "Bad Source Station",
+		BroadcastType:  catalogm.BroadcastTypeInternet,
+		PlaylistSource: &bad,
+	})
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid playlist source")
+}
+
 func (suite *RadioServiceIntegrationTestSuite) TestCreateStation_UniqueSlugCollision() {
 	suite.createStation("KEXP")
 
@@ -337,6 +351,19 @@ func (suite *RadioServiceIntegrationTestSuite) TestUpdateStation_InvalidBroadcas
 
 	suite.Error(err)
 	suite.Contains(err.Error(), "invalid broadcast type")
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestUpdateStation_InvalidPlaylistSource() {
+	// PSY-927: an existing station can't be updated to the invalid value either.
+	station := suite.createStation("KEXP")
+
+	bad := "wfmu_html"
+	_, err := suite.radioService.UpdateStation(station.ID, &contracts.UpdateRadioStationRequest{
+		PlaylistSource: &bad,
+	})
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid playlist source")
 }
 
 func (suite *RadioServiceIntegrationTestSuite) TestUpdateStation_NotFound() {

--- a/backend/internal/services/catalog/radio_unmatched.go
+++ b/backend/internal/services/catalog/radio_unmatched.go
@@ -423,14 +423,20 @@ func (s *RadioService) ReMatchUnmatched() (*contracts.MatchResult, error) {
 	return matcher.MatchAllUnmatched()
 }
 
-// GetActiveStationsWithPlaylistSource returns all active stations that have a playlist_source set.
+// GetActiveStationsWithPlaylistSource returns all active stations that have an
+// AUTOMATED playlist provider (an actual scraper/API source). 'manual'
+// (hand-curated, no provider) and empty/NULL (link-only) are excluded so the
+// scheduled discover/fetch cycle never dispatches a station getProvider can't
+// serve — which would otherwise log a permanent failure and trip the circuit
+// breaker every cycle for a deliberately-configured manual station. (PSY-927)
 func (s *RadioService) GetActiveStationsWithPlaylistSource() ([]catalogm.RadioStation, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
 	var stations []catalogm.RadioStation
-	err := s.db.Where("is_active = TRUE AND playlist_source IS NOT NULL AND playlist_source != ''").
+	err := s.db.
+		Where("is_active = TRUE AND playlist_source IS NOT NULL AND playlist_source != '' AND playlist_source != ?", catalogm.PlaylistSourceManual).
 		Find(&stations).Error
 	if err != nil {
 		return nil, fmt.Errorf("querying active stations: %w", err)


### PR DESCRIPTION
Closes PSY-927.

## Summary
Every WFMU show on the Radio page was importing **0 tracks**. Root-caused via local repro to **two independent bugs**, both required for WFMU playlists to import:

- **Invalid `playlist_source` data.** The WFMU flagship station had `playlist_source='wfmu_html'` — a value no provider handles, so `getProvider()` errored and nothing imported (discovery created the episode shells; the playlist fetch died). The seed set `wfmu_scrape`; `wfmu_html` was an unvalidated runtime write. A **data migration** restores `wfmu_scrape`, `IsValidPlaylistSource` now **validates** the field on station create/update so an invalid value can't be persisted again, and `getProvider` **logs unrecognized sources at ERROR** so a misconfig is visible instead of silently zeroing out tracks.
- **Auto-backfill date round-trip.** `since`/`until` persist in Postgres DATE columns and round-trip through GORM as `"2026-03-02T00:00:00Z"`, which `importShowEpisodesWithProgress` parsed with a date-only layout → **every auto-backfill job failed** (affects all providers, also explains KEXP's 0 plays). Extracted `parseImportDate` to normalize first, reusing the existing `normalizeDateString`.

## Verification (local repro)
- **Before:** WFMU station = 0 episodes / 0 plays; backfill jobs failed with `invalid since date "2026-03-02T00:00:00Z": … extra text "T00:00:00Z"`.
- **After** the data fix + date fix: discovery succeeded (572 shows), and the async import-job for the **Feelings** show completed — `episodes_imported=8, plays_imported=249`. WFMU now has **249 plays** where it had 0.

## Adversarial review
`/adversarial-review` — 2-round panel; CONCERNS, all addressed in commit `5c7f42ee`. **Security lens CLEAN.**
- [MEDIUM] A `manual` station would be pulled into the scheduled cycle and trip the circuit breaker (getProvider can't serve it); the getProvider `manual` comment over-promised. → Excluded `manual` from `GetActiveStationsWithPlaylistSource` (no automated provider ⇒ never auto-scheduled; correct semantics) + made the comment honest.
- [MEDIUM] The date fix was tested only at the helper (hard-coded `T00:00:00Z`). → Added a DB-backed test that persists a job and asserts the reloaded `since`/`until` parse (locks the GORM round-trip premise against a future driver change).
- [LOW] getProvider `manual` branch untested → `TestGetProvider_Manual`.
- [LOW] Migration comment overstated recurrence-prevention (only the API write path is guarded) → softened to "API-side validation … on that path".
Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/services/catalog/ ./internal/models/catalog/` — clean
- [x] `go test ./internal/services/catalog/... ./internal/models/catalog/...` — pass (testcontainers; runs all migrations incl. the new one)
- [x] New tests: `TestParseImportDate` (incl. the `T00:00:00Z` round-trip form), `TestIsValidPlaylistSource_{Valid,Invalid}` (rejects `wfmu_html`), `TestCreateStation_InvalidPlaylistSource` + `TestUpdateStation_InvalidPlaylistSource` (end-to-end rejection), `TestImportJob_PersistedDatesParse` (DB round-trip), `TestGetProvider_Manual`
- [x] Migration reversibility round-trip locally (`up → down -all → up` on a throwaway DB) — version `20260531202754`, not dirty; mirrors the CI `migration-reversibility` guard
- [x] `/code-review` — 2 fixes applied (manual getProvider case + e2e rejection tests); kept the canonical `IsValidBroadcastType` pattern
- [x] `/adversarial-review` — 2 rounds; CONCERNS addressed; fixes in separate commit `5c7f42ee`
- [x] `/psy-self-review` — 3 agents; all 8 test-plan items evidence-PASS, convention CLEAN (64-char title, `Closes` + Adversarial + Coverage sections present). One coverage note folded in below.
- [x] Manual repro: async import-job for the Feelings show completed → 249 tracks imported across 8 episodes (was 0)

## Coverage gaps
- **Frontend not screenshotted.** This is a backend fix; verified empirically via the import-job result + DB counts (249 tracks). The stage Radio page populates on deploy — the migration corrects the row and the date fix lets the scheduled auto-backfill complete.
- **Full historical backfill not run here.** Only the Feelings show was manually imported during verification; in production the scheduled discover→auto-backfill now completes for all WFMU shows (it was failing on the date bug before). Historical playlists can be backfilled separately as needed.
- **`manual` station path** has no live data (no `manual` stations exist today). The scheduler exclusion is enforced by the SQL clause in `GetActiveStationsWithPlaylistSource` (no test asserts the query-level exclusion itself); the getProvider `manual` branch is unit-tested (`TestGetProvider_Manual`). No end-to-end manual-station run.
- **getProvider ERROR log** on a truly-unrecognized `playlist_source` is asserted via getProvider's returned error, not by capturing log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
