### PR TITLE
PSY-932: show city filter with ≥1 city on shows/home/explore

### DIFF
--- a/frontend/features/explore/components/UpcomingShowsList.test.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.test.tsx
@@ -166,8 +166,20 @@ describe('UpcomingShowsList', () => {
     expect(await screen.findByTestId('city-filters')).toBeInTheDocument()
   })
 
-  it('hides the city filter when only one city has shows', () => {
+  it('renders the city filter when one city has shows (PSY-932)', async () => {
     mockShowCities = [{ city: 'Phoenix', state: 'AZ', show_count: 5 }]
+    mockUseExploreUpcomingShows.mockReturnValue({
+      data: sampleResponse,
+      isLoading: false,
+      error: null,
+    })
+    render(<UpcomingShowsList />)
+    // CityFilters is dynamic-imported (ssr:false) — await its async mount.
+    expect(await screen.findByTestId('city-filters')).toBeInTheDocument()
+  })
+
+  it('hides the city filter when no cities have shows', () => {
+    mockShowCities = []
     mockUseExploreUpcomingShows.mockReturnValue({
       data: sampleResponse,
       isLoading: false,

--- a/frontend/features/explore/components/UpcomingShowsList.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.tsx
@@ -42,7 +42,7 @@ import type { CityState, CityWithCount } from '@/components/filters/CityFilters'
 // tree on the critical path, which pushed the TTI gate (error-level,
 // PSY-868) over budget. dynamic(ssr:false) defers the filter's hydration
 // off the initial /explore hydration path; since the bar only appears
-// after the useShowCities fetch resolves (cities.length > 1), the
+// after the useShowCities fetch resolves (cities.length > 0), the
 // deferral is effectively invisible. See PSY-840.
 const CityFilters = dynamic(
   () =>
@@ -139,7 +139,9 @@ export function UpcomingShowsList({ limit = 5 }: UpcomingShowsListProps) {
   )
 
   const filterBar =
-    cities.length > 1 ? (
+    // Show the filter whenever ≥1 city has shows (PSY-932) — consistent with
+    // /venues and /artists; hidden only when there are no cities.
+    cities.length > 0 ? (
       <div className="mb-5">
         <CityFilters
           cities={cities}

--- a/frontend/features/shows/components/HomeShowList.test.tsx
+++ b/frontend/features/shows/components/HomeShowList.test.tsx
@@ -214,7 +214,7 @@ describe('HomeShowList', () => {
       expect(screen.getByTestId('city-filters')).toBeInTheDocument()
     })
 
-    it('hides city filters when only one city', () => {
+    it('shows city filters when one city has shows (PSY-932)', () => {
       mockUseShowCities.mockReturnValue({
         data: {
           cities: [{ city: 'Phoenix', state: 'AZ', show_count: 10 }],
@@ -227,7 +227,7 @@ describe('HomeShowList', () => {
         error: null,
       })
       render(<HomeShowList />)
-      expect(screen.queryByTestId('city-filters')).not.toBeInTheDocument()
+      expect(screen.getByTestId('city-filters')).toBeInTheDocument()
     })
 
     it('hides city filters when no cities', () => {

--- a/frontend/features/shows/components/HomeShowList.tsx
+++ b/frontend/features/shows/components/HomeShowList.tsx
@@ -94,7 +94,9 @@ export function HomeShowList() {
 
   return (
     <div className="w-full">
-      {cities.length > 1 && (
+      {/* Show the filter whenever ≥1 city has shows (PSY-932) — consistent
+          with /venues and /artists; hidden only when there are no cities. */}
+      {cities.length > 0 && (
         <div className="mb-6">
           <CityFilters
             cities={cities}

--- a/frontend/features/shows/components/ShowList.test.tsx
+++ b/frontend/features/shows/components/ShowList.test.tsx
@@ -369,11 +369,31 @@ describe('ShowList', () => {
       expect(screen.getByTestId('city-filters')).toBeInTheDocument()
     })
 
-    it('hides city filters when only one city', () => {
+    it('shows city filters when one city has shows (PSY-932)', () => {
       mockUseShowCities.mockReturnValue({
         data: {
           cities: [{ city: 'Phoenix', state: 'AZ', show_count: 10 }],
         },
+        isLoading: false,
+        isFetching: false,
+      })
+      mockUseUpcomingShows.mockReturnValue({
+        data: {
+          shows: [makeShow()],
+          pagination: { has_more: false, next_cursor: null, limit: 20 },
+        },
+        isLoading: false,
+        isFetching: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+      render(<ShowList />)
+      expect(screen.getByTestId('city-filters')).toBeInTheDocument()
+    })
+
+    it('hides city filters when no cities have shows', () => {
+      mockUseShowCities.mockReturnValue({
+        data: { cities: [] },
         isLoading: false,
         isFetching: false,
       })

--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -191,7 +191,9 @@ export function ShowList() {
 
   return (
     <section className="w-full max-w-6xl">
-      {cities.length > 1 && (
+      {/* Show the filter whenever ≥1 city has shows (PSY-932) — consistent
+          with /venues and /artists; hidden only when there are no cities. */}
+      {cities.length > 0 && (
         <div className="mb-6">
           <CityFilters
             cities={cities}


### PR DESCRIPTION
Closes PSY-932.

## Problem

The `?cities=` city-filter visibility gate was inconsistent across the list surfaces:

- `/venues` + `/artists` → render the filter when `cities.length > 0`
- `/shows` + homepage + `/explore` → required `cities.length > 1`

So on a data set where only one city has upcoming shows (**stage** right now — only Phoenix — or a quiet week in prod), the filter silently disappeared from the shows-family surfaces while staying on venues/artists, and the feature was undiscoverable with a single active city. (Surfaced on stage: `/shows` showed no city filter.)

## Change

Lower the gate from `> 1` to `> 0` on `ShowList` (`/shows`), `HomeShowList` (home), and `UpcomingShowsList` (`/explore`). All five list surfaces now gate identically at `> 0`. Still hidden at 0 cities — a combobox with no options is broken UX. This intentionally revisits PSY-840's `/explore` `> 1` choice for cross-surface consistency.

## Tests

- The three "hides … when only one city" specs flip to assert the filter **renders** with one city (`UpcomingShowsList` uses async `findByTestId` — its `CityFilters` is dynamic-imported).
- Added a "hides with 0 cities" spec to `ShowList` + `UpcomingShowsList` (`HomeShowList` already had one).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test:run features/shows features/explore` — **398/398 pass**
- [x] Gate boundaries covered per surface: 0 cities → hidden · 1 city → shown · ≥2 → shown
- [x] Self-reviewed diff (3 gate flips + stale-comment fix + test updates, +46/−8) — proportionate to a one-condition change; no agent fan-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)
