### PR TITLE
PSY-881: render magic-link server errors discriminately

### DIFF
--- a/frontend/app/auth/magic-link/page.test.tsx
+++ b/frontend/app/auth/magic-link/page.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderWithProviders, waitFor } from '@/test/utils'
+import { renderWithProviders, waitFor, screen } from '@/test/utils'
 import { act } from '@testing-library/react'
+import { AuthError } from '@/lib/errors'
+import type { ApiError } from '@/lib/api'
 import MagicLinkPage from './page'
 
 const mockPush = vi.fn()
@@ -84,6 +86,96 @@ describe('MagicLinkPage', () => {
     })
 
     expect(mockPush).toHaveBeenCalledWith('/')
+  })
+
+  it('renders "Link Expired" for a body-encoded INVALID_TOKEN error', async () => {
+    // PSY-875/PSY-881: the invalid/expired-token path returns HTTP 200 +
+    // { success: false, error_code: 'INVALID_TOKEN' }, which the hook
+    // re-throws as an AuthError with status 401. A new link is the correct
+    // remedy, so this stays on the "Link Expired" pane.
+    const bodyError = new AuthError(
+      'This magic link has expired or is invalid.',
+      'TOKEN_INVALID',
+      { status: 401 }
+    )
+    mockUseVerifyMagicLink.mockImplementation(() => ({
+      mutate: mockMutate,
+      reset: vi.fn(),
+      isPending: false,
+      isError: true,
+      isSuccess: false,
+      error: bodyError,
+    }))
+
+    renderWithProviders(<MagicLinkPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Link Expired')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByRole('button', { name: /back to sign in/i })
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument()
+  })
+
+  it('renders the retry pane (not "Link Expired") for a 5xx error', async () => {
+    // PSY-875 flipped the JWT-mint failure from a silent HTTP 200 to a real
+    // 5xx (ApiError with status >= 500). Requesting a new link can't fix a
+    // backend outage, so this renders the server-error + retry pane.
+    const serverError: ApiError = Object.assign(
+      new Error('HTTP 500: Internal Server Error'),
+      { status: 500 }
+    )
+    const mockReset = vi.fn()
+    mockUseVerifyMagicLink.mockImplementation(() => ({
+      mutate: mockMutate,
+      reset: mockReset,
+      isPending: false,
+      isError: true,
+      isSuccess: false,
+      error: serverError,
+    }))
+
+    renderWithProviders(<MagicLinkPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Link Expired')).not.toBeInTheDocument()
+
+    const retryButton = screen.getByRole('button', { name: /try again/i })
+    expect(retryButton).toBeInTheDocument()
+    // There is no request-new-link CTA on the server-error pane.
+    expect(
+      screen.queryByRole('button', { name: /back to sign in/i })
+    ).not.toBeInTheDocument()
+
+    // Retry resets the mutation so the same token is re-verified.
+    await act(async () => {
+      retryButton.click()
+    })
+    expect(mockReset).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the retry pane for a status-less network failure', async () => {
+    // A network outage re-throws the raw fetch error (a TypeError with no
+    // `status`). That is also a "try again" situation, not "link expired".
+    const networkError = new TypeError('Failed to fetch')
+    mockUseVerifyMagicLink.mockImplementation(() => ({
+      mutate: mockMutate,
+      reset: vi.fn(),
+      isPending: false,
+      isError: true,
+      isSuccess: false,
+      error: networkError,
+    }))
+
+    renderWithProviders(<MagicLinkPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Link Expired')).not.toBeInTheDocument()
   })
 
   it('cleans up scheduled redirect on unmount', async () => {

--- a/frontend/app/auth/magic-link/page.tsx
+++ b/frontend/app/auth/magic-link/page.tsx
@@ -2,11 +2,32 @@
 
 import { Suspense, useEffect, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Loader2, CheckCircle2, AlertCircle, Mail } from 'lucide-react'
+import { Loader2, CheckCircle2, AlertCircle, Mail, ServerCrash } from 'lucide-react'
 import { useVerifyMagicLink } from '@/features/auth'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+/**
+ * Distinguish a genuine backend/transport failure from an expired/invalid
+ * magic link.
+ *
+ * Background (PSY-875 → PSY-881): the backend's invalid/expired-token path
+ * returns HTTP 200 + `{ success: false, error_code: "INVALID_TOKEN" }`, which
+ * `useVerifyMagicLink` re-throws as an AuthError with `status: 401`. After
+ * PSY-875 flipped the JWT-mint failure from a silent 200 to a real 5xx, a
+ * failed mint now surfaces as an ApiError with `status >= 500`, and a network
+ * outage re-throws the raw fetch error with no `status` at all.
+ *
+ * "Link Expired" copy (request-a-new-link CTA) is only correct for the
+ * body-encoded token error — a new link cannot fix a 5xx or a dead network.
+ * So treat anything that is NOT a sub-500 status (i.e. 5xx OR a status-less
+ * transport throw) as a server-side failure that wants a retry CTA instead.
+ */
+function isServerSideFailure(error: unknown): boolean {
+  const status = (error as { status?: number } | null)?.status
+  return typeof status !== 'number' || status >= 500
+}
 
 function MagicLinkContent() {
   const router = useRouter()
@@ -113,7 +134,41 @@ function MagicLinkContent() {
     )
   }
 
-  // Error state
+  // Server-side / transport failure (5xx mint failure post-PSY-875, or a
+  // network outage). Requesting a new link won't help, so offer a retry of the
+  // same token instead of the "Link Expired" request-new-link CTA.
+  if (isServerSideFailure(verifyMagicLink.error)) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
+        <Card className="w-full max-w-md border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+              <ServerCrash className="h-6 w-6 text-destructive" />
+            </div>
+            <CardTitle>Something went wrong</CardTitle>
+            <CardDescription>
+              We couldn&apos;t sign you in because of a problem on our end. Your
+              link is still valid — please try again in a moment.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <Button
+              onClick={() => {
+                // Force a fresh verification of the same token.
+                attemptedTokenRef.current = null
+                verifyMagicLink.reset()
+              }}
+            >
+              Try Again
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  // Expired / invalid token (body-encoded INVALID_TOKEN, HTTP 200 + AuthError
+  // status 401). A new link is the correct remedy here.
   return (
     <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
       <Card className="w-full max-w-md border-border/50 bg-card/50 backdrop-blur-sm">


### PR DESCRIPTION
## Summary

After PSY-875 flipped `VerifyMagicLinkHandler`'s JWT-mint failure from a silent HTTP 200 to a genuine 5xx, the magic-link page rendered the "Link Expired" + request-new-link pane on **any** `verifyMagicLink.isError` — including a real 5xx backend outage. Telling the user to request a new link doesn't help when the JWT service is unhealthy.

This splits the error render into two discriminated branches:

- **Server-side / transport failure** (`status >= 500`, or a status-less network throw): a "Something went wrong" pane with a **Try Again** button that resets the mutation and re-verifies the **same** token. No request-new-link CTA. The raw 5xx `error.message` is deliberately not surfaced.
- **Body-encoded `INVALID_TOKEN` / expiry** (HTTP 200 + `{success:false}`, re-thrown by the hook as an `AuthError` with `status: 401`): unchanged **"Link Expired"** + **Back to Sign In** request-new-link pane.

The discriminator is a small documented `isServerSideFailure()` predicate. The `INVALID_TOKEN` path always carries `status: 401` (set by `useVerifyMagicLink`), so it stays sub-500 and keeps the canonical UX.

Files: `frontend/app/auth/magic-link/page.tsx`, `frontend/app/auth/magic-link/page.test.tsx`.

## Test plan

- [x] `bun run typecheck` — clean (`tsc --noEmit`)
- [x] `bun run test:run app/auth/magic-link` — 6/6 pass (3 existing + 3 new)
- [x] `bun run test:run app/auth` — 38/38 pass (no adjacent regression)

New tests: (a) `INVALID_TOKEN` body-error → "Link Expired" + Back-to-Sign-In; (b) 5xx → retry pane, asserts `reset()` on Try Again **and** absence of the request-new-link CTA; (c) status-less network `TypeError` → retry pane.

## Manual repro

Brought up the shared dispatch stack (`stack-up.sh --mode=shared`) and confirmed the backend behavior directly:

- `POST /auth/magic-link/verify {"token":"garbage"}` → **HTTP 200** + `{success:false, error_code:"INVALID_TOKEN"}` (confirms the body-encoded path is sub-500).
- Navigated `/auth/magic-link?token=garbage` → rendered **"Link Expired"** + **Back to Sign In**. Screenshot captured to `dogfood-output/PSY-881/screenshots/link-expired-invalid-token.png`.

**Split disclosed:** the 5xx pane is hard to force end-to-end (requires injecting a JWT-mint failure in the backend), so it is covered by component-test DOM assertions rather than a live screenshot — per the ticket's allowance. Stack torn down after.

## Code review

`/code-review` (inline, dispatched sub-agent without Agent tool — three lenses: reuse / quality / efficiency). No findings. Verified: the error pane only renders when `isError` is true (so `error` is non-null); no existing `isServerError(error)` helper to reuse (the codebase's `>= 500` checks operate on `Response`, not error objects); the retry → `reset()` → effect re-fire loop is correct; `verifyMagicLink.reset()` is always present on a TanStack `UseMutationResult`.

## Adversarial review

`/adversarial-review` — CLEAN, no findings, no fixes commit. Panel (run inline, no prior session context): Saboteur · Future-Maintainer · Security · Completeness.
- Saboteur: boundary values (401/5xx/undefined/429) all classify correctly; retry requires a user click (no infinite auto-retry). CLEAN.
- Future-Maintainer: helper well-named + documented; tests assert behavior incl. CTA absence. CLEAN.
- Security: server-error pane suppresses the raw 5xx message — an info-disclosure improvement; no new attack surface. CLEAN.
- Completeness: all acceptance criteria met. CLEAN.

Closes PSY-881


## Screenshots

**"Link Expired" pane** — anonymous visit to `/auth/magic-link?token=garbage` against the local dev stack. The backend returns HTTP 200 + `error_code: "INVALID_TOKEN"` (the body-encoded path), and the page renders the request-new-link UX — confirming the canonical expired-link path is unchanged by the new 5xx discrimination.

![Link Expired pane for INVALID_TOKEN](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-3bf47e333cfb34b96be9/link-expired-invalid-token.png)

*The 5xx "Something went wrong" retry pane is covered by component-test DOM assertions (see Manual repro above) — forcing a live JWT-mint failure requires backend fault injection.*
