### PR TITLE
PSY-911: AdminFormLayout + migrate Radio Create Station to a Sheet

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.reset.test.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.reset.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// CreateStationForm calls useCreateRadioStation; stub just that hook so the form
+// renders without a real mutation/QueryClient. Other module exports load as-is.
+vi.mock('@/lib/hooks/admin/useAdminRadio', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/hooks/admin/useAdminRadio')>()
+  return {
+    ...actual,
+    useCreateRadioStation: () => ({ mutate: vi.fn(), isPending: false }),
+  }
+})
+
+import { CreateStationForm } from './RadioManagement'
+
+const noop = () => {}
+
+function open(rerender: (ui: React.ReactElement) => void, isOpen: boolean) {
+  rerender(
+    <CreateStationForm open={isOpen} onOpenChange={noop} onSuccess={noop} />
+  )
+}
+
+describe('CreateStationForm reset-on-open (PSY-911)', () => {
+  it('clears entered field values when the Sheet is closed and reopened', () => {
+    const { rerender } = render(
+      <CreateStationForm open={false} onOpenChange={noop} onSuccess={noop} />
+    )
+
+    // Open, type a value.
+    open(rerender, true)
+    const name = () => screen.getByLabelText('Name *') as HTMLInputElement
+    fireEvent.change(name(), { target: { value: 'KEXP' } })
+    expect(name().value).toBe('KEXP') // persists while open (no clobber)
+
+    // Close, then reopen — the form must be blank again, not stale 'KEXP'.
+    open(rerender, false)
+    open(rerender, true)
+    expect(name().value).toBe('')
+    // Defaults restored (not blanked).
+    expect((screen.getByLabelText('Country') as HTMLInputElement).value).toBe(
+      'US'
+    )
+  })
+})

--- a/frontend/app/admin/radio/_components/RadioManagement.submit.test.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.submit.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// Stable mutate spy (module-level) so we can assert the exact payload the form
+// builds. The mock returns the SAME fn across renders — a fresh `vi.fn()` per
+// call (as in the reset test) would lose the recorded args. Other module exports
+// load as-is.
+const mutate = vi.fn()
+vi.mock('@/lib/hooks/admin/useAdminRadio', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/hooks/admin/useAdminRadio')>()
+  return {
+    ...actual,
+    useCreateRadioStation: () => ({ mutate, isPending: false }),
+  }
+})
+
+import { CreateStationForm } from './RadioManagement'
+
+const noop = () => {}
+
+function fill(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } })
+}
+
+// Guards the field-wiring parity claim of the Dialog->Sheet migration (PSY-911):
+// the AdminFormLayout move must not change which keys reach the create mutation,
+// the camelCase->snake_case mapping, the trims, the parseFloat on frequency, or
+// the omit-empty-optionals behaviour.
+describe('CreateStationForm submit payload (PSY-911 field-wiring parity)', () => {
+  beforeEach(() => mutate.mockClear())
+
+  it('maps fields to the snake_case API payload, trims, and omits empty optionals', () => {
+    render(<CreateStationForm open onOpenChange={noop} onSuccess={noop} />)
+
+    fill('Name *', '  KEXP  ') // leading/trailing space -> trimmed
+    fill('Slug (auto if empty)', 'kexp')
+    fill('City', 'Seattle')
+    fill('State', 'WA')
+    // Country is left at its 'US' default (still included — non-empty).
+    fill('Frequency (MHz)', '90.3')
+    fill('Stream URL', 'https://kexp.org/stream')
+
+    fireEvent.click(screen.getByRole('button', { name: /create station/i }))
+
+    expect(mutate).toHaveBeenCalledTimes(1)
+    const [payload] = mutate.mock.calls[0]
+    expect(payload).toEqual({
+      name: 'KEXP', // trimmed
+      broadcast_type: 'both', // Select default
+      slug: 'kexp',
+      city: 'Seattle',
+      state: 'WA',
+      country: 'US', // default retained
+      stream_url: 'https://kexp.org/stream',
+      frequency_mhz: 90.3, // parseFloat -> number, NOT the string '90.3'
+    })
+    expect(typeof payload.frequency_mhz).toBe('number')
+    // Empty optionals are omitted entirely, not sent as ''.
+    expect(payload).not.toHaveProperty('description')
+    expect(payload).not.toHaveProperty('timezone')
+    expect(payload).not.toHaveProperty('website')
+    expect(payload).not.toHaveProperty('donation_url')
+    expect(payload).not.toHaveProperty('logo_url')
+    expect(payload).not.toHaveProperty('playlist_source')
+    expect(payload).not.toHaveProperty('playlist_config')
+  })
+
+  it('blocks submit with a role=alert error when Name is empty (mutate not called)', () => {
+    render(<CreateStationForm open onOpenChange={noop} onSuccess={noop} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /create station/i }))
+
+    expect(mutate).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert')).toHaveTextContent(/name is required/i)
+  })
+})

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -109,7 +109,7 @@ type DialogMode = 'create-station' | 'edit-station' | 'delete-station' | 'create
 // Create Station Form
 // ============================================================================
 
