### PR TITLE
PSY-928: dedup ?cities= URL helpers onto shared cityParams

### DIFF
--- a/frontend/components/filters/cityParams.ts
+++ b/frontend/components/filters/cityParams.ts
@@ -8,11 +8,12 @@ import type { CityState } from './CityFilters'
  * between pairs; each segment must be exactly city,state, matching the
  * /explore backend parser in handlers/explore/explore.go.
  *
- * Duplication: ShowList, VenueList, and ArtistList keep local
- * parse+build copies; useShows keeps a local buildCitiesParam;
- * HomeShowList keeps a local citiesEqual (it holds selection in
- * component state, not the URL). PSY-928 tracks migrating all of them
- * onto these shared exports so the wire format has one definition.
+ * Single source of truth for the `?cities=` wire format (PSY-928):
+ * every surface that reads or writes the param — the shows/venues/
+ * artists list components and their data hooks, HomeShowList, and
+ * /explore's UpcomingShowsList — imports these, so a format change
+ * lands in exactly one place. (The local CityState *type* is still
+ * duplicated in useVenues + SaveDefaultsButton — separate follow-up.)
  */
 
 /** Parse the `?cities=` param ("Phoenix,AZ|Mesa,AZ") into typed pairs.

--- a/frontend/features/artists/components/ArtistList.tsx
+++ b/frontend/features/artists/components/ArtistList.tsx
@@ -6,6 +6,7 @@ import { useArtists, useArtistCities } from '../hooks/useArtists'
 import { ArtistCard } from './ArtistCard'
 import { ArtistSearch } from './ArtistSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
+import { parseCitiesParam, buildCitiesParam } from '@/components/filters/cityParams'
 import { LoadingSpinner, DensityToggle } from '@/components/shared'
 import { useDensity } from '@/lib/hooks/common/useDensity'
 import { Button } from '@/components/ui/button'
@@ -15,23 +16,6 @@ import {
   parseTagsParam,
   buildTagsParam,
 } from '@/features/tags'
-
-/** Parse cities param from URL: "Phoenix,AZ|Mesa,AZ" -> CityState[] */
-function parseCitiesParam(param: string | null): CityState[] {
-  if (!param) return []
-  return param
-    .split('|')
-    .map(pair => {
-      const [city, state] = pair.split(',')
-      return city && state ? { city: city.trim(), state: state.trim() } : null
-    })
-    .filter((c): c is CityState => c !== null)
-}
-
-/** Build cities param for URL: CityState[] -> "Phoenix,AZ|Mesa,AZ" */
-function buildCitiesParam(cities: CityState[]): string {
-  return cities.map(c => `${c.city},${c.state}`).join('|')
-}
 
 export function ArtistList() {
   const router = useRouter()

--- a/frontend/features/artists/hooks/useArtists.ts
+++ b/frontend/features/artists/hooks/useArtists.ts
@@ -10,6 +10,7 @@ import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest } from '@/lib/api'
 import { createNamedDetailHook } from '@/lib/hooks/factories'
 import { artistEndpoints, artistQueryKeys } from '@/features/artists/api'
