### PR TITLE
PSY-910: AdminTable — unify Collections / Radio / Pipeline tables

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -26,6 +26,7 @@ import {
   History,
 } from 'lucide-react'
 import { AdminEmptyState } from '@/components/admin'
+import { AdminTable, type AdminTableColumn } from '@/components/admin/AdminTable'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -1707,6 +1708,46 @@ export function RadioManagement() {
     [deleteMutation]
   )
 
+  const stationColumns: AdminTableColumn<RadioStationListItem>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      render: (s) => (
+        <div className="flex items-center gap-2">
+          <Radio className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium">{s.name}</span>
+          {s.frequency_mhz && (
+            <Badge variant="outline" className="text-xs">
+              {s.frequency_mhz} MHz
+            </Badge>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'city',
+      header: 'City',
+      cellClassName: 'text-muted-foreground',
+      render: (s) => `${s.city}${s.state ? `, ${s.state}` : ''}`,
+    },
+    {
+      key: 'broadcast',
+      header: 'Broadcast Type',
+      cellClassName: 'text-muted-foreground capitalize',
+      render: (s) => s.broadcast_type,
+    },
+    { key: 'shows', header: 'Shows', render: (s) => s.show_count },
+    {
+      key: 'active',
+      header: 'Active',
+      render: (s) => (
+        <Badge variant={s.is_active ? 'default' : 'secondary'} className="text-xs">
+          {s.is_active ? 'Active' : 'Inactive'}
+        </Badge>
+      ),
+    },
+  ]
+
   // If viewing station detail, render that panel
   if (detailStation) {
     return (
@@ -1846,52 +1887,12 @@ export function RadioManagement() {
               }
             />
           ) : (
-            <div className="rounded-lg border">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b bg-muted/50">
-                    <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Name</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">City</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Broadcast Type</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Shows</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Active</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {filteredStations.map((station) => (
-                    <tr
-                      key={station.id}
-                      className="cursor-pointer hover:bg-muted/50 transition-colors"
-                      onClick={() => handleStationClick(station)}
-                    >
-                      <td className="px-4 py-3">
-                        <div className="flex items-center gap-2">
-                          <Radio className="h-4 w-4 text-muted-foreground" />
-                          <span className="font-medium">{station.name}</span>
-                          {station.frequency_mhz && (
-                            <Badge variant="outline" className="text-xs">
-                              {station.frequency_mhz} MHz
-                            </Badge>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {station.city}{station.state ? `, ${station.state}` : ''}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground capitalize">
-                        {station.broadcast_type}
-                      </td>
-                      <td className="px-4 py-3 text-sm">{station.show_count}</td>
-                      <td className="px-4 py-3">
-                        <Badge variant={station.is_active ? 'default' : 'secondary'} className="text-xs">
-                          {station.is_active ? 'Active' : 'Inactive'}
-                        </Badge>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <AdminTable
+              columns={stationColumns}
+              rows={filteredStations}
+              rowKey={(s) => s.id}
+              onRowClick={handleStationClick}
+            />
           )}
         </div>
 

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -1892,6 +1892,7 @@ export function RadioManagement() {
               rows={filteredStations}
               rowKey={(s) => s.id}
               onRowClick={handleStationClick}
+              rowLabel={(s) => `Station: ${s.name}`}
             />
           )}
         </div>

--- a/frontend/components/admin/AdminTable.test.tsx
+++ b/frontend/components/admin/AdminTable.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { AdminTable, type AdminTableColumn } from './AdminTable'
+
+interface Row {
+  id: number
+  name: string
+  count: number
+}
+
+const rows: Row[] = [
+  { id: 1, name: 'Alpha', count: 3 },
+  { id: 2, name: 'Beta', count: 0 },
+]
+
+const columns: AdminTableColumn<Row>[] = [
+  { key: 'name', header: 'Name', render: r => r.name },
+  { key: 'count', header: 'Count', align: 'center', render: r => r.count },
+]
+
+describe('AdminTable', () => {
+  it('renders column headers and a cell per row via render()', () => {
+    render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} />)
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Count' })).toBeInTheDocument()
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+    // 1 header row + 2 data rows
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+  })
+
+  it('applies the editorial mono-uppercase header treatment', () => {
+    render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} />)
+    const header = screen.getByRole('columnheader', { name: 'Name' })
+    expect(header.className).toContain('font-mono')
+    expect(header.className).toContain('uppercase')
+  })
+
+  it('aligns columns per the align prop', () => {
+    render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} />)
+    expect(screen.getByRole('columnheader', { name: 'Count' }).className).toContain('text-center')
+  })
+
+  it('calls onRowClick with the row, and rows are keyboard/hover-affordanced', () => {
+    const onRowClick = vi.fn()
+    render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} onRowClick={onRowClick} />)
+    const row = screen.getByText('Alpha').closest('tr')!
+    expect(row.className).toContain('cursor-pointer')
+    fireEvent.click(row)
+    expect(onRowClick).toHaveBeenCalledWith(rows[0])
+  })
+
+  it('does not add clickable affordance when onRowClick is absent', () => {
+    render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} />)
+    expect(screen.getByText('Alpha').closest('tr')!.className).not.toContain('cursor-pointer')
+  })
+
+  it('stopRowClick cells do not trigger the row click', () => {
+    const onRowClick = vi.fn()
+    const cols: AdminTableColumn<Row>[] = [
+      { key: 'name', header: 'Name', render: r => r.name },
+      {
+        key: 'toggle',
+        header: 'Toggle',
+        stopRowClick: true,
+        render: () => <button>toggle</button>,
+      },
+    ]
+    render(<AdminTable columns={cols} rows={rows} rowKey={r => r.id} onRowClick={onRowClick} />)
+    fireEvent.click(screen.getAllByText('toggle')[0])
+    expect(onRowClick).not.toHaveBeenCalled()
+  })
+
+  it('applies rowClassName (e.g. a selected highlight)', () => {
+    render(
+      <AdminTable
+        columns={columns}
+        rows={rows}
+        rowKey={r => r.id}
+        rowClassName={r => (r.id === 1 ? 'bg-muted/50' : undefined)}
+      />
+    )
+    expect(screen.getByText('Alpha').closest('tr')!.className).toContain('bg-muted/50')
+    expect(screen.getByText('Beta').closest('tr')!.className).not.toContain('bg-muted/50')
+  })
+
+  it('renders the empty slot (spanning all columns) when there are no rows', () => {
+    render(
+      <AdminTable
+        columns={columns}
+        rows={[]}
+        rowKey={(r: Row) => r.id}
+        empty={<span>Nothing here</span>}
+      />
+    )
+    const cell = screen.getByText('Nothing here').closest('td')!
+    expect(cell).toHaveAttribute('colspan', String(columns.length))
+  })
+
+  it('supports rich cell content (badges, multi-line) via render()', () => {
+    const cols: AdminTableColumn<Row>[] = [
+      {
+        key: 'name',
+        header: 'Name',
+        render: r => (
+          <div>
+            <div data-testid="title">{r.name}</div>
+            <div data-testid="sub">id-{r.id}</div>
+          </div>
+        ),
+      },
+    ]
+    render(<AdminTable columns={cols} rows={[rows[0]]} rowKey={r => r.id} />)
+    const row = screen.getByText('Alpha').closest('tr')!
+    expect(within(row).getByTestId('sub')).toHaveTextContent('id-1')
+  })
+})