-function CreateStationForm({
+export function CreateStationForm({
   open,
   onOpenChange,
   onSuccess,
@@ -136,6 +136,36 @@ function CreateStationForm({
   const [playlistSource, setPlaylistSource] = useState('')
   const [playlistConfigJson, setPlaylistConfigJson] = useState('')
   const [error, setError] = useState<string | null>(null)
+
+  // Reset the form when the Sheet (re)opens. AdminFormLayout keeps this component
+  // mounted (so the Sheet's close animation can run), so — unlike the old
+  // unmount-on-close Dialog — its state would otherwise persist a prior session's
+  // input (or a just-created station's values) into the next "Add Station".
+  // This is the React "adjust state during render" pattern: resetting here rather
+  // than in an effect avoids a cascading re-render (react-hooks/set-state-in-effect)
+  // and an extra paint. (PSY-911)
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setName('')
+      setSlug('')
+      setDescription('')
+      setCity('')
+      setState('')
+      setCountry('US')
+      setTimezone('')
+      setBroadcastType('both')
+      setFrequencyMHz('')
+      setStreamUrl('')
+      setWebsite('')
+      setDonationUrl('')
+      setLogoUrl('')
+      setPlaylistSource('')
+      setPlaylistConfigJson('')
+      setError(null)
+    }
+  }
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -300,6 +330,12 @@ function CreateStationForm({
 // ============================================================================
 // Edit Station Form
 // ============================================================================
+//
+// NOTE: still on the raw <form> + Dialog pattern. CreateStationForm migrated to
+// AdminFormLayout (Sheet) in PSY-911; the Edit migration is deferred to PSY-930
+// because it loads through EditStationFormWrapper (async detail fetch) and needs
+// careful state-init-on-load handling. Create = Sheet / Edit = Modal is a
+// temporary split until PSY-930 lands.
 
 function EditStationForm({
   station,

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -43,6 +43,11 @@ import {
 } from './playlistSourceSelect'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import {
+  AdminFormLayout,
+  AdminFormRow,
+  AdminFormField,
+} from '@/components/admin/AdminFormLayout'
 import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -105,11 +110,13 @@ type DialogMode = 'create-station' | 'edit-station' | 'delete-station' | 'create
 // ============================================================================
 
 function CreateStationForm({
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const createMutation = useCreateRadioStation()
 
@@ -181,49 +188,56 @@ function CreateStationForm({
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
-      )}
-
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="station-name">Name *</Label>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Add Radio Station"
+      description="Create a new radio station."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={createMutation.isPending}>
+            {createMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create Station
+          </Button>
+        </>
+      }
+    >
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Name *" htmlFor="station-name">
           <Input id="station-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="KEXP" />
-        </div>
-        <div>
-          <Label htmlFor="station-slug">Slug (auto if empty)</Label>
+        </AdminFormField>
+        <AdminFormField label="Slug (auto if empty)" htmlFor="station-slug">
           <Input id="station-slug" value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="kexp" />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div>
-        <Label htmlFor="station-description">Description</Label>
+      <AdminFormField label="Description" htmlFor="station-description">
         <Textarea id="station-description" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Station description..." rows={2} />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-4 gap-4">
-        <div>
-          <Label htmlFor="station-city">City</Label>
+      <AdminFormRow cols={4}>
+        <AdminFormField label="City" htmlFor="station-city">
           <Input id="station-city" value={city} onChange={(e) => setCity(e.target.value)} placeholder="Seattle" />
-        </div>
-        <div>
-          <Label htmlFor="station-state">State</Label>
+        </AdminFormField>
+        <AdminFormField label="State" htmlFor="station-state">
           <Input id="station-state" value={state} onChange={(e) => setState(e.target.value)} placeholder="WA" />
-        </div>
-        <div>
-          <Label htmlFor="station-country">Country</Label>
+        </AdminFormField>
+        <AdminFormField label="Country" htmlFor="station-country">
           <Input id="station-country" value={country} onChange={(e) => setCountry(e.target.value)} placeholder="US" />
-        </div>
-        <div>
-          <Label htmlFor="station-timezone">Timezone</Label>
+        </AdminFormField>
+        <AdminFormField label="Timezone" htmlFor="station-timezone">
           <Input id="station-timezone" value={timezone} onChange={(e) => setTimezone(e.target.value)} placeholder="America/Los_Angeles" />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="station-broadcast-type">Broadcast Type *</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Broadcast Type *" htmlFor="station-broadcast-type">
           <Select value={broadcastType} onValueChange={setBroadcastType}>
             <SelectTrigger id="station-broadcast-type" className="w-full">
               <SelectValue />
@@ -234,38 +248,32 @@ function CreateStationForm({
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div>
-          <Label htmlFor="station-frequency">Frequency (MHz)</Label>
+        </AdminFormField>
+        <AdminFormField label="Frequency (MHz)" htmlFor="station-frequency">
           <Input id="station-frequency" type="number" step="0.1" value={frequencyMHz} onChange={(e) => setFrequencyMHz(e.target.value)} placeholder="90.3" />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="station-stream-url">Stream URL</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Stream URL" htmlFor="station-stream-url">
           <Input id="station-stream-url" value={streamUrl} onChange={(e) => setStreamUrl(e.target.value)} placeholder="https://..." />
-        </div>
-        <div>
-          <Label htmlFor="station-website">Website</Label>
+        </AdminFormField>
+        <AdminFormField label="Website" htmlFor="station-website">
           <Input id="station-website" value={website} onChange={(e) => setWebsite(e.target.value)} placeholder="https://..." />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="station-donation-url">Donation URL</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Donation URL" htmlFor="station-donation-url">
           <Input id="station-donation-url" value={donationUrl} onChange={(e) => setDonationUrl(e.target.value)} placeholder="https://..." />
-        </div>
-        <div>
-          <Label htmlFor="station-logo-url">Logo URL</Label>
+        </AdminFormField>
+        <AdminFormField label="Logo URL" htmlFor="station-logo-url">
           <Input id="station-logo-url" value={logoUrl} onChange={(e) => setLogoUrl(e.target.value)} placeholder="https://..." />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="station-playlist-source">Playlist Source</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Playlist Source" htmlFor="station-playlist-source">
           <Select
             value={toPlaylistSelectValue(playlistSource)}
             onValueChange={(v) => setPlaylistSource(fromPlaylistSelectValue(v))}
@@ -280,21 +288,12 @@ function CreateStationForm({
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div>
-          <Label htmlFor="station-playlist-config">Playlist Config (JSON)</Label>
+        </AdminFormField>
+        <AdminFormField label="Playlist Config (JSON)" htmlFor="station-playlist-config">
           <Input id="station-playlist-config" value={playlistConfigJson} onChange={(e) => setPlaylistConfigJson(e.target.value)} placeholder='{"api_key": "..."}' />
-        </div>
-      </div>
-
-      <DialogFooter>
-        <Button type="button" variant="outline" onClick={onCancel}>Cancel</Button>
-        <Button type="submit" disabled={createMutation.isPending}>
-          {createMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          Create Station
-        </Button>
-      </DialogFooter>
-    </form>
+        </AdminFormField>
+      </AdminFormRow>
+    </AdminFormLayout>
   )
 }
 
@@ -1860,19 +1859,12 @@ export function RadioManagement() {
           )}
         </div>
 
-        {/* Create Station Dialog */}
-        <Dialog open={dialogMode === 'create-station'} onOpenChange={(open) => !open && setDialogMode(null)}>
-          <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle>Add Radio Station</DialogTitle>
-              <DialogDescription>Create a new radio station.</DialogDescription>
-            </DialogHeader>
-            <CreateStationForm
-              onSuccess={() => setDialogMode(null)}
-              onCancel={() => setDialogMode(null)}
-            />
-          </DialogContent>
-        </Dialog>
+        {/* Create Station — right-anchored Sheet (PSY-911 AdminFormLayout) */}
+        <CreateStationForm
+          open={dialogMode === 'create-station'}
+          onOpenChange={(open) => !open && setDialogMode(null)}
+          onSuccess={() => setDialogMode(null)}
+        />
       </TabsContent>
 
       <TabsContent value="matching">

--- a/frontend/components/admin/AdminFormLayout.test.tsx
+++ b/frontend/components/admin/AdminFormLayout.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AdminFormLayout, AdminFormRow, AdminFormField } from './AdminFormLayout'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+function noop() {}
+
+describe('AdminFormLayout', () => {
+  it('renders the sheet variant with title, description, fields, and footer', () => {
+    render(
+      <AdminFormLayout
+        open
+        onOpenChange={noop}
+        title="Add Radio Station"
+        description="Create a new station."
+        onSubmit={(e) => e.preventDefault()}
+        footer={<Button type="submit">Create Station</Button>}
+      >
+        <AdminFormRow cols={2}>
+          <AdminFormField label="Name *" htmlFor="name">
+            <Input id="name" />
+          </AdminFormField>
+        </AdminFormRow>
+      </AdminFormLayout>
+    )
+    expect(screen.getByText('Add Radio Station')).toBeInTheDocument()
+    expect(screen.getByText('Create a new station.')).toBeInTheDocument()
+    expect(screen.getByLabelText('Name *')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Create Station' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the modal variant inside a dialog', () => {
+    render(
+      <AdminFormLayout
+        variant="modal"
+        open
+        onOpenChange={noop}
+        title="Confirm"
+        description="Confirm this action."
+        onSubmit={(e) => e.preventDefault()}
+        footer={<Button type="submit">OK</Button>}
+      >
+        <p>body</p>
+      </AdminFormLayout>
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Confirm')).toBeInTheDocument()
+  })
+
+  it('fires onSubmit when the footer submit button is clicked', () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault())
+    render(
+      <AdminFormLayout
+        open
+        onOpenChange={noop}
+        title="T"
+        description="A form."
+        onSubmit={onSubmit}
+        footer={<Button type="submit">Save</Button>}
+      >
+        <AdminFormField label="X" htmlFor="x">
+          <Input id="x" />
+        </AdminFormField>
+      </AdminFormLayout>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders nothing when closed', () => {
+    render(
+      <AdminFormLayout
+        open={false}
+        onOpenChange={noop}
+        title="Hidden"
+        onSubmit={noop}
+        footer={null}
+      >
+        <p>nope</p>
+      </AdminFormLayout>
+    )
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument()
+  })
+})
+
+describe('AdminFormRow', () => {
+  it('applies the responsive column class for cols={2}', () => {
+    const { container } = render(
+      <AdminFormRow cols={2}>
+        <div>a</div>
+        <div>b</div>
+      </AdminFormRow>
+    )
+    const row = container.firstElementChild as HTMLElement
+    expect(row).toHaveClass('grid', 'grid-cols-1', 'sm:grid-cols-2')
+  })
+
+  it('defaults to a single column (no sm:grid-cols-* class)', () => {
+    const { container } = render(
+      <AdminFormRow>
+        <div>a</div>
+      </AdminFormRow>
+    )
+    const row = container.firstElementChild as HTMLElement
+    expect(row).toHaveClass('grid-cols-1')
+    expect(row.className).not.toContain('sm:grid-cols-')
+  })
+})
+
+describe('AdminFormField', () => {
+  it('renders the label associated with the control via htmlFor', () => {
+    render(
+      <AdminFormField label="Email" htmlFor="email">
+        <Input id="email" />
+      </AdminFormField>
+    )
+    // getByLabelText resolves the label→control association.
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/admin/AdminFormLayout.tsx
+++ b/frontend/components/admin/AdminFormLayout.tsx
@@ -23,11 +23,17 @@ import { cn } from '@/lib/utils'
 /**
  * AdminFormLayout — the canonical scaffold for admin entity create/edit forms
  * (PSY-911). Per the PSY-912 Hybrid decision, long multi-field forms use a
- * right-anchored Sheet (`variant="sheet"`, the default) and short confirm /
- * simple-edit forms use a centered Dialog (`variant="modal"`). Either way the
- * chrome is identical: header (title + optional description), a scrollable form
- * body, and a footer button row pinned to the bottom. The caller supplies the
- * fields (composed with AdminFormRow / AdminFormField) and the footer buttons.
+ * right-anchored Sheet (`variant="sheet"`, the default); the `variant="modal"`
+ * (centered Dialog) path is available for short confirm / simple-edit forms as
+ * they migrate — no admin form consumes it yet. Either way the chrome is
+ * identical: header (title + optional description), a scrollable form body, and
+ * a footer button row pinned to the bottom. The caller supplies the fields
+ * (composed with AdminFormRow / AdminFormField) and the footer buttons.
+ *
+ * This is the admin-CRUD scaffold (plain-useState forms). It is intentionally
+ * separate from EntityEditDrawer (features/contributions/) — the trusted-tier
+ * *suggest-edit* drawer with change-diff preview, a summary field, and trust
+ * routing. Different flow, not a second generic drawer to reconcile (PSY-911).
  */
 export interface AdminFormLayoutProps {
   /** Container shape. Sheet (default) for long forms, Modal for short ones. */

--- a/frontend/components/admin/AdminFormLayout.tsx
+++ b/frontend/components/admin/AdminFormLayout.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Label } from '@/components/ui/label'
+import { InlineErrorBanner } from '@/components/shared'
+import { cn } from '@/lib/utils'
+
+/**
+ * AdminFormLayout — the canonical scaffold for admin entity create/edit forms
+ * (PSY-911). Per the PSY-912 Hybrid decision, long multi-field forms use a
+ * right-anchored Sheet (`variant="sheet"`, the default) and short confirm /
+ * simple-edit forms use a centered Dialog (`variant="modal"`). Either way the
+ * chrome is identical: header (title + optional description), a scrollable form
+ * body, and a footer button row pinned to the bottom. The caller supplies the
+ * fields (composed with AdminFormRow / AdminFormField) and the footer buttons.
+ */
+export interface AdminFormLayoutProps {
+  /** Container shape. Sheet (default) for long forms, Modal for short ones. */
+  variant?: 'sheet' | 'modal'
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: string
+  /** Top-of-form error banner (e.g. a failed submit). */
+  error?: string
+  onSubmit: React.FormEventHandler<HTMLFormElement>
+  /** The footer button row (e.g. Cancel + Submit). Right-aligned on desktop. */
+  footer: React.ReactNode
+  children: React.ReactNode
+  /** Override the container width/size (e.g. "sm:max-w-xl"). */
+  contentClassName?: string
+}
+
+export function AdminFormLayout({
+  variant = 'sheet',
+  open,
+  onOpenChange,
+  title,
+  description,
+  error,
+  onSubmit,
+  footer,
+  children,
+  contentClassName,
+}: AdminFormLayoutProps) {
+  // The form body is container-agnostic: a <form> that fills the remaining
+  // height (min-h-0 + flex-1 so the body can scroll) with the field content
+  // scrolling and the footer pinned to the bottom.
+  const body = (
+    <form onSubmit={onSubmit} className="flex min-h-0 flex-1 flex-col">
+      <div className="flex-1 space-y-4 overflow-y-auto p-4">
+        {error ? <InlineErrorBanner>{error}</InlineErrorBanner> : null}
+        {children}
+      </div>
+      <div className="flex flex-col-reverse gap-2 border-t p-4 sm:flex-row sm:justify-end">
+        {footer}
+      </div>
+    </form>
+  )
+
+  if (variant === 'modal') {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          className={cn(
+            'flex max-h-[90vh] flex-col gap-0 overflow-hidden p-0',
+            contentClassName
+          )}
+        >
+          <DialogHeader className="space-y-1.5 border-b p-4 text-left">
+            <DialogTitle className="pr-10">{title}</DialogTitle>
+            {description ? (
+              <DialogDescription>{description}</DialogDescription>
+            ) : (
+              // Always provide an accessible description so Radix doesn't warn
+              // and screen readers get context even when no visible copy is set.
+              <DialogDescription className="sr-only">{title}</DialogDescription>
+            )}
+          </DialogHeader>
+          {body}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className={cn('flex w-full flex-col gap-0 p-0 sm:max-w-2xl', contentClassName)}
+      >
+        <SheetHeader className="border-b">
+          <SheetTitle className="pr-10">{title}</SheetTitle>
+          {description ? (
+            <SheetDescription>{description}</SheetDescription>
+          ) : (
+            <SheetDescription className="sr-only">{title}</SheetDescription>
+          )}
+        </SheetHeader>
+        {body}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+const ROW_COLS: Record<1 | 2 | 3 | 4, string> = {
+  1: '',
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+  4: 'sm:grid-cols-4',
+}
+
+/**
+ * AdminFormRow — a responsive field grid. One column on mobile; `cols` columns
+ * from the `sm` breakpoint up. Group related fields (e.g. City / State / Country
+ * / Timezone) into a single row.
+ */
+export function AdminFormRow({
+  cols = 1,
+  className,
+  children,
+}: {
+  cols?: 1 | 2 | 3 | 4
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className={cn('grid grid-cols-1 gap-4', ROW_COLS[cols], className)}>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * AdminFormField — a single labelled control. Pass the control (Input / Select /
+ * Textarea / …) as children with an `id` matching `htmlFor`. Include any
+ * required marker in the `label` text.
+ *
+ * Per-field inline errors are intentionally omitted for now: the admin forms
+ * use a single form-level error banner (AdminFormLayout's `error`). When a form
+ * needs field-level validation display, add an `error` prop here that also wires
+ * `aria-invalid` / `aria-describedby` onto the control (don't render an
+ * unassociated <p>).
+ */
+export function AdminFormField({
+  label,
+  htmlFor,
+  className,
+  children,
+}: {
+  label: React.ReactNode
+  htmlFor?: string
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  )
+}

--- a/frontend/components/admin/index.ts
+++ b/frontend/components/admin/index.ts
@@ -15,3 +15,9 @@ export { AdminEmptyState } from './AdminEmptyState'
 export type { AdminEmptyStateProps } from './AdminEmptyState'
 export { CategoryBadge } from './CategoryBadge'
 export type { CategoryBadgeProps, AdminCategoryKind } from './CategoryBadge'
+export {
+  AdminFormLayout,
+  AdminFormRow,
+  AdminFormField,
+} from './AdminFormLayout'
+export type { AdminFormLayoutProps } from './AdminFormLayout'


### PR DESCRIPTION
Closes PSY-911.

## Summary
Realizes the PSY-912 **Hybrid** decision (long entity forms → right-anchored Sheet; short confirm forms → Modal) by building the canonical admin form scaffold and proving it on the densest form:
- **`AdminFormLayout`** (`frontend/components/admin/AdminFormLayout.tsx`) — compound primitive: the layout (`variant="sheet"|"modal"` → DS Sheet or Dialog, with header + scrollable body + footer pinned to the bottom), `AdminFormRow` (responsive 1–4 col grid), `AdminFormField` (Label + control). DS-token bound; composes the DS Input/Select/Textarea. Colocated tests (both variants, submit, closed state, rows, label association).
- **Migrated the Radio Create Station form** (12 fields, 2/4-col grids) from a centered Dialog to a right-anchored Sheet via AdminFormLayout. Field wiring is behavior-preserving — locked by a submit-payload parity test (asserts the exact create-mutation payload: camelCase→snake_case mapping, trims, `parseFloat` on `frequency_mhz`, omit-empty-optionals, empty-Name guard). Cancel routes through `onOpenChange`; the error moves to `InlineErrorBanner` (`role="alert"`).

The `modal` variant is built + tested (per "supports both") but not yet consumed — available for the short-form migrations. AdminFormLayout is intentionally distinct from `EntityEditDrawer` (admin CRUD vs. the trusted-tier suggest-edit drawer with diff preview/summary) — not a second generic drawer.

## Decision (AC #1)
Documented in the **PSY-912** Linear comment (Hybrid: Add/Edit Station, Release, Label, Festival → Sheet; short confirm → Modal; AdminFormLayout supports both). This PR implements it.

## Deferred → PSY-930
EditStation (its async-load `EditStationFormWrapper` needs careful state-init handling) + Release + Label + Festival long forms. Filed **PSY-930**; an in-code marker at `EditStationForm` points to it. Short confirm/delete forms stay Modal.

## Adversarial review
`/adversarial-review` — 2 rounds; BLOCK → resolved in commit `416ac3e4`. Round-2 Saboteur re-verified the fix.
- **[HIGH]** CreateStationForm now stays mounted (AdminFormLayout owns the Sheet, so the close animation runs), so its `useState` persisted across open/close — stale values on reopen, and post-create the next "Add Station" pre-filled the just-created station. Fixed with a reset-on-(re)open via the React "adjust state during render" pattern (not an effect — avoids `react-hooks/set-state-in-effect`), plus a regression test.
- **[CRITICAL]** Tail follow-up wasn't filed → AC #3 unmet. Filed **PSY-930**.
- **[MEDIUM]** EditStation create/edit container split had no in-code marker → added one citing PSY-930. Doc reworded (modal not-yet-consumed; EntityEditDrawer distinction stated).
- **[LOW]** Exported AdminFormLayout/Row/Field from the `components/admin` barrel.
Panel: Saboteur · Future-Maintainer · Completeness (Security N/A — frontend form chrome on already-admin-gated routes).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/admin/AdminFormLayout.test.tsx` — 7/7 (both variants, submit, closed, rows, field/label)
- [x] `bun run test:run app/admin/radio/_components/RadioManagement.reset.test.tsx` — reset-on-open regression (type → close → reopen → blank; `Country` default `US` restored)
- [x] `bun run test:run app/admin/radio/_components/RadioManagement.submit.test.tsx` — 2/2 field-wiring parity (exact mutation payload + empty-Name `role="alert"` guard, mutate not called)
- [x] `bun run test:run components/admin/AdminFormLayout.test.tsx app/admin/radio` — all passing (17 total)
- [x] changed-file ESLint — 0 errors (only 5 pre-existing unused-import warnings)
- [x] `/code-review` — behavior-preservation CLEAN (field-by-field); fixes applied (dropped the unused/un-a11y-wired `error` prop, sr-only description fallback, `pr-10` title to clear the close button)
- [x] `/adversarial-review` — 2 rounds; BLOCK → resolved; fixes in separate commit `416ac3e4`
- [x] `/psy-self-review` — 2 PASS (evidence + convention/asymmetry: 15 useState fields = 15 resets, symmetric a11y, no placeholders); 1 coverage warning (field-wiring claim was review-only) → closed by adding the submit-payload parity test in commit `fbd57b3d`

## Coverage gaps
- **No in-browser screenshot of the Sheet** was captured (a dev server already held :3000; this was a long session). The Dialog→Sheet change is covered by the primitive's 7 tests, the reset regression test, the submit-payload parity test, and the reviewers' analysis of the flex / `min-h-0` scroll / pinned-footer layout. Visual polish is easy to eyeball in review; PSY-930 will exercise the Sheet across the remaining forms.
- **EditStation + Release/Label/Festival** not migrated (deferred → PSY-930; in-code marker at EditStationForm).
- **`modal` variant** has no production consumer yet (test-covered; first consumer arrives with the short-form migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