+import { buildCitiesParam } from '@/components/filters/cityParams'
 import type { CityState } from '@/components/filters'
 import type {
   Artist,
@@ -36,7 +37,7 @@ export function useArtists(options: UseArtistsOptions = {}) {
   // Build query params
   const params = new URLSearchParams()
   if (cities && cities.length > 0) {
-    params.set('cities', cities.map(c => `${c.city},${c.state}`).join('|'))
+    params.set('cities', buildCitiesParam(cities))
   }
   if (tags && tags.length > 0) {
     params.set('tags', tags.join(','))

--- a/frontend/features/shows/components/HomeShowList.tsx
+++ b/frontend/features/shows/components/HomeShowList.tsx
@@ -11,14 +11,8 @@ import type { ShowResponse } from '../types'
 import type { CityState } from '@/components/filters'
 import { ShowCard } from './ShowCard'
 import { CityFilters, type CityWithCount } from '@/components/filters'
+import { citiesEqual } from '@/components/filters/cityParams'
 import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
-
-/** Compare two city arrays for equality (order-insensitive) */
-function citiesEqual(a: CityState[], b: CityState[]): boolean {
-  if (a.length !== b.length) return false
-  const setA = new Set(a.map(c => `${c.city}|${c.state}`))
-  return b.every(c => setA.has(`${c.city}|${c.state}`))
-}
 
 export function HomeShowList() {
   const { user, isAuthenticated } = useAuthContext()

--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -16,6 +16,11 @@ import { useDensity } from '@/lib/hooks/common/useDensity'
 import { ShowCard } from './ShowCard'
 import { ShowListSkeleton } from './ShowListSkeleton'
 import { CityFilters, type CityWithCount } from '@/components/filters'
+import {
+  parseCitiesParam,
+  buildCitiesParam,
+  citiesEqual,
+} from '@/components/filters/cityParams'
 import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
 import {
   TagFacetPanel,
@@ -23,30 +28,6 @@ import {
   parseTagsParam,
   buildTagsParam,
 } from '@/features/tags'
-
-/** Parse cities param from URL: "Phoenix,AZ|Mesa,AZ" -> CityState[] */
-function parseCitiesParam(param: string | null): CityState[] {
-  if (!param) return []
-  return param
-    .split('|')
-    .map(pair => {
-      const [city, state] = pair.split(',')
-      return city && state ? { city: city.trim(), state: state.trim() } : null
-    })
-    .filter((c): c is CityState => c !== null)
-}
-
-/** Build cities param for URL: CityState[] -> "Phoenix,AZ|Mesa,AZ" */
-function buildCitiesParam(cities: CityState[]): string {
-  return cities.map(c => `${c.city},${c.state}`).join('|')
-}
-
-/** Compare two city arrays for equality (order-insensitive) */
-function citiesEqual(a: CityState[], b: CityState[]): boolean {
-  if (a.length !== b.length) return false
-  const setA = new Set(a.map(c => `${c.city}|${c.state}`))
-  return b.every(c => setA.has(`${c.city}|${c.state}`))
-}
 
 export function ShowList() {
   const router = useRouter()

--- a/frontend/features/shows/hooks/useShows.ts
+++ b/frontend/features/shows/hooks/useShows.ts
@@ -10,6 +10,7 @@ import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest } from '@/lib/api'
 import { showEndpoints, showQueryKeys } from '@/features/shows/api'
 import type { UpcomingShowsResponse, ShowResponse, ShowCitiesResponse } from '../types'
+import { buildCitiesParam } from '@/components/filters/cityParams'
 
 interface UseUpcomingShowsOptions {
   timezone?: string
@@ -25,13 +26,6 @@ interface UseUpcomingShowsOptions {
   tags?: string[]
   /** Set to 'any' to switch the tag filter to OR semantics. */
   tagMatch?: 'all' | 'any'
-}
-
-/**
- * Build pipe-delimited cities param: "Phoenix,AZ|Mesa,AZ"
- */
-function buildCitiesParam(cities: Array<{ city: string; state: string }>): string {
-  return cities.map(c => `${c.city},${c.state}`).join('|')
 }
 
 /**

--- a/frontend/features/venues/components/VenueList.tsx
+++ b/frontend/features/venues/components/VenueList.tsx
@@ -7,6 +7,7 @@ import type { VenueWithShowCount } from '../types'
 import { VenueCard } from './VenueCard'
 import { VenueSearch } from './VenueSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
+import { parseCitiesParam, buildCitiesParam } from '@/components/filters/cityParams'
 import { LoadingSpinner } from '@/components/shared'
 import { Button } from '@/components/ui/button'
 import {
@@ -17,23 +18,6 @@ import {
 } from '@/features/tags'
 
 const VENUES_PER_PAGE = 50
-
-/** Parse cities param from URL: "Phoenix,AZ|Tucson,AZ" -> CityState[] */
-function parseCitiesParam(param: string | null): CityState[] {
-  if (!param) return []
-  return param
-    .split('|')
-    .map(pair => {
-      const [city, state] = pair.split(',')
-      return city && state ? { city: city.trim(), state: state.trim() } : null
-    })
-    .filter((c): c is CityState => c !== null)
-}
-
-/** Build cities param for URL: CityState[] -> "Phoenix,AZ|Tucson,AZ" */
-function buildCitiesParam(cities: CityState[]): string {
-  return cities.map(c => `${c.city},${c.state}`).join('|')
-}
 
 export function VenueList() {
   const router = useRouter()

--- a/frontend/features/venues/hooks/useVenues.ts
+++ b/frontend/features/venues/hooks/useVenues.ts
@@ -10,6 +10,7 @@ import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest } from '@/lib/api'
 import { createNamedDetailHook } from '@/lib/hooks/factories'
 import { venueEndpoints, venueQueryKeys } from '@/features/venues/api'
+import { buildCitiesParam } from '@/components/filters/cityParams'
 import type {
   Venue,
   VenuesListResponse,
@@ -46,8 +47,7 @@ export const useVenues = (options: UseVenuesOptions = {}) => {
   // Build query params
   const params = new URLSearchParams()
   if (cities && cities.length > 0) {
-    // Multi-city filter: "Phoenix,AZ|Tucson,AZ"
-    params.set('cities', cities.map(c => `${c.city},${c.state}`).join('|'))
+    params.set('cities', buildCitiesParam(cities))
   } else {
     if (state) params.set('state', state)
     if (city) params.set('city', city)


### PR DESCRIPTION
Closes PSY-928.

The `?cities=` URL wire format (`Phoenix,AZ|Mesa,AZ`) had its parse/build/equal helpers copy-pasted across the shows/venues/artists list components, `HomeShowList`, and the shows/venues/artists data hooks — so a format change had to land in 7+ places or the surfaces would silently disagree.

## What changed

- Deleted every local copy of `parseCitiesParam` / `buildCitiesParam` / `citiesEqual` and imported the canonical versions from **`@/components/filters/cityParams`** (the pure module, not the `@/components/filters` barrel).
  - Importing the pure module keeps the cmdk/Radix-heavy `CityFilters` component out of the data hooks' graph, and stops component mocks in tests from stubbing the pure helpers. This matches the existing **PSY-840 `UpcomingShowsList`** precedent.
- After grep + `/code-review`, the helper functions are now defined in **exactly one place** (`cityParams.ts`):
  ```
  grep -rn -E "(function|const)\s+(parseCitiesParam|buildCitiesParam|citiesEqual)\b" frontend/ --include="*.ts" --include="*.tsx"
  # → only frontend/components/filters/cityParams.ts
  ```

## Scope note — two extra sites folded in

The ticket enumerated 5 sites via a *named-function* grep, which missed two **inline** copies of the same encoder in sibling data hooks: `useVenues.ts` and `useArtists.ts` (`cities.map(c => \`${c.city},${c.state}\`).join('|')`). `/code-review` surfaced them; since they're the identical wire format and the whole point is one definition, they're migrated here too (the alternative — leaving them — would make the module's own "single source of truth" docstring false).

## Behaviour note (intentional convergence)

`/shows`, `/venues`, `/artists` now parse `?cities=` with the canonical **strict** parser (each segment must be exactly `city,state`), matching `/explore` and the backend `explore.go` parser. For real `City,ST` data this is identical. The only difference is a malformed `City,ST,extra` segment: previously partially parsed (first two parts), now dropped — which matches the backend. Every `?cities=` value the app emits comes from `buildCitiesParam`, which only ever produces `city,state`, so round-tripped URLs are unaffected.

## Out of scope (follow-up)

The local `CityState` **type** is still duplicated (`useVenues.ts`, `SaveDefaultsButton.tsx`) — a separate type-dedup, noted in the `cityParams.ts` docstring. Not folded in here to keep this PR a function-dedup.

## Review

`/code-review` ran two focused reviewers (proportionate to a +19/−80 mechanical dedup):
- **Correctness — CLEAN.** Strict-parser convergence verified safe against the backend parser; `useShows`/`useVenues`/`useArtists` type compatibility confirmed (all type `cities: CityState[]`, structurally `{city,state}`); no orphaned calls; import boundary clean (pure module, no `'use client'`).
- **Cleanup — CONCERNS → addressed** (the two inline hook encoders above).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test:run features/shows features/venues features/artists features/explore components/filters` — **824/824 pass** (76 files)
- [x] grep AC: the three helpers are defined only in `cityParams.ts`; no inline `?cities=` encoders remain (the `notifications/types.ts` `, `/`; ` map is a human-readable display string, not the wire format)
- [x] `/code-review` (2 reviewers) — correctness CLEAN, cleanup CONCERNS fixed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
