### PR TITLE
PSY-807: notification toggles for tier-change + edit-review emails

### DIFF
--- a/frontend/components/settings/notification-settings.test.tsx
+++ b/frontend/components/settings/notification-settings.test.tsx
@@ -20,11 +20,20 @@ let mockCollectionDigestState = {
   error: null as Error | null,
 }
 
+const mockTierEditMutate = vi.fn()
+let mockTierEditState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}
+
 let mockProfileData: {
   user?: {
     preferences?: {
       show_reminders?: boolean
       notify_on_collection_digest?: boolean
+      notify_on_tier_notifications?: boolean
+      notify_on_edit_notifications?: boolean
     }
   }
 } = {}
@@ -32,6 +41,10 @@ let mockProfileData: {
 vi.mock('@/features/auth', () => ({
   useProfile: () => ({
     data: mockProfileData,
+  }),
+  useSetTierEditNotificationPreference: () => ({
+    mutate: mockTierEditMutate,
+    ...mockTierEditState,
   }),
 }))
 
@@ -61,6 +74,12 @@ describe('NotificationSettings', () => {
       isError: false,
       error: null,
     }
+    mockTierEditMutate.mockReset()
+    mockTierEditState = {
+      isPending: false,
+      isError: false,
+      error: null,
+    }
     mockProfileData = {}
   })
 
@@ -70,7 +89,7 @@ describe('NotificationSettings', () => {
     expect(screen.getByText('Notifications')).toBeInTheDocument()
     expect(
       screen.getByText(
-        /Control how you're notified about upcoming shows and your collections/
+        /Control how you're notified about upcoming shows, your collections, and your contributions/
       )
     ).toBeInTheDocument()
   })
@@ -291,6 +310,180 @@ describe('NotificationSettings', () => {
       )
       expect(errors.length).toBeGreaterThanOrEqual(1)
     })