--- a/frontend/components/admin/AdminTable.test.tsx
+++ b/frontend/components/admin/AdminTable.test.tsx
@@ -51,6 +51,25 @@ describe('AdminTable', () => {
     expect(onRowClick).toHaveBeenCalledWith(rows[0])
   })
 
+  it('exposes clickable rows as labelled buttons to assistive tech', () => {
+    render(
+      <AdminTable
+        columns={columns}
+        rows={rows}
+        rowKey={r => r.id}
+        onRowClick={vi.fn()}
+        rowLabel={r => `Row: ${r.name}`}
+      />
+    )
+    const row = screen.getByRole('button', { name: 'Row: Alpha' })
+    expect(row.tagName).toBe('TR')
+  })
+
+  it('non-clickable rows are not buttons', () => {
+    render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
   it('activates onRowClick via keyboard (Enter / Space) when the row is focused', () => {
     const onRowClick = vi.fn()
     render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} onRowClick={onRowClick} />)

--- a/frontend/components/admin/AdminTable.test.tsx
+++ b/frontend/components/admin/AdminTable.test.tsx
@@ -41,18 +41,54 @@ describe('AdminTable', () => {
     expect(screen.getByRole('columnheader', { name: 'Count' }).className).toContain('text-center')
   })
 
-  it('calls onRowClick with the row, and rows are keyboard/hover-affordanced', () => {
+  it('calls onRowClick on click; clickable rows are focusable + cursor-affordanced', () => {
     const onRowClick = vi.fn()
     render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} onRowClick={onRowClick} />)
     const row = screen.getByText('Alpha').closest('tr')!
     expect(row.className).toContain('cursor-pointer')
+    expect(row).toHaveAttribute('tabindex', '0')
     fireEvent.click(row)
     expect(onRowClick).toHaveBeenCalledWith(rows[0])
   })
 
-  it('does not add clickable affordance when onRowClick is absent', () => {
+  it('activates onRowClick via keyboard (Enter / Space) when the row is focused', () => {
+    const onRowClick = vi.fn()
+    render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} onRowClick={onRowClick} />)
+    const row = screen.getByText('Alpha').closest('tr')!
+    fireEvent.keyDown(row, { key: 'Enter' })
+    fireEvent.keyDown(row, { key: ' ' })
+    expect(onRowClick).toHaveBeenCalledTimes(2)
+    expect(onRowClick).toHaveBeenCalledWith(rows[0])
+  })
+
+  it('does NOT activate the row when a focused child control receives the key', () => {
+    const onRowClick = vi.fn()
+    const cols: AdminTableColumn<Row>[] = [
+      { key: 'name', header: 'Name', render: r => r.name },
+      { key: 'toggle', header: 'Toggle', stopRowClick: true, render: () => <button>toggle</button> },
+    ]
+    render(<AdminTable columns={cols} rows={rows} rowKey={r => r.id} onRowClick={onRowClick} />)
+    // Key event originates on the child button (target !== the row), so the
+    // row's Enter/Space handler must not fire onRowClick.
+    fireEvent.keyDown(screen.getAllByText('toggle')[0], { key: 'Enter' })
+    expect(onRowClick).not.toHaveBeenCalled()
+  })
+
+  it('does not add clickable affordance (cursor/tabindex) when onRowClick is absent', () => {
     render(<AdminTable columns={columns} rows={rows} rowKey={r => r.id} />)
-    expect(screen.getByText('Alpha').closest('tr')!.className).not.toContain('cursor-pointer')
+    const row = screen.getByText('Alpha').closest('tr')!
+    expect(row.className).not.toContain('cursor-pointer')
+    expect(row).not.toHaveAttribute('tabindex')
+  })
+
+  it('passes align=right and cellClassName through to cells', () => {
+    const cols: AdminTableColumn<Row>[] = [
+      { key: 'count', header: 'Count', align: 'right', cellClassName: 'text-muted-foreground', render: r => r.count },
+    ]
+    render(<AdminTable columns={cols} rows={[rows[0]]} rowKey={r => r.id} />)
+    const cell = screen.getByText('3').closest('td')!
+    expect(cell.className).toContain('text-right')
+    expect(cell.className).toContain('text-muted-foreground')
   })
 
   it('stopRowClick cells do not trigger the row click', () => {

--- a/frontend/components/admin/AdminTable.tsx
+++ b/frontend/components/admin/AdminTable.tsx
@@ -4,11 +4,14 @@ import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 /**
- * AdminTable — the canonical admin entity-list table (PSY-910). Replaces the
- * per-surface bespoke `<table>`s (Collections, Radio Stations, Pipeline history)
- * with one dense, hairline-divided table: a muted column-header band with
- * mono-uppercase labels (the editorial upgrade locked in PSY-912), dense rows,
- * and per-column alignment + render.
+ * AdminTable — the canonical admin entity-list table (PSY-910). Unifies the
+ * top-level admin entity-list tables (Collections, Radio Stations, Pipeline
+ * Import History) behind one dense, hairline-divided table: a muted
+ * column-header band with mono-uppercase labels (the editorial upgrade locked in
+ * PSY-912), dense rows, and per-column alignment + render. Nested / detail
+ * tables (collection items, venue config, extraction-run history, unmatched
+ * plays) intentionally stay hand-rolled — they aren't single-click-to-detail
+ * lists and don't fit this config-driven shape.
  *
  * Render-only by design. Sorting isn't included (no admin table sorts today);
  * pagination stays with the parent (e.g. Pipeline Import History owns its
@@ -21,7 +24,10 @@ import { cn } from '@/lib/utils'
  * Distinct from `components/shared/DenseTable`: that is a *composition* primitive
  * (you pass `<thead>/<tbody>` children, variants) for public entity pages;
  * AdminTable is *config-driven* (a columns array) for admin entity lists. Reach
- * for DenseTable on entity pages, AdminTable for admin lists.
+ * for DenseTable on entity pages, AdminTable for admin lists. Their header
+ * treatments intentionally differ — AdminTable uses a mono-uppercase band per
+ * PSY-912; DenseTable does not. Keep them divergent unless a cohesion pass
+ * deliberately reconciles both.
  */
 export interface AdminTableColumn<T> {
   /** Stable column id (React key for the cell). */
@@ -32,7 +38,9 @@ export interface AdminTableColumn<T> {
   render: (row: T) => React.ReactNode
   align?: 'left' | 'center' | 'right'
   /** Stop the row's onClick when interacting with this cell (e.g. a toggle in a
-   *  click-to-detail row). */
+   *  click-to-detail row). Covers the MOUSE click only — keyboard isolation for a
+   *  focused in-cell control relies on the row's `e.target === e.currentTarget`
+   *  keydown guard (don't remove that guard or child controls double-fire). */
   stopRowClick?: boolean
   headerClassName?: string
   cellClassName?: string
@@ -43,8 +51,13 @@ export interface AdminTableProps<T> {
   rows: T[]
   /** Stable React key per row. */
   rowKey: (row: T) => React.Key
-  /** Click-to-detail affordance. When set, rows get hover + cursor styling. */
+  /** Click-to-detail affordance. When set, rows become keyboard-operable
+   *  (focusable, Enter/Space) and get hover + cursor styling + role="button". */
   onRowClick?: (row: T) => void
+  /** Accessible label for a clickable row (announced by screen readers, since a
+   *  role="button" row otherwise reads only its cells). Strongly recommended
+   *  whenever onRowClick is set — e.g. the entity name. */
+  rowLabel?: (row: T) => string
   /** Extra per-row classes — e.g. a selected-row highlight. */
   rowClassName?: (row: T) => string | undefined
   /** Rendered (spanning all columns) when `rows` is empty. Omit to render an
@@ -65,6 +78,7 @@ export function AdminTable<T>({
   rows,
   rowKey,
   onRowClick,
+  rowLabel,
   rowClassName,
   empty,
   className,
@@ -104,6 +118,8 @@ export function AdminTable<T>({
             rows.map(row => (
               <tr
                 key={rowKey(row)}
+                role={clickable ? 'button' : undefined}
+                aria-label={clickable ? rowLabel?.(row) : undefined}
                 onClick={clickable ? () => onRowClick!(row) : undefined}
                 onKeyDown={
                   clickable

--- a/frontend/components/admin/AdminTable.tsx
+++ b/frontend/components/admin/AdminTable.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * AdminTable — the canonical admin entity-list table (PSY-910). Replaces the
+ * per-surface bespoke `<table>`s (Collections, Radio Stations, Pipeline history)
+ * with one dense, hairline-divided table: a muted column-header band with
+ * mono-uppercase labels (the editorial upgrade locked in PSY-912), dense rows,
+ * and per-column alignment + render.
+ *
+ * Render-only by design. Sorting isn't included (no admin table sorts today);
+ * pagination stays with the parent (e.g. Pipeline Import History owns its
+ * Prev/Next + offset) — AdminTable just renders the rows it's given. The column
+ * API leaves room to add a `sortable` hook later without a breaking change.
+ *
+ * Loading / error states stay in the parent (it early-returns before rendering
+ * the table); pass `empty` for the no-rows message.
+ */
+export interface AdminTableColumn<T> {
+  /** Stable column id (React key for the cell). */
+  key: string
+  header: React.ReactNode
+  /** Cell content for a row. Closures here capture the parent's state/mutations
+   *  (e.g. a Featured toggle), so AdminTable stays presentation-only. */
+  render: (row: T) => React.ReactNode
+  align?: 'left' | 'center' | 'right'
+  /** Stop the row's onClick when interacting with this cell (e.g. a toggle in a
+   *  click-to-detail row). */
+  stopRowClick?: boolean
+  headerClassName?: string
+  cellClassName?: string
+}
+
+export interface AdminTableProps<T> {
+  columns: AdminTableColumn<T>[]
+  rows: T[]
+  /** Stable React key per row. */
+  rowKey: (row: T) => React.Key
+  /** Click-to-detail affordance. When set, rows get hover + cursor styling. */
+  onRowClick?: (row: T) => void
+  /** Extra per-row classes — e.g. a selected-row highlight. */
+  rowClassName?: (row: T) => string | undefined
+  /** Rendered (spanning all columns) when `rows` is empty. Omit to render an
+   *  empty body — most parents early-return their own empty state instead. */
+  empty?: React.ReactNode
+  /** Override the container (e.g. width). */
+  className?: string
+}
+
+const ALIGN: Record<NonNullable<AdminTableColumn<unknown>['align']>, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+}
+
+export function AdminTable<T>({
+  columns,
+  rows,
+  rowKey,
+  onRowClick,
+  rowClassName,
+  empty,
+  className,
+}: AdminTableProps<T>) {
+  const clickable = !!onRowClick
+
+  return (
+    <div className={cn('overflow-hidden rounded-lg border border-border', className)}>
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr className="border-b border-border">
+            {columns.map(col => (
+              <th
+                key={col.key}
+                className={cn(
+                  'px-3 py-2 font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground',
+                  ALIGN[col.align ?? 'left'],
+                  col.headerClassName
+                )}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.length === 0 && empty != null ? (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className="px-3 py-8 text-center text-muted-foreground"
+              >
+                {empty}
+              </td>
+            </tr>
+          ) : (
+            rows.map(row => (
+              <tr
+                key={rowKey(row)}
+                onClick={clickable ? () => onRowClick!(row) : undefined}
+                className={cn(
+                  clickable && 'cursor-pointer transition-colors hover:bg-muted/30',
+                  rowClassName?.(row)
+                )}
+              >
+                {columns.map(col => (
+                  <td
+                    key={col.key}
+                    onClick={col.stopRowClick ? e => e.stopPropagation() : undefined}
+                    className={cn('px-3 py-2', ALIGN[col.align ?? 'left'], col.cellClassName)}
+                  >
+                    {col.render(row)}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/components/admin/AdminTable.tsx
+++ b/frontend/components/admin/AdminTable.tsx
@@ -17,6 +17,11 @@ import { cn } from '@/lib/utils'
  *
  * Loading / error states stay in the parent (it early-returns before rendering
  * the table); pass `empty` for the no-rows message.
+ *
+ * Distinct from `components/shared/DenseTable`: that is a *composition* primitive
+ * (you pass `<thead>/<tbody>` children, variants) for public entity pages;
+ * AdminTable is *config-driven* (a columns array) for admin entity lists. Reach
+ * for DenseTable on entity pages, AdminTable for admin lists.
  */
 export interface AdminTableColumn<T> {
   /** Stable column id (React key for the cell). */
@@ -100,8 +105,25 @@ export function AdminTable<T>({
               <tr
                 key={rowKey(row)}
                 onClick={clickable ? () => onRowClick!(row) : undefined}
+                onKeyDown={
+                  clickable
+                    ? e => {
+                        // Activate only from the row itself, so focused child
+                        // controls (e.g. a Featured toggle) keep their own keys.
+                        if (
+                          e.target === e.currentTarget &&
+                          (e.key === 'Enter' || e.key === ' ')
+                        ) {
+                          e.preventDefault()
+                          onRowClick!(row)
+                        }
+                      }
+                    : undefined
+                }
+                tabIndex={clickable ? 0 : undefined}
                 className={cn(
-                  clickable && 'cursor-pointer transition-colors hover:bg-muted/30',
+                  clickable &&
+                    'cursor-pointer transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
                   rowClassName?.(row)
                 )}
               >

--- a/frontend/components/admin/CollectionManagement.tsx
+++ b/frontend/components/admin/CollectionManagement.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/features/collections'
 import type { Collection } from '@/features/collections'
 import { Switch } from '@/components/ui/switch'
+import { AdminTable, type AdminTableColumn } from './AdminTable'
 
 function EntityTypeBadge({ type }: { type: string }) {
   const colors: Record<string, string> = {
@@ -215,6 +216,79 @@ export function CollectionManagement() {
   const collections = data?.collections ?? []
   const selectedCollection = collections.find((c) => c.slug === selectedSlug)
 
+  const columns: AdminTableColumn<Collection>[] = [
+    {
+      key: 'title',
+      header: 'Title',
+      render: (c) => (
+        <>
+          <div className="font-medium">{c.title}</div>
+          <div className="text-xs text-muted-foreground">/{c.slug}</div>
+        </>
+      ),
+    },
+    {
+      key: 'creator',
+      header: 'Creator',
+      cellClassName: 'text-muted-foreground',
+      render: (c) => c.creator_name,
+    },
+    { key: 'items', header: 'Items', align: 'center', render: (c) => c.item_count },
+    {
+      key: 'subscribers',
+      header: 'Subscribers',
+      align: 'center',
+      render: (c) => c.subscriber_count,
+    },
+    {
+      key: 'featured',
+      header: 'Featured',
+      align: 'center',
+      stopRowClick: true,
+      render: (c) => (
+        <Switch
+          checked={c.is_featured}
+          onCheckedChange={(checked) => {
+            setFeaturedError(null)
+            setFeatured.mutate(
+              { slug: c.slug, featured: checked },
+              {
+                // Clears-on-next-success per the sticky-on-error
+                // mutation-feedback convention (PSY-609).
+                onSuccess: () => setFeaturedError(null),
+                onError: (err) =>
+                  setFeaturedError(
+                    err instanceof Error
+                      ? err.message
+                      : 'Failed to update featured status'
+                  ),
+              }
+            )
+          }}
+          disabled={setFeatured.isPending}
+          size="sm"
+        />
+      ),
+    },
+    {
+      key: 'public',
+      header: 'Public',
+      align: 'center',
+      render: (c) =>
+        c.is_public ? (
+          <span className="text-green-400 text-xs">Yes</span>
+        ) : (
+          <span className="text-muted-foreground text-xs">No</span>
+        ),
+    },
+    {
+      key: 'created',
+      header: 'Created',
+      cellClassName: 'text-muted-foreground text-xs',
+      render: (c) => new Date(c.created_at).toLocaleDateString(),
+    },
+  ]
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -240,100 +314,18 @@ export function CollectionManagement() {
         <p className="text-muted-foreground">No collections yet</p>
       ) : (
         <>
-          {/* Collections table */}
-          <div className="border border-border rounded-lg overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-muted/50">
-                <tr>
-                  <th className="text-left p-3 font-medium">Title</th>
-                  <th className="text-left p-3 font-medium">Creator</th>
-                  <th className="text-center p-3 font-medium">Items</th>
-                  <th className="text-center p-3 font-medium">Subscribers</th>
-                  <th className="text-center p-3 font-medium">Featured</th>
-                  <th className="text-center p-3 font-medium">Public</th>
-                  <th className="text-left p-3 font-medium">Created</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {collections.map((collection) => (
-                  <tr
-                    key={collection.id}
-                    onClick={() =>
-                      setSelectedSlug(
-                        selectedSlug === collection.slug
-                          ? null
-                          : collection.slug
-                      )
-                    }
-                    className={`cursor-pointer hover:bg-muted/30 ${
-                      selectedSlug === collection.slug ? 'bg-muted/50' : ''
-                    }`}
-                  >
-                    <td className="p-3">
-                      <div className="font-medium">{collection.title}</div>
-                      <div className="text-xs text-muted-foreground">
-                        /{collection.slug}
-                      </div>
-                    </td>
-                    <td className="p-3 text-muted-foreground">
-                      {collection.creator_name}
-                    </td>
-                    <td className="p-3 text-center">{collection.item_count}</td>
-                    <td className="p-3 text-center">
-                      {collection.subscriber_count}
-                    </td>
-                    <td
-                      className="p-3 text-center"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Switch
-                        checked={collection.is_featured}
-                        onCheckedChange={(checked) => {
-                          setFeaturedError(null)
-                          setFeatured.mutate(
-                            {
-                              slug: collection.slug,
-                              featured: checked,
-                            },
-                            {
-                              onSuccess: () => {
-                                // Clears-on-next-success per the
-                                // sticky-on-error mutation-feedback
-                                // convention. The click handler's
-                                // pre-mutate reset covers the common
-                                // case but misses retries / parallel
-                                // successes that don't go through it.
-                                setFeaturedError(null)
-                              },
-                              onError: (err) => {
-                                setFeaturedError(
-                                  err instanceof Error
-                                    ? err.message
-                                    : 'Failed to update featured status'
-                                )
-                              },
-                            }
-                          )
-                        }}
-                        disabled={setFeatured.isPending}
-                        size="sm"
-                      />
-                    </td>
-                    <td className="p-3 text-center">
-                      {collection.is_public ? (
-                        <span className="text-green-400 text-xs">Yes</span>
-                      ) : (
-                        <span className="text-muted-foreground text-xs">No</span>
-                      )}
-                    </td>
-                    <td className="p-3 text-muted-foreground text-xs">
-                      {new Date(collection.created_at).toLocaleDateString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          {/* Collections table (AdminTable — PSY-910) */}
+          <AdminTable
+            columns={columns}
+            rows={collections}
+            rowKey={(c) => c.id}
+            onRowClick={(c) =>
+              setSelectedSlug(selectedSlug === c.slug ? null : c.slug)
+            }
+            rowClassName={(c) =>
+              selectedSlug === c.slug ? 'bg-muted/50' : undefined
+            }
+          />
 
           {/* Detail panel */}
           {selectedCollection && (

--- a/frontend/components/admin/CollectionManagement.tsx
+++ b/frontend/components/admin/CollectionManagement.tsx
@@ -322,6 +322,7 @@ export function CollectionManagement() {
             onRowClick={(c) =>
               setSelectedSlug(selectedSlug === c.slug ? null : c.slug)
             }
+            rowLabel={(c) => `Collection: ${c.title}`}
             rowClassName={(c) =>
               selectedSlug === c.slug ? 'bg-muted/50' : undefined
             }

--- a/frontend/components/admin/PipelineVenues.tsx
+++ b/frontend/components/admin/PipelineVenues.tsx
@@ -16,6 +16,7 @@ import {
 import { useVenueSearch } from '@/features/venues'
 import { Switch } from '@/components/ui/switch'
 import { InlineErrorBanner } from '@/components/shared'
+import { AdminTable, type AdminTableColumn } from './AdminTable'
 import { formatShortDate, formatTimestamp } from '@/lib/utils/formatters'
 
 function ApprovalBadge({ rate }: { rate?: number }) {
@@ -598,54 +599,54 @@ function ImportHistorySection() {
     return <p className="text-muted-foreground text-sm">No extraction runs recorded yet.</p>
   }
 
+  const columns: AdminTableColumn<ImportHistoryEntry>[] = [
+    {
+      key: 'date',
+      header: 'Date',
+      cellClassName: 'text-muted-foreground text-xs',
+      render: (e) => formatTimestamp(e.run_at),
+    },
+    {
+      key: 'venue',
+      header: 'Venue',
+      render: (e) => <span className="font-medium">{e.venue_name}</span>,
+    },
+    {
+      key: 'source',
+      header: 'Source',
+      align: 'center',
+      render: (e) => <SourceTypeBadge sourceType={e.source_type} />,
+    },
+    { key: 'extracted', header: 'Extracted', align: 'center', render: (e) => e.events_extracted },
+    { key: 'imported', header: 'Imported', align: 'center', render: (e) => e.events_imported },
+    {
+      key: 'duration',
+      header: 'Duration',
+      align: 'right',
+      cellClassName: 'text-muted-foreground text-xs',
+      render: (e) =>
+        e.duration_ms >= 1000
+          ? `${(e.duration_ms / 1000).toFixed(1)}s`
+          : `${e.duration_ms}ms`,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      align: 'center',
+      render: (e) =>
+        e.error ? (
+          <span className="text-red-400 text-xs" title={e.error}>
+            Error
+          </span>
+        ) : (
+          <span className="text-green-400 text-xs">OK</span>
+        ),
+    },
+  ]
+
   return (
     <div className="space-y-3">
-      <div className="border border-border rounded-lg overflow-hidden">
-        <table className="w-full text-sm">
-          <thead className="bg-muted/50">
-            <tr>
-              <th className="text-left p-3 font-medium">Date</th>
-              <th className="text-left p-3 font-medium">Venue</th>
-              <th className="text-center p-3 font-medium">Source</th>
-              <th className="text-center p-3 font-medium">Extracted</th>
-              <th className="text-center p-3 font-medium">Imported</th>
-              <th className="text-right p-3 font-medium">Duration</th>
-              <th className="text-center p-3 font-medium">Status</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border">
-            {imports.map((entry: ImportHistoryEntry) => (
-              <tr key={entry.id}>
-                <td className="p-3 text-muted-foreground text-xs">
-                  {formatTimestamp(entry.run_at)}
-                </td>
-                <td className="p-3">
-                  <span className="font-medium">{entry.venue_name}</span>
-                </td>
-                <td className="p-3 text-center">
-                  <SourceTypeBadge sourceType={entry.source_type} />
-                </td>
-                <td className="p-3 text-center">{entry.events_extracted}</td>
-                <td className="p-3 text-center">{entry.events_imported}</td>
-                <td className="p-3 text-right text-muted-foreground text-xs">
-                  {entry.duration_ms >= 1000
-                    ? `${(entry.duration_ms / 1000).toFixed(1)}s`
-                    : `${entry.duration_ms}ms`}
-                </td>
-                <td className="p-3 text-center">
-                  {entry.error ? (
-                    <span className="text-red-400 text-xs" title={entry.error}>
-                      Error
-                    </span>
-                  ) : (
-                    <span className="text-green-400 text-xs">OK</span>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <AdminTable columns={columns} rows={imports} rowKey={(e) => e.id} />
 
       {/* Pagination */}
       {(hasPrev || hasMore) && (

--- a/frontend/components/admin/index.ts
+++ b/frontend/components/admin/index.ts
@@ -21,3 +21,5 @@ export {
   AdminFormField,
 } from './AdminFormLayout'
 export type { AdminFormLayoutProps } from './AdminFormLayout'
+export { AdminTable } from './AdminTable'
+export type { AdminTableColumn, AdminTableProps } from './AdminTable'


### PR DESCRIPTION
Closes PSY-910.

## Summary
Admin rendered tabular data through separate bespoke `<table>`s per surface. This extracts a shared **`AdminTable`** primitive (`components/admin/AdminTable.tsx`) and migrates the three top-level admin entity-list tables onto it — **Collections, Radio Stations, Pipeline Import History** — with the PSY-912 editorial styling (dense, hairline-divided, muted header band with **mono-uppercase** labels, DS-token-bound).

## AdminTable API
Config-driven, render-only: `{ columns, rows, rowKey, onRowClick?, rowLabel?, rowClassName?, empty?, className? }`; per-column `{ header, render, align?, stopRowClick?, headerClassName?, cellClassName? }`.
- `render()` closures capture the parent's state/mutations → the primitive stays presentation-only (Collections' Featured `Switch`, badges, formatted cells).
- **No sorting** (no admin table sorts today; the API leaves room for a future `sortable` hook). **Pagination stays with the parent** (Import History keeps its Prev/Next + offset).
- `onRowClick` is the primary affordance (all three are click-to-detail) — clickable rows are **keyboard-accessible** (`role="button"`, `tabIndex`, Enter/Space, focus ring, `rowLabel` for screen readers), fixing once what all three originals lacked. `stopRowClick` lets an interactive cell (the Featured toggle) opt out of the row click.
- Intentionally distinct from `components/shared/DenseTable` (composition primitive for public entity pages) — documented to prevent drift.

## Migrations (behavior-preserving)
- **Collections** — row-click toggles the detail panel + selected-row highlight (`rowClassName`); the Featured `Switch` keeps its PSY-609 sticky-error behavior via `stopRowClick`.
- **Radio Stations** — row-click → detail panel; Name (icon + frequency badge) + Active badge preserved.
- **Pipeline Import History** — static rows (no row-click); the parent keeps its Prev/Next pagination + loading/empty guards + the error `title=` tooltip.

Columns/data/handlers preserved (7→7, 5→5, 7→7). The header restyle to mono-uppercase + row-hover standardized to `bg-muted/30` (Radio's list was `/50`) are the intended cohesion changes.

## Deferred → PSY-942
The Pipeline **Venue Status** table (a 4th top-level bespoke table) → **PSY-942**. Nested/detail tables (collection items, extraction-run history, unmatched plays) intentionally stay hand-rolled — they aren't single-click-to-detail lists.

## Adversarial review
`/adversarial-review` — 3 lenses, 3× CONCERNS → resolved in `2942b0a0`. Security N/A (admin-gated table chrome, no new data/auth surface).
- **[HIGH]** keyboard-operable rows had no role/aria → added `role="button"` + `rowLabel` aria-label, matching the repo's canonical clickable-element pattern (DataQualityDashboard / AdminDashboard). Saboteur confirmed the keyboard double-fire worry is prevented by the `e.target === e.currentTarget` guard.
- **[MEDIUM]** doc overstatement reworded; the AdminTable/DenseTable header divergence documented; the Venue Status follow-up filed (PSY-942).
- **[LOW]** `stopRowClick` keyboard caveat documented.
Panel: Saboteur · Future-Maintainer · Completeness.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run` (full frontend) — **5317 passing**
- [x] `components/admin/AdminTable.test.tsx` — render, mono-uppercase header, align (incl. right + cellClassName passthrough), onRowClick (click + Enter/Space), child-key guard, stopRowClick, rowClassName, `role="button"`+aria-label, non-clickable rows aren't buttons, empty slot (colSpan), rich cells
- [x] `components/admin/CollectionManagement.test.tsx` (21) + `PipelineVenues.test.tsx` (28) — pre-existing behavior tests pass unchanged (no-regression signal, incl. the Featured-toggle sticky-error path)
- [x] changed-file ESLint — 0 errors (only 5 pre-existing RadioManagement unused-import warnings, not introduced here)
- [x] `/code-review` — behavior-preservation CLEAN (column-by-column); fixes applied (keyboard a11y, DenseTable cross-ref, test corrections)
- [x] `/adversarial-review` — 3× CONCERNS → resolved in `2942b0a0`
- [x] `/psy-self-review` — both reviewers PASS: evidence substantiated (AdminTable cases present, commits `36fb8986`/`2942b0a0` exist, 5→5/7→7 column counts verified, CollectionManagement/PipelineVenues behavior tests intact); convention/asymmetry clean (`rowLabel` on both clickable tables, Import History correctly omits it; Featured `stopRowClick` set; no orphaned imports; no new hardcoded colors)

## Coverage gaps
- **No in-browser screenshot** — the dev stack was down (no Postgres container) this session. The change is behavior-preserving and covered by the primitive's tests, the 3 parents' existing behavior tests, and column-by-column code-review verification. The intended visual changes (mono-uppercase header, hover `/30`, denser padding) are easy to eyeball in review / on stage.
- **Venue Status** + nested tables not migrated (deferred → PSY-942 / intentionally out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
