### PR TITLE
PSY-795: ShowForm key-remount + defaultValues for AI extraction

### DIFF
--- a/frontend/app/shows/submit/page.tsx
+++ b/frontend/app/shows/submit/page.tsx
@@ -95,6 +95,15 @@ export default function SubmitShowPage() {
   const [extractedData, setExtractedData] = useState<
     ExtractedShowData | undefined
   >()
+  // Bumped on each extraction so <ShowForm key={...}> remounts and re-seeds
+  // its defaultValues from the new extraction (PSY-795 — replaces the prior
+  // prop-derived useEffect inside ShowForm).
+  const [extractionVersion, setExtractionVersion] = useState(0)
+
+  const handleExtracted = (data: ExtractedShowData) => {
+    setExtractedData(data)
+    setExtractionVersion(v => v + 1)
+  }
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -135,11 +144,15 @@ export default function SubmitShowPage() {
           )}
         </div>
 
-        <AIFormFiller onExtracted={setExtractedData} />
+        <AIFormFiller onExtracted={handleExtracted} />
 
         <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
           <CardContent className="pt-4">
-            <ShowForm mode="create" initialExtraction={extractedData} />
+            <ShowForm
+              key={extractionVersion}
+              mode="create"
+              initialExtraction={extractedData}
+            />
           </CardContent>
         </Card>
       </div>

--- a/frontend/components/forms/ShowForm.test.tsx
+++ b/frontend/components/forms/ShowForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { act, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
 import type { ExtractedShowData } from '@/lib/types/extraction'
@@ -182,7 +182,7 @@ function makeShow(overrides: Partial<ShowResponse> = {}): ShowResponse {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Regression guards (PSY-724 stable keys + PSY-? rAF cleanup)
+// Regression guards (PSY-724 stable keys)
 //
 // These were the original tests. They use the shared mock state defined
 // above. Kept in their own describe blocks so the file's intent is clear
@@ -246,98 +246,10 @@ describe('ShowForm — artists list stable keys', () => {
   })
 })
 
-// Regression guard for the AI-extraction effect's requestAnimationFrame
-// cleanup. The effect defers form.setFieldValue calls to the next animation
-// frame to batch state updates. Without cancelAnimationFrame in the cleanup,
-// unmounting the form between the schedule and the callback let setFieldValue
-// run against an unmounted form — producing a React dev warning (and a
-// double-schedule under StrictMode). These tests drive that exact ordering by
-// controlling rAF deterministically: capture the scheduled callback, unmount,
-// then assert the frame was cancelled and that running the stale callback
-// afterward neither warns nor writes extracted values into the DOM.
-describe('ShowForm — AI extraction rAF cleanup', () => {
-  const extraction: ExtractedShowData = {
-    artists: [{ name: 'Extracted Artist', is_headliner: true }],
-    venue: { name: 'Extracted Venue', city: 'Phoenix', state: 'AZ' },
-    date: '2099-12-31',
-    time: '20:00',
-    cost: '$10',
-    ages: '21+',
-    description: 'from the flyer',
-  }
-
-  let rafCallbacks: Map<number, FrameRequestCallback>
-  let cancelled: number[]
-  let nextRafId: number
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    resetMockState()
-    rafCallbacks = new Map()
-    cancelled = []
-    nextRafId = 0
-
-    // Capture rAF callbacks instead of running them, so the test controls
-    // whether the deferred setFieldValue work happens before or after unmount.
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
-      const id = ++nextRafId
-      rafCallbacks.set(id, cb)
-      return id
-    })
-    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
-      cancelled.push(id)
-      rafCallbacks.delete(id)
-    })
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('cancels the pending extraction frame on unmount before it fires', () => {
-    const { unmount } = renderWithProviders(
-      <ShowForm mode="create" initialExtraction={extraction} />
-    )
-
-    // The effect scheduled exactly one frame and has not run it yet.
-    expect(rafCallbacks.size).toBe(1)
-    const [scheduledId] = [...rafCallbacks.keys()]
-
-    // Unmount before the frame fires — the cleanup must cancel it.
-    unmount()
-
-    expect(cancelled).toContain(scheduledId)
-    expect(rafCallbacks.has(scheduledId)).toBe(false)
-  })
-
-  it('does not warn or write extracted values when a stale frame runs after unmount', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    const { unmount } = renderWithProviders(
-      <ShowForm mode="create" initialExtraction={extraction} />
-    )
-    const staleCallback = [...rafCallbacks.values()][0]
-
-    unmount()
-
-    // Force the captured frame to run post-unmount, simulating a frame the
-    // browser had already queued slipping through. This proves the deferred
-    // setFieldValue work cannot warn even if a frame leaks past the cleanup.
-    act(() => {
-      staleCallback(performance.now())
-    })
-
-    expect(errorSpy).not.toHaveBeenCalled()
-    // Nothing extracted should be rendered after unmount.
-    expect(screen.queryByDisplayValue('Extracted Artist')).toBeNull()
-    expect(screen.queryByDisplayValue('Extracted Venue')).toBeNull()
-  })
-})
-
 // ─────────────────────────────────────────────────────────────
 // PSY-693 coverage: behavioral surface
 //
