### PR TITLE
PSY-939: ISR revalidation rules engine for proxy-routed mutations

### DIFF
--- a/frontend/app/api/[...path]/route.test.ts
+++ b/frontend/app/api/[...path]/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { NextRequest } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
 import { cookies } from 'next/headers'
+import { revalidatePath } from 'next/cache'
 import { GET, POST, PUT, DELETE, PATCH, OPTIONS } from './route'
 
 // Mock Sentry so capture calls are observable and never hit the network.
@@ -14,6 +15,14 @@ vi.mock('@sentry/nextjs', () => ({
 vi.mock('next/headers', () => ({
   cookies: vi.fn(),
 }))
+
+// Mock next/cache so the ISR revalidation triggered by proxied mutations
+// (lib/proxy-revalidation.ts, PSY-939) is observable and side-effect free.
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const mockRevalidatePath = vi.mocked(revalidatePath)
 
 const mockCookies = vi.mocked(cookies)
 
@@ -44,7 +53,9 @@ function setAuthToken(token?: string) {
 let fetchSpy: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
-  vi.clearAllMocks()
+  // resetAllMocks (not clearAllMocks) so mockImplementation overrides from
+  // throwing-path tests don't leak into later tests.
+  vi.resetAllMocks()
   setAuthToken()
   fetchSpy = vi.spyOn(globalThis, 'fetch')
 })
@@ -372,6 +383,121 @@ describe('api/[...path] proxy route', () => {
       expect(res.status).toBe(204)
       expect(fetchSpy).not.toHaveBeenCalled()
       expect(await res.text()).toBe('')
+    })
+  })
+
+  describe('ISR revalidation on mutations (PSY-939)', () => {
+    it('revalidates the affected ISR page after a successful proxied mutation', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ id: 42, entity_type: 'artist' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+
+      const req = new NextRequest(
+        'http://localhost:3000/api/collections/desert-punk/items',
+        {
+          method: 'POST',
+          body: JSON.stringify({ entity_type: 'artist', entity_id: 1 }),
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+      const res = await POST(req)
+
+      expect(res.status).toBe(201)
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/collections/desert-punk')
+    })
+
+    it('revalidates pages derived from the mutation response body', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 7,
+            slug: 'bright-eyes-at-the-rebel-lounge',
+            artists: [{ id: 1, slug: 'bright-eyes' }],
+            venues: [],
+          }),
+          { status: 201, headers: { 'content-type': 'application/json' } }
+        )
+      )
+
+      const req = new NextRequest('http://localhost:3000/api/shows', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'New Show' }),
+        headers: { 'content-type': 'application/json' },
+      })
+      await POST(req)
+
+      const revalidatedPaths = mockRevalidatePath.mock.calls.map(
+        ([path]) => path
+      )
+      expect(revalidatedPaths).toContain('/shows/bright-eyes-at-the-rebel-lounge')
+      expect(revalidatedPaths).toContain('/shows')
+      expect(revalidatedPaths).toContain('/artists/bright-eyes')
+    })
+
+    it('revalidates on 204 No Content responses (path-based rules)', async () => {
+      fetchSpy.mockResolvedValue(new Response(null, { status: 204 }))
+
+      const req = new NextRequest(
+        'http://localhost:3000/api/collections/desert-punk/items/42',
+        { method: 'DELETE' }
+      )
+      const res = await DELETE(req)
+
+      expect(res.status).toBe(204)
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/collections/desert-punk')
+    })
+
+    it('does not revalidate when the backend rejects the mutation', async () => {
+      fetchSpy.mockResolvedValue(new Response('forbidden', { status: 403 }))
+
+      const req = new NextRequest(
+        'http://localhost:3000/api/collections/desert-punk/items',
+        { method: 'POST', body: '{}' }
+      )
+      const res = await POST(req)
+
+      expect(res.status).toBe(403)
+      expect(mockRevalidatePath).not.toHaveBeenCalled()
+    })
+
+    it('does not revalidate on GET requests', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ slug: 'desert-punk' }), { status: 200 })
+      )
+
+      const req = new NextRequest(
+        'http://localhost:3000/api/collections/desert-punk'
+      )
+      await GET(req)
+
+      expect(mockRevalidatePath).not.toHaveBeenCalled()
+    })
+
+    it('passes the backend response through unchanged when revalidation throws', async () => {
+      mockRevalidatePath.mockImplementation(() => {
+        throw new Error('static generation store missing')
+      })
+      const backendBody = JSON.stringify({ id: 1, slug: 'desert-punk' })
+      fetchSpy.mockResolvedValue(
+        new Response(backendBody, {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+
+      const req = new NextRequest(
+        'http://localhost:3000/api/collections/desert-punk/like',
+        { method: 'POST' }
+      )
+      const res = await POST(req)
+
+      // The persisted mutation must never be turned into an error by a
+      // cache-revalidation failure.
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe(backendBody)
     })
   })
 })

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import * as Sentry from '@sentry/nextjs'
+import {
+  isMutationMethod,
+  revalidateAfterProxyMutation,
+} from '@/lib/proxy-revalidation'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -25,18 +29,25 @@ async function proxyRequest(request: NextRequest) {
     // Forward auth cookie from browser
     const cookieStore = await cookies()
     const authToken = cookieStore.get('auth_token')
-    if (authToken) {
-      headers['Cookie'] = `auth_token=${authToken.value}`
+    const cookieHeader = authToken
+      ? `auth_token=${authToken.value}`
+      : undefined
+    if (cookieHeader) {
+      headers['Cookie'] = cookieHeader
     }
+
+    // Capture the request body so it can be forwarded AND inspected by the
+    // ISR revalidation rules (some rules read entity refs from the request).
+    const requestBody =
+      request.method !== 'GET' && request.method !== 'HEAD'
+        ? await request.text()
+        : undefined
 
     // Make request to backend
     const backendResponse = await fetch(url, {
       method: request.method,
       headers,
-      body:
-        request.method !== 'GET' && request.method !== 'HEAD'
-          ? await request.text()
-          : undefined,
+      body: requestBody,
     })
 
     // Capture 5xx errors from backend to Sentry
@@ -51,6 +62,18 @@ async function proxyRequest(request: NextRequest) {
     // Read response - handle 204 No Content specially (no body allowed)
     const isNoContent = backendResponse.status === 204
     const responseData = isNoContent ? null : await backendResponse.text()
+
+    // Keep ISR pages in sync after successful mutations (PSY-939). Never
+    // throws — see lib/proxy-revalidation.ts.
+    if (backendResponse.ok && isMutationMethod(request.method)) {
+      await revalidateAfterProxyMutation({
+        method: request.method,
+        path,
+        responseText: responseData,
+        requestText: requestBody,
+        cookieHeader,
+      })
+    }
 
     // Create response
     const response = new NextResponse(responseData, {

--- a/frontend/lib/proxy-revalidation.test.ts
+++ b/frontend/lib/proxy-revalidation.test.ts
@@ -1,0 +1,679 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { revalidatePath } from 'next/cache'
+import * as Sentry from '@sentry/nextjs'
+import {
+  isMutationMethod,
+  revalidateAfterProxyMutation,
+  type ProxyMutationArgs,
+} from './proxy-revalidation'
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+const mockRevalidatePath = vi.mocked(revalidatePath)
+const mockCaptureMessage = vi.mocked(Sentry.captureMessage)
+const mockCaptureException = vi.mocked(Sentry.captureException)
+
+// BACKEND_URL is unset in the vitest env, so lookups fall back to this.
+const BACKEND = 'http://localhost:8080'
+
+let fetchSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  // resetAllMocks (not clearAllMocks) so mockImplementation overrides from
+  // throwing-path tests don't leak into later tests.
+  vi.resetAllMocks()
+  fetchSpy = vi.spyOn(globalThis, 'fetch')
+})
+
+afterEach(() => {
+  fetchSpy.mockRestore()
+})
+
+/** Run the engine with sane defaults for the args not under test. */
+function run(
+  args: Partial<ProxyMutationArgs> & Pick<ProxyMutationArgs, 'method' | 'path'>
+) {
+  return revalidateAfterProxyMutation({
+    responseText: null,
+    requestText: null,
+    cookieHeader: undefined,
+    ...args,
+  })
+}
+
+/** Every path revalidated during the current test, in call order. */
+function revalidated(): string[] {
+  return mockRevalidatePath.mock.calls.map(([path]) => path as string)
+}
+
+/** Mock the next lookup GET to return an entity with the given slug. */
+function mockLookupResponse(slug: string) {
+  fetchSpy.mockResolvedValueOnce(
+    new Response(JSON.stringify({ id: 1, slug }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  )
+}
+
+describe('isMutationMethod', () => {
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])('%s is a mutation', (method) => {
+    expect(isMutationMethod(method)).toBe(true)
+  })
+
+  it.each(['GET', 'HEAD', 'OPTIONS'])('%s is not a mutation', (method) => {
+    expect(isMutationMethod(method)).toBe(false)
+  })
+})
+
+describe('no-op cases', () => {
+  it('does nothing for GET requests', async () => {
+    await run({ method: 'GET', path: '/shows' })
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for mutation paths with no matching rule', async () => {
+    await run({ method: 'POST', path: '/auth/login' })
+    await run({ method: 'POST', path: '/comments/5/vote' })
+    await run({ method: 'POST', path: '/saved-shows/12' })
+    await run({ method: 'POST', path: '/requests/3/vote' })
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the path matches a rule pattern but not its method', async () => {
+    // /shows only has POST (create) — PATCH matches no rule.
+    await run({ method: 'PATCH', path: '/shows' })
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+})
+
+describe('show rules', () => {
+  const showBody = JSON.stringify({
+    id: 7,
+    slug: 'bright-eyes-at-the-rebel-lounge-2026-07-01',
+    artists: [{ id: 1, slug: 'bright-eyes' }, { id: 2, slug: 'cursive' }],
+    venues: [{ id: 3, slug: 'the-rebel-lounge' }],
+  })
+
+  const expectedShowPages = [
+    '/shows/bright-eyes-at-the-rebel-lounge-2026-07-01',
+    '/shows',
+    '/explore',
+    '/artists',
+    '/venues',
+    '/artists/bright-eyes',
+    '/artists/cursive',
+  ]
+
+  it('show create revalidates the show, list surfaces, and billed artists', async () => {
+    await run({ method: 'POST', path: '/shows', responseText: showBody })
+    expect(revalidated()).toEqual(expectedShowPages)
+  })
+
+  it('show update revalidates the same set', async () => {
+    await run({ method: 'PUT', path: '/shows/7', responseText: showBody })
+    expect(revalidated()).toEqual(expectedShowPages)
+  })
+
+  it('show status ops revalidate the same set', async () => {
+    for (const op of [
+      'publish',
+      'unpublish',
+      'make-private',
+      'sold-out',
+      'cancelled',
+    ]) {
+      mockRevalidatePath.mockClear()
+      await run({
+        method: 'POST',
+        path: `/shows/7/${op}`,
+        responseText: showBody,
+      })
+      expect(revalidated()).toEqual(expectedShowPages)
+    }
+  })
+
+  it('admin show approve/reject revalidates the same set', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/shows/7/approve',
+      responseText: showBody,
+    })
+    expect(revalidated()).toEqual(expectedShowPages)
+  })
+
+  it('show delete revalidates list surfaces only (empty response)', async () => {
+    await run({ method: 'DELETE', path: '/shows/7' })
+    expect(revalidated()).toEqual(['/shows', '/explore', '/artists', '/venues'])
+  })
+
+  it('degrades to list surfaces when the response body is not JSON', async () => {
+    await run({ method: 'POST', path: '/shows', responseText: 'created' })
+    expect(revalidated()).toEqual(['/shows', '/explore', '/artists', '/venues'])
+  })
+})
+
+describe('suggest-edit rules', () => {
+  function suggestEditBody(applied: boolean, entitySlug?: string) {
+    return JSON.stringify({
+      applied,
+      message: 'ok',
+      pending_edit: {
+        id: 1,
+        entity_type: 'artist',
+        entity_id: 10,
+        entity_slug: entitySlug,
+      },
+    })
+  }
+
+  it('revalidates the entity + list page when the edit was auto-applied', async () => {
+    await run({
+      method: 'PUT',
+      path: '/artists/10/suggest-edit',
+      responseText: suggestEditBody(true, 'bright-eyes'),
+    })
+    expect(revalidated()).toEqual(['/artists/bright-eyes', '/artists'])
+  })
+
+  it('does nothing when the edit went to the pending queue (applied: false)', async () => {
+    await run({
+      method: 'PUT',
+      path: '/artists/10/suggest-edit',
+      responseText: suggestEditBody(false, 'bright-eyes'),
+    })
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('revalidates only the list page when the slug is missing', async () => {
+    await run({
+      method: 'PUT',
+      path: '/artists/10/suggest-edit',
+      responseText: suggestEditBody(true, undefined),
+    })
+    expect(revalidated()).toEqual(['/artists'])
+  })
+
+  it('uses the entity type from the path (venue)', async () => {
+    await run({
+      method: 'PUT',
+      path: '/venues/4/suggest-edit',
+      responseText: suggestEditBody(true, 'the-rebel-lounge'),
+    })
+    expect(revalidated()).toEqual(['/venues/the-rebel-lounge', '/venues'])
+  })
+
+  it('skips the list page for entity types without an ISR list route (release)', async () => {
+    await run({
+      method: 'PUT',
+      path: '/releases/9/suggest-edit',
+      responseText: suggestEditBody(true, 'fevers-and-mirrors'),
+    })
+    expect(revalidated()).toEqual(['/releases/fevers-and-mirrors'])
+  })
+})
+
+describe('pending-edit moderation rules', () => {
+  it('approve revalidates the affected entity + list page', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/pending-edits/55/approve',
+      responseText: JSON.stringify({
+        id: 55,
+        entity_type: 'artist',
+        entity_slug: 'bright-eyes',
+      }),
+    })
+    expect(revalidated()).toEqual(['/artists/bright-eyes', '/artists'])
+  })
+
+  it('approve maps singular entity types without ISR list pages (label)', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/pending-edits/55/approve',
+      responseText: JSON.stringify({
+        id: 55,
+        entity_type: 'label',
+        entity_slug: 'saddle-creek',
+      }),
+    })
+    expect(revalidated()).toEqual(['/labels/saddle-creek'])
+  })
+
+  it('approve does nothing for unknown entity types', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/pending-edits/55/approve',
+      responseText: JSON.stringify({
+        id: 55,
+        entity_type: 'mixtape',
+        entity_slug: 'whatever',
+      }),
+    })
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('reject has no rule (entity unchanged)', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/pending-edits/55/reject',
+      responseText: JSON.stringify({
+        id: 55,
+        entity_type: 'artist',
+        entity_slug: 'bright-eyes',
+      }),
+    })
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+})
+
+describe('artist rules', () => {
+  it('admin create revalidates the artist + list', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/artists',
+      responseText: JSON.stringify({ id: 1, slug: 'new-artist' }),
+    })
+    expect(revalidated()).toEqual(['/artists/new-artist', '/artists'])
+  })
+
+  it('admin update revalidates the artist + list', async () => {
+    await run({
+      method: 'PATCH',
+      path: '/admin/artists/1',
+      responseText: JSON.stringify({ id: 1, slug: 'renamed-artist' }),
+    })
+    expect(revalidated()).toEqual(['/artists/renamed-artist', '/artists'])
+  })
+
+  it('delete revalidates the list only', async () => {
+    await run({ method: 'DELETE', path: '/artists/1' })
+    expect(revalidated()).toEqual(['/artists'])
+  })
+
+  it('merge resolves the canonical artist slug via backend lookup', async () => {
+    mockLookupResponse('bright-eyes')
+    await run({
+      method: 'POST',
+      path: '/admin/artists/merge',
+      responseText: JSON.stringify({
+        canonical_artist_id: 42,
+        merged_artist_id: 99,
+      }),
+    })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND}/artists/42`,
+      expect.objectContaining({ cache: 'no-store' })
+    )
+    expect(revalidated()).toEqual(['/artists/bright-eyes', '/artists'])
+  })
+
+  it('merge falls back to the list page when the lookup fails', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('gone', { status: 404 }))
+    await run({
+      method: 'POST',
+      path: '/admin/artists/merge',
+      responseText: JSON.stringify({ canonical_artist_id: 42 }),
+    })
+    expect(revalidated()).toEqual(['/artists'])
+    // Lookup failures are observable so the staleness gap is visible.
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'isr-revalidation: slug lookup failed',
+      expect.objectContaining({ level: 'warning' })
+    )
+  })
+})
+
+describe('venue rules', () => {
+  it('admin create revalidates the venue + list', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/venues',
+      responseText: JSON.stringify({ id: 3, slug: 'new-venue' }),
+    })
+    expect(revalidated()).toEqual(['/venues/new-venue', '/venues'])
+  })
+
+  it('update revalidates the venue + list', async () => {
+    await run({
+      method: 'PUT',
+      path: '/venues/3',
+      responseText: JSON.stringify({ id: 3, slug: 'the-rebel-lounge' }),
+    })
+    expect(revalidated()).toEqual(['/venues/the-rebel-lounge', '/venues'])
+  })
+
+  it('delete revalidates the list only', async () => {
+    await run({ method: 'DELETE', path: '/venues/3' })
+    expect(revalidated()).toEqual(['/venues'])
+  })
+
+  it('verify revalidates the venue + list', async () => {
+    await run({
+      method: 'POST',
+      path: '/admin/venues/3/verify',
+      responseText: JSON.stringify({ id: 3, slug: 'the-rebel-lounge' }),
+    })
+    expect(revalidated()).toEqual(['/venues/the-rebel-lounge', '/venues'])
+  })
+})
+
+describe('release rules', () => {
+  it('create revalidates the release + credited artist pages', async () => {
+    await run({
+      method: 'POST',
+      path: '/releases',
+      responseText: JSON.stringify({
+        id: 9,
+        slug: 'fevers-and-mirrors',
+        artists: [{ id: 1, slug: 'bright-eyes' }],
+      }),
+    })
+    expect(revalidated()).toEqual([
+      '/releases/fevers-and-mirrors',
+      '/artists/bright-eyes',
+    ])
+  })
+
+  it('update revalidates the release + credited artist pages', async () => {
+    await run({
+      method: 'PUT',
+      path: '/releases/9',
+      responseText: JSON.stringify({
+        id: 9,
+        slug: 'fevers-and-mirrors',
+        artists: [{ id: 1, slug: 'bright-eyes' }],
+      }),
+    })
+    expect(revalidated()).toEqual([
+      '/releases/fevers-and-mirrors',
+      '/artists/bright-eyes',
+    ])
+  })
+
+  it('link add resolves the release slug from the path ID', async () => {
+    mockLookupResponse('fevers-and-mirrors')
+    await run({ method: 'POST', path: '/releases/9/links' })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND}/releases/9`,
+      expect.anything()
+    )
+    expect(revalidated()).toEqual(['/releases/fevers-and-mirrors'])
+  })
+
+  it('link remove resolves the release slug from the path ID', async () => {
+    mockLookupResponse('fevers-and-mirrors')
+    await run({ method: 'DELETE', path: '/releases/9/links/2' })
+    expect(revalidated()).toEqual(['/releases/fevers-and-mirrors'])
+  })
+})
+
+describe('label rules', () => {
+  it('create revalidates the label page', async () => {
+    await run({
+      method: 'POST',
+      path: '/labels',
+      responseText: JSON.stringify({ id: 5, slug: 'saddle-creek' }),
+    })
+    expect(revalidated()).toEqual(['/labels/saddle-creek'])
+  })
+
+  it('update revalidates the label page', async () => {
+    await run({
+      method: 'PUT',
+      path: '/labels/5',
+      responseText: JSON.stringify({ id: 5, slug: 'saddle-creek' }),
+    })
+    expect(revalidated()).toEqual(['/labels/saddle-creek'])
+  })
+
+  it('roster ops resolve the label slug from the path ID', async () => {
+    for (const subResource of ['artists', 'releases']) {
+      mockRevalidatePath.mockClear()
+      mockLookupResponse('saddle-creek')
+      await run({ method: 'POST', path: `/admin/labels/5/${subResource}` })
+      expect(revalidated()).toEqual(['/labels/saddle-creek'])
+    }
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND}/labels/5`,
+      expect.anything()
+    )
+  })
+})
+
+describe('festival rules', () => {
+  it('create revalidates the festival page', async () => {
+    await run({
+      method: 'POST',
+      path: '/festivals',
+      responseText: JSON.stringify({ id: 6, slug: 'riot-fest-2026' }),
+    })
+    expect(revalidated()).toEqual(['/festivals/riot-fest-2026'])
+  })
+
+  it('update revalidates the festival page', async () => {
+    await run({
+      method: 'PUT',
+      path: '/festivals/6',
+      responseText: JSON.stringify({ id: 6, slug: 'riot-fest-2026' }),
+    })
+    expect(revalidated()).toEqual(['/festivals/riot-fest-2026'])
+  })
+
+  it('lineup ops resolve the festival slug from the path ID', async () => {
+    const lineupOps: Array<[string, string]> = [
+      ['POST', '/festivals/6/artists'],
+      ['PUT', '/festivals/6/artists/12'],
+      ['DELETE', '/festivals/6/artists/12'],
+      ['POST', '/festivals/6/venues'],
+      ['DELETE', '/festivals/6/venues/3'],
+    ]
+    for (const [method, path] of lineupOps) {
+      mockRevalidatePath.mockClear()
+      mockLookupResponse('riot-fest-2026')
+      await run({ method, path })
+      expect(revalidated()).toEqual(['/festivals/riot-fest-2026'])
+    }
+  })
+})
+
+describe('collection rules', () => {
+  it('create revalidates the new collection page', async () => {
+    await run({
+      method: 'POST',
+      path: '/collections',
+      responseText: JSON.stringify({ id: 1, slug: 'desert-punk-essentials' }),
+    })
+    expect(revalidated()).toEqual(['/collections/desert-punk-essentials'])
+  })
+
+  it('clone revalidates the newly created clone', async () => {
+    await run({
+      method: 'POST',
+      path: '/collections/desert-punk-essentials/clone',
+      responseText: JSON.stringify({ id: 2, slug: 'desert-punk-essentials-2' }),
+    })
+    expect(revalidated()).toEqual(['/collections/desert-punk-essentials-2'])
+  })
+
+  it('update revalidates both the path slug and the response slug (rename-safe)', async () => {
+    await run({
+      method: 'PUT',
+      path: '/collections/old-name',
+      responseText: JSON.stringify({ id: 1, slug: 'new-name' }),
+    })
+    expect(revalidated()).toEqual([
+      '/collections/old-name',
+      '/collections/new-name',
+    ])
+  })
+
+  it('update dedupes when the slug did not change', async () => {
+    await run({
+      method: 'PUT',
+      path: '/collections/same-name',
+      responseText: JSON.stringify({ id: 1, slug: 'same-name' }),
+    })
+    expect(revalidated()).toEqual(['/collections/same-name'])
+  })
+
+  it('delete revalidates the collection page', async () => {
+    await run({ method: 'DELETE', path: '/collections/desert-punk-essentials' })
+    expect(revalidated()).toEqual(['/collections/desert-punk-essentials'])
+  })
+
+  it('feature revalidates the collection + /explore', async () => {
+    await run({ method: 'PUT', path: '/collections/desert-punk-essentials/feature' })
+    expect(revalidated()).toEqual([
+      '/collections/desert-punk-essentials',
+      '/explore',
+    ])
+  })
+
+  it('engagement ops (items/like/subscribe/tags) revalidate the collection page', async () => {
+    const engagementOps: Array<[string, string]> = [
+      ['POST', '/collections/my-list/items'],
+      ['POST', '/collections/my-list/items/bulk'],
+      ['PATCH', '/collections/my-list/items/42'],
+      ['DELETE', '/collections/my-list/items/42'],
+      ['PUT', '/collections/my-list/items/reorder'],
+      ['POST', '/collections/my-list/like'],
+      ['DELETE', '/collections/my-list/like'],
+      ['POST', '/collections/my-list/subscribe'],
+      ['DELETE', '/collections/my-list/subscribe'],
+      ['POST', '/collections/my-list/tags'],
+      ['DELETE', '/collections/my-list/tags/3'],
+    ]
+    for (const [method, path] of engagementOps) {
+      mockRevalidatePath.mockClear()
+      await run({ method, path })
+      expect(revalidated()).toEqual(['/collections/my-list'])
+    }
+  })
+
+  it('resolve-items matches no rule (read-style POST)', async () => {
+    await run({ method: 'POST', path: '/collections/resolve-items' })
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+})
+
+describe('tag rules', () => {
+  it('create revalidates the new tag page', async () => {
+    await run({
+      method: 'POST',
+      path: '/tags',
+      responseText: JSON.stringify({ id: 3, slug: 'post-punk' }),
+    })
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+  })
+
+  it('update revalidates the tag page', async () => {
+    await run({
+      method: 'PUT',
+      path: '/tags/3',
+      responseText: JSON.stringify({ id: 3, slug: 'post-punk' }),
+    })
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+  })
+
+  it('entity tag add resolves the tag slug from the request body tag_id', async () => {
+    mockLookupResponse('post-punk')
+    await run({
+      method: 'POST',
+      path: '/entities/artist/10/tags',
+      requestText: JSON.stringify({ tag_id: 3 }),
+    })
+    expect(fetchSpy).toHaveBeenCalledWith(`${BACKEND}/tags/3`, expect.anything())
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+  })
+
+  it('entity tag add by tag_name does nothing (brand-new tag has no cached page)', async () => {
+    await run({
+      method: 'POST',
+      path: '/entities/artist/10/tags',
+      requestText: JSON.stringify({ tag_name: 'desert rock', category: 'genre' }),
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('entity tag remove resolves the tag slug from the path tag_id', async () => {
+    mockLookupResponse('post-punk')
+    await run({ method: 'DELETE', path: '/entities/venue/4/tags/3' })
+    expect(fetchSpy).toHaveBeenCalledWith(`${BACKEND}/tags/3`, expect.anything())
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+  })
+})
+
+describe('explore curation rules', () => {
+  it('featured slot set/delete revalidates /explore', async () => {
+    await run({ method: 'POST', path: '/admin/featured-slots' })
+    expect(revalidated()).toEqual(['/explore'])
+
+    mockRevalidatePath.mockClear()
+    await run({ method: 'DELETE', path: '/admin/featured-slots/collection' })
+    expect(revalidated()).toEqual(['/explore'])
+  })
+})
+
+describe('resilience', () => {
+  it('never throws when revalidatePath throws — reports each failure to Sentry', async () => {
+    mockRevalidatePath.mockImplementation(() => {
+      throw new Error('static generation store missing')
+    })
+
+    await expect(
+      run({ method: 'DELETE', path: '/shows/7' })
+    ).resolves.toBeUndefined()
+    // show-delete touches 4 list pages; each failure is captured separately.
+    expect(mockCaptureException).toHaveBeenCalledTimes(4)
+  })
+
+  it('never throws when the lookup fetch rejects — skips the page and reports', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    await expect(
+      run({ method: 'DELETE', path: '/entities/artist/10/tags/3' })
+    ).resolves.toBeUndefined()
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+    expect(mockCaptureException).toHaveBeenCalledTimes(1)
+  })
+
+  it('never throws on malformed request body JSON', async () => {
+    await expect(
+      run({
+        method: 'POST',
+        path: '/entities/artist/10/tags',
+        requestText: 'not json',
+      })
+    ).resolves.toBeUndefined()
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('forwards the auth cookie on lookup GETs', async () => {
+    mockLookupResponse('post-punk')
+    await run({
+      method: 'DELETE',
+      path: '/entities/artist/10/tags/3',
+      cookieHeader: 'auth_token=abc123',
+    })
+    const init = fetchSpy.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>)['Cookie']).toBe(
+      'auth_token=abc123'
+    )
+  })
+
+  it('omits the cookie header on lookup GETs when not authenticated', async () => {
+    mockLookupResponse('post-punk')
+    await run({ method: 'DELETE', path: '/entities/artist/10/tags/3' })
+    const init = fetchSpy.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>)['Cookie']).toBeUndefined()
+  })
+})

--- a/frontend/lib/proxy-revalidation.ts
+++ b/frontend/lib/proxy-revalidation.ts
@@ -1,0 +1,613 @@
+import * as Sentry from '@sentry/nextjs'
+import { safeRevalidatePath } from './revalidate-entity'
+
+/**
+ * ISR revalidation rules for mutations routed through the catch-all API
+ * proxy (app/api/[...path]/route.ts) — PSY-939.
+ *
+ * Entity pages are ISR-cached (revalidate: 3600; /explore: 300) and re-seed
+ * the TanStack Query cache via prefetchEntity on load. Any mutation that
+ * changes data embedded in an ISR payload must revalidate the affected
+ * paths, or a reload within the window re-serves pre-mutation data and the
+ * save appears lost (PSY-936/PSY-937).
+ *
+ * Each rule maps (HTTP method + backend path pattern) → the ISR paths made
+ * stale by that mutation. Slugs come from, in order of preference:
+ *   1. the mutation response body (most backend mutations return the entity)
+ *   2. the request path (collection routes are slug-addressed)
+ *   3. a backend ID→slug lookup GET (entity GETs accept ID-or-slug)
+ *
+ * Rules exist ONLY for data that is actually in an ISR payload. Verified
+ * non-cases (no rule on purpose): comments/field notes, follows, likes,
+ * saved shows, attendance, votes, requests, notification/profile/auth
+ * surfaces, and entity tagging → *entity* pages (entity pages client-fetch
+ * their tags; only the /tags/{slug} page ISR-caches usage counts).
+ *
+ * Known gaps (follow-up tickets):
+ *   - PSY-940: collections tagged via the generic /entities/collection/...
+ *     path (collections GET is slug-only; no ID→slug lookup possible)
+ *   - PSY-941: cascade renames (artist rename → show pages embedding the
+ *     name) need revalidateTag; out of reach for path-based rules
+ *   - Deletes by numeric ID can't revalidate the deleted entity's own detail
+ *     page (empty response, entity gone); the soft-404 proxy handles dead
+ *     slugs (PSY-897/913/906)
+ *   - Admin tag hygiene (merge/snooze/parent/bulk) and radio admin CRUD
+ */
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+/** True for HTTP methods that can mutate backend state. */
+export function isMutationMethod(method: string): boolean {
+  return MUTATION_METHODS.has(method)
+}
+
+// ---------------------------------------------------------------------------
+// Rule types
+// ---------------------------------------------------------------------------
+
+interface RuleContext {
+  /** Match of the rule's pattern against the backend path. */
+  match: RegExpMatchArray
+  /** Parsed JSON response body; undefined when empty or unparseable. */
+  body: unknown
+  /** Parsed JSON request body; undefined when empty or unparseable. */
+  requestBody: unknown
+  /** Resolve an entity slug from a numeric ID via a backend GET. */
+  lookupSlug: (urlSegment: string, id: string) => Promise<string | undefined>
+}
+
+interface RevalidationRule {
+  /** Identifies the rule in Sentry reports. */
+  name: string
+  methods: readonly string[]
+  /** Matched against the backend path (no /api prefix, no query string). */
+  pattern: RegExp
+  /**
+   * ISR paths made stale by this mutation. undefined entries (missing slugs)
+   * are dropped; duplicates are revalidated once.
+   */
+  paths: (
+    ctx: RuleContext
+  ) => Promise<Array<string | undefined>> | Array<string | undefined>
+}
+
+// ---------------------------------------------------------------------------
+// Safe field access on untyped JSON bodies
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+/** Non-empty string field of a JSON object, else undefined. */
+function stringField(value: unknown, key: string): string | undefined {
+  const field = asRecord(value)?.[key]
+  return typeof field === 'string' && field !== '' ? field : undefined
+}
+
+/** body.slug — the shape every backend entity mutation response uses. */
+function slugOf(body: unknown): string | undefined {
+  return stringField(body, 'slug')
+}
+
+/** Slugs of the objects under body[key][] (e.g. a show's artists/venues). */
+function nestedSlugs(body: unknown, key: string): string[] {
+  const list = asRecord(body)?.[key]
+  if (!Array.isArray(list)) return []
+  return list
+    .map((item) => slugOf(item))
+    .filter((slug): slug is string => slug !== undefined)
+}
+
+// ---------------------------------------------------------------------------
+// Page-path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * ISR list pages by entity URL segment. Only /artists, /venues, and /shows
+ * have ISR list routes (revalidate: 3600); the other entity types' browse
+ * pages are client-fetched.
+ */
+const ISR_LIST_PAGES: Readonly<Record<string, string>> = {
+  artists: '/artists',
+  venues: '/venues',
+  shows: '/shows',
+}
+
+/**
+ * Singular entity_type values (backend contracts) → URL path segments.
+ *
+ * Deliberately parallel to ENTITY_PLURAL in
+ * features/contributions/hooks/useSuggestEdit.ts (a client module this
+ * server-only lib must not import). Keep both in sync when adding entity
+ * types.
+ */
+const SINGULAR_TO_SEGMENT: Readonly<Record<string, string>> = {
+  artist: 'artists',
+  venue: 'venues',
+  show: 'shows',
+  release: 'releases',
+  label: 'labels',
+  festival: 'festivals',
+  collection: 'collections',
+}
+
+/** Detail page (when the slug is known) + ISR list page (when one exists). */
+function entityPages(
+  segment: string,
+  slug: string | undefined
+): Array<string | undefined> {
+  return [slug ? `/${segment}/${slug}` : undefined, ISR_LIST_PAGES[segment]]
+}
+
+/**
+ * Rule resolver for the most common shape: the mutation response is the
+ * entity itself, so revalidate its detail page (+ ISR list page if one
+ * exists) using the slug from the response body.
+ */
+function bodySlugPages(segment: string): RevalidationRule['paths'] {
+  return ({ body }) => entityPages(segment, slugOf(body))
+}
+
+/**
+ * Pages affected by a show mutation: the show itself, the upcoming-show
+ * surfaces (/shows, /explore), the /artists and /venues lists (both embed
+ * upcoming-show data), and each billed artist's detail page (artist pages
+ * ISR-cache stats.shows_tracked).
+ */
+function showPages(body: unknown): Array<string | undefined> {
+  const slug = slugOf(body)
+  return [
+    slug ? `/shows/${slug}` : undefined,
+    '/shows',
+    '/explore',
+    '/artists',
+    '/venues',
+    ...nestedSlugs(body, 'artists').map((artistSlug) => `/artists/${artistSlug}`),
+  ]
+}
+
+/**
+ * Pages affected by a release mutation: the release itself plus each
+ * credited artist's detail page (artist pages ISR-cache stats.releases).
+ */
+function releasePages(body: unknown): Array<string | undefined> {
+  return [
+    ...entityPages('releases', slugOf(body)),
+    ...nestedSlugs(body, 'artists').map((artistSlug) => `/artists/${artistSlug}`),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+//
+// First match wins (rules are disjoint by method+path; ordering is only a
+// tiebreaker for readability — most-specific patterns first within a group).
+
+const RULES: readonly RevalidationRule[] = [
+  // --- shows -------------------------------------------------------------
+  {
+    name: 'show-create',
+    methods: ['POST'],
+    pattern: /^\/shows$/,
+    paths: ({ body }) => showPages(body),
+  },
+  {
+    name: 'show-update',
+    methods: ['PUT'],
+    pattern: /^\/shows\/\d+$/,
+    paths: ({ body }) => showPages(body),
+  },
+  {
+    name: 'show-delete',
+    methods: ['DELETE'],
+    pattern: /^\/shows\/\d+$/,
+    // Empty response body — the show's own page can't be resolved, but every
+    // list surface that embedded it can.
+    paths: () => ['/shows', '/explore', '/artists', '/venues'],
+  },
+  {
+    name: 'show-status',
+    methods: ['POST'],
+    pattern: /^\/shows\/\d+\/(publish|unpublish|make-private|sold-out|cancelled)$/,
+    paths: ({ body }) => showPages(body),
+  },
+  {
+    name: 'show-moderation',
+    methods: ['POST'],
+    pattern: /^\/admin\/shows\/\d+\/(approve|reject)$/,
+    paths: ({ body }) => showPages(body),
+  },
+
+  // --- suggest-edit pipeline + moderation --------------------------------
+  {
+    name: 'suggest-edit',
+    methods: ['PUT'],
+    pattern: /^\/(artists|venues|festivals|releases|labels)\/\d+\/suggest-edit$/,
+    paths: ({ match, body }) => {
+      // Pending-only edits don't change the entity; only auto-applied edits
+      // (admin / trusted tier — `applied: true`) make ISR pages stale.
+      const record = asRecord(body)
+      if (record?.applied !== true) return []
+      const slug = stringField(record.pending_edit, 'entity_slug')
+      return entityPages(match[1], slug)
+    },
+  },
+  {
+    name: 'pending-edit-approve',
+    methods: ['POST'],
+    pattern: /^\/admin\/pending-edits\/\d+\/approve$/,
+    // Rejections don't change the entity, so there is no /reject rule.
+    paths: ({ body }) => {
+      const entityType = stringField(body, 'entity_type')
+      const segment = entityType ? SINGULAR_TO_SEGMENT[entityType] : undefined
+      if (!segment) return []
+      return entityPages(segment, stringField(body, 'entity_slug'))
+    },
+  },
+
+  // --- artists ------------------------------------------------------------
+  {
+    name: 'artist-create',
+    methods: ['POST'],
+    pattern: /^\/admin\/artists$/,
+    paths: bodySlugPages('artists'),
+  },
+  {
+    name: 'artist-update',
+    methods: ['PATCH'],
+    pattern: /^\/admin\/artists\/\d+$/,
+    paths: bodySlugPages('artists'),
+  },
+  {
+    name: 'artist-delete',
+    methods: ['DELETE'],
+    pattern: /^\/artists\/\d+$/,
+    paths: () => ['/artists'],
+  },
+  {
+    name: 'artist-merge',
+    methods: ['POST'],
+    pattern: /^\/admin\/artists\/merge$/,
+    // MergeArtistResult carries IDs only; resolve the canonical artist's slug.
+    paths: async ({ body, lookupSlug }) => {
+      const canonicalId = asRecord(body)?.canonical_artist_id
+      const slug =
+        typeof canonicalId === 'number'
+          ? await lookupSlug('artists', String(canonicalId))
+          : undefined
+      return entityPages('artists', slug)
+    },
+  },
+
+  // --- venues -------------------------------------------------------------
+  {
+    name: 'venue-create',
+    methods: ['POST'],
+    pattern: /^\/admin\/venues$/,
+    paths: bodySlugPages('venues'),
+  },
+  {
+    name: 'venue-update',
+    methods: ['PUT'],
+    pattern: /^\/venues\/\d+$/,
+    paths: bodySlugPages('venues'),
+  },
+  {
+    name: 'venue-delete',
+    methods: ['DELETE'],
+    pattern: /^\/venues\/\d+$/,
+    paths: () => ['/venues'],
+  },
+  {
+    name: 'venue-verify',
+    methods: ['POST'],
+    pattern: /^\/admin\/venues\/\d+\/verify$/,
+    paths: bodySlugPages('venues'),
+  },
+
+  // --- releases -----------------------------------------------------------
+  {
+    name: 'release-create',
+    methods: ['POST'],
+    pattern: /^\/releases$/,
+    paths: ({ body }) => releasePages(body),
+  },
+  {
+    name: 'release-update',
+    methods: ['PUT'],
+    pattern: /^\/releases\/\d+$/,
+    paths: ({ body }) => releasePages(body),
+  },
+  {
+    name: 'release-links',
+    methods: ['POST', 'DELETE'],
+    pattern: /^\/releases\/(\d+)\/links(\/\d+)?$/,
+    // Release pages ISR-cache external_links[]; the response is the link
+    // (or empty), so resolve the release slug from the path ID.
+    paths: async ({ match, lookupSlug }) => {
+      const slug = await lookupSlug('releases', match[1])
+      return [slug ? `/releases/${slug}` : undefined]
+    },
+  },
+
+  // --- labels -------------------------------------------------------------
+  {
+    name: 'label-create',
+    methods: ['POST'],
+    pattern: /^\/labels$/,
+    paths: bodySlugPages('labels'),
+  },
+  {
+    name: 'label-update',
+    methods: ['PUT'],
+    pattern: /^\/labels\/\d+$/,
+    paths: bodySlugPages('labels'),
+  },
+  {
+    name: 'label-roster',
+    methods: ['POST'],
+    pattern: /^\/admin\/labels\/(\d+)\/(artists|releases)$/,
+    // Label pages ISR-cache artist_count / release_count; the response is
+    // just {success}, so resolve the label slug from the path ID.
+    paths: async ({ match, lookupSlug }) => {
+      const slug = await lookupSlug('labels', match[1])
+      return [slug ? `/labels/${slug}` : undefined]
+    },
+  },
+
+  // --- festivals ----------------------------------------------------------
+  {
+    name: 'festival-create',
+    methods: ['POST'],
+    pattern: /^\/festivals$/,
+    paths: bodySlugPages('festivals'),
+  },
+  {
+    name: 'festival-update',
+    methods: ['PUT'],
+    pattern: /^\/festivals\/\d+$/,
+    paths: bodySlugPages('festivals'),
+  },
+  {
+    name: 'festival-lineup',
+    methods: ['POST', 'PUT', 'DELETE'],
+    pattern: /^\/festivals\/(\d+)\/(artists|venues)(\/\d+)?$/,
+    // Festival pages ISR-cache artist_count / venue_count; the response is
+    // the lineup entry (or empty), so resolve the festival slug from the
+    // path ID.
+    paths: async ({ match, lookupSlug }) => {
+      const slug = await lookupSlug('festivals', match[1])
+      return [slug ? `/festivals/${slug}` : undefined]
+    },
+  },
+
+  // --- collections ---------------------------------------------------------
+  // Collection routes are slug-addressed, and the collection ISR payload
+  // embeds everything the routes below touch (items[], item_count,
+  // like_count, subscriber_count, tags[], is_featured).
+  {
+    name: 'collection-create',
+    methods: ['POST'],
+    pattern: /^\/collections$/,
+    paths: bodySlugPages('collections'),
+  },
+  {
+    name: 'collection-clone',
+    methods: ['POST'],
+    pattern: /^\/collections\/[^/]+\/clone$/,
+    // The response is the newly created clone.
+    paths: bodySlugPages('collections'),
+  },
+  {
+    name: 'collection-feature',
+    methods: ['PUT'],
+    pattern: /^\/collections\/([^/]+)\/feature$/,
+    // Featured collections also surface on /explore.
+    paths: ({ match }) => [`/collections/${match[1]}`, '/explore'],
+  },
+  {
+    name: 'collection-engagement',
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
+    pattern: /^\/collections\/([^/]+)\/(items|like|subscribe|tags)(\/.*)?$/,
+    paths: ({ match }) => [`/collections/${match[1]}`],
+  },
+  {
+    name: 'collection-update',
+    methods: ['PUT'],
+    pattern: /^\/collections\/([^/]+)$/,
+    // A title edit can change the slug — revalidate both the old (path) and
+    // new (response body) URLs so neither serves stale ISR HTML.
+    paths: ({ match, body }) => {
+      const bodySlug = slugOf(body)
+      return [
+        `/collections/${match[1]}`,
+        bodySlug ? `/collections/${bodySlug}` : undefined,
+      ]
+    },
+  },
+  {
+    name: 'collection-delete',
+    methods: ['DELETE'],
+    pattern: /^\/collections\/([^/]+)$/,
+    paths: ({ match }) => [`/collections/${match[1]}`],
+  },
+
+  // --- tags ----------------------------------------------------------------
+  {
+    name: 'tag-create',
+    methods: ['POST'],
+    pattern: /^\/tags$/,
+    paths: bodySlugPages('tags'),
+  },
+  {
+    name: 'tag-update',
+    methods: ['PUT'],
+    pattern: /^\/tags\/\d+$/,
+    paths: bodySlugPages('tags'),
+  },
+  {
+    name: 'entity-tag-add',
+    methods: ['POST'],
+    pattern: /^\/entities\/[a-z]+\/\d+\/tags$/,
+    // Entity detail pages client-fetch their tags, so they are NOT affected.
+    // The /tags/{slug} page IS affected (usage_breakdown is ISR-cached). The
+    // response body is empty; the tag reference lives in the REQUEST body —
+    // tag_id for existing tags. (tag_name-only requests create a brand-new
+    // tag, which has no cached ISR page yet, so nothing to revalidate.)
+    paths: async ({ requestBody, lookupSlug }) => {
+      const tagId = asRecord(requestBody)?.tag_id
+      if (typeof tagId !== 'number' || tagId === 0) return []
+      const slug = await lookupSlug('tags', String(tagId))
+      return [slug ? `/tags/${slug}` : undefined]
+    },
+  },
+  {
+    name: 'entity-tag-remove',
+    methods: ['DELETE'],
+    pattern: /^\/entities\/[a-z]+\/\d+\/tags\/(\d+)$/,
+    paths: async ({ match, lookupSlug }) => {
+      const slug = await lookupSlug('tags', match[1])
+      return [slug ? `/tags/${slug}` : undefined]
+    },
+  },
+
+  // --- explore curation ----------------------------------------------------
+  {
+    name: 'featured-slots',
+    methods: ['POST', 'DELETE'],
+    pattern: /^\/admin\/featured-slots(\/.+)?$/,
+    paths: () => ['/explore'],
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+export interface ProxyMutationArgs {
+  method: string
+  /** Backend path: pathname with the /api prefix stripped, no query string. */
+  path: string
+  /** Raw response body text (null for 204 No Content). */
+  responseText: string | null
+  /** Raw request body text that was forwarded to the backend. */
+  requestText: string | null | undefined
+  /** Cookie header to forward on lookup GETs (for auth-gated entities). */
+  cookieHeader: string | undefined
+}
+
+/**
+ * Revalidate the ISR pages affected by a successful proxied mutation.
+ *
+ * Call AFTER the backend returned 2xx. Never throws — revalidation is a
+ * cache-freshness concern and must not break an already-persisted mutation.
+ */
+export async function revalidateAfterProxyMutation(
+  args: ProxyMutationArgs
+): Promise<void> {
+  const { method, path } = args
+  if (!isMutationMethod(method)) return
+
+  // Single pass: find the first rule whose method + pattern match, keeping
+  // the match for its capture groups.
+  let rule: RevalidationRule | undefined
+  let match: RegExpMatchArray | null = null
+  for (const candidate of RULES) {
+    if (!candidate.methods.includes(method)) continue
+    match = path.match(candidate.pattern)
+    if (match) {
+      rule = candidate
+      break
+    }
+  }
+  if (!rule || !match) return
+
+  try {
+    const ctx: RuleContext = {
+      match,
+      body: parseJson(args.responseText),
+      requestBody: parseJson(args.requestText),
+      lookupSlug: (urlSegment, id) =>
+        lookupSlug(urlSegment, id, args.cookieHeader),
+    }
+
+    const paths = await rule.paths(ctx)
+    const uniquePaths = [
+      ...new Set(paths.filter((p): p is string => typeof p === 'string')),
+    ]
+    for (const isrPath of uniquePaths) {
+      safeRevalidatePath(isrPath, rule.name)
+    }
+  } catch (error) {
+    // A rules-engine bug must never break the mutation response.
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'isr-revalidation', rule: rule.name },
+      extra: { method, path },
+    })
+  }
+}
+
+function parseJson(text: string | null | undefined): unknown {
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Resolve an entity's slug from its numeric ID via the backend GET endpoint.
+ *
+ * Every URL segment used by the rules above (artists, releases, labels,
+ * festivals, tags) has a GET that accepts ID-or-slug. Returns undefined on
+ * any failure — the caller then skips that page, which means it stays stale
+ * until its ISR window expires; failures are reported so the gap is visible.
+ *
+ * Lookups run synchronously before the mutation response returns, adding one
+ * backend GET to the rules that need them (admin sub-resource ops, entity
+ * tagging). Deliberate tradeoff: revalidation stays inside the request
+ * context where revalidatePath is known to work. Moving lookups behind
+ * next/server's after() would unblock the response but needs verification
+ * that revalidatePath still functions there — candidate optimization for
+ * PSY-941.
+ */
+async function lookupSlug(
+  urlSegment: string,
+  id: string,
+  cookieHeader: string | undefined
+): Promise<string | undefined> {
+  try {
+    const headers: Record<string, string> = {}
+    if (cookieHeader) {
+      headers['Cookie'] = cookieHeader
+    }
+    const res = await fetch(`${BACKEND_URL}/${urlSegment}/${id}`, {
+      headers,
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      Sentry.captureMessage('isr-revalidation: slug lookup failed', {
+        level: 'warning',
+        tags: { service: 'isr-revalidation' },
+        extra: { urlSegment, id, status: res.status },
+      })
+      return undefined
+    }
+    return slugOf(await res.json())
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'warning',
+      tags: { service: 'isr-revalidation' },
+      extra: { urlSegment, id },
+    })
+    return undefined
+  }
+}

--- a/frontend/lib/revalidate-entity.test.ts
+++ b/frontend/lib/revalidate-entity.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { revalidatePath } from 'next/cache'
 import * as Sentry from '@sentry/nextjs'
-import { revalidateArtistDetail } from './revalidate-entity'
+import { revalidateArtistDetail, safeRevalidatePath } from './revalidate-entity'
 
 vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
@@ -17,7 +17,9 @@ const mockCaptureMessage = vi.mocked(Sentry.captureMessage)
 const mockCaptureException = vi.mocked(Sentry.captureException)
 
 beforeEach(() => {
-  vi.clearAllMocks()
+  // resetAllMocks (not clearAllMocks) so mockImplementation overrides from
+  // throwing-path tests don't leak into later tests.
+  vi.resetAllMocks()
 })
 
 describe('revalidateArtistDetail', () => {
@@ -45,5 +47,34 @@ describe('revalidateArtistDetail', () => {
 
     expect(() => revalidateArtistDetail('bright-eyes')).not.toThrow()
     expect(mockCaptureException).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('safeRevalidatePath', () => {
+  it('revalidates the given path', () => {
+    safeRevalidatePath('/collections/my-list', 'collection-engagement')
+
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/collections/my-list')
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('never throws when revalidatePath throws — reports to Sentry with the source tag', () => {
+    mockRevalidatePath.mockImplementation(() => {
+      throw new Error('static generation store missing')
+    })
+
+    expect(() => safeRevalidatePath('/explore', 'featured-slots')).not.toThrow()
+    expect(mockCaptureException).toHaveBeenCalledTimes(1)
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          service: 'isr-revalidation',
+          source: 'featured-slots',
+        }),
+        extra: expect.objectContaining({ path: '/explore' }),
+      })
+    )
   })
 })

--- a/frontend/lib/revalidate-entity.ts
+++ b/frontend/lib/revalidate-entity.ts
@@ -2,6 +2,28 @@ import { revalidatePath } from 'next/cache'
 import * as Sentry from '@sentry/nextjs'
 
 /**
+ * Revalidate one ISR path, never throwing.
+ *
+ * A revalidation failure must not turn an already-persisted backend save
+ * into an error response — errors are reported to Sentry instead. Shared by
+ * the dedicated admin routes (PSY-936) and the proxy revalidation rules
+ * engine (PSY-939, lib/proxy-revalidation.ts).
+ *
+ * `source` identifies the caller in Sentry (an entity type or rule name).
+ */
+export function safeRevalidatePath(path: string, source: string): void {
+  try {
+    revalidatePath(path)
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'isr-revalidation', source },
+      extra: { path },
+    })
+  }
+}
+
+/**
  * Revalidate the ISR-cached detail page for an artist after a mutation.
  *
  * Entity detail pages are ISR-cached (revalidate: 3600) and re-seed the
@@ -13,8 +35,9 @@ import * as Sentry from '@sentry/nextjs'
  * backend save into an error response. Missing slugs and revalidation
  * errors are reported to Sentry instead.
  *
- * Server-only (route handlers / server actions). PSY-937 extends this
- * pattern to the remaining entity types and the proxy-routed mutations.
+ * Server-only (route handlers / server actions). Used by the dedicated
+ * admin music routes; proxy-routed mutations are covered by
+ * lib/proxy-revalidation.ts (PSY-939).
  */
 export function revalidateArtistDetail(slug: string | undefined | null): void {
   if (!slug) {
@@ -25,13 +48,5 @@ export function revalidateArtistDetail(slug: string | undefined | null): void {
     return
   }
 
-  try {
-    revalidatePath(`/artists/${slug}`)
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
-      tags: { service: 'isr-revalidation', entity: 'artist' },
-      extra: { slug },
-    })
-  }
+  safeRevalidatePath(`/artists/${slug}`, 'artist')
 }


### PR DESCRIPTION
Closes PSY-939

Implements the architecture chosen in PSY-937 (decision record): a declarative revalidation rules engine in the catch-all API proxy, so every proxy-routed mutation invalidates the ISR pages it makes stale.

## Problem

PSY-936 fixed stale-ISR-after-mutation for the two dedicated admin music routes, but every other entity mutation flows through `app/api/[...path]/route.ts`, which never called `revalidatePath`. Result: suggest-edits, show edits, collection changes, admin CRUD, tagging — all could appear "lost" for up to 1 hour after a reload (ISR `revalidate: 3600` re-serving pre-mutation HTML that re-seeds the TanStack cache).

## What's here

**`lib/proxy-revalidation.ts` (new)** — rules table + matching engine:
- Each rule: HTTP methods + backend path pattern → ISR paths to revalidate
- Slug sources, in order of preference: response body → request path → backend ID→slug lookup GET
- Never throws (a cache-freshness failure must not break a persisted mutation); failures go to Sentry
- Rules exist **only** for data verified to be in an ISR payload (entity tags/comments/show-lists are client-fetched → deliberately no rule)

**`app/api/[...path]/route.ts`** — calls the engine after successful (2xx) mutations; request body captured so rules can read entity refs from it.

**`lib/revalidate-entity.ts`** — `safeRevalidatePath` extracted as the shared never-throw + Sentry primitive; `revalidateArtistDetail` (PSY-936) now delegates to it.

## Rules coverage

| Mutation group | Revalidates |
|---|---|
| Show create/update/status ops/admin moderation | show page, `/shows`, `/explore`, `/artists`, `/venues`, billed artists' pages (stats counts) |
| Show delete | list surfaces |
| Suggest-edit ×5 entity types (when auto-applied) | entity page + ISR list page |
| Pending-edit approve | entity page + ISR list page |
| Admin artist/venue CRUD + verify + merge | entity page + list (merge resolves canonical slug via lookup) |
| Release CRUD + external links | release page + credited artists' pages |
| Label CRUD + roster ops | label page (roster via lookup) |
| Festival CRUD + lineup ops | festival page (lineup via lookup) |
| Collection create/update/delete/clone/feature/items/like/subscribe/tags | collection page (+ `/explore` for feature); update is rename-safe (revalidates old + new slug) |
| Tag CRUD + entity tagging | tag page (`usage_breakdown` is ISR-cached; entity pages client-fetch tags so are deliberately not revalidated) |
| Featured slots | `/explore` |

Verified non-cases (no rules on purpose): comments/field notes, follows, likes, saved shows, attendance, votes, requests, notification/profile/auth surfaces.

## Known gaps (documented in code, follow-ups filed)

- **PSY-940** — collections tagged via the generic `/entities/collection/{id}/tags` path (collections GET is slug-only; no ID→slug lookup possible)
- **PSY-941** — cascade renames (artist rename → show pages embedding the name) need `revalidateTag`; also tracks moving lookups behind `next/server`'s `after()` to unblock mutation responses
- Deletes by numeric ID can't revalidate the deleted entity's own page (mitigated by the soft-404 proxy, PSY-897)
- Admin tag hygiene (merge/snooze/parent/bulk) and radio admin CRUD not covered (admin-only, low frequency)

## Tradeoffs

Lookup-based rules (admin sub-resource ops, entity tagging) add one synchronous backend GET before the mutation response returns. Deliberate: revalidation stays inside the request context where `revalidatePath` is known to work; `after()` is the candidate optimization (noted in PSY-941).

## Test plan

- [x] `bun run typecheck` clean
- [x] New unit tests: `lib/proxy-revalidation.test.ts` — every rule group, lookup behavior, auth-cookie forwarding, dedup, resilience (revalidatePath throwing, lookup failures, malformed JSON)
- [x] Extended `lib/revalidate-entity.test.ts` — `safeRevalidatePath` + existing PSY-936 tests still pass
- [x] Extended `app/api/[...path]/route.test.ts` — integration: mutation triggers revalidation, body-derived paths, 204 handling, 4xx doesn't revalidate, GET doesn't revalidate, revalidation failure passes the backend response through unchanged
- [x] Full frontend suite green
- [x] `/code-review` (5 finder agents: 3 correctness + reuse/simplification + efficiency/altitude) — 3 correctness angles returned zero findings; cleanup findings folded in (single-pass rule matching, `bodySlugPages` factory, cross-reference comments, documented lookup tradeoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
