### PR TITLE
PSY-929: allow x-vercel-protection-bypass in non-prod CORS

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -174,8 +174,11 @@ func main() {
 			}
 			return false
 		},
-		AllowedMethods:   cfg.CORS.AllowedMethods,
-		AllowedHeaders:   cfg.CORS.AllowedHeaders,
+		AllowedMethods: cfg.CORS.AllowedMethods,
+		// Non-prod also allows the Lighthouse perf gate's Vercel SSO
+		// bypass header so its cross-origin API calls pass preflight
+		// (PSY-929). Prod stays tight — see config.CORSAllowedHeaders.
+		AllowedHeaders:   config.CORSAllowedHeaders(cfg.CORS.AllowedHeaders, isProduction),
 		AllowCredentials: cfg.CORS.AllowCredentials,
 		MaxAge:           300,           // Cache preflight for 5 minutes
 		Debug:            !isProduction, // Only enable debug logging in development

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -154,37 +154,11 @@ func main() {
 	log.Printf("CORS Configuration: Origins=%v, Methods=%v, Headers=%v, Credentials=%v",
 		cfg.CORS.AllowedOrigins, cfg.CORS.AllowedMethods, cfg.CORS.AllowedHeaders, cfg.CORS.AllowCredentials)
 
-	// Create a map for fast origin lookup
-	allowedOriginsMap := make(map[string]bool)
-	for _, origin := range cfg.CORS.AllowedOrigins {
-		allowedOriginsMap[origin] = true
-	}
-
-	// CORS middleware with dynamic origin validation
-	corsMiddleware := cors.New(cors.Options{
-		AllowOriginFunc: func(r *http.Request, origin string) bool {
-			// Check explicit allowed origins (from CORS_ALLOWED_ORIGINS or env defaults)
-			if allowedOriginsMap[origin] {
-				return true
-			}
-			// Allow Vercel preview deployments only in non-production environments.
-			// For production, add specific preview URLs to CORS_ALLOWED_ORIGINS instead.
-			if !isProduction && strings.HasSuffix(origin, ".vercel.app") {
-				return true
-			}
-			return false
-		},
-		AllowedMethods: cfg.CORS.AllowedMethods,
-		// Non-prod also allows the Lighthouse perf gate's Vercel SSO
-		// bypass header so its cross-origin API calls pass preflight
-		// (PSY-929). Prod stays tight — see config.CORSAllowedHeaders.
-		AllowedHeaders:   config.CORSAllowedHeaders(cfg.CORS.AllowedHeaders, isProduction),
-		AllowCredentials: cfg.CORS.AllowCredentials,
-		MaxAge:           300,           // Cache preflight for 5 minutes
-		Debug:            !isProduction, // Only enable debug logging in development
-	})
-
-	router.Use(corsMiddleware.Handler)
+	// CORS middleware with dynamic origin validation. Construction is
+	// extracted to newCORSMiddleware so the preflight contract — notably
+	// that non-prod echoes the Lighthouse x-vercel-protection-bypass header
+	// (PSY-929) — is unit-testable.
+	router.Use(newCORSMiddleware(cfg.CORS, isProduction).Handler)
 
 	// Add security headers middleware
 	// Adds headers like X-Content-Type-Options, X-Frame-Options, CSP, HSTS (in production)
@@ -358,6 +332,43 @@ func main() {
 	}
 
 	log.Println("Server gracefully stopped.")
+}
+
+// newCORSMiddleware builds the chi CORS middleware from the configured
+// allowlists. Extracted from main() so the preflight behaviour is
+// unit-testable end-to-end (cmd/server/main_test.go) rather than only the
+// CORSAllowedHeaders helper in isolation: a wiring drop or a go-chi/cors
+// version bump that stopped echoing the Lighthouse bypass header would slip
+// past a helper-only test and silently re-break the /explore gate (PSY-929).
+func newCORSMiddleware(corsCfg config.CORSConfig, isProduction bool) *cors.Cors {
+	// Map for fast origin lookup against the explicit allowlist.
+	allowedOriginsMap := make(map[string]bool)
+	for _, origin := range corsCfg.AllowedOrigins {
+		allowedOriginsMap[origin] = true
+	}
+
+	return cors.New(cors.Options{
+		AllowOriginFunc: func(r *http.Request, origin string) bool {
+			// Check explicit allowed origins (from CORS_ALLOWED_ORIGINS or env defaults)
+			if allowedOriginsMap[origin] {
+				return true
+			}
+			// Allow Vercel preview deployments only in non-production environments.
+			// For production, add specific preview URLs to CORS_ALLOWED_ORIGINS instead.
+			if !isProduction && strings.HasSuffix(origin, ".vercel.app") {
+				return true
+			}
+			return false
+		},
+		AllowedMethods: corsCfg.AllowedMethods,
+		// Non-prod also allows the Lighthouse perf gate's Vercel SSO
+		// bypass header so its cross-origin API calls pass preflight
+		// (PSY-929). Prod stays tight — see config.CORSAllowedHeaders.
+		AllowedHeaders:   config.CORSAllowedHeaders(corsCfg.AllowedHeaders, isProduction),
+		AllowCredentials: corsCfg.AllowCredentials,
+		MaxAge:           300,           // Cache preflight for 5 minutes
+		Debug:            !isProduction, // Only enable debug logging in development
+	})
 }
 
 // Helper function (you can move this to config package if you prefer)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/cors"
