### PR TITLE
PSY-933: context-aware admin sidebar (retire the 18-tab scroll strip)

### DIFF
--- a/frontend/app/admin/page.test.tsx
+++ b/frontend/app/admin/page.test.tsx
@@ -3,18 +3,19 @@ import { screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 import AdminPage from './page'
 
-// The admin index page (app/admin/page.tsx) is the tabbed shell. It reads the
-// active tab from the URL, gates on the authenticated admin, and lazy-loads
-// each tab's panel via next/dynamic. We mount it with an admin user + the
-// badge-count hooks mocked and assert the console shell + tab bar render, and
-// that the default (dashboard) panel resolves with its stats panels.
+// The admin index page (app/admin/page.tsx) is the tabbed shell. It derives the
+// active section from the URL ?tab= param, gates on the authenticated admin, and
+// lazy-loads each section's panel via next/dynamic. Section navigation now lives
+// in the context-aware Sidebar / mobile drawer (PSY-933), NOT an in-page tab bar.
+// We mount it with an admin user and assert the console shell renders and the
+// default (dashboard) panel resolves with its stats panels.
 //
 // The tab panels are dynamically imported via next/dynamic. We replace it with
 // a component that resolves the loader in an effect and renders the result.
 // (React.lazy would suspend the whole AdminPageContent tree — including the
-// eager tab bar — under the page's single top-level <Suspense>, so the tab bar
-// would not be queryable synchronously. An effect-driven swap keeps the shell
-// eager and resolves each panel asynchronously, matching next/dynamic's shape.)
+// eager shell header — under the page's single top-level <Suspense>, so the
+// header would not be queryable synchronously. An effect-driven swap keeps the
+// shell eager and resolves each panel asynchronously, matching next/dynamic's shape.)
 vi.mock('next/dynamic', async () => {
   const React = await import('react')
   return {
@@ -83,40 +84,13 @@ vi.mock('@/lib/context/AuthContext', () => ({
   }),
 }))
 
-// Badge-count hooks — the shell sums these into the moderation/reports badges.
-const emptyQuery = { data: undefined as unknown }
-
-vi.mock('@/lib/hooks/admin/useAdminVenues', () => ({
-  useUnverifiedVenues: () => emptyQuery,
-}))
-vi.mock('@/lib/hooks/admin/useAdminReports', () => ({
-  usePendingReports: () => emptyQuery,
-}))
-vi.mock('@/lib/hooks/admin/useAdminArtistReports', () => ({
-  usePendingArtistReports: () => emptyQuery,
-}))
-vi.mock('@/lib/hooks/admin/useAdminShows', () => ({
-  usePendingShows: () => emptyQuery,
-}))
-vi.mock('@/lib/hooks/admin/useAdminPendingEdits', () => ({
-  useAdminPendingEdits: () => emptyQuery,
-}))
-vi.mock('@/lib/hooks/admin/useAdminEntityReports', () => ({
-  useAdminEntityReports: () => emptyQuery,
-}))
-vi.mock('@/lib/hooks/admin/useAdminComments', () => ({
-  useAdminPendingComments: () => emptyQuery,
-}))
+// The badge-count hooks moved out of this page to the Sidebar (PSY-933), so the
+// shell no longer imports them — no mocks needed here.
 
 describe('AdminPage (app/admin shell)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSearchParams = new URLSearchParams()
-    // jsdom doesn't implement Element scroll methods. The page's
-    // ScrollableTabBar calls scrollTo/scrollBy from a layout effect to keep the
-    // active tab in view; stub them so those effects don't throw.
-    Element.prototype.scrollTo = vi.fn()
-    Element.prototype.scrollBy = vi.fn()
   })
 
   it('renders the Admin Console header for an authenticated admin', () => {
@@ -127,27 +101,13 @@ describe('AdminPage (app/admin shell)', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders the full tab bar', () => {
+  it('no longer renders an in-page tab bar (nav moved to the context-aware Sidebar, PSY-933)', () => {
     renderWithProviders(<AdminPage />)
 
-    for (const tab of [
-      'Dashboard',
-      'Moderation',
-      'Pending Shows',
-      'Unverified Venues',
-      'Reports',
-      'Releases',
-      'Labels',
-      'Festivals',
-      'Tags',
-      'Data Quality',
-      'Analytics',
-      'Radio',
-      'Users',
-      'Audit Log',
-    ]) {
-      expect(screen.getByRole('tab', { name: new RegExp(tab) })).toBeInTheDocument()
-    }
+    // The 18-tab ScrollableTabBar was retired; section navigation now lives in
+    // the Sidebar / mobile drawer. The page is a value-controlled content shell.
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('tab')).toHaveLength(0)
   })
 
   it('renders the dashboard skeleton panels on the default tab', async () => {

--- a/frontend/app/admin/page.test.tsx
+++ b/frontend/app/admin/page.test.tsx
@@ -110,6 +110,18 @@ describe('AdminPage (app/admin shell)', () => {
     expect(screen.queryAllByRole('tab')).toHaveLength(0)
   })
 
+  it('selects the section panel matching the ?tab= param (deep-link contract)', () => {
+    // The nav-removal relies on activeTab deriving from ?tab=. Radix keeps every
+    // TabsContent mounted but marks only the active one data-state="active" (the
+    // rest are hidden) — so a deep-link to ?tab=moderation makes moderation the
+    // active panel and dashboard inactive, proving the URL drives the section.
+    mockSearchParams = new URLSearchParams('tab=moderation')
+    renderWithProviders(<AdminPage />)
+
+    expect(screen.getByTestId('admin-tab-moderation')).toHaveAttribute('data-state', 'active')
+    expect(screen.getByTestId('admin-tab-dashboard')).toHaveAttribute('data-state', 'inactive')
+  })
+
   it('renders the dashboard skeleton panels on the default tab', async () => {
     renderWithProviders(<AdminPage />)
 

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic'
 import { Shield, Loader2 } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Tabs, TabsContent } from '@/components/ui/tabs'
+import { isValidTab } from '@/components/layout/adminNav'
 
 // Dynamic imports for heavy components - only loaded when their tab is active
 const ShowImportPanel = dynamic(
@@ -161,19 +162,6 @@ const CollectionManagementComponent = dynamic(
   }
 )
 
-const VALID_TABS = [
-  'dashboard', 'moderation', 'pending-shows', 'unverified-venues',
-  'reports', 'import-show', 'releases', 'labels', 'festivals', 'pipeline',
-  'collections', 'tags', 'data-quality', 'analytics', 'artists-admin', 'radio',
-  'users', 'audit-log',
-] as const
-
-type AdminTab = (typeof VALID_TABS)[number]
-
-function isValidTab(value: string | null): value is AdminTab {
-  return value !== null && (VALID_TABS as readonly string[]).includes(value)
-}
-
 function AdminPageContent() {
   const searchParams = useSearchParams()
   const tabParam = searchParams.get('tab')
@@ -232,7 +220,8 @@ function AdminPageContent() {
           {/* Section navigation lives in the context-aware Sidebar / mobile
               drawer (PSY-933) — the old horizontal ScrollableTabBar (18 tabs,
               past NN/G's 3–6 limit) was retired. Tabs stay value-controlled:
-              sidebar links set ?tab=, the searchParams effect syncs activeTab. */}
+              sidebar links / quick-links set ?tab=, and activeTab is derived
+              from it above (no mirrored state, no sync effect). */}
 
           <TabsContent value="dashboard" className="space-y-4" data-testid="admin-tab-dashboard">
             <DashboardPage onNavigate={handleTabChange} />

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,18 +1,11 @@
 'use client'
 
-import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
+import { useEffect, useCallback, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
-import { Shield, ShieldCheck, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library, Music, ClipboardCheck, BarChart3, Radio, ChevronLeft, ChevronRight } from 'lucide-react'
-import { useUnverifiedVenues } from '@/lib/hooks/admin/useAdminVenues'
-import { usePendingReports } from '@/lib/hooks/admin/useAdminReports'
-import { usePendingArtistReports } from '@/lib/hooks/admin/useAdminArtistReports'
-import { usePendingShows } from '@/lib/hooks/admin/useAdminShows'
-import { useAdminPendingEdits } from '@/lib/hooks/admin/useAdminPendingEdits'
-import { useAdminEntityReports } from '@/lib/hooks/admin/useAdminEntityReports'
-import { useAdminPendingComments } from '@/lib/hooks/admin/useAdminComments'
+import { Shield, Loader2 } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Tabs, TabsContent } from '@/components/ui/tabs'
 
 // Dynamic imports for heavy components - only loaded when their tab is active
 const ShowImportPanel = dynamic(
@@ -181,114 +174,22 @@ function isValidTab(value: string | null): value is AdminTab {
   return value !== null && (VALID_TABS as readonly string[]).includes(value)
 }
 
-function ScrollableTabBar({ children, activeTab }: { children: React.ReactNode; activeTab: string }) {
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const [canScrollLeft, setCanScrollLeft] = useState(false)
-  const [canScrollRight, setCanScrollRight] = useState(false)
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current
-    if (!el) return
-    setCanScrollLeft(el.scrollLeft > 0)
-    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1)
-  }, [])
-
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
-    updateScrollState()
-    el.addEventListener('scroll', updateScrollState, { passive: true })
-    const observer = new ResizeObserver(updateScrollState)
-    observer.observe(el)
-    return () => {
-      el.removeEventListener('scroll', updateScrollState)
-      observer.disconnect()
-    }
-  }, [updateScrollState])
-
-  // Scroll active tab into view when it changes
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
-    const activeButton = el.querySelector(`[data-state="active"]`) as HTMLElement | null
-    if (activeButton) {
-      const containerRect = el.getBoundingClientRect()
-      const buttonRect = activeButton.getBoundingClientRect()
-      const offsetLeft = buttonRect.left - containerRect.left + el.scrollLeft
-      // Center the active tab in the visible area
-      const scrollTarget = offsetLeft - (containerRect.width / 2) + (buttonRect.width / 2)
-      el.scrollTo({ left: scrollTarget, behavior: 'smooth' })
-    }
-  }, [activeTab])
-
-  const scroll = useCallback((direction: 'left' | 'right') => {
-    const el = scrollRef.current
-    if (!el) return
-    const scrollAmount = el.clientWidth * 0.6
-    el.scrollBy({
-      left: direction === 'left' ? -scrollAmount : scrollAmount,
-      behavior: 'smooth',
-    })
-  }, [])
-
-  return (
-    <div className="relative mb-6">
-      {/* Left scroll arrow */}
-      {canScrollLeft && (
-        <button
-          onClick={() => scroll('left')}
-          className="absolute left-0 top-0 z-10 flex h-full w-8 items-center justify-center bg-gradient-to-r from-background to-transparent"
-          aria-label="Scroll tabs left"
-        >
-          <ChevronLeft className="h-4 w-4 text-muted-foreground" />
-        </button>
-      )}
-
-      {/* Scrollable tabs container */}
-      <div
-        ref={scrollRef}
-        className="overflow-x-auto scrollbar-none"
-        style={{ WebkitOverflowScrolling: 'touch' }}
-      >
-        <TabsList className="w-max flex-nowrap">
-          {children}
-        </TabsList>
-      </div>
-
-      {/* Right scroll arrow */}
-      {canScrollRight && (
-        <button
-          onClick={() => scroll('right')}
-          className="absolute right-0 top-0 z-10 flex h-full w-8 items-center justify-center bg-gradient-to-l from-background to-transparent"
-          aria-label="Scroll tabs right"
-        >
-          <ChevronRight className="h-4 w-4 text-muted-foreground" />
-        </button>
-      )}
-    </div>
-  )
-}
-
 function AdminPageContent() {
   const searchParams = useSearchParams()
   const tabParam = searchParams.get('tab')
-  const initialTab = isValidTab(tabParam) ? tabParam : 'dashboard'
-  const [activeTab, setActiveTab] = useState<string>(initialTab)
+  // The URL ?tab= param is the single source of truth for the active section —
+  // the context-aware Sidebar / mobile drawer (PSY-933) navigate by setting it,
+  // and it's deep-linkable. Deriving activeTab from it (rather than mirroring it
+  // into useState + a sync effect) keeps the two from desyncing and avoids the
+  // react-hooks/set-state-in-effect cascade.
+  const activeTab: string = isValidTab(tabParam) ? tabParam : 'dashboard'
   const { user, isLoading, isAuthenticated } = useAuthContext()
   const isAdmin = !!user?.is_admin
   const router = useRouter()
 
-  // Sync tab state when URL search params change (e.g. from Cmd+K navigation)
-  useEffect(() => {
-    const newTab = searchParams.get('tab')
-    if (isValidTab(newTab) && newTab !== activeTab) {
-      setActiveTab(newTab)
-    }
-  }, [searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
-
+  // Programmatic tab switches (e.g. DashboardPage quick-links) update the URL;
+  // activeTab re-derives from it on the next render.
   const handleTabChange = useCallback((value: string) => {
-    setActiveTab(value)
-    // Update URL without full navigation so the tab is bookmarkable
     const url = value === 'dashboard' ? '/admin' : `/admin?tab=${value}`
     router.replace(url, { scroll: false })
   }, [router])
@@ -301,30 +202,6 @@ function AdminPageContent() {
       router.replace('/')
     }
   }, [isLoading, isAuthenticated, isAdmin, router])
-
-  const {
-    data: pendingShowsData,
-  } = usePendingShows({ enabled: isAdmin })
-  const {
-    data: unverifiedVenuesData,
-  } = useUnverifiedVenues({ enabled: isAdmin })
-  const {
-    data: reportsData,
-  } = usePendingReports()
-  const {
-    data: artistReportsData,
-  } = usePendingArtistReports()
-  const {
-    data: pendingEditsData,
-  } = useAdminPendingEdits({ status: 'pending' })
-  const {
-    data: entityReportsData,
-  } = useAdminEntityReports({ status: 'pending' })
-  const {
-    data: pendingCommentsData,
-  } = useAdminPendingComments()
-
-  const moderationCount = (pendingEditsData?.total || 0) + (entityReportsData?.total || 0) + (pendingCommentsData?.total || 0)
 
   if (isLoading || !isAuthenticated || !isAdmin) {
     return (
@@ -351,103 +228,11 @@ function AdminPageContent() {
         </div>
 
         {/* Tabs */}
-        <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-          <ScrollableTabBar activeTab={activeTab}>
-            <TabsTrigger value="dashboard" className="gap-2">
-              <LayoutDashboard className="h-4 w-4" />
-              Dashboard
-            </TabsTrigger>
-            <TabsTrigger value="moderation" className="gap-2">
-              <ShieldCheck className="h-4 w-4" />
-              Moderation
-              {moderationCount > 0 && (
-                  <span className="ml-1 rounded-full bg-purple-500 px-2 py-0.5 text-xs font-medium text-white">
-                    {moderationCount}
-                  </span>
-                )}
-            </TabsTrigger>
-            <TabsTrigger value="pending-shows" className="gap-2">
-              <Clock className="h-4 w-4" />
-              Pending Shows
-              {pendingShowsData?.total !== undefined &&
-                pendingShowsData.total > 0 && (
-                  <span className="ml-1 rounded-full bg-amber-500 px-2 py-0.5 text-xs font-medium text-white">
-                    {pendingShowsData.total}
-                  </span>
-                )}
-            </TabsTrigger>
-            <TabsTrigger value="unverified-venues" className="gap-2">
-              <BadgeCheck className="h-4 w-4" />
-              Unverified Venues
-              {unverifiedVenuesData?.total !== undefined &&
-                unverifiedVenuesData.total > 0 && (
-                  <span className="ml-1 rounded-full bg-orange-500 px-2 py-0.5 text-xs font-medium text-white">
-                    {unverifiedVenuesData.total}
-                  </span>
-                )}
-            </TabsTrigger>
-            <TabsTrigger value="reports" className="gap-2">
-              <Flag className="h-4 w-4" />
-              Reports
-              {((reportsData?.total || 0) + (artistReportsData?.total || 0)) > 0 && (
-                  <span className="ml-1 rounded-full bg-red-500 px-2 py-0.5 text-xs font-medium text-white">
-                    {(reportsData?.total || 0) + (artistReportsData?.total || 0)}
-                  </span>
-                )}
-            </TabsTrigger>
-            <TabsTrigger value="import-show" className="gap-2">
-              <Upload className="h-4 w-4" />
-              Import Show
-            </TabsTrigger>
-            <TabsTrigger value="releases" className="gap-2">
-              <Disc3 className="h-4 w-4" />
-              Releases
-            </TabsTrigger>
-            <TabsTrigger value="labels" className="gap-2">
-              <Tag className="h-4 w-4" />
-              Labels
-            </TabsTrigger>
-            <TabsTrigger value="festivals" className="gap-2">
-              <Tent className="h-4 w-4" />
-              Festivals
-            </TabsTrigger>
-            <TabsTrigger value="pipeline" className="gap-2">
-              <Workflow className="h-4 w-4" />
-              Data Pipeline
-            </TabsTrigger>
-            <TabsTrigger value="collections" className="gap-2">
-              <Library className="h-4 w-4" />
-              Collections
-            </TabsTrigger>
-            <TabsTrigger value="tags" className="gap-2">
-              <Tags className="h-4 w-4" />
-              Tags
-            </TabsTrigger>
-            <TabsTrigger value="data-quality" className="gap-2">
-              <ClipboardCheck className="h-4 w-4" />
-              Data Quality
-            </TabsTrigger>
-            <TabsTrigger value="analytics" className="gap-2">
-              <BarChart3 className="h-4 w-4" />
-              Analytics
-            </TabsTrigger>
-            <TabsTrigger value="artists-admin" className="gap-2">
-              <Music className="h-4 w-4" />
-              Artists
-            </TabsTrigger>
-            <TabsTrigger value="radio" className="gap-2">
-              <Radio className="h-4 w-4" />
-              Radio
-            </TabsTrigger>
-            <TabsTrigger value="users" className="gap-2">
-              <Users className="h-4 w-4" />
-              Users
-            </TabsTrigger>
-            <TabsTrigger value="audit-log" className="gap-2">
-              <ScrollText className="h-4 w-4" />
-              Audit Log
-            </TabsTrigger>
-          </ScrollableTabBar>
+        <Tabs value={activeTab} className="w-full">
+          {/* Section navigation lives in the context-aware Sidebar / mobile
+              drawer (PSY-933) — the old horizontal ScrollableTabBar (18 tabs,
+              past NN/G's 3–6 limit) was retired. Tabs stay value-controlled:
+              sidebar links set ?tab=, the searchParams effect syncs activeTab. */}
 
           <TabsContent value="dashboard" className="space-y-4" data-testid="admin-tab-dashboard">
             <DashboardPage onNavigate={handleTabChange} />

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -176,15 +176,6 @@
   }
 }
 
-/* Hide scrollbar while preserving scroll functionality */
-.scrollbar-none {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-.scrollbar-none::-webkit-scrollbar {
-  display: none;
-}
-
 /* Music embed container for responsive iframes */
 .music-embed-container {
   width: 100%;

--- a/frontend/components/layout/AdminDrawerNav.test.tsx
+++ b/frontend/components/layout/AdminDrawerNav.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AdminDrawerNav from './AdminDrawerNav'
+
+const mockPathname = vi.fn(() => '/admin')
+let mockSearchParams = new URLSearchParams()
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+  useSearchParams: () => mockSearchParams,
+}))
+
+const mockNavCounts = vi.fn(() => ({
+  moderation: 0,
+  pendingShows: 0,
+  unverifiedVenues: 0,
+  reports: 0,
+}))
+vi.mock('@/lib/hooks/admin/useAdminNavCounts', () => ({
+  useAdminNavCounts: () => mockNavCounts(),
+}))
+
+const ACTIVE = 'bg-accent text-accent-foreground'
+
+describe('AdminDrawerNav', () => {
+  const onNavigate = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPathname.mockReturnValue('/admin')
+    mockSearchParams = new URLSearchParams()
+    mockNavCounts.mockReturnValue({
+      moderation: 0,
+      pendingShows: 0,
+      unverifiedVenues: 0,
+      reports: 0,
+    })
+  })
+
+  it('renders the 6 admin group headers + Back to site', () => {
+    render(<AdminDrawerNav onNavigate={onNavigate} />)
+    for (const h of [
+      'Overview',
+      'Moderation & Queues',
+      'Catalog',
+      'Curation & Taxonomy',
+      'Tools',
+      'Insights & System',
+    ]) {
+      expect(screen.getByText(h)).toBeInTheDocument()
+    }
+    expect(screen.getByText('Back to site').closest('a')).toHaveAttribute('href', '/')
+  })
+
+  it('marks the section matching ?tab= as active', () => {
+    mockSearchParams = new URLSearchParams('tab=moderation')
+    render(<AdminDrawerNav onNavigate={onNavigate} />)
+    expect(screen.getByText('Moderation').closest('a')!.className).toContain(ACTIVE)
+    expect(screen.getByText('Releases').closest('a')!.className).not.toContain(ACTIVE)
+  })
+
+  it('renders queue badges and omits zero counts', () => {
+    mockNavCounts.mockReturnValue({
+      moderation: 5,
+      pendingShows: 2,
+      unverifiedVenues: 0,
+      reports: 3,
+    })
+    render(<AdminDrawerNav onNavigate={onNavigate} />)
+    expect(within(screen.getByText('Moderation').closest('a')!).getByText('5')).toBeInTheDocument()
+    expect(within(screen.getByText('Reports').closest('a')!).getByText('3')).toBeInTheDocument()
+    expect(
+      within(screen.getByText('Unverified Venues').closest('a')!).queryByText('0')
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes the drawer when an admin section is clicked', async () => {
+    const user = userEvent.setup()
+    render(<AdminDrawerNav onNavigate={onNavigate} />)
+    await user.click(screen.getByText('Moderation'))
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('Back to site points at / and closes the drawer', async () => {
+    const user = userEvent.setup()
+    render(<AdminDrawerNav onNavigate={onNavigate} />)
+    const back = screen.getByText('Back to site').closest('a')!
+    expect(back).toHaveAttribute('href', '/')
+    await user.click(back)
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/components/layout/AdminDrawerNav.tsx
+++ b/frontend/components/layout/AdminDrawerNav.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  adminNavGroups, adminTabHref, isAdminTabActive, ADMIN_BADGE_CLASS,
+} from './adminNav'
+import { useAdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
+
+/**
+ * Mobile drawer admin nav content (PSY-933). Dynamically imported by TopBar and
+ * mounted ONLY on the /admin tab-shell for admins (the desktop Sidebar is
+ * hidden < md, so this is the sole admin nav on mobile). Same chunk-splitting
+ * rationale as AdminSidebarNav: keeps admin-only code out of the public bundle.
+ *
+ * `onNavigate` closes the drawer on selection. Default export for `next/dynamic`.
+ */
+export default function AdminDrawerNav({ onNavigate }: { onNavigate: () => void }) {
+  const pathname = usePathname()
+  const tabParam = useSearchParams().get('tab')
+  const counts = useAdminNavCounts({ enabled: true })
+
+  return (
+    <>
+      <Link
+        href="/"
+        onClick={onNavigate}
+        className="mb-2 flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium text-foreground/70 transition-colors hover:bg-accent/50 hover:text-accent-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        <span>Back to site</span>
+      </Link>
+      {adminNavGroups.map(group => (
+        <div key={group.label} className="mb-4">
+          <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground/50">
+            {group.label}
+          </p>
+          {group.items.map(item => {
+            const Icon = item.icon
+            const active = isAdminTabActive(item.tab, pathname, tabParam)
+            const count = item.badgeKey ? counts[item.badgeKey] : 0
+            return (
+              <Link
+                key={item.tab}
+                href={adminTabHref(item.tab)}
+                onClick={onNavigate}
+                className={cn(
+                  'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
+                  active
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-foreground/70 hover:bg-accent/50 hover:text-accent-foreground'
+                )}
+              >
+                <Icon className="h-4 w-4" />
+                <span>{item.label}</span>
+                {item.badgeKey && count > 0 && (
+                  <span className={cn('ml-auto rounded-full px-2 py-0.5 text-xs font-medium text-white', ADMIN_BADGE_CLASS[item.badgeKey])}>
+                    {count}
+                  </span>
+                )}
+              </Link>
+            )
+          })}
+        </div>
+      ))}
+    </>
+  )
+}

--- a/frontend/components/layout/AdminSidebarNav.test.tsx
+++ b/frontend/components/layout/AdminSidebarNav.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import AdminSidebarNav from './AdminSidebarNav'
+
+// AdminSidebarNav derives the active section from usePathname + ?tab=.
+const mockPathname = vi.fn(() => '/admin')
+let mockSearchParams = new URLSearchParams()
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+  useSearchParams: () => mockSearchParams,
+}))
+
+// Stub the counts hook so we don't need a QueryClientProvider; the aggregation +
+// gating contract are covered by useAdminNavCounts.test.ts.
+const mockNavCounts = vi.fn(() => ({
+  moderation: 0,
+  pendingShows: 0,
+  unverifiedVenues: 0,
+  reports: 0,
+}))
+vi.mock('@/lib/hooks/admin/useAdminNavCounts', () => ({
+  useAdminNavCounts: () => mockNavCounts(),
+}))
+
+const ACTIVE_TOKEN = 'bg-sidebar-accent text-sidebar-accent-foreground'
+
+// Tooltips (collapsed mode) require a TooltipProvider — Sidebar's aside supplies
+// one in the app; provide it here.
+function renderNav(collapsed = false) {
+  return render(
+    <TooltipProvider>
+      <AdminSidebarNav collapsed={collapsed} />
+    </TooltipProvider>
+  )
+}
+
+describe('AdminSidebarNav', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPathname.mockReturnValue('/admin')
+    mockSearchParams = new URLSearchParams()
+    mockNavCounts.mockReturnValue({
+      moderation: 0,
+      pendingShows: 0,
+      unverifiedVenues: 0,
+      reports: 0,
+    })
+  })
+
+  it('renders the 6 admin group headers + Back to site', () => {
+    renderNav()
+    for (const h of [
+      'Overview',
+      'Moderation & Queues',
+      'Catalog',
+      'Curation & Taxonomy',
+      'Tools',
+      'Insights & System',
+    ]) {
+      expect(screen.getByText(h)).toBeInTheDocument()
+    }
+    expect(screen.getByText('Back to site').closest('a')).toHaveAttribute('href', '/')
+  })
+
+  it('marks the section matching ?tab= as active', () => {
+    mockSearchParams = new URLSearchParams('tab=moderation')
+    renderNav()
+    expect(screen.getByText('Moderation').closest('a')!.className).toContain(ACTIVE_TOKEN)
+    expect(screen.getByText('Releases').closest('a')!.className).not.toContain(ACTIVE_TOKEN)
+  })
+
+  it('treats bare /admin (no tab) as Dashboard active', () => {
+    renderNav()
+    expect(screen.getByText('Dashboard').closest('a')!.className).toContain(ACTIVE_TOKEN)
+  })
+
+  it('renders queue count badges and omits zero counts', () => {
+    mockNavCounts.mockReturnValue({
+      moderation: 5,
+      pendingShows: 2,
+      unverifiedVenues: 0,
+      reports: 3,
+    })
+    renderNav()
+    expect(within(screen.getByText('Moderation').closest('a')!).getByText('5')).toBeInTheDocument()
+    expect(within(screen.getByText('Reports').closest('a')!).getByText('3')).toBeInTheDocument()
+    expect(
+      within(screen.getByText('Unverified Venues').closest('a')!).queryByText('0')
+    ).not.toBeInTheDocument()
+  })
+
+  it('collapsed: a queued section shows a corner dot (not the number)', () => {
+    mockNavCounts.mockReturnValue({
+      moderation: 5,
+      pendingShows: 0,
+      unverifiedVenues: 0,
+      reports: 0,
+    })
+    renderNav(true)
+    const links = Array.from(document.querySelectorAll('a'))
+    const moderation = links.find(a => a.getAttribute('href') === '/admin?tab=moderation')!
+    expect(moderation).toBeTruthy()
+    expect(moderation.querySelector('.bg-purple-500')).toBeTruthy()
+    expect(moderation.textContent).not.toContain('5')
+  })
+})

--- a/frontend/components/layout/AdminSidebarNav.tsx
+++ b/frontend/components/layout/AdminSidebarNav.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { usePathname, useSearchParams } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  adminNavGroups, adminTabHref, isAdminTabActive, ADMIN_BADGE_CLASS,
+} from './adminNav'
+import { useAdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
+import { SidebarNavLink } from './SidebarNavLink'
+
+/**
+ * Desktop admin rail content (PSY-933). Dynamically imported by Sidebar and
+ * mounted ONLY on the /admin tab-shell for admins, so this module — the admin
+ * nav config + the 7 queue-count hooks — is a separate chunk that public pages
+ * (e.g. /explore) never download. Because it only mounts under that gate, the
+ * count queries are unconditionally enabled here.
+ *
+ * Default export so `next/dynamic` can load it.
+ */
+export default function AdminSidebarNav({ collapsed }: { collapsed: boolean }) {
+  const pathname = usePathname()
+  const tabParam = useSearchParams().get('tab')
+  const counts = useAdminNavCounts({ enabled: true })
+
+  return (
+    <>
+      <div>
+        <div className="space-y-0.5">
+          <SidebarNavLink
+            href="/"
+            label="Back to site"
+            icon={ArrowLeft}
+            active={false}
+            collapsed={collapsed}
+          />
+        </div>
+        <div className={cn('mt-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
+      </div>
+      {adminNavGroups.map(group => (
+        <div key={group.label}>
+          {!collapsed && (
+            <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-sidebar-foreground/50">
+              {group.label}
+            </p>
+          )}
+          <div className="space-y-0.5">
+            {group.items.map(item => (
+              <SidebarNavLink
+                key={item.tab}
+                href={adminTabHref(item.tab)}
+                label={item.label}
+                icon={item.icon}
+                active={isAdminTabActive(item.tab, pathname, tabParam)}
+                collapsed={collapsed}
+                badge={item.badgeKey
+                  ? { count: counts[item.badgeKey], className: ADMIN_BADGE_CLASS[item.badgeKey] }
+                  : null}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  )
+}

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -1,25 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Sidebar, sidebarGroups } from './Sidebar'
 
 const mockPathname = vi.fn(() => '/shows')
-let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
-  useSearchParams: () => mockSearchParams,
 }))
 
-// Admin nav counts are wired in the admin tests below; default to zeros so the
-// public-nav tests don't need a QueryClientProvider.
-const mockNavCounts = vi.fn(() => ({
-  moderation: 0,
-  pendingShows: 0,
-  unverifiedVenues: 0,
-  reports: 0,
-}))
-vi.mock('@/lib/hooks/admin/useAdminNavCounts', () => ({
-  useAdminNavCounts: () => mockNavCounts(),
+// The admin rail is a dynamically-imported chunk (AdminSidebarNav, kept off the
+// public bundle). Stub next/dynamic so Sidebar renders a synchronous marker we
+// can assert on; the rail's own behavior (groups, badges, active state) is
+// covered by AdminSidebarNav.test.tsx.
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function AdminSidebarNavStub() {
+      return <div data-testid="admin-sidebar-nav" />
+    },
 }))
 
 // Return type widened so individual tests can override `user`/`isAuthenticated`
@@ -81,13 +78,6 @@ describe('Sidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockPathname.mockReturnValue('/shows')
-    mockSearchParams = new URLSearchParams()
-    mockNavCounts.mockReturnValue({
-      moderation: 0,
-      pendingShows: 0,
-      unverifiedVenues: 0,
-      reports: 0,
-    })
     mockAuthContext.mockReturnValue({
       user: null,
       isAuthenticated: false,
@@ -171,7 +161,6 @@ describe('Sidebar', () => {
       logout: vi.fn(),
     })
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-    // Only "Collections" (plural, in Discover group) should exist — no "Collection" singular entry.
     expect(screen.queryByText('Collection')).not.toBeInTheDocument()
     expect(screen.getByText('Collections')).toBeInTheDocument()
   })
@@ -224,9 +213,8 @@ describe('Sidebar', () => {
   })
 
   // Active state: the current route should get the active class; siblings
-  // should NOT. Catches regressions where every link styles as active.
-  // We match on the exact active token (with surrounding whitespace) to
-  // avoid colliding with hover utility `bg-sidebar-accent/50`.
+  // should NOT. We match on the exact active token (with surrounding whitespace)
+  // to avoid colliding with hover utility `bg-sidebar-accent/50`.
   const ACTIVE_TOKEN = 'bg-sidebar-accent text-sidebar-accent-foreground'
 
   it('marks the current route as active when pathname matches exactly', () => {
@@ -256,14 +244,9 @@ describe('Sidebar', () => {
     mockPathname.mockReturnValue('https://psychichomily.substack.com/')
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
     const substack = screen.getByText('Substack').closest('a')!
-    // External items are never treated as "active" so the highlight follows
-    // in-app navigation only.
     expect(substack.className).not.toContain(ACTIVE_TOKEN)
   })
 
-  // Collapsible behavior: the collapse button is the canonical way to flip
-  // state. The label flip (Collapse → expand) drives the existing tests; add
-  // explicit aria-label on each branch.
   it('collapse button toggles aria-label between collapsed/expanded states', () => {
     const { rerender } = render(
       <Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />
@@ -277,10 +260,7 @@ describe('Sidebar', () => {
   it('collapsed mode keeps nav links present (icons-only) — labels hidden', () => {
     mockPathname.mockReturnValue('/shows')
     render(<Sidebar collapsed={true} onToggleCollapse={onToggleCollapse} />)
-    // The label "Shows" should NOT render in collapsed mode...
     expect(screen.queryByText('Shows')).not.toBeInTheDocument()
-    // ...but the underlying nav still has the /shows link element so
-    // tooltips (rendered on hover) and clickable icons still work.
     const links = document.querySelectorAll('a')
     const showsLink = Array.from(links).find(a => a.getAttribute('href') === '/shows')
     expect(showsLink).toBeTruthy()
@@ -293,9 +273,11 @@ describe('Sidebar', () => {
     expect(onToggleCollapse).toHaveBeenCalledTimes(1)
   })
 
-  // Context-aware admin nav (PSY-933): under /admin the rail swaps the public
-  // Discover/Community groups for the 6 grouped admin sections + "Back to site".
-  describe('context-aware admin nav', () => {
+  // Context-aware delegation (PSY-933): Sidebar mounts the lazily-loaded admin
+  // rail ONLY for an admin on the exact /admin shell; everywhere else (and for
+  // non-admins) it renders the public nav. The rail's contents are tested in
+  // AdminSidebarNav.test.tsx.
+  describe('admin nav delegation', () => {
     const asAdmin = () =>
       mockAuthContext.mockReturnValue({
         user: { email: 'admin@test.com', is_admin: true },
@@ -304,21 +286,15 @@ describe('Sidebar', () => {
         logout: vi.fn(),
       })
 
-    it('swaps to the admin groups (and hides public groups) for an admin in /admin', () => {
+    it('mounts the admin rail (and hides public groups) for an admin on /admin', () => {
       asAdmin()
       mockPathname.mockReturnValue('/admin')
       render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      // Admin group headers + a representative item.
-      expect(screen.getByText('Moderation & Queues')).toBeInTheDocument()
-      expect(screen.getByText('Catalog')).toBeInTheDocument()
-      expect(screen.getByText('Insights & System')).toBeInTheDocument()
-      expect(screen.getByText('Back to site')).toBeInTheDocument()
-      // Public groups are gone.
+      expect(screen.getByTestId('admin-sidebar-nav')).toBeInTheDocument()
       expect(screen.queryByText('Discover')).not.toBeInTheDocument()
-      expect(screen.queryByText('Community')).not.toBeInTheDocument()
     })
 
-    it('keeps the public nav for a NON-admin even at /admin (mid-redirect safety)', () => {
+    it('keeps the public nav for a NON-admin at /admin (mid-redirect safety)', () => {
       mockAuthContext.mockReturnValue({
         user: { email: 'user@test.com', is_admin: false },
         isAuthenticated: true,
@@ -328,79 +304,15 @@ describe('Sidebar', () => {
       mockPathname.mockReturnValue('/admin')
       render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
       expect(screen.getByText('Discover')).toBeInTheDocument()
-      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('admin-sidebar-nav')).not.toBeInTheDocument()
     })
 
-    it('marks the section matching ?tab= as active', () => {
-      asAdmin()
-      mockPathname.mockReturnValue('/admin')
-      mockSearchParams = new URLSearchParams('tab=moderation')
-      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      const moderation = screen.getByText('Moderation').closest('a')!
-      expect(moderation.className).toContain(ACTIVE_TOKEN)
-      const releases = screen.getByText('Releases').closest('a')!
-      expect(releases.className).not.toContain(ACTIVE_TOKEN)
-    })
-
-    it('treats bare /admin (no tab) as Dashboard active', () => {
-      asAdmin()
-      mockPathname.mockReturnValue('/admin')
-      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      const dashboard = screen.getByText('Dashboard').closest('a')!
-      expect(dashboard.className).toContain(ACTIVE_TOKEN)
-    })
-
-    it('renders queue count badges from useAdminNavCounts (and omits zero counts)', () => {
-      asAdmin()
-      mockPathname.mockReturnValue('/admin')
-      mockNavCounts.mockReturnValue({
-        moderation: 5,
-        pendingShows: 2,
-        unverifiedVenues: 0, // zero → no badge
-        reports: 3,
-      })
-      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      const moderation = screen.getByText('Moderation').closest('a')!
-      expect(within(moderation).getByText('5')).toBeInTheDocument()
-      const reports = screen.getByText('Reports').closest('a')!
-      expect(within(reports).getByText('3')).toBeInTheDocument()
-      // Unverified Venues has a zero count → no badge text beyond the label.
-      const unverified = screen.getByText('Unverified Venues').closest('a')!
-      expect(within(unverified).queryByText('0')).not.toBeInTheDocument()
-    })
-
-    it('points the back-to-site link at /', () => {
-      asAdmin()
-      mockPathname.mockReturnValue('/admin')
-      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      expect(screen.getByText('Back to site').closest('a')).toHaveAttribute('href', '/')
-    })
-
-    it('keeps the public nav on standalone /admin/<section> sub-routes (rail is scoped to the tab-shell, not startsWith)', () => {
+    it('keeps the public nav on standalone /admin/<section> sub-routes (scoped to the tab-shell, not startsWith)', () => {
       asAdmin()
       mockPathname.mockReturnValue('/admin/featured')
       render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
       expect(screen.getByText('Discover')).toBeInTheDocument()
-      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
-    })
-
-    it('collapsed: a queued section shows a corner dot (not the number)', () => {
-      asAdmin()
-      mockPathname.mockReturnValue('/admin')
-      mockNavCounts.mockReturnValue({
-        moderation: 5,
-        pendingShows: 0,
-        unverifiedVenues: 0,
-        reports: 0,
-      })
-      render(<Sidebar collapsed={true} onToggleCollapse={onToggleCollapse} />)
-      // Labels are hidden when collapsed, so find the Moderation item by href.
-      const links = Array.from(document.querySelectorAll('a'))
-      const moderation = links.find(a => a.getAttribute('href') === '/admin?tab=moderation')!
-      expect(moderation).toBeTruthy()
-      // The expanded pill's number is replaced by an aria-hidden dot in the queue color.
-      expect(moderation.querySelector('.bg-purple-500')).toBeTruthy()
-      expect(moderation.textContent).not.toContain('5')
+      expect(screen.queryByTestId('admin-sidebar-nav')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -1,11 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Sidebar, sidebarGroups } from './Sidebar'
 
 const mockPathname = vi.fn(() => '/shows')
+let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
+  useSearchParams: () => mockSearchParams,
+}))
+
+// Admin nav counts are wired in the admin tests below; default to zeros so the
+// public-nav tests don't need a QueryClientProvider.
+const mockNavCounts = vi.fn(() => ({
+  moderation: 0,
+  pendingShows: 0,
+  unverifiedVenues: 0,
+  reports: 0,
+}))
+vi.mock('@/lib/hooks/admin/useAdminNavCounts', () => ({
+  useAdminNavCounts: () => mockNavCounts(),
 }))
 
 // Return type widened so individual tests can override `user`/`isAuthenticated`
@@ -67,6 +81,13 @@ describe('Sidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockPathname.mockReturnValue('/shows')
+    mockSearchParams = new URLSearchParams()
+    mockNavCounts.mockReturnValue({
+      moderation: 0,
+      pendingShows: 0,
+      unverifiedVenues: 0,
+      reports: 0,
+    })
     mockAuthContext.mockReturnValue({
       user: null,
       isAuthenticated: false,
@@ -270,5 +291,89 @@ describe('Sidebar', () => {
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
     await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }))
     expect(onToggleCollapse).toHaveBeenCalledTimes(1)
+  })
+
+  // Context-aware admin nav (PSY-933): under /admin the rail swaps the public
+  // Discover/Community groups for the 6 grouped admin sections + "Back to site".
+  describe('context-aware admin nav', () => {
+    const asAdmin = () =>
+      mockAuthContext.mockReturnValue({
+        user: { email: 'admin@test.com', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+
+    it('swaps to the admin groups (and hides public groups) for an admin in /admin', () => {
+      asAdmin()
+      mockPathname.mockReturnValue('/admin')
+      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+      // Admin group headers + a representative item.
+      expect(screen.getByText('Moderation & Queues')).toBeInTheDocument()
+      expect(screen.getByText('Catalog')).toBeInTheDocument()
+      expect(screen.getByText('Insights & System')).toBeInTheDocument()
+      expect(screen.getByText('Back to site')).toBeInTheDocument()
+      // Public groups are gone.
+      expect(screen.queryByText('Discover')).not.toBeInTheDocument()
+      expect(screen.queryByText('Community')).not.toBeInTheDocument()
+    })
+
+    it('keeps the public nav for a NON-admin even at /admin (mid-redirect safety)', () => {
+      mockAuthContext.mockReturnValue({
+        user: { email: 'user@test.com', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockPathname.mockReturnValue('/admin')
+      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+      expect(screen.getByText('Discover')).toBeInTheDocument()
+      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
+    })
+
+    it('marks the section matching ?tab= as active', () => {
+      asAdmin()
+      mockPathname.mockReturnValue('/admin')
+      mockSearchParams = new URLSearchParams('tab=moderation')
+      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+      const moderation = screen.getByText('Moderation').closest('a')!
+      expect(moderation.className).toContain('bg-sidebar-accent text-sidebar-accent-foreground')
+      const releases = screen.getByText('Releases').closest('a')!
+      expect(releases.className).not.toContain('bg-sidebar-accent text-sidebar-accent-foreground')
+    })
+
+    it('treats bare /admin (no tab) as Dashboard active', () => {
+      asAdmin()
+      mockPathname.mockReturnValue('/admin')
+      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+      const dashboard = screen.getByText('Dashboard').closest('a')!
+      expect(dashboard.className).toContain('bg-sidebar-accent text-sidebar-accent-foreground')
+    })
+
+    it('renders queue count badges from useAdminNavCounts (and omits zero counts)', () => {
+      asAdmin()
+      mockPathname.mockReturnValue('/admin')
+      mockNavCounts.mockReturnValue({
+        moderation: 5,
+        pendingShows: 2,
+        unverifiedVenues: 0, // zero → no badge
+        reports: 3,
+      })
+      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+      const moderation = screen.getByText('Moderation').closest('a')!
+      expect(within(moderation).getByText('5')).toBeInTheDocument()
+      const reports = screen.getByText('Reports').closest('a')!
+      expect(within(reports).getByText('3')).toBeInTheDocument()
+      // Unverified Venues has a zero count → no badge text beyond the label.
+      const unverified = screen.getByText('Unverified Venues').closest('a')!
+      expect(within(unverified).queryByText('0')).not.toBeInTheDocument()
+    })
+
+    it('points the back-to-site link at /', () => {
+      asAdmin()
+      mockPathname.mockReturnValue('/admin')
+      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+      expect(screen.getByText('Back to site').closest('a')).toHaveAttribute('href', '/')
+    })
   })
 })

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -383,5 +383,24 @@ describe('Sidebar', () => {
       expect(screen.getByText('Discover')).toBeInTheDocument()
       expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
     })
+
+    it('collapsed: a queued section shows a corner dot (not the number)', () => {
+      asAdmin()
+      mockPathname.mockReturnValue('/admin')
+      mockNavCounts.mockReturnValue({
+        moderation: 5,
+        pendingShows: 0,
+        unverifiedVenues: 0,
+        reports: 0,
+      })
+      render(<Sidebar collapsed={true} onToggleCollapse={onToggleCollapse} />)
+      // Labels are hidden when collapsed, so find the Moderation item by href.
+      const links = Array.from(document.querySelectorAll('a'))
+      const moderation = links.find(a => a.getAttribute('href') === '/admin?tab=moderation')!
+      expect(moderation).toBeTruthy()
+      // The expanded pill's number is replaced by an aria-hidden dot in the queue color.
+      expect(moderation.querySelector('.bg-purple-500')).toBeTruthy()
+      expect(moderation.textContent).not.toContain('5')
+    })
   })
 })

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -337,9 +337,9 @@ describe('Sidebar', () => {
       mockSearchParams = new URLSearchParams('tab=moderation')
       render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
       const moderation = screen.getByText('Moderation').closest('a')!
-      expect(moderation.className).toContain('bg-sidebar-accent text-sidebar-accent-foreground')
+      expect(moderation.className).toContain(ACTIVE_TOKEN)
       const releases = screen.getByText('Releases').closest('a')!
-      expect(releases.className).not.toContain('bg-sidebar-accent text-sidebar-accent-foreground')
+      expect(releases.className).not.toContain(ACTIVE_TOKEN)
     })
 
     it('treats bare /admin (no tab) as Dashboard active', () => {
@@ -347,7 +347,7 @@ describe('Sidebar', () => {
       mockPathname.mockReturnValue('/admin')
       render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
       const dashboard = screen.getByText('Dashboard').closest('a')!
-      expect(dashboard.className).toContain('bg-sidebar-accent text-sidebar-accent-foreground')
+      expect(dashboard.className).toContain(ACTIVE_TOKEN)
     })
 
     it('renders queue count badges from useAdminNavCounts (and omits zero counts)', () => {
@@ -374,6 +374,14 @@ describe('Sidebar', () => {
       mockPathname.mockReturnValue('/admin')
       render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
       expect(screen.getByText('Back to site').closest('a')).toHaveAttribute('href', '/')
+    })
+
+    it('keeps the public nav on standalone /admin/<section> sub-routes (rail is scoped to the tab-shell, not startsWith)', () => {
+      asAdmin()
+      mockPathname.mockReturnValue('/admin/featured')
+      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+      expect(screen.getByText('Discover')).toBeInTheDocument()
+      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -76,8 +76,12 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   // In the admin area the rail becomes context-aware (PSY-933): it swaps the
   // public Discover/Community groups for the grouped admin sections. Gated on
   // isAdmin so a non-admin mid-redirect at /admin still sees the public nav.
+  // Scoped to the exact /admin tab-shell (usePathname() strips the ?tab= query,
+  // so this still matches /admin?tab=…). Standalone /admin/<section> sub-routes
+  // keep the public nav — their pre-PSY-933 behavior — rather than mis-rendering
+  // a ?tab=-only active state; a path-aware rail for those is a follow-up.
   const isAdmin = !!user?.is_admin
-  const showAdminNav = isAdmin && pathname.startsWith('/admin')
+  const showAdminNav = isAdmin && pathname === '/admin'
   const tabParam = searchParams.get('tab')
   // Gated by showAdminNav: these admin-only count queries must not fire on
   // public routes or for non-admins (they'd 403 / waste requests).

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, UserCircle, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink, Globe, TrendingUp, Bell, HeartHandshake, Trophy, Radio, Music, Compass,
+  ExternalLink, Globe, TrendingUp, Bell, HeartHandshake, Trophy, Radio, Music, Compass, ArrowLeft,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -13,6 +13,10 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import {
   Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,
 } from '@/components/ui/tooltip'
+import {
+  adminNavGroups, adminTabHref, isAdminTabActive, ADMIN_BADGE_CLASS,
+} from './adminNav'
+import { useAdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
 
 export interface SidebarNavItem {
   href: string
@@ -66,49 +70,97 @@ interface SidebarProps {
 
 export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const { user, isAuthenticated } = useAuthContext()
+
+  // In the admin area the rail becomes context-aware (PSY-933): it swaps the
+  // public Discover/Community groups for the grouped admin sections. Gated on
+  // isAdmin so a non-admin mid-redirect at /admin still sees the public nav.
+  const isAdmin = !!user?.is_admin
+  const showAdminNav = isAdmin && pathname.startsWith('/admin')
+  const tabParam = searchParams.get('tab')
+  // Gated by showAdminNav: these admin-only count queries must not fire on
+  // public routes or for non-admins (they'd 403 / waste requests).
+  const counts = useAdminNavCounts({ enabled: showAdminNav })
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/'
     return pathname === href || pathname.startsWith(href + '/')
   }
 
-  const renderItem = (item: SidebarNavItem) => {
-    const Icon = item.icon
-    const active = !item.external && isActive(item.href)
-
+  // Unified link row used by both the public and admin nav. `badge`, when set,
+  // renders a count pill (expanded) or a corner dot (collapsed).
+  const renderNavLink = ({
+    keyVal, href, label, icon: Icon, active, external = false,
+    badge = null,
+  }: {
+    keyVal: string
+    href: string
+    label: string
+    icon: LucideIcon
+    active: boolean
+    external?: boolean
+    badge?: { count: number; className: string } | null
+  }) => {
+    const showBadge = badge != null && badge.count > 0
     const link = (
       <Link
-        href={item.href}
-        target={item.external ? '_blank' : undefined}
-        rel={item.external ? 'noopener noreferrer' : undefined}
+        href={href}
+        target={external ? '_blank' : undefined}
+        rel={external ? 'noopener noreferrer' : undefined}
         className={cn(
           'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
           active
             ? 'bg-sidebar-accent text-sidebar-accent-foreground'
             : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
-          collapsed && 'justify-center px-2'
+          collapsed && 'relative justify-center px-2'
         )}
       >
         <Icon className="h-4 w-4 shrink-0" />
-        {!collapsed && <span>{item.label}</span>}
-        {!collapsed && item.external && (
+        {!collapsed && <span>{label}</span>}
+        {!collapsed && external && (
           <ExternalLink className="ml-auto h-3 w-3 opacity-50" />
+        )}
+        {!collapsed && showBadge && (
+          <span className={cn('ml-auto rounded-full px-2 py-0.5 text-xs font-medium text-white', badge!.className)}>
+            {badge!.count}
+          </span>
+        )}
+        {collapsed && showBadge && (
+          <span className={cn('absolute right-1.5 top-1.5 h-2 w-2 rounded-full', badge!.className)} aria-hidden />
         )}
       </Link>
     )
 
     if (collapsed) {
       return (
-        <Tooltip key={item.href}>
+        <Tooltip key={keyVal}>
           <TooltipTrigger asChild>{link}</TooltipTrigger>
-          <TooltipContent side="right">{item.label}</TooltipContent>
+          <TooltipContent side="right">
+            {label}{showBadge ? ` (${badge!.count})` : ''}
+          </TooltipContent>
         </Tooltip>
       )
     }
-
-    return <div key={item.href}>{link}</div>
+    return <div key={keyVal}>{link}</div>
   }
+
+  const renderItem = (item: SidebarNavItem) =>
+    renderNavLink({
+      keyVal: item.href,
+      href: item.href,
+      label: item.label,
+      icon: item.icon,
+      active: !item.external && isActive(item.href),
+      external: item.external,
+    })
+
+  const renderGroupHeader = (label: string) =>
+    !collapsed && (
+      <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-sidebar-foreground/50">
+        {label}
+      </p>
+    )
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -119,29 +171,63 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
         )}
       >
         <nav className="flex-1 space-y-6 overflow-y-auto px-2 py-4">
-          {sidebarGroups.map(group => (
-            <div key={group.label}>
-              {!collapsed && (
-                <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-sidebar-foreground/50">
-                  {group.label}
-                </p>
-              )}
-              <div className="space-y-0.5">
-                {group.items.map(renderItem)}
+          {showAdminNav ? (
+            <>
+              <div>
+                <div className="space-y-0.5">
+                  {renderNavLink({
+                    keyVal: 'back-to-site',
+                    href: '/',
+                    label: 'Back to site',
+                    icon: ArrowLeft,
+                    active: false,
+                  })}
+                </div>
+                <div className={cn('mt-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
               </div>
-            </div>
-          ))}
+              {adminNavGroups.map(group => (
+                <div key={group.label}>
+                  {renderGroupHeader(group.label)}
+                  <div className="space-y-0.5">
+                    {group.items.map(item =>
+                      renderNavLink({
+                        keyVal: item.tab,
+                        href: adminTabHref(item.tab),
+                        label: item.label,
+                        icon: item.icon,
+                        active: isAdminTabActive(item.tab, pathname, tabParam),
+                        badge: item.badgeKey
+                          ? { count: counts[item.badgeKey], className: ADMIN_BADGE_CLASS[item.badgeKey] }
+                          : null,
+                      })
+                    )}
+                  </div>
+                </div>
+              ))}
+            </>
+          ) : (
+            <>
+              {sidebarGroups.map(group => (
+                <div key={group.label}>
+                  {renderGroupHeader(group.label)}
+                  <div className="space-y-0.5">
+                    {group.items.map(renderItem)}
+                  </div>
+                </div>
+              ))}
 
-          {isAuthenticated && (
-            <div>
-              <div className={cn('mb-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
-              <div className="space-y-0.5">
-                {renderItem({ href: '/library', label: 'Library', icon: Library })}
-                {renderItem({ href: '/settings/notification-filters', label: 'Notification Filters', icon: Bell })}
-                {renderItem({ href: '/profile', label: 'Profile', icon: UserCircle })}
-                {user?.is_admin && renderItem({ href: '/admin', label: 'Admin', icon: Shield })}
-              </div>
-            </div>
+              {isAuthenticated && (
+                <div>
+                  <div className={cn('mb-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
+                  <div className="space-y-0.5">
+                    {renderItem({ href: '/library', label: 'Library', icon: Library })}
+                    {renderItem({ href: '/settings/notification-filters', label: 'Notification Filters', icon: Bell })}
+                    {renderItem({ href: '/profile', label: 'Profile', icon: UserCircle })}
+                    {user?.is_admin && renderItem({ href: '/admin', label: 'Admin', icon: Shield })}
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </nav>
 

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
+import dynamic from 'next/dynamic'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, UserCircle, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink, Globe, TrendingUp, Bell, HeartHandshake, Trophy, Radio, Music, Compass, ArrowLeft,
+  Globe, TrendingUp, Bell, HeartHandshake, Trophy, Radio, Music, Compass,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -13,10 +13,11 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import {
   Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,
 } from '@/components/ui/tooltip'
-import {
-  adminNavGroups, adminTabHref, isAdminTabActive, ADMIN_BADGE_CLASS,
-} from './adminNav'
-import { useAdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
+import { SidebarNavLink } from './SidebarNavLink'
+
+// The admin rail (config + the 7 queue-count hooks) is a separate chunk loaded
+// only when an admin is on the /admin shell — public pages never download it.
+const AdminSidebarNav = dynamic(() => import('./AdminSidebarNav'), { ssr: false })
 
 export interface SidebarNavItem {
   href: string
@@ -70,94 +71,35 @@ interface SidebarProps {
 
 export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const pathname = usePathname()
-  const searchParams = useSearchParams()
   const { user, isAuthenticated } = useAuthContext()
 
   // In the admin area the rail becomes context-aware (PSY-933): it swaps the
-  // public Discover/Community groups for the grouped admin sections. Gated on
-  // isAdmin so a non-admin mid-redirect at /admin still sees the public nav.
-  // Scoped to the exact /admin tab-shell (usePathname() strips the ?tab= query,
-  // so this still matches /admin?tab=…). Standalone /admin/<section> sub-routes
-  // keep the public nav — their pre-PSY-933 behavior — rather than mis-rendering
-  // a ?tab=-only active state; a path-aware rail for those is a follow-up.
+  // public Discover/Community groups for the grouped admin sections (rendered by
+  // the lazily-loaded AdminSidebarNav). Gated on isAdmin so a non-admin
+  // mid-redirect at /admin still sees the public nav, and scoped to the exact
+  // /admin tab-shell (usePathname() strips the ?tab= query, so this still matches
+  // /admin?tab=…). Standalone /admin/<section> sub-routes keep the public nav —
+  // their pre-PSY-933 behavior — rather than mis-rendering a ?tab=-only active
+  // state; a path-aware rail for those is a follow-up.
   const isAdmin = !!user?.is_admin
   const showAdminNav = isAdmin && pathname === '/admin'
-  const tabParam = searchParams.get('tab')
-  // Gated by showAdminNav: these admin-only count queries must not fire on
-  // public routes or for non-admins (they'd 403 / waste requests).
-  const counts = useAdminNavCounts({ enabled: showAdminNav })
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/'
     return pathname === href || pathname.startsWith(href + '/')
   }
 
-  // Unified link row used by both the public and admin nav. `badge`, when set,
-  // renders a count pill (expanded) or a corner dot (collapsed).
-  const renderNavLink = ({
-    keyVal, href, label, icon: Icon, active, external = false,
-    badge = null,
-  }: {
-    keyVal: string
-    href: string
-    label: string
-    icon: LucideIcon
-    active: boolean
-    external?: boolean
-    badge?: { count: number; className: string } | null
-  }) => {
-    const showBadge = badge != null && badge.count > 0
-    const link = (
-      <Link
-        href={href}
-        target={external ? '_blank' : undefined}
-        rel={external ? 'noopener noreferrer' : undefined}
-        className={cn(
-          'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-          active
-            ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-            : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
-          collapsed && 'relative justify-center px-2'
-        )}
-      >
-        <Icon className="h-4 w-4 shrink-0" />
-        {!collapsed && <span>{label}</span>}
-        {!collapsed && external && (
-          <ExternalLink className="ml-auto h-3 w-3 opacity-50" />
-        )}
-        {!collapsed && showBadge && (
-          <span className={cn('ml-auto rounded-full px-2 py-0.5 text-xs font-medium text-white', badge!.className)}>
-            {badge!.count}
-          </span>
-        )}
-        {collapsed && showBadge && (
-          <span className={cn('absolute right-1.5 top-1.5 h-2 w-2 rounded-full', badge!.className)} aria-hidden />
-        )}
-      </Link>
-    )
-
-    if (collapsed) {
-      return (
-        <Tooltip key={keyVal}>
-          <TooltipTrigger asChild>{link}</TooltipTrigger>
-          <TooltipContent side="right">
-            {label}{showBadge ? ` (${badge!.count})` : ''}
-          </TooltipContent>
-        </Tooltip>
-      )
-    }
-    return <div key={keyVal}>{link}</div>
-  }
-
-  const renderItem = (item: SidebarNavItem) =>
-    renderNavLink({
-      keyVal: item.href,
-      href: item.href,
-      label: item.label,
-      icon: item.icon,
-      active: !item.external && isActive(item.href),
-      external: item.external,
-    })
+  const renderItem = (item: SidebarNavItem) => (
+    <SidebarNavLink
+      key={item.href}
+      href={item.href}
+      label={item.label}
+      icon={item.icon}
+      active={!item.external && isActive(item.href)}
+      collapsed={collapsed}
+      external={item.external}
+    />
+  )
 
   const renderGroupHeader = (label: string) =>
     !collapsed && (
@@ -176,39 +118,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
       >
         <nav className="flex-1 space-y-6 overflow-y-auto px-2 py-4">
           {showAdminNav ? (
-            <>
-              <div>
-                <div className="space-y-0.5">
-                  {renderNavLink({
-                    keyVal: 'back-to-site',
-                    href: '/',
-                    label: 'Back to site',
-                    icon: ArrowLeft,
-                    active: false,
-                  })}
-                </div>
-                <div className={cn('mt-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
-              </div>
-              {adminNavGroups.map(group => (
-                <div key={group.label}>
-                  {renderGroupHeader(group.label)}
-                  <div className="space-y-0.5">
-                    {group.items.map(item =>
-                      renderNavLink({
-                        keyVal: item.tab,
-                        href: adminTabHref(item.tab),
-                        label: item.label,
-                        icon: item.icon,
-                        active: isAdminTabActive(item.tab, pathname, tabParam),
-                        badge: item.badgeKey
-                          ? { count: counts[item.badgeKey], className: ADMIN_BADGE_CLASS[item.badgeKey] }
-                          : null,
-                      })
-                    )}
-                  </div>
-                </div>
-              ))}
-            </>
+            <AdminSidebarNav collapsed={collapsed} />
           ) : (
             <>
               {sidebarGroups.map(group => (

--- a/frontend/components/layout/SidebarNavLink.tsx
+++ b/frontend/components/layout/SidebarNavLink.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import { ExternalLink } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+export interface SidebarNavLinkProps {
+  href: string
+  label: string
+  icon: LucideIcon
+  active: boolean
+  collapsed: boolean
+  external?: boolean
+  /** Count badge: a pill (expanded) or a corner dot (collapsed). */
+  badge?: { count: number; className: string } | null
+}
+
+/**
+ * The canonical sidebar link row — shared by the public Sidebar and the
+ * (dynamically-loaded) admin rail so the active/badge/collapse/tooltip treatment
+ * stays identical. Must render inside a `TooltipProvider` (the Sidebar's aside
+ * provides one) for the collapsed-mode label tooltip.
+ */
+export function SidebarNavLink({
+  href, label, icon: Icon, active, collapsed, external = false, badge = null,
+}: SidebarNavLinkProps) {
+  const showBadge = badge != null && badge.count > 0
+  const link = (
+    <Link
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      className={cn(
+        'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+        active
+          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+          : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
+        collapsed && 'relative justify-center px-2'
+      )}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      {!collapsed && <span>{label}</span>}
+      {!collapsed && external && (
+        <ExternalLink className="ml-auto h-3 w-3 opacity-50" />
+      )}
+      {!collapsed && showBadge && (
+        <span className={cn('ml-auto rounded-full px-2 py-0.5 text-xs font-medium text-white', badge!.className)}>
+          {badge!.count}
+        </span>
+      )}
+      {collapsed && showBadge && (
+        <span className={cn('absolute right-1.5 top-1.5 h-2 w-2 rounded-full', badge!.className)} aria-hidden />
+      )}
+    </Link>
+  )
+
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{link}</TooltipTrigger>
+        <TooltipContent side="right">
+          {label}{showBadge ? ` (${badge!.count})` : ''}
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+  return link
+}

--- a/frontend/components/layout/TopBar.test.tsx
+++ b/frontend/components/layout/TopBar.test.tsx
@@ -10,10 +10,11 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => mockSearchParams,
 }))
 
-// Admin nav counts hook is exercised by its own unit + the Sidebar admin tests;
-// stub it here so the public TopBar tests don't need a QueryClientProvider.
+// Admin nav counts hook — stubbed so tests don't need a QueryClientProvider.
+// Reassignable so the admin-drawer badge test can supply non-zero counts.
+let mockNavCounts = { moderation: 0, pendingShows: 0, unverifiedVenues: 0, reports: 0 }
 vi.mock('@/lib/hooks/admin/useAdminNavCounts', () => ({
-  useAdminNavCounts: () => ({ moderation: 0, pendingShows: 0, unverifiedVenues: 0, reports: 0 }),
+  useAdminNavCounts: () => mockNavCounts,
 }))
 
 vi.mock('next/image', () => ({
@@ -68,6 +69,8 @@ describe('TopBar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockPathname = '/'
+    mockSearchParams = new URLSearchParams()
+    mockNavCounts = { moderation: 0, pendingShows: 0, unverifiedVenues: 0, reports: 0 }
     mockTheme = 'dark'
     mockAuthContext.mockReturnValue({
       user: null,
@@ -415,6 +418,95 @@ describe('TopBar', () => {
 
       await user.click(screen.getByText('Notifications'))
       expect(onMobileOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  // PSY-933: the mobile drawer is the ONLY admin nav on mobile (the desktop
+  // Sidebar is hidden < md), so this path is load-bearing — mirror the desktop
+  // Sidebar admin-nav suite against the drawer.
+  describe('context-aware admin drawer (PSY-933)', () => {
+    const asAdmin = () =>
+      mockAuthContext.mockReturnValue({
+        user: { email: 'admin@test.com', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      })
+    const ACTIVE = 'bg-accent text-accent-foreground'
+
+    it('swaps to the admin groups + Back to site for an admin under /admin', () => {
+      asAdmin()
+      mockPathname = '/admin'
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+      expect(screen.getByText('Moderation & Queues')).toBeInTheDocument()
+      expect(screen.getByText('Catalog')).toBeInTheDocument()
+      expect(screen.getByText('Insights & System')).toBeInTheDocument()
+      expect(screen.getByText('Back to site')).toBeInTheDocument()
+      // Public groups are swapped out.
+      expect(screen.queryByText('Discover')).not.toBeInTheDocument()
+      expect(screen.queryByText('Community')).not.toBeInTheDocument()
+    })
+
+    it('keeps the public nav for a non-admin even under /admin', () => {
+      mockAuthContext.mockReturnValue({
+        user: { email: 'user@test.com', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      })
+      mockPathname = '/admin'
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+      expect(screen.getByText('Discover')).toBeInTheDocument()
+      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
+    })
+
+    it('marks the section matching ?tab= as active', () => {
+      asAdmin()
+      mockPathname = '/admin'
+      mockSearchParams = new URLSearchParams('tab=moderation')
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+      expect(screen.getByText('Moderation').closest('a')!.className).toContain(ACTIVE)
+      expect(screen.getByText('Releases').closest('a')!.className).not.toContain(ACTIVE)
+    })
+
+    it('renders queue badges from useAdminNavCounts and omits zero counts', () => {
+      asAdmin()
+      mockPathname = '/admin'
+      mockNavCounts = { moderation: 5, pendingShows: 2, unverifiedVenues: 0, reports: 3 }
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+      expect(within(screen.getByText('Moderation').closest('a')!).getByText('5')).toBeInTheDocument()
+      expect(within(screen.getByText('Reports').closest('a')!).getByText('3')).toBeInTheDocument()
+      expect(
+        within(screen.getByText('Unverified Venues').closest('a')!).queryByText('0')
+      ).not.toBeInTheDocument()
+    })
+
+    it('clicking an admin section closes the drawer', async () => {
+      asAdmin()
+      mockPathname = '/admin'
+      const user = userEvent.setup()
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+      await user.click(screen.getByText('Moderation'))
+      expect(onMobileOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('Back to site points at / and closes the drawer', async () => {
+      asAdmin()
+      mockPathname = '/admin'
+      const user = userEvent.setup()
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+      const back = screen.getByText('Back to site').closest('a')!
+      expect(back).toHaveAttribute('href', '/')
+      await user.click(back)
+      expect(onMobileOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('keeps the public nav on standalone /admin/<section> sub-routes (scoped to the tab-shell, not startsWith)', () => {
+      asAdmin()
+      mockPathname = '/admin/featured'
+      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
+      expect(screen.getByText('Discover')).toBeInTheDocument()
+      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/components/layout/TopBar.test.tsx
+++ b/frontend/components/layout/TopBar.test.tsx
@@ -1,20 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TopBar } from './TopBar'
 
 let mockPathname = '/'
-let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
-  useSearchParams: () => mockSearchParams,
 }))
 
-// Admin nav counts hook — stubbed so tests don't need a QueryClientProvider.
-// Reassignable so the admin-drawer badge test can supply non-zero counts.
-let mockNavCounts = { moderation: 0, pendingShows: 0, unverifiedVenues: 0, reports: 0 }
-vi.mock('@/lib/hooks/admin/useAdminNavCounts', () => ({
-  useAdminNavCounts: () => mockNavCounts,
+// The admin drawer is a dynamically-imported chunk (AdminDrawerNav, kept off the
+// public bundle); stub next/dynamic so TopBar renders a synchronous marker. The
+// drawer's own behavior is covered by AdminDrawerNav.test.tsx.
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function AdminDrawerNavStub() {
+      return <div data-testid="admin-drawer-nav" />
+    },
 }))
 
 vi.mock('next/image', () => ({
@@ -69,8 +70,6 @@ describe('TopBar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockPathname = '/'
-    mockSearchParams = new URLSearchParams()
-    mockNavCounts = { moderation: 0, pendingShows: 0, unverifiedVenues: 0, reports: 0 }
     mockTheme = 'dark'
     mockAuthContext.mockReturnValue({
       user: null,
@@ -422,9 +421,10 @@ describe('TopBar', () => {
   })
 
   // PSY-933: the mobile drawer is the ONLY admin nav on mobile (the desktop
-  // Sidebar is hidden < md), so this path is load-bearing — mirror the desktop
-  // Sidebar admin-nav suite against the drawer.
-  describe('context-aware admin drawer (PSY-933)', () => {
+  // Sidebar is hidden < md). TopBar mounts the lazily-loaded AdminDrawerNav only
+  // for an admin on the exact /admin shell; its contents are tested in
+  // AdminDrawerNav.test.tsx.
+  describe('admin drawer delegation (PSY-933)', () => {
     const asAdmin = () =>
       mockAuthContext.mockReturnValue({
         user: { email: 'admin@test.com', is_admin: true },
@@ -432,22 +432,16 @@ describe('TopBar', () => {
         isLoading: false,
         logout: mockLogout,
       })
-    const ACTIVE = 'bg-accent text-accent-foreground'
 
-    it('swaps to the admin groups + Back to site for an admin under /admin', () => {
+    it('mounts the admin drawer (hides public groups) for an admin on /admin', () => {
       asAdmin()
       mockPathname = '/admin'
       render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
-      expect(screen.getByText('Moderation & Queues')).toBeInTheDocument()
-      expect(screen.getByText('Catalog')).toBeInTheDocument()
-      expect(screen.getByText('Insights & System')).toBeInTheDocument()
-      expect(screen.getByText('Back to site')).toBeInTheDocument()
-      // Public groups are swapped out.
+      expect(screen.getByTestId('admin-drawer-nav')).toBeInTheDocument()
       expect(screen.queryByText('Discover')).not.toBeInTheDocument()
-      expect(screen.queryByText('Community')).not.toBeInTheDocument()
     })
 
-    it('keeps the public nav for a non-admin even under /admin', () => {
+    it('keeps the public nav for a non-admin at /admin', () => {
       mockAuthContext.mockReturnValue({
         user: { email: 'user@test.com', is_admin: false },
         isAuthenticated: true,
@@ -457,56 +451,15 @@ describe('TopBar', () => {
       mockPathname = '/admin'
       render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
       expect(screen.getByText('Discover')).toBeInTheDocument()
-      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('admin-drawer-nav')).not.toBeInTheDocument()
     })
 
-    it('marks the section matching ?tab= as active', () => {
-      asAdmin()
-      mockPathname = '/admin'
-      mockSearchParams = new URLSearchParams('tab=moderation')
-      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
-      expect(screen.getByText('Moderation').closest('a')!.className).toContain(ACTIVE)
-      expect(screen.getByText('Releases').closest('a')!.className).not.toContain(ACTIVE)
-    })
-
-    it('renders queue badges from useAdminNavCounts and omits zero counts', () => {
-      asAdmin()
-      mockPathname = '/admin'
-      mockNavCounts = { moderation: 5, pendingShows: 2, unverifiedVenues: 0, reports: 3 }
-      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
-      expect(within(screen.getByText('Moderation').closest('a')!).getByText('5')).toBeInTheDocument()
-      expect(within(screen.getByText('Reports').closest('a')!).getByText('3')).toBeInTheDocument()
-      expect(
-        within(screen.getByText('Unverified Venues').closest('a')!).queryByText('0')
-      ).not.toBeInTheDocument()
-    })
-
-    it('clicking an admin section closes the drawer', async () => {
-      asAdmin()
-      mockPathname = '/admin'
-      const user = userEvent.setup()
-      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
-      await user.click(screen.getByText('Moderation'))
-      expect(onMobileOpenChange).toHaveBeenCalledWith(false)
-    })
-
-    it('Back to site points at / and closes the drawer', async () => {
-      asAdmin()
-      mockPathname = '/admin'
-      const user = userEvent.setup()
-      render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
-      const back = screen.getByText('Back to site').closest('a')!
-      expect(back).toHaveAttribute('href', '/')
-      await user.click(back)
-      expect(onMobileOpenChange).toHaveBeenCalledWith(false)
-    })
-
-    it('keeps the public nav on standalone /admin/<section> sub-routes (scoped to the tab-shell, not startsWith)', () => {
+    it('keeps the public nav on standalone /admin/<section> sub-routes (scoped to the tab-shell)', () => {
       asAdmin()
       mockPathname = '/admin/featured'
       render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
       expect(screen.getByText('Discover')).toBeInTheDocument()
-      expect(screen.queryByText('Moderation & Queues')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('admin-drawer-nav')).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/components/layout/TopBar.test.tsx
+++ b/frontend/components/layout/TopBar.test.tsx
@@ -4,8 +4,16 @@ import userEvent from '@testing-library/user-event'
 import { TopBar } from './TopBar'
 
 let mockPathname = '/'
+let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}))
+
+// Admin nav counts hook is exercised by its own unit + the Sidebar admin tests;
+// stub it here so the public TopBar tests don't need a QueryClientProvider.
+vi.mock('@/lib/hooks/admin/useAdminNavCounts', () => ({
+  useAdminNavCounts: () => ({ moderation: 0, pendingShows: 0, unverifiedVenues: 0, reports: 0 }),
 }))
 
 vi.mock('next/image', () => ({

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -2,11 +2,11 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import {
   Menu, LogOut, Loader2, Shield, Settings, Moon, Sun, Search,
-  Library, ExternalLink, Bell,
+  Library, ExternalLink, Bell, ArrowLeft,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -20,6 +20,10 @@ import {
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { getUserInitials, getUserDisplayName } from '@/app/nav-utils'
 import { sidebarGroups } from './Sidebar'
+import {
+  adminNavGroups, adminTabHref, isAdminTabActive, ADMIN_BADGE_CLASS,
+} from './adminNav'
+import { useAdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
 import { NotificationBell } from '@/features/notifications'
 
 interface TopBarProps {
@@ -32,6 +36,15 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
   const { user, isAuthenticated, isLoading, logout } = useAuthContext()
   const { theme, setTheme } = useTheme()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // Context-aware mobile drawer (PSY-933): in /admin the nav groups swap to the
+  // grouped admin sections + "Back to site". Gated on isAdmin (mid-redirect
+  // safety) and used to gate the admin-only count queries.
+  const isAdmin = !!user?.is_admin
+  const showAdminNav = isAdmin && pathname.startsWith('/admin')
+  const tabParam = searchParams.get('tab')
+  const counts = useAdminNavCounts({ enabled: showAdminNav })
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/'
@@ -70,7 +83,52 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
                 <SheetTitle className="text-left">Menu</SheetTitle>
               </SheetHeader>
               <nav className="flex flex-col gap-1 px-2 py-4">
-                {sidebarGroups.map(group => (
+                {showAdminNav ? (
+                  <>
+                    <Link
+                      href="/"
+                      onClick={() => onMobileOpenChange(false)}
+                      className="mb-2 flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium text-foreground/70 transition-colors hover:bg-accent/50 hover:text-accent-foreground"
+                    >
+                      <ArrowLeft className="h-4 w-4" />
+                      <span>Back to site</span>
+                    </Link>
+                    {adminNavGroups.map(group => (
+                      <div key={group.label} className="mb-4">
+                        <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground/50">
+                          {group.label}
+                        </p>
+                        {group.items.map(item => {
+                          const Icon = item.icon
+                          const active = isAdminTabActive(item.tab, pathname, tabParam)
+                          const count = item.badgeKey ? counts[item.badgeKey] : 0
+                          return (
+                            <Link
+                              key={item.tab}
+                              href={adminTabHref(item.tab)}
+                              onClick={() => onMobileOpenChange(false)}
+                              className={cn(
+                                'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
+                                active
+                                  ? 'bg-accent text-accent-foreground'
+                                  : 'text-foreground/70 hover:bg-accent/50 hover:text-accent-foreground'
+                              )}
+                            >
+                              <Icon className="h-4 w-4" />
+                              <span>{item.label}</span>
+                              {item.badgeKey && count > 0 && (
+                                <span className={cn('ml-auto rounded-full px-2 py-0.5 text-xs font-medium text-white', ADMIN_BADGE_CLASS[item.badgeKey])}>
+                                  {count}
+                                </span>
+                              )}
+                            </Link>
+                          )
+                        })}
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  sidebarGroups.map(group => (
                   <div key={group.label} className="mb-4">
                     <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground/50">
                       {group.label}
@@ -99,7 +157,8 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
                       )
                     })}
                   </div>
-                ))}
+                  ))
+                )}
 
                 {/* Mobile auth section */}
                 {isLoading ? (

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -2,11 +2,12 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
+import dynamic from 'next/dynamic'
 import { useTheme } from 'next-themes'
 import {
   Menu, LogOut, Loader2, Shield, Settings, Moon, Sun, Search,
-  Library, ExternalLink, Bell, ArrowLeft,
+  Library, ExternalLink, Bell,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -20,11 +21,11 @@ import {
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { getUserInitials, getUserDisplayName } from '@/app/nav-utils'
 import { sidebarGroups } from './Sidebar'
-import {
-  adminNavGroups, adminTabHref, isAdminTabActive, ADMIN_BADGE_CLASS,
-} from './adminNav'
-import { useAdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
 import { NotificationBell } from '@/features/notifications'
+
+// Mobile admin drawer (config + the 7 queue-count hooks) is a separate chunk
+// loaded only when an admin opens the drawer on /admin — off the public bundle.
+const AdminDrawerNav = dynamic(() => import('./AdminDrawerNav'), { ssr: false })
 
 interface TopBarProps {
   mobileOpen: boolean
@@ -36,17 +37,15 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
   const { user, isAuthenticated, isLoading, logout } = useAuthContext()
   const { theme, setTheme } = useTheme()
   const pathname = usePathname()
-  const searchParams = useSearchParams()
 
-  // Context-aware mobile drawer (PSY-933): in /admin the nav groups swap to the
-  // grouped admin sections + "Back to site". Gated on isAdmin (mid-redirect
-  // safety) and used to gate the admin-only count queries. Scoped to the exact
-  // /admin tab-shell (usePathname() strips ?tab=); standalone /admin/<section>
-  // sub-routes keep the public nav, matching the desktop Sidebar.
+  // Context-aware mobile drawer (PSY-933): under the /admin shell the nav groups
+  // swap to the grouped admin sections (rendered by the lazily-loaded
+  // AdminDrawerNav — admin-only code stays out of the public bundle). Gated on
+  // isAdmin (mid-redirect safety) + scoped to the exact /admin tab-shell
+  // (usePathname() strips ?tab=); standalone /admin/<section> sub-routes keep the
+  // public nav, matching the desktop Sidebar.
   const isAdmin = !!user?.is_admin
   const showAdminNav = isAdmin && pathname === '/admin'
-  const tabParam = searchParams.get('tab')
-  const counts = useAdminNavCounts({ enabled: showAdminNav })
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/'
@@ -86,49 +85,7 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
               </SheetHeader>
               <nav className="flex flex-col gap-1 px-2 py-4">
                 {showAdminNav ? (
-                  <>
-                    <Link
-                      href="/"
-                      onClick={() => onMobileOpenChange(false)}
-                      className="mb-2 flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium text-foreground/70 transition-colors hover:bg-accent/50 hover:text-accent-foreground"
-                    >
-                      <ArrowLeft className="h-4 w-4" />
-                      <span>Back to site</span>
-                    </Link>
-                    {adminNavGroups.map(group => (
-                      <div key={group.label} className="mb-4">
-                        <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground/50">
-                          {group.label}
-                        </p>
-                        {group.items.map(item => {
-                          const Icon = item.icon
-                          const active = isAdminTabActive(item.tab, pathname, tabParam)
-                          const count = item.badgeKey ? counts[item.badgeKey] : 0
-                          return (
-                            <Link
-                              key={item.tab}
-                              href={adminTabHref(item.tab)}
-                              onClick={() => onMobileOpenChange(false)}
-                              className={cn(
-                                'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
-                                active
-                                  ? 'bg-accent text-accent-foreground'
-                                  : 'text-foreground/70 hover:bg-accent/50 hover:text-accent-foreground'
-                              )}
-                            >
-                              <Icon className="h-4 w-4" />
-                              <span>{item.label}</span>
-                              {item.badgeKey && count > 0 && (
-                                <span className={cn('ml-auto rounded-full px-2 py-0.5 text-xs font-medium text-white', ADMIN_BADGE_CLASS[item.badgeKey])}>
-                                  {count}
-                                </span>
-                              )}
-                            </Link>
-                          )
-                        })}
-                      </div>
-                    ))}
-                  </>
+                  <AdminDrawerNav onNavigate={() => onMobileOpenChange(false)} />
                 ) : (
                   sidebarGroups.map(group => (
                   <div key={group.label} className="mb-4">

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -40,9 +40,11 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
 
   // Context-aware mobile drawer (PSY-933): in /admin the nav groups swap to the
   // grouped admin sections + "Back to site". Gated on isAdmin (mid-redirect
-  // safety) and used to gate the admin-only count queries.
+  // safety) and used to gate the admin-only count queries. Scoped to the exact
+  // /admin tab-shell (usePathname() strips ?tab=); standalone /admin/<section>
+  // sub-routes keep the public nav, matching the desktop Sidebar.
   const isAdmin = !!user?.is_admin
-  const showAdminNav = isAdmin && pathname.startsWith('/admin')
+  const showAdminNav = isAdmin && pathname === '/admin'
   const tabParam = searchParams.get('tab')
   const counts = useAdminNavCounts({ enabled: showAdminNav })
 

--- a/frontend/components/layout/adminNav.test.ts
+++ b/frontend/components/layout/adminNav.test.ts
@@ -51,4 +51,11 @@ describe('adminNav', () => {
     expect(isAdminTabActive('reports', '/admin', 'moderation')).toBe(false)
     expect(isAdminTabActive('moderation', '/shows', null)).toBe(false)
   })
+
+  it('isAdminTabActive: an invalid ?tab= falls back to Dashboard active (mirrors page.tsx)', () => {
+    // page.tsx renders the dashboard panel for an unknown tab; the nav must
+    // agree so there's no highlight/content mismatch (e.g. a stale link).
+    expect(isAdminTabActive('dashboard', '/admin', 'pending-venue-edits')).toBe(true)
+    expect(isAdminTabActive('moderation', '/admin', 'pending-venue-edits')).toBe(false)
+  })
 })

--- a/frontend/components/layout/adminNav.test.ts
+++ b/frontend/components/layout/adminNav.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import {
+  adminNavGroups,
+  VALID_TABS,
+  isValidTab,
+  adminTabHref,
+  isAdminTabActive,
+} from './adminNav'
+
+// Guards the single-source-of-truth coupling (PSY-933): the admin nav is now the
+// ONLY way into the /admin tab content, so a section in VALID_TABS with no nav
+// item is unreachable, and a nav item with a stray tab lands on a dead section.
+// `tab: AdminTab` makes a bad literal a compile error; this makes the
+// coverage/uniqueness a test error.
+describe('adminNav', () => {
+  const navTabs = adminNavGroups.flatMap(g => g.items.map(i => i.tab))
+
+  it('covers exactly VALID_TABS — no missing or extra sections', () => {
+    expect([...navTabs].sort()).toEqual([...VALID_TABS].sort())
+  })
+
+  it('lists every section exactly once (no duplicate nav items)', () => {
+    expect(new Set(navTabs).size).toBe(navTabs.length)
+  })
+
+  it('only the four queue sections carry a badge key', () => {
+    const badged = adminNavGroups
+      .flatMap(g => g.items)
+      .filter(i => i.badgeKey)
+      .map(i => i.tab)
+    expect(badged.sort()).toEqual(
+      ['moderation', 'pending-shows', 'reports', 'unverified-venues'].sort()
+    )
+  })
+
+  it('adminTabHref: dashboard is bare /admin, others carry ?tab=', () => {
+    expect(adminTabHref('dashboard')).toBe('/admin')
+    expect(adminTabHref('moderation')).toBe('/admin?tab=moderation')
+  })
+
+  it('isValidTab accepts known tabs and rejects unknown / null', () => {
+    expect(isValidTab('moderation')).toBe(true)
+    expect(isValidTab('pending-venue-edits')).toBe(false) // a known stale value
+    expect(isValidTab(null)).toBe(false)
+  })
+
+  it('isAdminTabActive: dashboard active at bare /admin; sections match ?tab=', () => {
+    expect(isAdminTabActive('dashboard', '/admin', null)).toBe(true)
+    expect(isAdminTabActive('dashboard', '/admin', 'moderation')).toBe(false)
+    expect(isAdminTabActive('moderation', '/admin', 'moderation')).toBe(true)
+    expect(isAdminTabActive('reports', '/admin', 'moderation')).toBe(false)
+    expect(isAdminTabActive('moderation', '/shows', null)).toBe(false)
+  })
+})

--- a/frontend/components/layout/adminNav.ts
+++ b/frontend/components/layout/adminNav.ts
@@ -1,0 +1,114 @@
+import {
+  LayoutDashboard, ShieldCheck, Clock, BadgeCheck, Flag,
+  Disc3, Tag, Tent, Music, Radio, Library, Tags,
+  Upload, Workflow, ClipboardCheck, BarChart3, Users, ScrollText,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import type { AdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
+
+/**
+ * Admin navigation model (PSY-933). The admin area swaps the global Sidebar's
+ * public Discover/Community groups for these 6 grouped admin sections (the
+ * context-aware-sidebar decision — see the PSY-933 Figma mock + ticket). Items
+ * link to the existing `/admin?tab=` model rather than nested routes, so this is
+ * a nav-chrome change only; `app/admin/page.tsx` still owns the tab content.
+ */
+
+/** Sections whose tab carries an attention-count badge. Keys match AdminNavCounts. */
+export type AdminBadgeKey = keyof AdminNavCounts
+
+export interface AdminNavItem {
+  /** The `?tab=` value on /admin (also the VALID_TABS member). */
+  tab: string
+  label: string
+  icon: LucideIcon
+  /** When set, the item shows the matching count from useAdminNavCounts. */
+  badgeKey?: AdminBadgeKey
+}
+
+export interface AdminNavGroup {
+  label: string
+  items: AdminNavItem[]
+}
+
+export const adminNavGroups: AdminNavGroup[] = [
+  {
+    label: 'Overview',
+    items: [{ tab: 'dashboard', label: 'Dashboard', icon: LayoutDashboard }],
+  },
+  {
+    label: 'Moderation & Queues',
+    items: [
+      { tab: 'moderation', label: 'Moderation', icon: ShieldCheck, badgeKey: 'moderation' },
+      { tab: 'pending-shows', label: 'Pending Shows', icon: Clock, badgeKey: 'pendingShows' },
+      { tab: 'unverified-venues', label: 'Unverified Venues', icon: BadgeCheck, badgeKey: 'unverifiedVenues' },
+      { tab: 'reports', label: 'Reports', icon: Flag, badgeKey: 'reports' },
+    ],
+  },
+  {
+    label: 'Catalog',
+    items: [
+      { tab: 'releases', label: 'Releases', icon: Disc3 },
+      { tab: 'labels', label: 'Labels', icon: Tag },
+      { tab: 'festivals', label: 'Festivals', icon: Tent },
+      { tab: 'artists-admin', label: 'Artists', icon: Music },
+      { tab: 'radio', label: 'Radio Stations', icon: Radio },
+    ],
+  },
+  {
+    label: 'Curation & Taxonomy',
+    items: [
+      { tab: 'collections', label: 'Collections', icon: Library },
+      { tab: 'tags', label: 'Tags', icon: Tags },
+    ],
+  },
+  {
+    label: 'Tools',
+    items: [
+      { tab: 'import-show', label: 'Import Show', icon: Upload },
+      { tab: 'pipeline', label: 'Data Pipeline', icon: Workflow },
+      { tab: 'data-quality', label: 'Data Quality', icon: ClipboardCheck },
+    ],
+  },
+  {
+    label: 'Insights & System',
+    items: [
+      { tab: 'analytics', label: 'Analytics', icon: BarChart3 },
+      { tab: 'users', label: 'Users', icon: Users },
+      { tab: 'audit-log', label: 'Audit Log', icon: ScrollText },
+    ],
+  },
+]
+
+/** The /admin URL for a section. Dashboard is the bare /admin (no tab param). */
+export function adminTabHref(tab: string): string {
+  return tab === 'dashboard' ? '/admin' : `/admin?tab=${tab}`
+}
+
+/**
+ * Active-state test for an admin item against the current location. Dashboard
+ * is active at /admin with no (or `dashboard`) tab param; every other section
+ * matches its exact tab param. Mirrors page.tsx's tab resolution.
+ */
+export function isAdminTabActive(
+  tab: string,
+  pathname: string,
+  tabParam: string | null
+): boolean {
+  if (!pathname.startsWith('/admin')) return false
+  if (tab === 'dashboard') return tabParam === null || tabParam === 'dashboard'
+  return tabParam === tab
+}
+
+/**
+ * Per-queue badge color. Kept as today's ad-hoc Tailwind tints (purple / amber /
+ * orange / red) to preserve the current information scent; tokenizing these to
+ * the DS palette is the PSY-908 cohesion decision (the PSY-933 mock showed a
+ * single illustrative token).
+ */
+export const ADMIN_BADGE_CLASS: Record<AdminBadgeKey, string> = {
+  moderation: 'bg-purple-500',
+  pendingShows: 'bg-amber-500',
+  unverifiedVenues: 'bg-orange-500',
+  reports: 'bg-red-500',
+}

--- a/frontend/components/layout/adminNav.ts
+++ b/frontend/components/layout/adminNav.ts
@@ -14,12 +14,34 @@ import type { AdminNavCounts } from '@/lib/hooks/admin/useAdminNavCounts'
  * a nav-chrome change only; `app/admin/page.tsx` still owns the tab content.
  */
 
+/**
+ * The admin section tabs — the `?tab=` values on /admin. Single source of truth
+ * for valid sections: app/admin/page.tsx imports isValidTab to resolve the
+ * active section, and adminNavGroups below must cover exactly these (enforced by
+ * adminNav.test.ts). Adding a section = add it here + its TabsContent in
+ * page.tsx + a nav item below. Lives here (not page.tsx) so the always-mounted
+ * Sidebar can type its nav items against it without importing the page module.
+ */
+export const VALID_TABS = [
+  'dashboard', 'moderation', 'pending-shows', 'unverified-venues',
+  'reports', 'import-show', 'releases', 'labels', 'festivals', 'pipeline',
+  'collections', 'tags', 'data-quality', 'analytics', 'artists-admin', 'radio',
+  'users', 'audit-log',
+] as const
+
+export type AdminTab = (typeof VALID_TABS)[number]
+
+export function isValidTab(value: string | null): value is AdminTab {
+  return value !== null && (VALID_TABS as readonly string[]).includes(value)
+}
+
 /** Sections whose tab carries an attention-count badge. Keys match AdminNavCounts. */
 export type AdminBadgeKey = keyof AdminNavCounts
 
 export interface AdminNavItem {
-  /** The `?tab=` value on /admin (also the VALID_TABS member). */
-  tab: string
+  /** The `?tab=` value on /admin. Typed against VALID_TABS so a typo or a
+   *  renamed section is a compile error, not a silent dead nav link. */
+  tab: AdminTab
   label: string
   icon: LucideIcon
   /** When set, the item shows the matching count from useAdminNavCounts. */

--- a/frontend/components/layout/adminNav.ts
+++ b/frontend/components/layout/adminNav.ts
@@ -108,17 +108,20 @@ export function adminTabHref(tab: string): string {
 }
 
 /**
- * Active-state test for an admin item against the current location. Dashboard
- * is active at /admin with no (or `dashboard`) tab param; every other section
- * matches its exact tab param. Mirrors page.tsx's tab resolution.
+ * Active-state test for an admin item against the current location. Mirrors
+ * page.tsx's `isValidTab(tabParam) ? tabParam : 'dashboard'` resolution exactly:
+ * a non-section tab param (missing, `dashboard`, or anything invalid like a
+ * stale `pending-venue-edits` link) falls back to Dashboard, so Dashboard is the
+ * active item there too — never a highlight/content mismatch. Other sections
+ * match their exact tab param.
  */
 export function isAdminTabActive(
-  tab: string,
+  tab: AdminTab,
   pathname: string,
   tabParam: string | null
 ): boolean {
   if (!pathname.startsWith('/admin')) return false
-  if (tab === 'dashboard') return tabParam === null || tabParam === 'dashboard'
+  if (tab === 'dashboard') return tabParam === 'dashboard' || !isValidTab(tabParam)
   return tabParam === tab
 }
 

--- a/frontend/lib/hooks/admin/useAdminArtistReports.ts
+++ b/frontend/lib/hooks/admin/useAdminArtistReports.ts
@@ -12,6 +12,8 @@ import type { AdminReportActionRequest } from '@/features/shows'
 interface UsePendingArtistReportsOptions {
   limit?: number
   offset?: number
+  /** When false, the query does not fire (e.g. the admin nav badge off-route). Defaults to true. */
+  enabled?: boolean
 }
 
 /**
@@ -20,7 +22,7 @@ interface UsePendingArtistReportsOptions {
 export const usePendingArtistReports = (
   options: UsePendingArtistReportsOptions = {}
 ) => {
-  const { limit = 50, offset = 0 } = options
+  const { limit = 50, offset = 0, enabled = true } = options
 
   const params = new URLSearchParams()
   params.set('limit', limit.toString())
@@ -36,6 +38,7 @@ export const usePendingArtistReports = (
       })
     },
     staleTime: 30 * 1000, // 30 seconds
+    enabled,
   })
 }
 

--- a/frontend/lib/hooks/admin/useAdminComments.ts
+++ b/frontend/lib/hooks/admin/useAdminComments.ts
@@ -85,7 +85,13 @@ const ADMIN_COMMENT_ENDPOINTS = {
 /**
  * Hook to fetch pending comments awaiting admin review.
  */
-export function useAdminPendingComments(limit = 25, offset = 0) {
+export function useAdminPendingComments(
+  limit = 25,
+  offset = 0,
+  // When false, the query does not fire (e.g. the admin nav badge off-route). Defaults to true.
+  options: { enabled?: boolean } = {}
+) {
+  const { enabled = true } = options
   const params = new URLSearchParams()
   params.set('limit', limit.toString())
   params.set('offset', offset.toString())
@@ -100,6 +106,7 @@ export function useAdminPendingComments(limit = 25, offset = 0) {
       })
     },
     staleTime: 30 * 1000, // 30 seconds
+    enabled,
   })
 }
 

--- a/frontend/lib/hooks/admin/useAdminEntityReports.ts
+++ b/frontend/lib/hooks/admin/useAdminEntityReports.ts
@@ -54,6 +54,8 @@ export interface EntityReportFilters {
   entity_type?: string
   limit?: number
   offset?: number
+  /** When false, the query does not fire (e.g. the admin nav badge off-route). Defaults to true. */
+  enabled?: boolean
 }
 
 // ─── Hooks ───────────────────────────────────────────────────────────────────
@@ -62,7 +64,7 @@ export interface EntityReportFilters {
  * Hook to fetch entity reports for admin review.
  */
 export function useAdminEntityReports(filters: EntityReportFilters = {}) {
-  const { status = 'pending', entity_type, limit = 50, offset = 0 } = filters
+  const { status = 'pending', entity_type, limit = 50, offset = 0, enabled = true } = filters
 
   const params = new URLSearchParams()
   if (status) params.set('status', status)
@@ -80,6 +82,7 @@ export function useAdminEntityReports(filters: EntityReportFilters = {}) {
       })
     },
     staleTime: 30 * 1000, // 30 seconds
+    enabled,
   })
 }
 

--- a/frontend/lib/hooks/admin/useAdminNavCounts.test.ts
+++ b/frontend/lib/hooks/admin/useAdminNavCounts.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// Stub the 7 underlying queue hooks so we can test (a) the aggregation math and
+// (b) that the `enabled` gate is threaded through to every one — the contract
+// that keeps these admin-only endpoints from firing for non-admins / off-route.
+const h = vi.hoisted(() => ({
+  usePendingShows: vi.fn(),
+  useUnverifiedVenues: vi.fn(),
+  usePendingReports: vi.fn(),
+  usePendingArtistReports: vi.fn(),
+  useAdminPendingEdits: vi.fn(),
+  useAdminEntityReports: vi.fn(),
+  useAdminPendingComments: vi.fn(),
+}))
+vi.mock('./useAdminShows', () => ({ usePendingShows: h.usePendingShows }))
+vi.mock('./useAdminVenues', () => ({ useUnverifiedVenues: h.useUnverifiedVenues }))
+vi.mock('./useAdminReports', () => ({ usePendingReports: h.usePendingReports }))
+vi.mock('./useAdminArtistReports', () => ({ usePendingArtistReports: h.usePendingArtistReports }))
+vi.mock('./useAdminPendingEdits', () => ({ useAdminPendingEdits: h.useAdminPendingEdits }))
+vi.mock('./useAdminEntityReports', () => ({ useAdminEntityReports: h.useAdminEntityReports }))
+vi.mock('./useAdminComments', () => ({ useAdminPendingComments: h.useAdminPendingComments }))
+
+import { useAdminNavCounts } from './useAdminNavCounts'
+
+const total = (n: number) => ({ data: { total: n } })
+
+describe('useAdminNavCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const fn of Object.values(h)) fn.mockReturnValue({ data: undefined })
+  })
+
+  it('aggregates the four nav counts (moderation = edits + entity reports + comments; reports = show + artist)', () => {
+    h.usePendingShows.mockReturnValue(total(2))
+    h.useUnverifiedVenues.mockReturnValue(total(1))
+    h.usePendingReports.mockReturnValue(total(3))
+    h.usePendingArtistReports.mockReturnValue(total(4))
+    h.useAdminPendingEdits.mockReturnValue(total(5))
+    h.useAdminEntityReports.mockReturnValue(total(6))
+    h.useAdminPendingComments.mockReturnValue(total(7))
+
+    const { result } = renderHook(() => useAdminNavCounts({ enabled: true }))
+
+    expect(result.current).toEqual({
+      moderation: 18, // 5 + 6 + 7
+      pendingShows: 2,
+      unverifiedVenues: 1,
+      reports: 7, // 3 + 4
+    })
+  })
+
+  it('treats missing data as zero', () => {
+    // all hooks return { data: undefined } from beforeEach
+    const { result } = renderHook(() => useAdminNavCounts({ enabled: true }))
+    expect(result.current).toEqual({
+      moderation: 0,
+      pendingShows: 0,
+      unverifiedVenues: 0,
+      reports: 0,
+    })
+  })
+
+  it('threads enabled through to every underlying query (the gating contract)', () => {
+    renderHook(() => useAdminNavCounts({ enabled: false }))
+
+    expect(h.usePendingShows).toHaveBeenCalledWith({ enabled: false })
+    expect(h.useUnverifiedVenues).toHaveBeenCalledWith({ enabled: false })
+    expect(h.usePendingReports).toHaveBeenCalledWith({ enabled: false })
+    expect(h.usePendingArtistReports).toHaveBeenCalledWith({ enabled: false })
+    expect(h.useAdminPendingEdits).toHaveBeenCalledWith({ status: 'pending', enabled: false })
+    expect(h.useAdminEntityReports).toHaveBeenCalledWith({ status: 'pending', enabled: false })
+    // positional signature: (limit, offset, options)
+    expect(h.useAdminPendingComments).toHaveBeenCalledWith(25, 0, { enabled: false })
+  })
+
+  it('passes enabled: true through when enabled', () => {
+    renderHook(() => useAdminNavCounts({ enabled: true }))
+    expect(h.usePendingShows).toHaveBeenCalledWith({ enabled: true })
+    expect(h.useAdminPendingComments).toHaveBeenCalledWith(25, 0, { enabled: true })
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminNavCounts.ts
+++ b/frontend/lib/hooks/admin/useAdminNavCounts.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useUnverifiedVenues } from './useAdminVenues'
+import { usePendingReports } from './useAdminReports'
+import { usePendingArtistReports } from './useAdminArtistReports'
+import { usePendingShows } from './useAdminShows'
+import { useAdminPendingEdits } from './useAdminPendingEdits'
+import { useAdminEntityReports } from './useAdminEntityReports'
+import { useAdminPendingComments } from './useAdminComments'
+
+/**
+ * The four attention counts the admin navigation surfaces as badges.
+ * `moderation` aggregates the three moderation-queue sources (pending edits +
+ * entity reports + pending comments) — mirroring the dashboard's tally.
+ */
+export interface AdminNavCounts {
+  moderation: number
+  pendingShows: number
+  unverifiedVenues: number
+  reports: number
+}
+
+/**
+ * Bundles the queue queries that back the admin-nav badge counts so the global
+ * Sidebar (and mobile drawer) can show them without each consumer re-deriving
+ * the aggregation. Every underlying query is gated by `enabled` because the
+ * Sidebar mounts on every page: pass `enabled: isAdmin && inAdmin` so these
+ * admin-only endpoints never fire for non-admins or on public routes (they'd
+ * 403 / waste requests otherwise). React Query dedupes the shared query keys,
+ * so the desktop Sidebar and mobile drawer issue a single fetch each.
+ */
+export function useAdminNavCounts({ enabled }: { enabled: boolean }): AdminNavCounts {
+  const { data: pendingShowsData } = usePendingShows({ enabled })
+  const { data: unverifiedVenuesData } = useUnverifiedVenues({ enabled })
+  const { data: reportsData } = usePendingReports({ enabled })
+  const { data: artistReportsData } = usePendingArtistReports({ enabled })
+  const { data: pendingEditsData } = useAdminPendingEdits({ status: 'pending', enabled })
+  const { data: entityReportsData } = useAdminEntityReports({ status: 'pending', enabled })
+  const { data: pendingCommentsData } = useAdminPendingComments(25, 0, { enabled })
+
+  return {
+    moderation:
+      (pendingEditsData?.total || 0) +
+      (entityReportsData?.total || 0) +
+      (pendingCommentsData?.total || 0),
+    pendingShows: pendingShowsData?.total || 0,
+    unverifiedVenues: unverifiedVenuesData?.total || 0,
+    reports: (reportsData?.total || 0) + (artistReportsData?.total || 0),
+  }
+}

--- a/frontend/lib/hooks/admin/useAdminNavCounts.ts
+++ b/frontend/lib/hooks/admin/useAdminNavCounts.ts
@@ -11,7 +11,8 @@ import { useAdminPendingComments } from './useAdminComments'
 /**
  * The four attention counts the admin navigation surfaces as badges.
  * `moderation` aggregates the three moderation-queue sources (pending edits +
- * entity reports + pending comments) — mirroring the dashboard's tally.
+ * entity reports + pending comments) — the same formula the retired admin tab
+ * bar used for its moderation badge.
  */
 export interface AdminNavCounts {
   moderation: number
@@ -26,8 +27,11 @@ export interface AdminNavCounts {
  * the aggregation. Every underlying query is gated by `enabled` because the
  * Sidebar mounts on every page: pass `enabled: isAdmin && inAdmin` so these
  * admin-only endpoints never fire for non-admins or on public routes (they'd
- * 403 / waste requests otherwise). React Query dedupes the shared query keys,
- * so the desktop Sidebar and mobile drawer issue a single fetch each.
+ * 403 / waste requests otherwise). React Query dedupes by query key, so the
+ * desktop Sidebar and mobile drawer share one in-flight fetch per count; an
+ * admin page already running the same (unfiltered) query reuses it too. (A page
+ * that filters — e.g. the moderation queue by entity_type — uses a different key
+ * and runs its own query; the nav badge intentionally keeps the global total.)
  */
 export function useAdminNavCounts({ enabled }: { enabled: boolean }): AdminNavCounts {
   const { data: pendingShowsData } = usePendingShows({ enabled })

--- a/frontend/lib/hooks/admin/useAdminPendingEdits.ts
+++ b/frontend/lib/hooks/admin/useAdminPendingEdits.ts
@@ -66,6 +66,8 @@ export interface PendingEditsFilters {
   entity_type?: string
   limit?: number
   offset?: number
+  /** When false, the query does not fire (e.g. the admin nav badge off-route). Defaults to true. */
+  enabled?: boolean
 }
 
 // ─── Hooks ───────────────────────────────────────────────────────────────────
@@ -74,7 +76,7 @@ export interface PendingEditsFilters {
  * Hook to fetch pending entity edits for admin review.
  */
 export function useAdminPendingEdits(filters: PendingEditsFilters = {}) {
-  const { status = 'pending', entity_type, limit = 50, offset = 0 } = filters
+  const { status = 'pending', entity_type, limit = 50, offset = 0, enabled = true } = filters
 
   const params = new URLSearchParams()
   if (status) params.set('status', status)
@@ -92,6 +94,7 @@ export function useAdminPendingEdits(filters: PendingEditsFilters = {}) {
       })
     },
     staleTime: 30 * 1000, // 30 seconds
+    enabled,
   })
 }
 

--- a/frontend/lib/hooks/admin/useAdminReports.ts
+++ b/frontend/lib/hooks/admin/useAdminReports.ts
@@ -13,13 +13,15 @@ import type {
 interface UsePendingReportsOptions {
   limit?: number
   offset?: number
+  /** When false, the query does not fire (e.g. the admin nav badge off-route). Defaults to true. */
+  enabled?: boolean
 }
 
 /**
  * Hook to fetch pending show reports for admin review
  */
 export const usePendingReports = (options: UsePendingReportsOptions = {}) => {
-  const { limit = 50, offset = 0 } = options
+  const { limit = 50, offset = 0, enabled = true } = options
 
   const params = new URLSearchParams()
   params.set('limit', limit.toString())
@@ -35,6 +37,7 @@ export const usePendingReports = (options: UsePendingReportsOptions = {}) => {
       })
     },
     staleTime: 30 * 1000, // 30 seconds
+    enabled,
   })
 }
 


### PR DESCRIPTION
Closes PSY-933.

## Summary
The `/admin` area packed **18 sections** into one horizontal Radix tab strip (a custom `ScrollableTabBar` chevron-scroll carousel) — well past NN/G's "3–6 tabs" limit, where hidden tabs lose discoverability. This makes the existing left **Sidebar context-aware**: on the `/admin` tab-shell it swaps the public Discover/Community groups for **6 grouped admin sections + queue-count badges + a "← Back to site" link**; the **mobile TopBar drawer** does the same (it's the only admin nav on mobile). Implements the PSY-933 decision — one rail, reuses the collapsible Sidebar + mobile drawer; Cmd-K palette deferred. Design mocked + **approved in Figma** (Product Designs → Admin page) before coding.

**IA — 18 sections → 6 groups:** Overview · Moderation & Queues · Catalog · Curation & Taxonomy · Tools · Insights & System.

## What changed
- **`components/layout/adminNav.ts`** (new) — single source of truth: `VALID_TABS` / `AdminTab` / `isValidTab` (moved out of page.tsx so the always-mounted Sidebar can type against it without importing the page module), the 6-group config (items typed `tab: AdminTab` → a typo / renamed section is a compile error, not a silent dead link), `adminTabHref` / `isAdminTabActive`, and `ADMIN_BADGE_CLASS` (today's per-queue tints kept; tokenizing → PSY-908). `adminNav.test.ts` asserts the nav covers `VALID_TABS` exactly.
- **`lib/hooks/admin/useAdminNavCounts.ts`** (new) — bundles the 4 badge counts from the 7 queue queries, gated `{ enabled }`. The global Sidebar/TopBar pass `enabled: isAdmin && pathname === '/admin'`, so admin-only endpoints never fire for non-admins / on public routes. Added `enabled` to the 5 count hooks that lacked it (backward-compatible).
- **`Sidebar.tsx` + `TopBar.tsx`** — context-aware: under the `/admin` shell render the admin groups + badges + back-to-site (else public nav). Scoped to `pathname === '/admin'` (still matches `/admin?tab=…` since `usePathname()` strips the query; standalone sub-routes keep the public nav).
- **Lazy-loaded off the public bundle** — the admin nav (the `adminNav` config + the 7 queue-count hooks) is split into dynamically-imported chunks (`AdminSidebarNav` / `AdminDrawerNav`, `next/dynamic` `ssr:false`) mounted only when `isAdmin && pathname === '/admin'`. Anonymous `/explore` (and every public page) no longer downloads admin-only code. A shared `SidebarNavLink` renders the public + admin link row from one source. The count queries are now gated by *mount* (strictly stronger than the prior `enabled` gate — non-admins/public routes never even load the module).
- **`app/admin/page.tsx`** — removed `ScrollableTabBar` + the 18-trigger strip + the in-page count hooks. `Tabs` stays value-controlled; `activeTab` now derives from `?tab=` (single source of truth) instead of mirrored `useState` + a sync effect — also clears a pre-existing `react-hooks/set-state-in-effect`.
- Removed the now-orphaned `.scrollbar-none` CSS (its only consumer was the retired strip).

## Decision (PSY-933)
Context-aware sidebar (one rail), 6-group IA, keep `?tab=`, Cmd-K deferred — chosen with Matt; mocked + approved in Figma before implementation.

## Deferred / follow-up
- **PSY-934** — pre-existing dead `?tab=pending-venue-edits` links (CommandPalette + dashboard quick-link); expanded to migrate CommandPalette's route list onto adminNav's single source + add its missing Radio entry.
- **PSY-908** — tokenize the per-queue badge colors.
- Path-aware admin rail for standalone `/admin/<section>` routes (`/admin/featured`, etc.) — they keep the public nav for now (pre-PSY-933 behavior).

## Adversarial review
`/adversarial-review` — 3 rounds → CLEAN. R1: Security **CLEAN** (gating fail-closed for non-admins + backend `rc.Admin` defense-in-depth); Saboteur/Future-Maintainer/Completeness CONCERNS. R2: **CLEAN**. Fixes in commit `89a4df01`:
- **[HIGH]** Scoped the rail to `pathname === '/admin'` — the prefix match mis-rendered on `/admin/<section>` sub-routes (wrong Dashboard highlight + URL relocation). + regression tests.
- **[HIGH]** Added the missing mobile-drawer admin-nav test suite (load-bearing — the only admin nav on mobile).
- **[MEDIUM]** `isAdminTabActive` now mirrors page.tsx for an invalid `?tab=` (falls back to Dashboard active — no highlight/content mismatch).
- **[MEDIUM]** Restored the page-level deep-link test.
- **[LOW]** Reuse the documented `ACTIVE_TOKEN`; softened a `useAdminNavCounts` doc comment.

R3 re-reviewed the lazy-load refactor (`77d1f218`) — behavior preservation verified character-identical vs the prior inline source, `ssr:false` safe (no hydration mismatch), TooltipProvider scope intact, counts gated by mount, no test coverage lost → **CLEAN**. (One INFO: the desktop rail pops in client-side on `/admin` load — cosmetic, no CLS, by design.)
Panel: Saboteur · Future-Maintainer · Security · Completeness.

## Lighthouse `/explore` gate (known environmental flake — not this PR)
The `Lighthouse /explore (mobile)` check is red on a **verified environmental flake**, not a regression from this admin-nav PR. From the LHR traces: TTI tracks cold-preview variance (the Sentry `/monitoring` beacon end-time + JS bootup), with a wild per-run spread (e.g. 2066 / 3256 / 7536ms) where individual runs pass but the median (~3.1s) sits above the 2500ms budget. My change adds **0 requests to `/explore`** (the count queries don't fire there) and — after the lazy-load above — ships **0 admin JS** to the public bundle. Same flaky-gate family as PSY-929 (whose CORS fix is already merged + working: 0 `status=-1`); full diagnosis saved to project memory. Re-running doesn't reliably clear it (median > budget) — a separate gate-recalibration follow-up is the durable fix.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run` (full frontend) — **5284 passing**
- [x] `components/layout/AdminSidebarNav.test.tsx` + `AdminDrawerNav.test.tsx` — the admin rail/drawer behavior (group swap, active `?tab=`, badges + zero-omission, collapsed dot, close-on-click, back-to-site), rendered directly
- [x] `lib/hooks/admin/useAdminNavCounts.test.ts` — aggregation math (moderation = edits + entity reports + comments; reports = show + artist), nullish→0, and the **gating contract** (`enabled` threaded to all 7 queue queries)
- [x] `components/layout/adminNav.test.ts` — nav↔`VALID_TABS` parity, `isValidTab`, `isAdminTabActive` (incl. invalid-tab → Dashboard fallback)
- [x] `components/layout/Sidebar.test.tsx` — admin group swap, non-admin safety, active `?tab=`, badge counts + zero-omission, collapsed-rail dot, back-to-site, scope-exactness (sub-route keeps public nav)
- [x] `components/layout/TopBar.test.tsx` — full mobile-drawer admin suite (swap, non-admin, active, badges, close-on-click, back-to-site, scope-exactness)
- [x] `app/admin/page.test.tsx` — no in-page tab bar; `?tab=` deep-link selects the panel (Radix `data-state`)
- [x] changed-file ESLint — 0 errors
- [x] `/code-review` — sound; fixes applied (single-source type binding + parity test, stale comment, dead CSS)
- [x] `/adversarial-review` — 3 rounds → CLEAN. R1 Security CLEAN + fixes in `89a4df01`; R3 re-checked the lazy-load boundary (behavior-preservation, `ssr:false`, TooltipProvider scope, mount-gating, test integrity) → CLEAN
- [x] `/psy-self-review` — evidence + convention/symmetry reviewers PASS (desktop↔mobile identical on gate / active-state / badge source / zero-omission / back-to-site); the coverage reviewer's 2 gaps (`useAdminNavCounts` untested; collapsed-rail dot branch untested) closed with tests in `f210d64b`

## Coverage gaps
- **No in-browser screenshot.** The dev stack was fully down (no Postgres container) and this was a long session, so I did not stand up backend + frontend + seed data to screenshot the live rail. Mitigation: (1) the visual design was mocked + **approved in Figma** (PSY-933) pre-implementation; (2) the change reuses the existing, production-proven Sidebar/TopBar render primitives (same Link styling, collapse, tooltips) — it swaps the data set, not the rendering; (3) every nav behavior is unit-tested across desktop + mobile + page + config. Worth a reviewer eyeball on stage.
- **Standalone `/admin/<section>` routes** keep the public nav (deliberate scope; path-aware rail is a follow-up).
- **Lazy-load pop-in:** with `ssr:false`, the desktop admin rail mounts client-side on `/admin` load (brief, no CLS — fixed-width aside). By design; a `loading:` skeleton is optional polish.
- **`pending-venue-edits` dead links** (CommandPalette + dashboard) — pre-existing, out of scope → PSY-934 (also covers migrating CommandPalette onto adminNav's single source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
