### PR TITLE
PSY-773: render profile-section content_html on public profile

### DIFF
--- a/frontend/components/contributor/ProfileSections.test.tsx
+++ b/frontend/components/contributor/ProfileSections.test.tsx
@@ -83,7 +83,7 @@ describe('ProfileSections', () => {
     expect(titles[2]).toHaveTextContent('Third')
   })
 
-  it('renders content in whitespace-pre-wrap element', () => {
+  it('renders content in whitespace-pre-wrap element when content_html is absent', () => {
     render(
       <ProfileSections
         sections={[
@@ -97,5 +97,65 @@ describe('ProfileSections', () => {
     const contentEl = document.querySelector('.whitespace-pre-wrap')
     expect(contentEl).toBeInTheDocument()
     expect(contentEl?.textContent).toBe('Line 1\nLine 2\nLine 3')
+  })
+
+  it('renders sanitized content_html as formatted markdown', () => {
+    render(
+      <ProfileSections
+        sections={[
+          makeSection({
+            content: '**bold** and a [link](https://example.com)',
+            content_html:
+              '<p><strong>bold</strong> and a <a href="https://example.com">link</a></p>',
+          }),
+        ]}
+      />
+    )
+    // Markdown renders as real HTML elements, not literal text.
+    const strong = document.querySelector('strong')
+    expect(strong).toBeInTheDocument()
+    expect(strong?.textContent).toBe('bold')
+    const link = document.querySelector('a[href="https://example.com"]')
+    expect(link).toBeInTheDocument()
+    expect(link?.textContent).toBe('link')
+    // The raw markdown source should NOT be rendered as literal text.
+    expect(
+      screen.queryByText('**bold** and a [link](https://example.com)')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders list markup from content_html', () => {
+    render(
+      <ProfileSections
+        sections={[
+          makeSection({
+            content: '- one\n- two',
+            content_html: '<ul>\n<li>one</li>\n<li>two</li>\n</ul>',
+          }),
+        ]}
+      />
+    )
+    const items = document.querySelectorAll('li')
+    expect(items).toHaveLength(2)
+    expect(items[0]?.textContent).toBe('one')
+    expect(items[1]?.textContent).toBe('two')
+  })
+
+  it('prefers content_html over raw content when both are present', () => {
+    render(
+      <ProfileSections
+        sections={[
+          makeSection({
+            content: 'raw markdown source',
+            content_html: '<p>rendered html</p>',
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText('rendered html')).toBeInTheDocument()
+    // The raw markdown source is not shown when content_html is present.
+    expect(screen.queryByText('raw markdown source')).not.toBeInTheDocument()
+    // No plain-text fallback element is rendered.
+    expect(document.querySelector('.whitespace-pre-wrap')).not.toBeInTheDocument()
   })
 })

--- a/frontend/components/contributor/ProfileSections.tsx
+++ b/frontend/components/contributor/ProfileSections.tsx
@@ -24,11 +24,21 @@ export function ProfileSections({ sections }: ProfileSectionsProps) {
             <CardTitle className="text-base">{section.title}</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="prose prose-sm dark:prose-invert max-w-none">
-              <p className="text-sm text-muted-foreground whitespace-pre-wrap">
-                {section.content}
-              </p>
-            </div>
+            {/* content_html is server-sanitized (goldmark + bluemonday, PSY-747),
+                matching tag/collection descriptions; fall back to raw content
+                when absent (e.g. empty content omits content_html). */}
+            {section.content_html ? (
+              <div
+                className="prose prose-sm dark:prose-invert max-w-none"
+                dangerouslySetInnerHTML={{ __html: section.content_html }}
+              />
+            ) : (
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                  {section.content}
+                </p>
+              </div>
+            )}
           </CardContent>
         </Card>
       ))}

--- a/frontend/features/auth/types.ts
+++ b/frontend/features/auth/types.ts
@@ -107,7 +107,14 @@ export interface ActivityHeatmapResponse {
 export interface ProfileSectionResponse {
   id: number
   title: string
+  /** Raw markdown source, preserved for edit-form round-tripping. */
   content: string
+  /**
+   * `content` rendered to sanitized HTML (goldmark + bluemonday) by the
+   * backend (PSY-747), mirroring tag/collection descriptions. Read this for
+   * display; keep `content` for editing. Omitted when `content` is empty.
+   */
+  content_html?: string
   position: number
   is_visible: boolean
   created_at: string


### PR DESCRIPTION
## Summary

Profile sections written with markdown (`**bold**`, lists, `[links](url)`) previously rendered as **literal plain text** on the public profile (`/users/[username]`), inconsistent with tag descriptions, collection descriptions, comments, and field notes — all of which render the backend-sanitized `*_html` field.

Backend PSY-747 already emits `content_html` on `ProfileSectionResponse` (goldmark + bluemonday via `utils.MarkdownRenderer`, the same allowlist policy as comments/field-notes/tags). The frontend simply wasn't consuming it. This wires it up:

- Add `content_html?: string` to the `ProfileSectionResponse` TS interface (`frontend/features/auth/types.ts`), with doc comments distinguishing raw-`content` (edit) from `content_html` (display).
- `ProfileSections` renders `content_html` via `dangerouslySetInnerHTML` inside the existing `prose` wrapper, mirroring `TagDetail.tsx`; falls back to the raw `content` plain-text block when `content_html` is absent (backend omits it for empty content).
- Editor (`ProfileSectionsEditor.tsx`) is **unchanged** — it still round-trips raw `content`; `content_html` is display-only.

The HTML is server-sanitized (bluemonday strips `<script>`, adds `rel="nofollow"` + `target="_blank"` on links), so `dangerouslySetInnerHTML` is safe — same trust model as `TagDetail` / `CommentCard` / `FieldNoteCard`.

## Test plan

- [x] `cd frontend && bun run typecheck` — passes clean (`tsc --noEmit`, no errors).
- [x] `cd frontend && bun run test:run components/contributor` — 242/242 pass (11 files), including 4 new `ProfileSections` cases: `<strong>` renders from `content_html`, list markup renders, raw markdown source is NOT shown when `content_html` present, and the plain-text fallback still works when `content_html` is absent.

## Manual repro

Ran the per-worktree dispatch stack (`--mode=shared`, frontend on a dynamic port against the shared dev backend at `:8080`):

1. Registered a fresh dev account, set username `psy773tester`.
2. Profile → Sections → Add Section with markdown content: `**post-punk**` bold, a bulleted list (Sub Pop / 4AD), and a `[bandcamp](https://bandcamp.com)` link.
3. Visited the public profile `/users/psy773tester`.
4. Verified the DOM (`agent-browser eval`): the "About Me" section renders `<strong>post-punk</strong>`, two `<li>` items, and `<a href="https://bandcamp.com" rel="nofollow noopener" target="_blank">` — and contains **no** literal `**` asterisks or `[bandcamp]` bracket text. Screenshot confirms formatted bold + bulleted list + underlined link.

The `rel="nofollow noopener" target="_blank"` on the link confirms the backend bluemonday policy is the one in effect end-to-end.

## Code review

`/code-review` (xhigh, run inline as a dispatched sub-agent across the 9 finder angles + sweep) — **no findings**. The change is a faithful, minimal application of the canonical `TagDetail` pattern; the only duplication (repeated `prose` className across the two branches) deliberately matches that canonical form. No correctness, reuse, simplification, efficiency, or altitude issues survived verification.

## Adversarial review

`/adversarial-review` — **CLEAN**, no findings, no fixes commit. Panel run inline (dispatched sub-agent, no Agent tool): Saboteur · Future-Maintainer · Security · Completeness, against the branch diff with no prior session context.
- **Security** (the ticket-flagged lens): verified the safety claim by reading `backend/internal/utils/markdown.go` — `Render()` always passes goldmark output through a bluemonday allowlist (`p/br/strong/b/em/i/code/pre/ul/ol/li/blockquote/h3-h6` + `href` on `a`; no `script`/`style`/`iframe`/`on*`/`img`), with `RequireNoFollowOnLinks` + `AddTargetBlankToFullyQualifiedLinks`. `contributor_profile.go:739` routes every section through this sanitizer. Same trust model as the already-shipped `TagDetail`/`CommentCard`/`FieldNoteCard`; no new attack surface.
- **Saboteur / Future-Maintainer / Completeness**: empty-string/absent `content_html` both correctly route to the fallback; `content` and `content_html` are derived from the same row in one server call so cannot diverge; editor untouched; all 5 acceptance criteria met.

Closes PSY-773


## Screenshots

**Public profile rendering markdown via `content_html`** — fresh dev account `psy773tester` with an "About Me" section authored in markdown. Bold (`**post-punk**`), the bulleted label list (Sub Pop / 4AD), and the `[bandcamp](url)` link all render as formatted HTML inside the `prose` wrapper — no literal `**` or `[bracket]` text.

![Public profile with markdown-rendered About Me section](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-64046c7e6b3881f5cc2a/public-profile-markdown-rendered.png)