+
+	"psychic-homily-backend/internal/config"
+)
+
+// firePreflight drives a real CORS preflight (OPTIONS + Access-Control-Request-*)
+// through the constructed middleware and returns the response, so the tests
+// assert the bytes a browser would actually see rather than re-implementing the
+// go-chi/cors decision logic.
+func firePreflight(t *testing.T, mw *cors.Cors, origin, reqHeaders string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodOptions, "/explore/upcoming-shows", nil)
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	req.Header.Set("Access-Control-Request-Headers", reqHeaders)
+
+	rec := httptest.NewRecorder()
+	handler := mw.Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	handler.ServeHTTP(rec, req)
+	return rec.Result()
+}
+
+func allowHeadersContains(resp *http.Response, header string) bool {
+	got := strings.ToLower(resp.Header.Get("Access-Control-Allow-Headers"))
+	return strings.Contains(got, strings.ToLower(header))
+}
+
+// TestNewCORSMiddlewarePreflight is the gate-critical behavioural contract for
+// PSY-929: it proves the WIRED middleware (not just the CORSAllowedHeaders
+// helper) echoes the Lighthouse x-vercel-protection-bypass header on a real
+// preflight in non-prod and withholds it in prod. A wiring drop in
+// newCORSMiddleware or a go-chi/cors bump that changed preflight echoing would
+// fail here even though the helper unit test still passed — which is exactly
+// how the /explore gate silently broke before.
+func TestNewCORSMiddlewarePreflight(t *testing.T) {
+	corsCfg := config.CORSConfig{
+		AllowedOrigins:   []string{"https://app.example.com"},
+		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		AllowCredentials: true,
+	}
+	const previewOrigin = "https://psychic-homily-abc123-matts-projects.vercel.app"
+
+	t.Run("non-prod preflight echoes the bypass header for a preview origin", func(t *testing.T) {
+		mw := newCORSMiddleware(corsCfg, false)
+		resp := firePreflight(t, mw, previewOrigin, config.LighthouseBypassHeader)
+
+		if !allowHeadersContains(resp, config.LighthouseBypassHeader) {
+			t.Errorf("non-prod preflight must echo %q in Access-Control-Allow-Headers; got %q",
+				config.LighthouseBypassHeader, resp.Header.Get("Access-Control-Allow-Headers"))
+		}
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != previewOrigin {
+			t.Errorf("non-prod preflight must allow the preview origin; Access-Control-Allow-Origin = %q, want %q", got, previewOrigin)
+		}
+	})
+
+	t.Run("prod preflight withholds the bypass header (browser would block)", func(t *testing.T) {
+		mw := newCORSMiddleware(corsCfg, true)
+		// Use an explicitly allowed origin so this isolates the HEADER decision
+		// from the origin decision: the request fails only because the bypass
+		// header is not allow-listed in prod.
+		resp := firePreflight(t, mw, "https://app.example.com", config.LighthouseBypassHeader)
+
+		if allowHeadersContains(resp, config.LighthouseBypassHeader) {
+			t.Errorf("prod preflight must NOT echo %q; got %q",
+				config.LighthouseBypassHeader, resp.Header.Get("Access-Control-Allow-Headers"))
+		}
+	})
+
+	t.Run("prod preflight still works for a normal header", func(t *testing.T) {
+		mw := newCORSMiddleware(corsCfg, true)
+		resp := firePreflight(t, mw, "https://app.example.com", "Content-Type")
+
+		if !allowHeadersContains(resp, "Content-Type") {
+			t.Errorf("prod preflight must still echo Content-Type; got %q", resp.Header.Get("Access-Control-Allow-Headers"))
+		}
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+			t.Errorf("prod preflight must allow the configured origin; got %q", got)
+		}
+	})
+
+	t.Run("prod still rejects unlisted vercel preview origins", func(t *testing.T) {
+		mw := newCORSMiddleware(corsCfg, true)
+		resp := firePreflight(t, mw, previewOrigin, "Content-Type")
+
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("prod must not allow unlisted *.vercel.app origins; Access-Control-Allow-Origin = %q", got)
+		}
+	})
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -355,6 +355,28 @@ func getCORSOrigins() []string {
 	}
 }
 
