### PR TITLE
PSY-936: revalidate artist ISR page after admin Bandcamp/Spotify save

### DIFF
--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { cookies } from 'next/headers'
+import { revalidatePath } from 'next/cache'
+import { POST, DELETE } from './route'
+
+// Mock Sentry so capture calls are observable and never hit the network.
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+// Mock next/headers cookies(); each test sets the resolved cookie store.
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}))
+
+// Mock next/cache so ISR revalidation calls are observable.
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const mockCookies = vi.mocked(cookies)
+const mockRevalidatePath = vi.mocked(revalidatePath)
+
+// BACKEND_URL is unset in the vitest env, so the route falls back to this.
+const BACKEND = 'http://localhost:8080'
+
+const ARTIST_ID = '47'
+const VALID_BANDCAMP_URL = 'https://brighteyes.bandcamp.com/album/kids-table'
+
+/**
+ * Build a cookie store stub matching the subset of the next/headers
+ * ReadonlyRequestCookies API the route uses: cookies().get('auth_token').
+ */
+function cookieStore(token?: string) {
+  return {
+    get: (name: string) =>
+      name === 'auth_token' && token !== undefined
+        ? { name: 'auth_token', value: token }
+        : undefined,
+  }
+}
+
+/** Resolve cookies() to a store with the given auth_token (or none). */
+function setAuthToken(token?: string) {
+  mockCookies.mockResolvedValue(
+    cookieStore(token) as unknown as Awaited<ReturnType<typeof cookies>>
+  )
+}
+
+/**
+ * Route fetch traffic by URL: auth profile check, Bandcamp URL validation,
+ * and the backend PATCH each get their own response.
+ */
+function mockFetchRouting({
+  isAdmin = true,
+  bandcampPageOk = true,
+  backendResponse = new Response(
+    JSON.stringify({ id: 47, slug: 'bright-eyes', name: 'Bright Eyes' }),
+    { status: 200 }
+  ),
+}: {
+  isAdmin?: boolean
+  bandcampPageOk?: boolean
+  backendResponse?: Response
+} = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === `${BACKEND}/auth/profile`) {
+        return new Response(
+          JSON.stringify({ success: true, user: { id: '1', is_admin: isAdmin } }),
+          { status: 200 }
+        )
+      }
+      if (url.includes('bandcamp.com') && !url.startsWith(BACKEND)) {
+        return bandcampPageOk
+          ? new Response('<html>album=12345</html>', { status: 200 })
+          : new Response('not found', { status: 404 })
+      }
+      if (url === `${BACKEND}/admin/artists/${ARTIST_ID}/bandcamp`) {
+        return backendResponse
+      }
+      throw new Error(`Unexpected fetch in test: ${url}`)
+    })
+}
+
+function postRequest(body: unknown) {
+  return new NextRequest(
+    `http://localhost:3000/api/admin/artists/${ARTIST_ID}/bandcamp`,
+    { method: 'POST', body: JSON.stringify(body) }
+  )
+}
+
+function deleteRequest() {
+  return new NextRequest(
+    `http://localhost:3000/api/admin/artists/${ARTIST_ID}/bandcamp`,
+    { method: 'DELETE' }
+  )
+}
+
+const params = { params: Promise.resolve({ id: ARTIST_ID }) }
+
+let fetchSpy: ReturnType<typeof vi.spyOn> | undefined
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setAuthToken('admin-token')
+})
+
+afterEach(() => {
+  fetchSpy?.mockRestore()
+  fetchSpy = undefined
+})
+
+describe('POST /api/admin/artists/[id]/bandcamp', () => {
+  it('saves the URL and revalidates the artist ISR page', async () => {
+    fetchSpy = mockFetchRouting()
+
+    const res = await POST(postRequest({ bandcamp_url: VALID_BANDCAMP_URL }), params)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
+  })
+
+  it('does NOT revalidate when the backend save fails', async () => {
+    fetchSpy = mockFetchRouting({
+      backendResponse: new Response(JSON.stringify({ detail: 'boom' }), {
+        status: 500,
+      }),
+    })
+
+    const res = await POST(postRequest({ bandcamp_url: VALID_BANDCAMP_URL }), params)
+
+    expect(res.status).toBe(500)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('does NOT revalidate or hit the backend when the caller is not admin', async () => {
+    fetchSpy = mockFetchRouting({ isAdmin: false })
+
+    const res = await POST(postRequest({ bandcamp_url: VALID_BANDCAMP_URL }), params)
+
+    expect(res.status).toBe(403)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+    // Only the auth profile check should have fired — never the backend PATCH.
+    const patchCalls = (fetchSpy.mock.calls as unknown[][]).filter((call) =>
+      String(call[0]).startsWith(`${BACKEND}/admin/`)
+    )
+    expect(patchCalls).toHaveLength(0)
+  })
+
+  it('returns 401 without auth and never revalidates', async () => {
+    setAuthToken(undefined)
+    fetchSpy = mockFetchRouting()
+
+    const res = await POST(postRequest({ bandcamp_url: VALID_BANDCAMP_URL }), params)
+
+    expect(res.status).toBe(401)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('skips revalidation when the backend response has no slug', async () => {
+    fetchSpy = mockFetchRouting({
+      backendResponse: new Response(
+        JSON.stringify({ id: 47, name: 'Bright Eyes' }),
+        { status: 200 }
+      ),
+    })
+
+    const res = await POST(postRequest({ bandcamp_url: VALID_BANDCAMP_URL }), params)
+
+    expect(res.status).toBe(200)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/admin/artists/[id]/bandcamp', () => {
+  it('clears the URL and revalidates the artist ISR page', async () => {
+    fetchSpy = mockFetchRouting()
+
+    const res = await DELETE(deleteRequest(), params)
+
+    expect(res.status).toBe(200)
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
+  })
+
+  it('does NOT revalidate when the backend clear fails', async () => {
+    fetchSpy = mockFetchRouting({
+      backendResponse: new Response(JSON.stringify({ detail: 'boom' }), {
+        status: 500,
+      }),
+    })
+
+    const res = await DELETE(deleteRequest(), params)
+
+    expect(res.status).toBe(500)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import * as Sentry from '@sentry/nextjs'
+import { revalidateArtistDetail } from '@/lib/revalidate-entity'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -14,6 +15,7 @@ interface UserProfile {
 
 interface Artist {
   id: number
+  slug: string
   name: string
   bandcamp_embed_url: string | null
 }
@@ -152,6 +154,8 @@ export async function POST(
 
     const artist: Artist = await response.json()
 
+    revalidateArtistDetail(artist.slug)
+
     return NextResponse.json({
       success: true,
       artist,
@@ -216,6 +220,8 @@ export async function DELETE(
     }
 
     const artist: Artist = await response.json()
+
+    revalidateArtistDetail(artist.slug)
 
     return NextResponse.json({
       success: true,

--- a/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { cookies } from 'next/headers'
+import { revalidatePath } from 'next/cache'
+import { POST, DELETE } from './route'
+
+// Mock Sentry so capture calls are observable and never hit the network.
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+// Mock next/headers cookies(); each test sets the resolved cookie store.
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}))
+
+// Mock next/cache so ISR revalidation calls are observable.
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const mockCookies = vi.mocked(cookies)
+const mockRevalidatePath = vi.mocked(revalidatePath)
+
+// BACKEND_URL is unset in the vitest env, so the route falls back to this.
+const BACKEND = 'http://localhost:8080'
+
+const ARTIST_ID = '47'
+const VALID_SPOTIFY_URL = 'https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP'
+
+/**
+ * Build a cookie store stub matching the subset of the next/headers
+ * ReadonlyRequestCookies API the route uses: cookies().get('auth_token').
+ */
+function cookieStore(token?: string) {
+  return {
+    get: (name: string) =>
+      name === 'auth_token' && token !== undefined
+        ? { name: 'auth_token', value: token }
+        : undefined,
+  }
+}
+
+/** Resolve cookies() to a store with the given auth_token (or none). */
+function setAuthToken(token?: string) {
+  mockCookies.mockResolvedValue(
+    cookieStore(token) as unknown as Awaited<ReturnType<typeof cookies>>
+  )
+}
+
+/**
+ * Route fetch traffic by URL: auth profile check and the backend PATCH.
+ * (Spotify URL validation is regex-only — no network call.)
+ */
+function mockFetchRouting({
+  isAdmin = true,
+  backendResponse = new Response(
+    JSON.stringify({ id: 47, slug: 'bright-eyes', name: 'Bright Eyes' }),
+    { status: 200 }
+  ),
+}: {
+  isAdmin?: boolean
+  backendResponse?: Response
+} = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === `${BACKEND}/auth/profile`) {
+        return new Response(
+          JSON.stringify({ success: true, user: { id: '1', is_admin: isAdmin } }),
+          { status: 200 }
+        )
+      }
+      if (url === `${BACKEND}/admin/artists/${ARTIST_ID}/spotify`) {
+        return backendResponse
+      }
+      throw new Error(`Unexpected fetch in test: ${url}`)
+    })
+}
+
+function postRequest(body: unknown) {
+  return new NextRequest(
+    `http://localhost:3000/api/admin/artists/${ARTIST_ID}/spotify`,
+    { method: 'POST', body: JSON.stringify(body) }
+  )
+}
+
+function deleteRequest() {
+  return new NextRequest(
+    `http://localhost:3000/api/admin/artists/${ARTIST_ID}/spotify`,
+    { method: 'DELETE' }
+  )
+}
+
+const params = { params: Promise.resolve({ id: ARTIST_ID }) }
+
+let fetchSpy: ReturnType<typeof vi.spyOn> | undefined
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setAuthToken('admin-token')
+})
+
+afterEach(() => {
+  fetchSpy?.mockRestore()
+  fetchSpy = undefined
+})
+
+describe('POST /api/admin/artists/[id]/spotify', () => {
+  it('saves the URL and revalidates the artist ISR page', async () => {
+    fetchSpy = mockFetchRouting()
+
+    const res = await POST(postRequest({ spotify_url: VALID_SPOTIFY_URL }), params)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
+  })
+
+  it('does NOT revalidate when the backend save fails', async () => {
+    fetchSpy = mockFetchRouting({
+      backendResponse: new Response(JSON.stringify({ detail: 'boom' }), {
+        status: 500,
+      }),
+    })
+
+    const res = await POST(postRequest({ spotify_url: VALID_SPOTIFY_URL }), params)
+
+    expect(res.status).toBe(500)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('does NOT revalidate or hit the backend when the caller is not admin', async () => {
+    fetchSpy = mockFetchRouting({ isAdmin: false })
+
+    const res = await POST(postRequest({ spotify_url: VALID_SPOTIFY_URL }), params)
+
+    expect(res.status).toBe(403)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+    const patchCalls = (fetchSpy.mock.calls as unknown[][]).filter((call) =>
+      String(call[0]).startsWith(`${BACKEND}/admin/`)
+    )
+    expect(patchCalls).toHaveLength(0)
+  })
+
+  it('returns 401 without auth and never revalidates', async () => {
+    setAuthToken(undefined)
+    fetchSpy = mockFetchRouting()
+
+    const res = await POST(postRequest({ spotify_url: VALID_SPOTIFY_URL }), params)
+
+    expect(res.status).toBe(401)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-artist Spotify URL without revalidating', async () => {
+    fetchSpy = mockFetchRouting()
+
+    const res = await POST(
+      postRequest({ spotify_url: 'https://open.spotify.com/track/abc123' }),
+      params
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/admin/artists/[id]/spotify', () => {
+  it('clears the URL and revalidates the artist ISR page', async () => {
+    fetchSpy = mockFetchRouting()
+
+    const res = await DELETE(deleteRequest(), params)
+
+    expect(res.status).toBe(200)
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
+  })
+
+  it('does NOT revalidate when the backend clear fails', async () => {
+    fetchSpy = mockFetchRouting({
+      backendResponse: new Response(JSON.stringify({ detail: 'boom' }), {
+        status: 500,
+      }),
+    })
+
+    const res = await DELETE(deleteRequest(), params)
+
+    expect(res.status).toBe(500)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/api/admin/artists/[id]/spotify/route.ts
+++ b/frontend/app/api/admin/artists/[id]/spotify/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import * as Sentry from '@sentry/nextjs'
+import { revalidateArtistDetail } from '@/lib/revalidate-entity'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -14,6 +15,7 @@ interface UserProfile {
 
 interface Artist {
   id: number
+  slug: string
   name: string
   social?: {
     spotify?: string | null
@@ -140,6 +142,8 @@ export async function POST(
 
     const artist: Artist = await response.json()
 
+    revalidateArtistDetail(artist.slug)
+
     return NextResponse.json({
       success: true,
       artist,
@@ -204,6 +208,8 @@ export async function DELETE(
     }
 
     const artist: Artist = await response.json()
+
+    revalidateArtistDetail(artist.slug)
 
     return NextResponse.json({
       success: true,

--- a/frontend/lib/revalidate-entity.test.ts
+++ b/frontend/lib/revalidate-entity.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { revalidatePath } from 'next/cache'
+import * as Sentry from '@sentry/nextjs'
+import { revalidateArtistDetail } from './revalidate-entity'
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+const mockRevalidatePath = vi.mocked(revalidatePath)
+const mockCaptureMessage = vi.mocked(Sentry.captureMessage)
+const mockCaptureException = vi.mocked(Sentry.captureException)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('revalidateArtistDetail', () => {
+  it('revalidates the artist detail path', () => {
+    revalidateArtistDetail('bright-eyes')
+
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
+    expect(mockCaptureMessage).not.toHaveBeenCalled()
+  })
+
+  it('skips revalidation and reports to Sentry when slug is missing', () => {
+    revalidateArtistDetail(undefined)
+    revalidateArtistDetail(null)
+    revalidateArtistDetail('')
+
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(3)
+  })
+
+  it('never throws when revalidatePath throws — reports to Sentry instead', () => {
+    mockRevalidatePath.mockImplementation(() => {
+      throw new Error('static generation store missing')
+    })
+
+    expect(() => revalidateArtistDetail('bright-eyes')).not.toThrow()
+    expect(mockCaptureException).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/lib/revalidate-entity.ts
+++ b/frontend/lib/revalidate-entity.ts
@@ -1,0 +1,37 @@
+import { revalidatePath } from 'next/cache'
+import * as Sentry from '@sentry/nextjs'
+
+/**
+ * Revalidate the ISR-cached detail page for an artist after a mutation.
+ *
+ * Entity detail pages are ISR-cached (revalidate: 3600) and re-seed the
+ * client query cache via prefetchEntity on load. Without revalidation, a
+ * reload within the window re-serves the pre-mutation page, making the
+ * save appear lost (PSY-936).
+ *
+ * Never throws: a revalidation failure must not turn an already-persisted
+ * backend save into an error response. Missing slugs and revalidation
+ * errors are reported to Sentry instead.
+ *
+ * Server-only (route handlers / server actions). PSY-937 extends this
+ * pattern to the remaining entity types and the proxy-routed mutations.
+ */
+export function revalidateArtistDetail(slug: string | undefined | null): void {
+  if (!slug) {
+    Sentry.captureMessage('revalidateArtistDetail: missing slug, skipped', {
+      level: 'warning',
+      tags: { service: 'isr-revalidation', entity: 'artist' },
+    })
+    return
+  }
+
+  try {
+    revalidatePath(`/artists/${slug}`)
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'isr-revalidation', entity: 'artist' },
+      extra: { slug },
+    })
+  }
+}


### PR DESCRIPTION
Closes PSY-936

## Problem

Admin saves of artist Bandcamp/Spotify URLs (Discover Music → "Use this", or manual entry) appeared to vanish after a page reload — found while dogfooding the Riot Fest 2026 Stage ingest on `/artists/bright-eyes`.

The saves actually persisted (verified directly against the Stage API: `bandcamp_embed_url` + `social.spotify` both present with matching `updated_at`). The bug is stale-cache display:

1. The artist detail page is **ISR-cached for 1 hour** (`app/artists/[slug]/page.tsx` — `next: { revalidate: 3600 }`).
2. The admin music routes mutated the artist via the Go backend but **never called `revalidatePath`** (zero `revalidatePath`/`revalidateTag` calls existed repo-wide).
3. On reload, the stale ISR HTML is re-served **and** re-seeds the TanStack Query cache via `prefetchEntity`, so the client also treats the stale data as fresh (15-min staleTime). The save looks lost for up to an hour.

## Change

- New shared helper `lib/revalidate-entity.ts` → `revalidateArtistDetail(slug)`:
  - calls `revalidatePath('/artists/{slug}')`
  - **never throws** — a revalidation failure must not turn an already-persisted backend save into a 500
  - reports missing slugs / revalidation errors to Sentry
- `app/api/admin/artists/[id]/bandcamp/route.ts` and `.../spotify/route.ts` call the helper after every successful backend PATCH (POST save + DELETE clear), and their `Artist` interface now includes `slug`.
- The helper is the convergence point for **PSY-937** (extending revalidation to proxy-routed entity mutations: suggest-edit, show edit, collections, tags).

## Audit context

A repo-wide audit found this gap is systemic: all 9 ISR'd entity detail pages + the catch-all proxy mutations share it. This PR fixes the dedicated admin music routes (where the bug was hit); **PSY-937** (filed, confidence:25 design ticket) covers the proxy-routed mutations, which need a design decision.

## Test plan

- [x] `bun run typecheck` — clean
- [x] New route-handler tests (first tests for `app/api/admin/*`): success → revalidate called with `/artists/{slug}`; backend failure → not called; non-admin (403) → not called and backend never hit; missing auth (401) → not called; missing slug in response → skipped without error
- [x] New `lib/revalidate-entity.test.ts`: path called correctly; missing slug → Sentry warning, no throw; `revalidatePath` throwing → caught + Sentry, no throw
- [x] Full frontend suite: 435 files / 5,275 tests pass
- [ ] Manual verify on Stage after deploy: save a music link on an artist, reload within the ISR window, embed persists (PSY-936 acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