+  })
+
+  // ----- PSY-756 / PSY-807: tier-change + edit-review email toggles -----
+
+  describe('tier-change email toggle', () => {
+    it('renders the tier-change label and description', () => {
+      renderWithProviders(<NotificationSettings />)
+
+      expect(screen.getByText('Tier-change emails')).toBeInTheDocument()
+      expect(
+        screen.getByText(/when your contributor tier changes/)
+      ).toBeInTheDocument()
+    })
+
+    it('defaults to ON when the preference is undefined (opt-OUT default)', () => {
+      mockProfileData = { user: { preferences: {} } }
+      renderWithProviders(<NotificationSettings />)
+
+      const toggle = screen.getByRole('switch', { name: 'Tier-change emails' })
+      expect(toggle).toBeChecked()
+    })
+
+    it('reflects current value when notify_on_tier_notifications is false', () => {
+      mockProfileData = {
+        user: { preferences: { notify_on_tier_notifications: false } },
+      }
+      renderWithProviders(<NotificationSettings />)
+
+      const toggle = screen.getByRole('switch', { name: 'Tier-change emails' })
+      expect(toggle).not.toBeChecked()
+    })
+
+    it('calls the mutation with only the tier field when toggled off', async () => {
+      mockProfileData = {
+        user: { preferences: { notify_on_tier_notifications: true } },
+      }
+      const user = userEvent.setup()
+      renderWithProviders(<NotificationSettings />)
+
+      await user.click(
+        screen.getByRole('switch', { name: 'Tier-change emails' })
+      )
+
+      expect(mockTierEditMutate).toHaveBeenCalledWith({
+        notify_on_tier_notifications: false,
+      })
+    })
+
+    it('calls the mutation with only the tier field when toggled back on', async () => {
+      mockProfileData = {
+        user: { preferences: { notify_on_tier_notifications: false } },
+      }
+      const user = userEvent.setup()
+      renderWithProviders(<NotificationSettings />)
+
+      await user.click(
+        screen.getByRole('switch', { name: 'Tier-change emails' })
+      )
+
+      expect(mockTierEditMutate).toHaveBeenCalledWith({
+        notify_on_tier_notifications: true,
+      })
+    })
+
+    it('persists across reload — re-rendering with the opted-out state shows it off', () => {
+      mockProfileData = {
+        user: { preferences: { notify_on_tier_notifications: true } },
+      }
+      const { unmount } = renderWithProviders(<NotificationSettings />)
+      let toggle = screen.getByRole('switch', { name: 'Tier-change emails' })
+      expect(toggle).toBeChecked()
+      unmount()
+
+      mockProfileData = {
+        user: { preferences: { notify_on_tier_notifications: false } },
+      }
+      renderWithProviders(<NotificationSettings />)
+      toggle = screen.getByRole('switch', { name: 'Tier-change emails' })
+      expect(toggle).not.toBeChecked()
+    })
+  })
+
+  describe('edit-review email toggle', () => {
+    it('renders the edit-review label and description', () => {
+      renderWithProviders(<NotificationSettings />)
+
+      expect(screen.getByText('Edit-review emails')).toBeInTheDocument()
+      expect(
+        screen.getByText(/when your submitted edits are approved or rejected/)
+      ).toBeInTheDocument()
+    })
+
+    it('defaults to ON when the preference is undefined (opt-OUT default)', () => {
+      mockProfileData = { user: { preferences: {} } }
+      renderWithProviders(<NotificationSettings />)
+
+      const toggle = screen.getByRole('switch', { name: 'Edit-review emails' })
+      expect(toggle).toBeChecked()
+    })
+
+    it('reflects current value when notify_on_edit_notifications is false', () => {
+      mockProfileData = {
+        user: { preferences: { notify_on_edit_notifications: false } },
+      }
+      renderWithProviders(<NotificationSettings />)
+
+      const toggle = screen.getByRole('switch', { name: 'Edit-review emails' })
+      expect(toggle).not.toBeChecked()
+    })
+
+    it('calls the mutation with only the edit field when toggled off', async () => {
+      mockProfileData = {
+        user: { preferences: { notify_on_edit_notifications: true } },
+      }
+      const user = userEvent.setup()
+      renderWithProviders(<NotificationSettings />)
+
+      await user.click(
+        screen.getByRole('switch', { name: 'Edit-review emails' })
+      )
+
+      expect(mockTierEditMutate).toHaveBeenCalledWith({
+        notify_on_edit_notifications: false,
+      })
+    })
+
+    it('toggling one category does not send the other category field', async () => {
+      mockProfileData = {
+        user: {
+          preferences: {
+            notify_on_tier_notifications: true,
+            notify_on_edit_notifications: true,
+          },
+        },
+      }
+      const user = userEvent.setup()
+      renderWithProviders(<NotificationSettings />)
+
+      await user.click(
+        screen.getByRole('switch', { name: 'Edit-review emails' })
+      )
+
+      expect(mockTierEditMutate).toHaveBeenCalledTimes(1)
+      expect(mockTierEditMutate).toHaveBeenCalledWith({
+        notify_on_edit_notifications: false,
+      })
+    })
+  })
+
+  it('disables both tier/edit switches while the shared mutation is in flight', () => {
+    mockTierEditState = { isPending: true, isError: false, error: null }
+    renderWithProviders(<NotificationSettings />)
+
+    expect(
+      screen.getByRole('switch', { name: 'Tier-change emails' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('switch', { name: 'Edit-review emails' })
+    ).toBeDisabled()
+  })
+
+  it('shows an error message when the tier/edit mutation fails', () => {
+    mockTierEditState = {
+      isPending: false,
+      isError: true,
+      error: new Error('Server error'),
+    }
+    renderWithProviders(<NotificationSettings />)
+
+    const errors = screen.getAllByText(
+      'Failed to update setting. Please try again.'
+    )
+    // Both tier and edit rows render the shared error copy.
+    expect(errors.length).toBeGreaterThanOrEqual(2)
   })
 
   // ----- Pending spinner placement (both rows) -----

--- a/frontend/components/settings/notification-settings.tsx
+++ b/frontend/components/settings/notification-settings.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import { useProfile } from '@/features/auth'
+import {
+  useProfile,
+  useSetTierEditNotificationPreference,
+} from '@/features/auth'
 import { useSetShowReminders } from '@/features/shows'
 import { useSetCollectionDigestPreference } from '@/features/collections'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -18,16 +21,25 @@ import { Bell, Loader2 } from 'lucide-react'
  *   - Weekly collection digest (PSY-350 / PSY-515): batched email of new
  *     items in collections you follow. Server default is OFF (opt-IN); the
  *     UI shows the unchecked Switch until the user enables it.
+ *   - Tier-change + edit-review emails (PSY-756 / PSY-807): per-category
+ *     opt-OUT. Server default is ON for both, so an undefined preference
+ *     renders the Switch checked until the user opts out.
  */
 export function NotificationSettings() {
   const { data: profileData } = useProfile()
   const setShowReminders = useSetShowReminders()
   const setCollectionDigest = useSetCollectionDigestPreference()
+  const setTierEditNotifications = useSetTierEditNotificationPreference()
 
   const showRemindersEnabled =
     profileData?.user?.preferences?.show_reminders ?? false
   const collectionDigestEnabled =
     profileData?.user?.preferences?.notify_on_collection_digest ?? false
+  // Opt-OUT: default to ON when the server hasn't sent an explicit value.
+  const tierNotificationsEnabled =
+    profileData?.user?.preferences?.notify_on_tier_notifications ?? true
+  const editNotificationsEnabled =
+    profileData?.user?.preferences?.notify_on_edit_notifications ?? true
 
   const handleShowRemindersToggle = (checked: boolean) => {
     setShowReminders.mutate(checked)
@@ -35,6 +47,14 @@ export function NotificationSettings() {
 
   const handleCollectionDigestToggle = (checked: boolean) => {
     setCollectionDigest.mutate(checked)
+  }
+
+  const handleTierNotificationsToggle = (checked: boolean) => {
+    setTierEditNotifications.mutate({ notify_on_tier_notifications: checked })
+  }
+
+  const handleEditNotificationsToggle = (checked: boolean) => {
+    setTierEditNotifications.mutate({ notify_on_edit_notifications: checked })
   }
 
   return (
@@ -45,8 +65,8 @@ export function NotificationSettings() {
           <CardTitle>Notifications</CardTitle>
         </div>
         <CardDescription>
-          Control how you&apos;re notified about upcoming shows and your
-          collections
+          Control how you&apos;re notified about upcoming shows, your
+          collections, and your contributions
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -103,6 +123,63 @@ export function NotificationSettings() {
             </div>
           </div>
           {setCollectionDigest.isError && (
+            <p className="mt-2 text-sm text-destructive">
+              Failed to update setting. Please try again.
+            </p>
+          )}
+        </div>
+
+        {/* Tier-change emails (PSY-756 / PSY-807) */}
+        <div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="tier-notifications">Tier-change emails</Label>
+              <p className="text-sm text-muted-foreground">
+                Get an email when your contributor tier changes (promotion,
+                demotion, or an at-risk warning).
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {setTierEditNotifications.isPending && (
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              )}
+              <Switch
+                id="tier-notifications"
+                checked={tierNotificationsEnabled}
+                onCheckedChange={handleTierNotificationsToggle}
+                disabled={setTierEditNotifications.isPending}
+              />
+            </div>
+          </div>
+          {setTierEditNotifications.isError && (
+            <p className="mt-2 text-sm text-destructive">
+              Failed to update setting. Please try again.
+            </p>
+          )}
+        </div>
+
+        {/* Edit-review emails (PSY-756 / PSY-807) */}
+        <div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="edit-notifications">Edit-review emails</Label>
+              <p className="text-sm text-muted-foreground">
+                Get an email when your submitted edits are approved or rejected.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {setTierEditNotifications.isPending && (
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              )}
+              <Switch
+                id="edit-notifications"
+                checked={editNotificationsEnabled}
+                onCheckedChange={handleEditNotificationsToggle}
+                disabled={setTierEditNotifications.isPending}
+              />
+            </div>
+          </div>
+          {setTierEditNotifications.isError && (
             <p className="mt-2 text-sm text-destructive">
               Failed to update setting. Please try again.
             </p>

--- a/frontend/features/auth/hooks/index.ts
+++ b/frontend/features/auth/hooks/index.ts
@@ -34,6 +34,9 @@ export {
 
 export { useSetFavoriteCities } from './useFavoriteCities'
 
+export { useSetTierEditNotificationPreference } from './useTierEditNotificationPreference'
+export type { TierEditNotificationUpdate } from './useTierEditNotificationPreference'
+
 export {
   useFavoriteVenues,
   useIsVenueFavorited,

--- a/frontend/features/auth/hooks/useAuth.ts
+++ b/frontend/features/auth/hooks/useAuth.ts
@@ -63,6 +63,11 @@ interface UserPreferencesData {
   // follows. Server default is FALSE (opt-IN); user toggles this from the
   // notification settings page.
   notify_on_collection_digest?: boolean
+  // PSY-756 / PSY-807: per-category opt-OUT for tier-change and edit-review
+  // emails. Server default is TRUE (opt-OUT) for both; the UI treats an
+  // undefined value as ON to match that default.
+  notify_on_tier_notifications?: boolean
+  notify_on_edit_notifications?: boolean
 }
 
 interface UserProfile {

--- a/frontend/features/auth/hooks/useTierEditNotificationPreference.test.tsx
+++ b/frontend/features/auth/hooks/useTierEditNotificationPreference.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    AUTH: {
+      TIER_EDIT_NOTIFICATIONS: '/auth/preferences/tier-edit-notifications',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    auth: {
+      profile: ['auth', 'profile'],
+    },
+  },
+}))
+
+import { useSetTierEditNotificationPreference } from './useTierEditNotificationPreference'
+
+describe('useSetTierEditNotificationPreference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('opts out of tier emails with PATCH and only the tier field', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      success: true,
+      notify_on_tier_notifications: false,
+      notify_on_edit_notifications: true,
+    })
+
+    const { result } = renderHook(
+      () => useSetTierEditNotificationPreference(),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      result.current.mutate({ notify_on_tier_notifications: false })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/tier-edit-notifications',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ notify_on_tier_notifications: false }),
+      })
+    )
+  })
+
+  it('opts out of edit emails with PATCH and only the edit field', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      success: true,
+      notify_on_tier_notifications: true,
+      notify_on_edit_notifications: false,
+    })
+
+    const { result } = renderHook(
+      () => useSetTierEditNotificationPreference(),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      result.current.mutate({ notify_on_edit_notifications: false })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/tier-edit-notifications',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ notify_on_edit_notifications: false }),
+      })
+    )
+  })
+
+  it('re-enables tier emails with PATCH and only the tier field', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      success: true,
+      notify_on_tier_notifications: true,
+      notify_on_edit_notifications: true,
+    })
+
+    const { result } = renderHook(
+      () => useSetTierEditNotificationPreference(),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      result.current.mutate({ notify_on_tier_notifications: true })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/tier-edit-notifications',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ notify_on_tier_notifications: true }),
+      })
+    )
+  })
+
+  it('surfaces mutation errors so the UI can show its error block', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => useSetTierEditNotificationPreference(),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      result.current.mutate({ notify_on_tier_notifications: false })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeDefined()
+  })
+})