-// The PSY-724 + rAF tests above prove specific regressions cannot return.
+// The PSY-724 test above proves the stable-keys regression cannot return.
 // The blocks below cover the load-bearing user flows that, if broken,
 // would silently block show submissions:
 //   - All required fields render in create mode
@@ -345,8 +257,8 @@ describe('ShowForm — AI extraction rAF cleanup', () => {
 //   - Venue select auto-fills city/state; verified venues lock the fields
 //   - Past-date validation blocks submit + surfaces a message
 //   - Successful submit calls useShowSubmit.mutate; onSuccess wires through
-//   - AI extraction populates fields AND deduplicates re-applications
-//     (lastAppliedExtraction ref guard)
+//   - AI extraction seeds the form via defaultValues at mount; a new
+//     extraction re-seeds it on key-remount (PSY-795)
 //   - Edit mode pre-fills from `initialData`
 //   - The "do not publish" private toggle is create-only (hidden in edit)
 // ─────────────────────────────────────────────────────────────
@@ -589,7 +501,16 @@ describe('ShowForm — successful submit', () => {
   })
 })
 
-describe('ShowForm — AI extraction populates fields + dedup guard', () => {
+// PSY-795: AI extraction is now folded into TanStack Form's `defaultValues`
+// at mount (calculate-during-render via mergeExtraction), replacing the old
+// prop-derived useEffect + rAF + lastAppliedExtraction ref. The parent
+// (app/shows/submit/page.tsx) remounts ShowForm via a `key` it bumps on each
+// extraction; these tests model that contract:
+//   1. An extraction passed at mount seeds every field.
+//   2. A NEW extraction with a fresh `key` re-seeds the form (remount).
+//   3. Without a key change, defaultValues are read once — a re-render that
+//      keeps the same key does NOT clobber a user edit.
+describe('ShowForm — AI extraction seeds defaultValues + key-remount re-seed', () => {
   const extraction: ExtractedShowData = {
     artists: [{ name: 'AI Artist', is_headliner: true }],
     venue: { name: 'AI Venue', city: 'Tempe', state: 'AZ' },
@@ -605,17 +526,15 @@ describe('ShowForm — AI extraction populates fields + dedup guard', () => {
     resetMockState()
   })
 
-  it('writes the extracted artist, venue, date, time, cost, ages, and description into the form', async () => {
-    renderWithProviders(<ShowForm mode="create" initialExtraction={extraction} />)
-
-    // The effect schedules a rAF then writes via form.setFieldValue. Real
-    // requestAnimationFrame runs in jsdom — no fake-timer juggling needed.
-    await waitFor(() =>
-      expect(
-        screen.getByPlaceholderText('Enter artist name') as HTMLInputElement
-      ).toHaveValue('AI Artist')
+  it('seeds the extracted artist, venue, date, time, cost, ages, and description into the form at mount', () => {
+    renderWithProviders(
+      <ShowForm key={0} mode="create" initialExtraction={extraction} />
     )
 
+    // defaultValues are read synchronously at mount — no rAF / waitFor needed.
+    expect(
+      (screen.getByPlaceholderText('Enter artist name') as HTMLInputElement).value
+    ).toBe('AI Artist')
     expect((screen.getByLabelText(/^Venue$/i) as HTMLInputElement).value).toBe('AI Venue')
     expect((screen.getByLabelText(/^City$/i) as HTMLInputElement).value).toBe('Tempe')
     expect((screen.getByLabelText(/^State$/i) as HTMLInputElement).value).toBe('AZ')
@@ -628,52 +547,65 @@ describe('ShowForm — AI extraction populates fields + dedup guard', () => {
     )
   })
 
-  it('does not re-apply the same extraction object on re-render (lastAppliedExtraction guard)', async () => {
-    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
-    try {
-      const { rerender } = renderWithProviders(
-        <ShowForm mode="create" initialExtraction={extraction} />
-      )
+  it('re-seeds the form when a new extraction arrives with a changed key (remount)', async () => {
+    const { rerender } = renderWithProviders(
+      <ShowForm key={0} mode="create" initialExtraction={extraction} />
+    )
 
-      // Wait for the initial extraction to land in the form.
-      await waitFor(() =>
-        expect(
-          (screen.getByPlaceholderText('Enter artist name') as HTMLInputElement).value
-        ).toBe('AI Artist')
-      )
+    expect(
+      (screen.getByPlaceholderText('Enter artist name') as HTMLInputElement).value
+    ).toBe('AI Artist')
 
-      const callsAfterFirstApply = rafSpy.mock.calls.length
-      expect(callsAfterFirstApply).toBeGreaterThanOrEqual(1)
-
-      // Edit the form so we can detect any unwanted second application
-      // (which would clobber the typed value).
-      const user = userEvent.setup()
-      const venueInput = screen.getByLabelText(/^Venue$/i) as HTMLInputElement
-      await user.clear(venueInput)
-      await user.type(venueInput, 'User Edited Venue')
-      expect(venueInput.value).toBe('User Edited Venue')
-
-      // Re-render with the SAME extraction object reference. The
-      // lastAppliedExtraction ref compares by identity, so this should be a
-      // no-op: no extra rAF scheduled, and the user's edit must survive.
-      rerender(<ShowForm mode="create" initialExtraction={extraction} />)
-
-      // Give the effect a microtask to run if it were going to.
-      await Promise.resolve()
-      await Promise.resolve()
-
-      // rAF wasn't scheduled again — proves the dedup actually fires.
-      // (Without the lastAppliedExtraction guard, the effect would re-run on
-      // every render where initialExtraction is present and schedule another
-      // frame, clobbering the user's edit.)
-      expect(rafSpy.mock.calls.length).toBe(callsAfterFirstApply)
-      // And the user's typed venue value survived.
-      expect((screen.getByLabelText(/^Venue$/i) as HTMLInputElement).value).toBe(
-        'User Edited Venue'
-      )
-    } finally {
-      rafSpy.mockRestore()
+    // A second extraction. The parent bumps `key`, so React unmounts the old
+    // form and mounts a fresh one whose defaultValues come from the NEW data.
+    const secondExtraction: ExtractedShowData = {
+      artists: [{ name: 'Second Artist', is_headliner: true }],
+      venue: { name: 'Second Venue', city: 'Mesa', state: 'AZ' },
+      date: '2099-10-10',
+      time: '19:00',
+      cost: 'Free',
+      ages: '21+',
+      description: 'second flyer',
     }
+
+    rerender(
+      <ShowForm key={1} mode="create" initialExtraction={secondExtraction} />
+    )
+
+    await waitFor(() =>
+      expect(
+        (screen.getByPlaceholderText('Enter artist name') as HTMLInputElement).value
+      ).toBe('Second Artist')
+    )
+    expect((screen.getByLabelText(/^Venue$/i) as HTMLInputElement).value).toBe('Second Venue')
+    expect((screen.getByLabelText(/^City$/i) as HTMLInputElement).value).toBe('Mesa')
+    expect((screen.getByLabelText(/^Date$/i) as HTMLInputElement).value).toBe('2099-10-10')
+    expect((screen.getByLabelText(/cost/i) as HTMLInputElement).value).toBe('Free')
+  })
+
+  it('does not clobber a user edit when re-rendered with the same key (defaultValues read once)', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderWithProviders(
+      <ShowForm key={0} mode="create" initialExtraction={extraction} />
+    )
+
+    const venueInput = screen.getByLabelText(/^Venue$/i) as HTMLInputElement
+    expect(venueInput.value).toBe('AI Venue')
+
+    // User edits the seeded value.
+    await user.clear(venueInput)
+    await user.type(venueInput, 'User Edited Venue')
+    expect(venueInput.value).toBe('User Edited Venue')
+
+    // Re-render with the SAME key and the SAME extraction (e.g. an unrelated
+    // parent re-render). Without a key change the form is not remounted, so
+    // defaultValues are not re-read and the user's edit must survive.
+    rerender(<ShowForm key={0} mode="create" initialExtraction={extraction} />)
+
+    await Promise.resolve()
+    expect((screen.getByLabelText(/^Venue$/i) as HTMLInputElement).value).toBe(
+      'User Edited Venue'
+    )
   })
 })
 

--- a/frontend/components/forms/ShowForm.tsx
+++ b/frontend/components/forms/ShowForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm } from '@tanstack/react-form'
 import { z } from 'zod'
@@ -46,6 +46,8 @@ import {
   removeArtistAtIndex,
   isVenueLocationEditable as computeVenueEditable,
   makeFormArtist,
+  mergeExtraction,
+  extractedVenueToSelected,
 } from './show-form-utils'
 
 // Form validation schema
@@ -134,21 +136,29 @@ export function ShowForm({
   const [orphanedArtists, setOrphanedArtists] = useState<OrphanedArtist[]>([])
   const [showOrphanDialog, setShowOrphanDialog] = useState(false)
 
-  // Track selected venue for editability checks
-  // Initialize from prefilledVenue, initialData (for edit mode), or null for create mode
+  // Track selected venue for editability checks.
+  // Initialize from prefilledVenue, initialData (edit mode), a matched AI
+  // extraction (create mode), or null. The form is remounted via `key` when a
+  // new extraction arrives, so this initializer runs once per extraction —
+  // mirroring what the old prop-derived effect did imperatively (PSY-795).
   const [selectedVenue, setSelectedVenue] = useState<VenueResponse | null>(
-    () =>
-      prefilledVenue
-        ? {
-            id: prefilledVenue.id,
-            slug: prefilledVenue.slug,
-            name: prefilledVenue.name,
-            city: prefilledVenue.city,
-            state: prefilledVenue.state,
-            address: prefilledVenue.address ?? null,
-            verified: prefilledVenue.verified ?? false,
-          }
-        : (initialData?.venues[0] ?? null)
+    () => {
+      if (prefilledVenue) {
+        return {
+          id: prefilledVenue.id,
+          slug: prefilledVenue.slug,
+          name: prefilledVenue.name,
+          city: prefilledVenue.city,
+          state: prefilledVenue.state,
+          address: prefilledVenue.address ?? null,
+          verified: prefilledVenue.verified ?? false,
+        }
+      }
+      if (initialData) {
+        return initialData.venues[0] ?? null
+      }
+      return extractedVenueToSelected(initialExtraction)
+    }
   )
 
   const isEditMode = mode === 'edit'
@@ -157,7 +167,12 @@ export function ShowForm({
 
   const isVenueLocationEditable = computeVenueEditable(isAdmin, selectedVenue, !!prefilledVenue)
 
-  // Compute initial values based on mode
+  // Compute initial values based on mode. In create mode, AI-extracted data
+  // (PSY-795) is folded into the defaults here so TanStack Form reads it as
+  // `defaultValues` at mount — the parent remounts the form via `key` on each
+  // new extraction. Edit / prefilled-venue paths take precedence; the
+  // AIFormFiller only renders on the create page so they never co-occur with
+  // an extraction in practice.
   const initialFormValues = (() => {
     if (isEditMode && initialData) {
       return showToFormValues(initialData)
@@ -174,11 +189,13 @@ export function ShowForm({
         },
       }
     }
-    return defaultFormValues
+    return mergeExtraction(defaultFormValues, initialExtraction)
   })()
 
-  // Track venue name for showing/hiding the "new venue" warning
-  const [venueName, setVenueName] = useState('')
+  // Track venue name for showing/hiding the "new venue" warning. Seed it from
+  // the extraction so the new/verified-venue banners render correctly on the
+  // first paint after a remount (mirrors the prior effect's setVenueName).
+  const [venueName, setVenueName] = useState(() => initialFormValues.venue.name)
 
   const form = useForm({
     defaultValues: initialFormValues,
@@ -294,91 +311,6 @@ export function ShowForm({
       onSubmit: showFormSchema,
     },
   })
-
-  // Populate form from AI extraction
-  // Using a ref to track the last applied extraction to avoid duplicate applications
-  const lastAppliedExtraction = useRef<ExtractedShowData | null>(null)
-
-  useEffect(() => {
-    if (!initialExtraction) return
-    // Skip if we've already applied this exact extraction
-    if (lastAppliedExtraction.current === initialExtraction) return
-    lastAppliedExtraction.current = initialExtraction
-
-    // Use requestAnimationFrame to batch state updates and avoid cascading renders
-    const rafId = requestAnimationFrame(() => {
-      // Set artists
-      if (initialExtraction.artists.length > 0) {
-        form.setFieldValue(
-          'artists',
-          initialExtraction.artists.map(a =>
-            makeFormArtist({
-              name: a.matched_name || a.name,
-              is_headliner: a.is_headliner,
-              matched_id: a.matched_id,
-              instagram_handle: a.matched_id ? undefined : a.instagram_handle,
-            })
-          )
-        )
-      }
-
-      // Set venue
-      if (initialExtraction.venue) {
-        const v = initialExtraction.venue
-        form.setFieldValue('venue.id', v.matched_id)
-        form.setFieldValue('venue.name', v.matched_name || v.name)
-        form.setFieldValue('venue.city', v.city || '')
-        form.setFieldValue('venue.state', v.state || '')
-        form.setFieldValue('venue.address', '')
-        // Update venue name for new venue warning
-        setVenueName(v.matched_name || v.name)
-        // Update selected venue if matched
-        if (v.matched_id && v.matched_name && v.matched_slug) {
-          setSelectedVenue({
-            id: v.matched_id,
-            slug: v.matched_slug,
-            name: v.matched_name,
-            address: null,
-            city: v.city || '',
-            state: v.state || '',
-            verified: true, // Assume matched venues are verified
-          })
-        } else {
-          setSelectedVenue(null)
-        }
-      }
-
-      // Set date
-      if (initialExtraction.date) {
-        form.setFieldValue('date', initialExtraction.date)
-      }
-
-      // Set time
-      if (initialExtraction.time) {
-        form.setFieldValue('time', initialExtraction.time)
-      }
-
-      // Set cost
-      if (initialExtraction.cost) {
-        form.setFieldValue('cost', initialExtraction.cost)
-      }
-
-      // Set ages
-      if (initialExtraction.ages) {
-        form.setFieldValue('ages', initialExtraction.ages)
-      }
-
-      // Set description
-      if (initialExtraction.description) {
-        form.setFieldValue('description', initialExtraction.description)
-      }
-    })
-
-    // Cancel the pending frame if the component unmounts (or the effect
-    // re-runs) before it fires, so setFieldValue never touches an unmounted
-    // form — avoids a dev warning and a StrictMode double-schedule.
-    return () => cancelAnimationFrame(rafId)
-  }, [initialExtraction, form])
 
   // Handle venue selection to auto-fill city/state and track selected venue
   const handleVenueSelect = (venue: Venue | null) => {

--- a/frontend/components/forms/show-form-utils.test.ts
+++ b/frontend/components/forms/show-form-utils.test.ts
@@ -6,9 +6,12 @@ import {
   isVenueLocationEditable,
   defaultFormValues,
   makeFormArtist,
+  mergeExtraction,
+  extractedVenueToSelected,
   type FormArtist,
 } from './show-form-utils'
 import type { ShowResponse, VenueResponse } from '@/features/shows'
+import type { ExtractedShowData } from '@/lib/types/extraction'
 
 // --- Helpers ---
 
@@ -354,5 +357,147 @@ describe('makeFormArtist', () => {
     expect(artist.is_headliner).toBe(true)
     expect(artist.matched_id).toBe(42)
     expect(artist.instagram_handle).toBe('@a')
+  })
+})
+
+// --- mergeExtraction (PSY-795) ---
+
+describe('mergeExtraction', () => {
+  const fullExtraction: ExtractedShowData = {
+    artists: [
+      { name: 'Headliner', is_headliner: true },
+      { name: 'Opener', is_headliner: false, instagram_handle: '@opener' },
+    ],
+    venue: { name: 'The Venue', city: 'Tempe', state: 'AZ' },
+    date: '2099-09-09',
+    time: '21:30',
+    cost: '$20',
+    ages: 'All Ages',
+    description: 'flyer text',
+  }
+
+  it('returns the base unchanged when extraction is undefined', () => {
+    expect(mergeExtraction(defaultFormValues, undefined)).toBe(defaultFormValues)
+  })
+
+  it('folds every extracted field into the form values', () => {
+    const result = mergeExtraction(defaultFormValues, fullExtraction)
+
+    expect(result.artists).toHaveLength(2)
+    expect(result.artists[0].name).toBe('Headliner')
+    expect(result.artists[0].is_headliner).toBe(true)
+    expect(result.artists[1].name).toBe('Opener')
+    expect(result.artists[1].instagram_handle).toBe('@opener')
+    expect(result.venue.name).toBe('The Venue')
+    expect(result.venue.city).toBe('Tempe')
+    expect(result.venue.state).toBe('AZ')
+    expect(result.date).toBe('2099-09-09')
+    expect(result.time).toBe('21:30')
+    expect(result.cost).toBe('$20')
+    expect(result.ages).toBe('All Ages')
+    expect(result.description).toBe('flyer text')
+  })
+
+  it('prefers the matched_name over the raw extracted name for artists and venue', () => {
+    const result = mergeExtraction(defaultFormValues, {
+      artists: [
+        { name: 'mountain goats', is_headliner: true, matched_id: 7, matched_name: 'The Mountain Goats' },
+      ],
+      venue: { name: 'valley bar', matched_id: 3, matched_name: 'Valley Bar', matched_slug: 'valley-bar' },
+    })
+
+    expect(result.artists[0].name).toBe('The Mountain Goats')
+    expect(result.artists[0].matched_id).toBe(7)
+    expect(result.venue.name).toBe('Valley Bar')
+    expect(result.venue.id).toBe(3)
+  })
+
+  it('drops the instagram handle for a matched artist', () => {
+    const result = mergeExtraction(defaultFormValues, {
+      artists: [
+        { name: 'Matched', is_headliner: true, matched_id: 9, instagram_handle: '@matched' },
+      ],
+    })
+    expect(result.artists[0].instagram_handle).toBeUndefined()
+  })
+
+  it('keeps base values for fields the sparse extraction omits', () => {
+    const result = mergeExtraction(defaultFormValues, {
+      artists: [{ name: 'Only Artist', is_headliner: true }],
+    })
+
+    // Only artists were extracted; everything else keeps the defaults.
+    expect(result.artists[0].name).toBe('Only Artist')
+    expect(result.venue).toEqual(defaultFormValues.venue)
+    expect(result.time).toBe('20:00') // default time survives
+    expect(result.date).toBe('')
+    expect(result.cost).toBe('')
+  })
+
+  it('keeps the default single artist when the extraction has no artists', () => {
+    const result = mergeExtraction(defaultFormValues, {
+      artists: [],
+      date: '2099-01-01',
+    })
+    expect(result.artists).toBe(defaultFormValues.artists)
+    expect(result.date).toBe('2099-01-01')
+  })
+
+  it('does not mutate the base form values', () => {
+    const base = { ...defaultFormValues, venue: { ...defaultFormValues.venue } }
+    mergeExtraction(base, fullExtraction)
+    expect(base.venue.name).toBe('')
+    expect(base.date).toBe('')
+    expect(base.artists).toBe(defaultFormValues.artists)
+  })
+})
+
+// --- extractedVenueToSelected (PSY-795) ---
+
+describe('extractedVenueToSelected', () => {
+  it('returns null when extraction is undefined', () => {
+    expect(extractedVenueToSelected(undefined)).toBeNull()
+  })
+
+  it('returns null when the venue did not match an existing entity', () => {
+    expect(
+      extractedVenueToSelected({
+        artists: [],
+        venue: { name: 'Unmatched Spot', city: 'Mesa', state: 'AZ' },
+      })
+    ).toBeNull()
+  })
+
+  it('returns a verified VenueResponse when the venue matched (id + name + slug)', () => {
+    const result = extractedVenueToSelected({
+      artists: [],
+      venue: {
+        name: 'valley bar',
+        city: 'Phoenix',
+        state: 'AZ',
+        matched_id: 5,
+        matched_name: 'Valley Bar',
+        matched_slug: 'valley-bar',
+      },
+    })
+
+    expect(result).toEqual({
+      id: 5,
+      slug: 'valley-bar',
+      name: 'Valley Bar',
+      address: null,
+      city: 'Phoenix',
+      state: 'AZ',
+      verified: true,
+    })
+  })
+
+  it('returns null when a match id is present but slug is missing', () => {
+    expect(
+      extractedVenueToSelected({
+        artists: [],
+        venue: { name: 'Partial', matched_id: 5, matched_name: 'Partial' },
+      })
+    ).toBeNull()
   })
 })

--- a/frontend/components/forms/show-form-utils.ts
+++ b/frontend/components/forms/show-form-utils.ts
@@ -3,6 +3,7 @@ import {
   getTimezoneForState,
 } from '@/lib/utils/timeUtils'
 import type { ShowResponse, VenueResponse } from '@/features/shows'
+import type { ExtractedShowData } from '@/lib/types/extraction'
 
 export interface FormArtist {
   /**
@@ -154,4 +155,79 @@ export function isVenueLocationEditable(
   hasPrefilledVenue: boolean
 ): boolean {
   return !hasPrefilledVenue && (isAdmin || !selectedVenue || !selectedVenue.verified)
+}
+
+/**
+ * Fold AI-extracted show data into a base set of form values, producing the
+ * `defaultValues` ShowForm hands to TanStack Form at mount.
+ *
+ * This is the calculate-during-render replacement for the old prop-derived
+ * `useEffect` (PSY-795): the parent remounts ShowForm via `key` on each new
+ * extraction, so seeding `defaultValues` here is the correct one-shot init.
+ * Only fields present in the extraction override the base; everything else
+ * keeps its base value (so a sparse extraction won't blank out defaults).
+ */
+export function mergeExtraction(
+  base: FormValues,
+  extraction: ExtractedShowData | undefined
+): FormValues {
+  if (!extraction) return base
+
+  const merged: FormValues = { ...base, venue: { ...base.venue } }
+
+  if (extraction.artists.length > 0) {
+    merged.artists = extraction.artists.map(a =>
+      makeFormArtist({
+        name: a.matched_name || a.name,
+        is_headliner: a.is_headliner,
+        matched_id: a.matched_id,
+        instagram_handle: a.matched_id ? undefined : a.instagram_handle,
+      })
+    )
+  }
+
+  if (extraction.venue) {
+    const v = extraction.venue
+    merged.venue = {
+      id: v.matched_id,
+      name: v.matched_name || v.name,
+      city: v.city || '',
+      state: v.state || '',
+      address: '',
+    }
+  }
+
+  if (extraction.date) merged.date = extraction.date
+  if (extraction.time) merged.time = extraction.time
+  if (extraction.cost) merged.cost = extraction.cost
+  if (extraction.ages) merged.ages = extraction.ages
+  if (extraction.description) merged.description = extraction.description
+
+  return merged
+}
+
+/**
+ * Derive the selected-venue state for a fresh ShowForm mount from an AI
+ * extraction. Returns a VenueResponse only when the extraction matched an
+ * existing venue (id + name + slug present) — matched venues are assumed
+ * verified, which locks the location fields for non-admins exactly as the old
+ * effect did. Returns null for an unmatched / absent venue, which surfaces the
+ * "New Venue" banner.
+ */
+export function extractedVenueToSelected(
+  extraction: ExtractedShowData | undefined
+): VenueResponse | null {
+  const v = extraction?.venue
+  if (v?.matched_id && v.matched_name && v.matched_slug) {
+    return {
+      id: v.matched_id,
+      slug: v.matched_slug,
+      name: v.matched_name,
+      address: null,
+      city: v.city || '',
+      state: v.state || '',
+      verified: true, // matched venues are assumed verified (mirrors prior effect)
+    }
+  }
+  return null
 }


### PR DESCRIPTION
## Summary

Replaces the prop-derived-state-via-effect anti-pattern in `ShowForm` (React docs "You Might Not Need an Effect") with a calculate-during-render approach.

AI-extracted data (`initialExtraction`) is now folded into TanStack Form's `defaultValues` at mount via a new pure helper `mergeExtraction`. The parent (`app/shows/submit/page.tsx`) remounts the form via a `key` it bumps on each extraction, so a new extraction re-seeds the form. TanStack Form reads `defaultValues` only at mount, so `key` is the correct re-init trigger.

Removed from `ShowForm`:
- the `useEffect` that replayed `form.setFieldValue` calls
- the `requestAnimationFrame` / `cancelAnimationFrame` batching (PSY-735 / #748)
- the `lastAppliedExtraction` ref dedup guard

The matched-venue / new-venue banner state the old effect set imperatively is now seeded via `useState` initializers (`extractedVenueToSelected` for `selectedVenue`, `initialFormValues.venue.name` for `venueName`), reproducing every side effect the effect performed.

New pure, unit-tested helpers in `show-form-utils.ts`:
- `mergeExtraction(base, extraction)` — folds a (possibly sparse) extraction into form values without mutating the base; prefers `matched_name`, drops Instagram handle for matched artists, keeps base values for omitted fields.
- `extractedVenueToSelected(extraction)` — derives `selectedVenue` for a fresh mount (verified `VenueResponse` only on a real id+name+slug match; null otherwise).

Files changed:
- `frontend/components/forms/ShowForm.tsx` — delete effect/rAF/ref; fold extraction into `defaultValues`; seed venue state at mount
- `frontend/components/forms/show-form-utils.ts` — add `mergeExtraction` + `extractedVenueToSelected`
- `frontend/app/shows/submit/page.tsx` — `extractionVersion` state + `key` remount + `handleExtracted`
- `frontend/components/forms/ShowForm.test.tsx` — drop obsolete rAF/dedup tests; add defaultValues-seed, key-remount re-seed, same-key no-clobber
- `frontend/components/forms/show-form-utils.test.ts` — unit coverage for the two new helpers

## Test plan

- [x] `cd frontend && bun run typecheck` → clean (`tsc --noEmit`)
- [x] `cd frontend && bun run test:run components/forms` → 10 files / 137 tests passed (incl. 15 in `ShowForm.test.tsx`, 53 in `show-form-utils.test.ts`)

## Manual repro

Brought up the shared dispatch stack (`stack-up.sh --mode=shared`). The full `/shows/submit` flow requires an authenticated/verified user plus a configured AI-extraction API key, so per the render-only carveout I exercised the **real** `ShowForm` + `mergeExtraction` + key-remount code path via a temporary throwaway harness route (deleted before commit, not in the diff) driven with agent-browser:

- Click "Extraction 1" → form seeds: artist `Harness Headliner`, venue `Harness Venue One`, city `Tempe`, date `2099-09-09`, cost `$20`. Screenshot `01-extraction-one.png`.
- Click "Extraction 2" (bumps key) → form **re-seeds** via remount: 2 artist rows `["Second Headliner","Second Opener"]`, venue `Harness Venue Two`, city `Mesa`, date `2099-10-10`, cost `Free`. Screenshot `02-extraction-two-reseed.png`.

Confirmed the new extraction fully replaces the prior form state on key change. Harness route + stack torn down.

*Note: the agent's original screenshot files were not preserved (deleted along with the throwaway harness). The orchestrator re-ran the identical harness flow post-PR and re-captured them — embedded in the Screenshots section below. Form-value reads during the re-capture matched the descriptions above exactly.*

## Code review

`/code-review` (inline, as dispatched sub-agent — reuse / quality / efficiency lenses, plus correctness angles A–E + removed-behavior auditor). No correctness findings. Verified the new code reproduces every field the deleted effect set (venue id/name/city/state/address, `selectedVenue` match logic, `venueName` seed, per-field truthy guards) byte-for-byte. Only `app/shows/submit/page.tsx` passes `initialExtraction`; the other 6 `ShowForm` call sites hit the edit/prefilled branches before `mergeExtraction`, so no regression for them.

## Adversarial review

`/adversarial-review` — CLEAN (inline panel, no fixes → no separate commit). Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran against the branch diff with no building-session context.
- Saboteur: probed empty-artist / sparse extraction, atomicity (key-remount is atomic vs. the old rAF-mid-typing race — strictly safer), leak removal. Clean.
- Future-Maintainer: helpers named for intent, documented with "why", unit-tested. Clean.
- Security: no auth/authz/trust-boundary/injection change; same data into the same React-escaped controlled inputs. Clean.
- Completeness: all four acceptance criteria met (verified effect/rAF/ref fully removed via grep; key + defaultValues wired).
- LOW (inert, recorded): `venueName` initializer now seeds a non-empty value in edit/prefilled modes (old code seeded `''`), but the "New Venue" banner is gated on `!selectedVenue` which is truthy in both those modes — verified inert by the passing edit-mode test.

Closes PSY-795

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

**1. Extraction 1 seeds the form at mount** — single artist `Harness Headliner`, unmatched venue `Harness Venue One` (Tempe, AZ — note the "New Venue" banner correctly appears for unmatched venues), date `09/09/2099`, cost `$20`. All values seeded via `defaultValues` at mount; no effect, no rAF.

![ShowForm seeded by Extraction 1](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-fa8fc731cbc7919a5f65/psy-795-01-extraction-one.png)

**2. Extraction 2 fully re-seeds via key-remount** — the form now shows two artist rows (`Second Headliner` + `Second Opener`), venue `Harness Venue Two` (Mesa, AZ), date `10/10/2099`, cost `Free`. The prior extraction's state is completely replaced — the parent's `key` bump remounted the form with new `defaultValues`.

![ShowForm re-seeded by Extraction 2 via key-remount](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-fa8fc731cbc7919a5f65/psy-795-02-extraction-two-reseed.png)