+// LighthouseBypassHeader is the Vercel SSO automation-bypass header the
+// /explore Lighthouse perf gate (.github/workflows/lighthouse-explore.yml)
+// injects into EVERY request via Lighthouse extraHeaders — including the
+// cross-origin calls to the stage API. Without it in the CORS allowlist
+// those calls fail preflight, the client retries, and the network never
+// goes quiet so TTI blows the budget (PSY-929).
+const LighthouseBypassHeader = "X-Vercel-Protection-Bypass"
+
+// CORSAllowedHeaders returns the configured CORS request headers, adding
+// the Lighthouse bypass header in NON-production only. Production stays
+// tight — real clients never send that header, so it must not widen the
+// prod allowlist (mirrors the !isProduction `.vercel.app` origin guard in
+// cmd/server/main.go). Does not mutate base.
+func CORSAllowedHeaders(base []string, isProduction bool) []string {
+	if isProduction {
+		return base
+	}
+	out := make([]string, len(base), len(base)+1)
+	copy(out, base)
+	return append(out, LighthouseBypassHeader)
+}
+
 // getWebAuthnRPID returns the WebAuthn Relying Party ID based on environment
 func getWebAuthnRPID() string {
 	if rpID := os.Getenv(EnvWebAuthnRPID); rpID != "" {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -86,8 +86,8 @@ func TestGetEnvAsInt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up environment variable
 			if tt.envValue != "" {
-				os.Setenv(tt.envKey, tt.envValue)         //nolint:errcheck // test setup; failure would manifest as test failure below
-				defer os.Unsetenv(tt.envKey)              //nolint:errcheck // test teardown best-effort
+				os.Setenv(tt.envKey, tt.envValue) //nolint:errcheck // test setup; failure would manifest as test failure below
+				defer os.Unsetenv(tt.envKey)      //nolint:errcheck // test teardown best-effort
 			} else {
 				// Ensure the environment variable is not set
 				os.Unsetenv(tt.envKey) //nolint:errcheck // test teardown best-effort
@@ -738,6 +738,36 @@ func TestLoad(t *testing.T) {
 		_, err := Load()
 		if err == nil {
 			t.Error("expected validation error for production with placeholder secrets, got nil")
+		}
+	})
+}
+
+func TestCORSAllowedHeaders(t *testing.T) {
+	base := []string{"Accept", "Content-Type"}
+	contains := func(s []string, v string) bool {
+		for _, x := range s {
+			if x == v {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("non-production includes the Lighthouse bypass header", func(t *testing.T) {
+		got := CORSAllowedHeaders(base, false)
+		if !contains(got, LighthouseBypassHeader) {
+			t.Errorf("non-prod CORS headers must include %q; got %v", LighthouseBypassHeader, got)
+		}
+		// base must not be mutated by the append.
+		if len(base) != 2 || base[0] != "Accept" || base[1] != "Content-Type" {
+			t.Errorf("base slice was mutated: %v", base)
+		}
+	})
+
+	t.Run("production excludes the bypass header", func(t *testing.T) {
+		got := CORSAllowedHeaders(base, true)
+		if contains(got, LighthouseBypassHeader) {
+			t.Errorf("prod CORS headers must NOT include %q; got %v", LighthouseBypassHeader, got)
 		}
 	})
 }


### PR DESCRIPTION
Closes PSY-929.

Fixes the `/explore` Lighthouse perf gate (`.github/workflows/lighthouse-explore.yml`), which was flaking/failing on a **CORS instrumentation artifact — not a real perf regression**. (Surfaced while shipping PSY-840, which merged on the evidence below; this PR stops the gate flaking on *every* future `/explore` PR.)

## Root cause

The gate injects `x-vercel-protection-bypass` into Lighthouse's `extraHeaders` to clear Vercel SSO on the **preview frontend**. Lighthouse applies that header to **every** request, including the cross-origin calls to the **stage API** (`stage.api.psychichomily.com`). A custom request header forces a CORS preflight that requires the header in the backend's `Access-Control-Allow-Headers` — which it wasn't (the list is a hardcoded default in `config.go`). So the preflight returns 200 with **no** `Access-Control-Allow-Origin`/`Access-Control-Allow-Headers`, the browser blocks the API GETs (`status=-1` in the trace), TanStack Query retries 3–4× ~2s apart, and the network never goes quiet → Lighthouse TTI lands at 7–9s instead of ~2s.

Real users never send that header, so **production is unaffected** — this is purely the gate measuring a preview whose own client API calls are CORS-blocked.

### Evidence (curl against stage, today)

```
# preflight requesting the bypass header → NO access-control-allow-headers / allow-origin → browser blocks
OPTIONS stage.api.psychichomily.com  (Access-Control-Request-Headers: x-vercel-protection-bypass)  → 200, no ACAH/ACAO
# preflight requesting only content-type → echoed → passes
OPTIONS stage.api.psychichomily.com  (Access-Control-Request-Headers: content-type)               → 200, ACAH: Content-Type
```

## The fix

- `config.CORSAllowedHeaders(base, isProduction)` appends `X-Vercel-Protection-Bypass` to the allowed request headers **in non-production only**. Production stays tight — it reuses the same `isProduction` boundary that already gates the `.vercel.app` origin wildcard in `cmd/server/main.go`, so the prod CORS allowlist is **not** widened. The base slice is not mutated.
- The inline CORS construction in `main()` is extracted to `newCORSMiddleware(corsCfg, isProduction)` (behaviour-identical) so the preflight contract is unit-testable end-to-end.

## Validation — out of band (please read before merging)

This is a **backend-only** change, so:

- The `lighthouse-explore` gate **does not run on this PR** (it triggers on `frontend/**`), and there is no backend-deploy workflow in-repo. **Green CI here does not prove the gate fix** — the change is inert until it's merged and **stage is redeployed**.
- After stage redeploys, confirm with the same curl (should now echo the header):
  ```
  curl -sS -D - -o /dev/null -X OPTIONS https://stage.api.psychichomily.com/shows/cities \
    -H 'Origin: https://psychic-homily-<hash>-matts-projects.vercel.app' \
    -H 'Access-Control-Request-Method: GET' \
    -H 'Access-Control-Request-Headers: x-vercel-protection-bypass'
  # expect: access-control-allow-headers: ...,X-Vercel-Protection-Bypass and an access-control-allow-origin echoing the preview origin
  ```
  Then re-run any `/explore` PR's Lighthouse gate to confirm it settles (warm TTI was already ~2030ms; removing the retry storm should hold the median under budget).

## Adversarial review

`/code-review` returned CLEAN. `/adversarial-review` (Security · Saboteur · Completeness) returned CONCERNS — Security + Saboteur CLEAN (runtime-verified prod stays tight, slice-safe, case-insensitive match), Completeness raised two items, both addressed in a separate commit (`cfc741ad`):

- **[LOW]** helper-only test couldn't catch a wiring drop or a `go-chi/cors` bump → added `cmd/server/main_test.go`, which drives **real preflight `OPTIONS` requests through the wired middleware**.
- **[MEDIUM]** PR can't self-validate in CI → documented above.

## Test plan

- [x] `gofmt` clean on all touched files
- [x] `go vet ./cmd/server/... ./internal/config/...` clean
- [x] `go build ./...` clean (whole graph)
- [x] `go test ./internal/config/...` — `TestCORSAllowedHeaders` (non-prod includes header / prod excludes / base not mutated), full package green
- [x] `go test ./cmd/server/...` — `TestNewCORSMiddlewarePreflight` (non-prod echoes bypass header for a preview origin · prod withholds it · prod still echoes a normal header · prod still rejects unlisted `*.vercel.app` origins), full package green
- [x] `/code-review` CLEAN · `/adversarial-review` CONCERNS → fixed in `cfc741ad`
- [ ] **Out-of-band:** stage redeploy + curl re-check + `/explore` gate re-run (see above) — cannot run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