--- a/frontend/features/auth/hooks/useTierEditNotificationPreference.ts
+++ b/frontend/features/auth/hooks/useTierEditNotificationPreference.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+
+/**
+ * Update payload for the tier-change / edit-review email preferences.
+ *
+ * Both fields are optional so a caller can flip one toggle without touching
+ * the other — the backend `PATCH /auth/preferences/tier-edit-notifications`
+ * endpoint applies one update per non-undefined field (PSY-756).
+ */
+export interface TierEditNotificationUpdate {
+  notify_on_tier_notifications?: boolean
+  notify_on_edit_notifications?: boolean
+}
+
+interface SetTierEditNotificationsResponse {
+  success: boolean
+  notify_on_tier_notifications: boolean
+  notify_on_edit_notifications: boolean
+}
+
+/**
+ * Mutation hook to toggle the tier-change and edit-review email preferences.
+ *
+ * PSY-756 (backend) / PSY-807 (this UI). Both server columns default to TRUE
+ * (opt-OUT) — these emails are one per discrete action, so users opt OUT from
+ * the notification-settings page (or the one-click unsubscribe link in the
+ * email). Mirrors `useSetCollectionDigestPreference`, but the request body
+ * carries the named preference field(s) instead of a single `enabled` flag
+ * because the endpoint updates two independent preferences.
+ *
+ * Invalidates the profile query on success so each toggle's `checked` value
+ * reflects the new server state without a manual refetch.
+ */
+export const useSetTierEditNotificationPreference = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (
+      update: TierEditNotificationUpdate
+    ): Promise<SetTierEditNotificationsResponse> => {
+      return apiRequest<SetTierEditNotificationsResponse>(
+        API_ENDPOINTS.AUTH.TIER_EDIT_NOTIFICATIONS,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(update),
+        }
+      )
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.auth.profile })
+    },
+  })
+}

--- a/frontend/features/auth/index.ts
+++ b/frontend/features/auth/index.ts
@@ -61,6 +61,10 @@ export {
 // Hooks — Favorite Cities
 export { useSetFavoriteCities } from './hooks'
 
+// Hooks — Tier-change / edit-review email preferences (PSY-756 / PSY-807)
+export { useSetTierEditNotificationPreference } from './hooks'
+export type { TierEditNotificationUpdate } from './hooks'
+
 // Hooks — Favorite Venues
 export {
   useFavoriteVenues,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -69,6 +69,8 @@ export const API_ENDPOINTS = {
     UNSUBSCRIBE_SHOW_REMINDERS: `${API_BASE_URL}/auth/unsubscribe/show-reminders`,
     // PSY-350 / PSY-515: weekly digest of new items in collections you follow.
     COLLECTION_DIGEST: `${API_BASE_URL}/auth/preferences/collection-digest`,
+    // PSY-756 / PSY-807: opt-OUT toggles for tier-change + edit-review emails.
+    TIER_EDIT_NOTIFICATIONS: `${API_BASE_URL}/auth/preferences/tier-edit-notifications`,
   },
 
   // Feature module endpoints (defined in features/*/api.ts, re-exported here)


### PR DESCRIPTION
## Summary

PSY-756 (PR #768) added RFC 8058 one-click unsubscribe + in-body opt-out to the five tier-change and edit-review notification senders, backed by two opt-OUT preference columns (`notify_on_tier_notifications` / `notify_on_edit_notifications`, both `DEFAULT TRUE`) and the `PATCH /auth/preferences/tier-edit-notifications` endpoint. The only in-app way to opt out was the email link or a raw API call.

This adds the two missing UI toggles to the notification-settings surface, wired to that endpoint:

- **Tier-change emails** — when your contributor tier changes (promotion / demotion / at-risk warning)
- **Edit-review emails** — when your submitted edits are approved or rejected

Both render **checked** when the preference is undefined (opt-OUT default), matching the server defaults. Each toggle sends only its own field so flipping one never clobbers the other (the endpoint applies one update per non-undefined field). On success the profile query is invalidated so the switch reflects persisted state — same convention as the collection-digest toggle.

New hook `useSetTierEditNotificationPreference` mirrors `useSetCollectionDigestPreference`, but carries a partial named-field payload instead of a single `enabled` flag, since the endpoint updates two independent preferences. The auth profile type (`UserPreferencesData`) gains the two new optional fields.

### Files changed
- `frontend/components/settings/notification-settings.tsx` — two new toggle rows + handlers; card description copy
- `frontend/components/settings/notification-settings.test.tsx` — component tests for both toggles
- `frontend/features/auth/hooks/useTierEditNotificationPreference.ts` — new mutation hook (+ test)
- `frontend/features/auth/hooks/index.ts`, `frontend/features/auth/index.ts` — barrel exports
- `frontend/features/auth/hooks/useAuth.ts` — two new preference fields on `UserPreferencesData`
- `frontend/lib/api.ts` — `TIER_EDIT_NOTIFICATIONS` endpoint constant

## Test plan

- [x] `cd frontend && bun run typecheck` — clean (`tsc --noEmit`, no errors)
- [x] `cd frontend && bun run test:run components/settings` — 10 files / 197 tests pass
- [x] `cd frontend && bun run test:run features/auth/hooks/useTierEditNotificationPreference` — 1 file / 4 tests pass

Coverage added: default-ON (opt-OUT) render for both rows; per-field mutation dispatch on toggle (off and back on); "toggling one category does not send the other field"; persistence across re-render; shared pending disables both switches; shared error banner. Hook tests assert the per-field PATCH body and error surfacing.

## Manual repro

Shared dispatch stack (`--mode=shared`, frontend-only diff): frontend on `:49203` against the dev backend on `:8080`. Registered a fresh user (no explicit preferences) and signed in via the browser.

- Both new toggles render under Profile → Settings → Notifications, **checked by default** (opt-OUT) for the fresh user.
- Toggled **Tier-change off** → switch unchecks, Edit-review stays checked. Backend `/auth/profile` confirms `notify_on_tier_notifications: false`, `notify_on_edit_notifications: true` (only the tier field changed).
- Reloaded the page → Tier-change stays off, Edit-review stays on (persisted).
- Toggled **Edit-review off** and **Tier-change back on** → backend confirms the exact inverse (`tier: true`, `edit: false`), proving each field is independent.

Screenshots in `dogfood-output/PSY-807/screenshots/` (gitignored): default-on, tier-off-after-reload, inverse state.

## Code review

`/code-review` (inline, dispatched sub-agent — 9 finder angles + sweep run against the branch diff): **no correctness findings, no cleanup changes warranted.** The new hook mirrors the established per-preference-hook pattern (show-reminders, collection-digest); the `?? true` opt-OUT default correctly uses nullish coalescing so an explicit `false` survives. No fixes applied.

## Adversarial review

`/adversarial-review` — **CLEAN** (no fixes, no separate commit needed). Panel run inline (dispatched sub-agent, no Agent tool): Saboteur · Future-Maintainer · Security · Completeness, against the branch diff with one-line intent only.
- **Saboteur:** shared mutation can't clobber state (each PATCH carries one field; independent columns; `disabled` gate prevents rapid-fire). CLEAN.
- **Future-Maintainer:** intent-revealing names, opt-OUT divergence commented, tests assert behavior. CLEAN (one LOW: a JSX comment on the shared-pending coupling — covered by the test name + hook docstring).
- **Security:** no authz in the diff (endpoint is `rc.Protected`, server-gated); no injection/PII/secrets. CLEAN.
- **Completeness:** all acceptance criteria met, including the TS type addition. CLEAN.

Closes PSY-807


## Screenshots

**Both new toggles, independent state** — Profile → Settings → Notifications on the local dev stack. **Tier-change emails ON** / **Edit-review emails OFF** (the "inverse" step of the manual repro), demonstrating the two new rows render with their descriptions and that each PATCH carries only its own field.

![Notification settings showing Tier-change ON and Edit-review OFF](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-dbcfc82a29eae0bdf581/03-tier-on-edit-off-inverse.png)

*Note: the agent's other two captures (`01-toggles-default-on.png`, `02-tier-off-persisted-after-reload.png`) were viewport-cropped above the new toggle rows and don't show the feature, so they are not embedded. The default-ON and persistence-across-reload behaviors are covered by the component tests and the backend `/auth/profile` verification described in Manual repro above.*
