### PR TITLE
PSY-908: bind admin analytics chart colors to the DS palette

### DIFF
--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
-import { AnalyticsDashboard } from './AnalyticsDashboard'
+import { AnalyticsDashboard, COLORS } from './AnalyticsDashboard'
 
 // Mock recharts to avoid SVG rendering issues in JSDOM
 vi.mock('recharts', () => {
@@ -318,5 +318,45 @@ describe('AnalyticsDashboard', () => {
     expect(
       screen.getByText('No contributions in the last 30 days.')
     ).toBeInTheDocument()
+  })
+})
+
+describe('COLORS palette invariants (PSY-908)', () => {
+  // Series rendered in the SAME chart must use distinct tokens, or two lines
+  // become visually indistinguishable. Tokens are intentionally reused ACROSS
+  // charts (see the COLORS doc comment), so distinctness is asserted per chart.
+  const chartGroups: Record<string, (keyof typeof COLORS)[]> = {
+    'Entity Creation': [
+      'shows',
+      'artists',
+      'venues',
+      'releases',
+      'labels',
+      'users',
+    ],
+    'Content Curation': ['tags_added', 'tag_votes', 'collection_items'],
+    'Requests & Voting': ['requests', 'request_votes'],
+    'Social Engagement': ['bookmarks', 'follows', 'attendance', 'revisions'],
+    'Show Approval': ['approved', 'rejected'],
+  }
+
+  it.each(Object.entries(chartGroups))(
+    'assigns a distinct token to every series in the %s chart',
+    (_chart, keys) => {
+      const tokens = keys.map((k) => COLORS[k])
+      expect(new Set(tokens).size).toBe(keys.length)
+    }
+  )
+
+  it('binds every series to a design-system var() token (no raw hex / recharts defaults)', () => {
+    for (const value of Object.values(COLORS)) {
+      expect(value).toMatch(/^var\(--[a-z0-9-]+\)$/)
+    }
+  })
+
+  it('keeps approval trends semantic: approved = chart-2 (green), rejected = destructive (red)', () => {
+    expect(COLORS.approved).toBe('var(--chart-2)')
+    expect(COLORS.rejected).toBe('var(--destructive)')
+    expect(COLORS.approved).not.toBe(COLORS.rejected)
   })
 })

--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
@@ -37,20 +37,32 @@ type MonthRange = 3 | 6 | 12 | 24
 const MONTH_OPTIONS: MonthRange[] = [3, 6, 12, 24]
 
 /**
- * Chart series colors, bound to the design-system palette
- * (`globals.css` `--chart-1`..`--chart-5` + `--destructive`, each with a
- * dark-mode variant — so series colors track light/dark automatically via the
- * CSS cascade). Replaces the previous ad-hoc Tailwind hexes (blue/violet/pink),
- * which clashed with the editorial burnt-orange/newsprint palette (PSY-908).
+ * Chart series colors, bound to the design-system palette (PSY-908). The token
+ * VALUES live in `globals.css` — `--chart-1`..`--chart-5` + `--destructive` +
+ * `--foreground`, each with a `:root` (light) and `.dark` override — so series
+ * colors track the theme automatically via the CSS cascade. Replaces the prior
+ * ad-hoc Tailwind hexes (blue/violet/pink) that clashed with the editorial
+ * burnt-orange/newsprint palette.
  *
- * Series colors only need to be distinguishable WITHIN a single chart, so the
- * five categorical tokens are reused across charts. Series are assigned
- * `--chart-1`..`--chart-5` in render order; the Entity Creation chart has a 6th
- * line (Users) that uses `--foreground` (high-contrast, on-brand neutral).
- * Approval trends are semantic: approved = `--chart-2` (green), rejected =
- * `--destructive` (red).
+ * Within a single chart every series is assigned a DISTINCT token; the five
+ * categorical tokens are reused ACROSS charts (a token only has to be unique
+ * per chart). The 6-line Entity Creation chart uses `--foreground` for its 6th
+ * line (Users). Approval trends are semantic: approved = `--chart-2` (green),
+ * rejected = `--destructive` (red).
+ *
+ * Caveat — the editorial palette is intentionally low-chroma and warm-skewed,
+ * so distinct tokens are not always maximally distinguishable: `--chart-1` and
+ * `--chart-3` sit close in dark mode. The legend (series names) is the primary
+ * disambiguator for the dense 6-line chart; a richer categorical sub-palette is
+ * deferred to the PSY-908 Figma follow-up. Also note `--chart-4` === `--destructive`
+ * in light mode (both `#9c2a1a`): they never share a chart today, so don't pair
+ * a `--chart-4` series with a `--destructive` series in one chart, and don't
+ * "dedupe" the two tokens in `globals.css`.
+ *
+ * Exported only for the invariant test that guards per-chart distinctness and
+ * the approved/rejected semantic pairing.
  */
-const COLORS = {
+export const COLORS = {
   // Entity Creation Trends (6 lines, one chart)
   shows: 'var(--chart-1)',
   artists: 'var(--chart-2)',
@@ -74,6 +86,24 @@ const COLORS = {
   approved: 'var(--chart-2)',
   rejected: 'var(--destructive)',
 }
+
+/**
+ * Shared recharts tooltip styling, bound to DS tokens. `contentStyle` uses bare
+ * `var(--token)` (this repo's tokens are raw hex, so the old `hsl(var(...))`
+ * wrapping produced invalid CSS and silently fell back to recharts' default
+ * box). The hover cursor also defaults to a raw `#ccc`; bind it to a token so
+ * the guide line / bar highlight stays on-palette in both themes.
+ */
+const TOOLTIP_CONTENT_STYLE: React.CSSProperties = {
+  backgroundColor: 'var(--popover)',
+  border: '1px solid var(--border)',
+  borderRadius: '0.5rem',
+  color: 'var(--popover-foreground)',
+}
+// Line/area charts draw a vertical guide line (stroke); the bar chart draws a
+// highlight rectangle behind the hovered bar (fill).
+const TOOLTIP_CURSOR_LINE = { stroke: 'var(--border)' }
+const TOOLTIP_CURSOR_BAR = { fill: 'var(--muted)' }
 
 // --- Sub-section labels ---
 type AnalyticsView = 'growth' | 'engagement' | 'community' | 'data-quality'
@@ -227,12 +257,8 @@ function GrowthSection({ months }: { months: MonthRange }) {
             />
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
-              contentStyle={{
-                backgroundColor: 'var(--popover)',
-                border: '1px solid var(--border)',
-                borderRadius: '0.5rem',
-                color: 'var(--popover-foreground)',
-              }}
+              contentStyle={TOOLTIP_CONTENT_STYLE}
+              cursor={TOOLTIP_CURSOR_LINE}
             />
             <Legend />
             <Line
@@ -333,12 +359,8 @@ function EngagementSection({ months }: { months: MonthRange }) {
             />
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
-              contentStyle={{
-                backgroundColor: 'var(--popover)',
-                border: '1px solid var(--border)',
-                borderRadius: '0.5rem',
-                color: 'var(--popover-foreground)',
-              }}
+              contentStyle={TOOLTIP_CONTENT_STYLE}
+              cursor={TOOLTIP_CURSOR_LINE}
             />
             <Legend />
             <Area
@@ -384,12 +406,8 @@ function EngagementSection({ months }: { months: MonthRange }) {
               />
               <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
               <Tooltip
-                contentStyle={{
-                  backgroundColor: 'var(--popover)',
-                  border: '1px solid var(--border)',
-                  borderRadius: '0.5rem',
-                  color: 'var(--popover-foreground)',
-                }}
+                contentStyle={TOOLTIP_CONTENT_STYLE}
+                cursor={TOOLTIP_CURSOR_LINE}
               />
               <Legend />
               <Area
@@ -425,12 +443,8 @@ function EngagementSection({ months }: { months: MonthRange }) {
               />
               <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
               <Tooltip
-                contentStyle={{
-                  backgroundColor: 'var(--popover)',
-                  border: '1px solid var(--border)',
-                  borderRadius: '0.5rem',
-                  color: 'var(--popover-foreground)',
-                }}
+                contentStyle={TOOLTIP_CONTENT_STYLE}
+                cursor={TOOLTIP_CURSOR_LINE}
               />
               <Legend />
               <Area
@@ -526,12 +540,8 @@ function CommunityHealthSection() {
             />
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
-              contentStyle={{
-                backgroundColor: 'var(--popover)',
-                border: '1px solid var(--border)',
-                borderRadius: '0.5rem',
-                color: 'var(--popover-foreground)',
-              }}
+              contentStyle={TOOLTIP_CONTENT_STYLE}
+              cursor={TOOLTIP_CURSOR_BAR}
             />
             <Bar
               dataKey="count"
@@ -640,12 +650,8 @@ function DataQualityTrendsSection({ months }: { months: MonthRange }) {
             />
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
-              contentStyle={{
-                backgroundColor: 'var(--popover)',
-                border: '1px solid var(--border)',
-                borderRadius: '0.5rem',
-                color: 'var(--popover-foreground)',
-              }}
+              contentStyle={TOOLTIP_CONTENT_STYLE}
+              cursor={TOOLTIP_CURSOR_LINE}
             />
             <Legend />
             <Area

--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
@@ -36,27 +36,43 @@ import {
 type MonthRange = 3 | 6 | 12 | 24
 const MONTH_OPTIONS: MonthRange[] = [3, 6, 12, 24]
 
-// Chart color palette — distinct, accessible colors
+/**
+ * Chart series colors, bound to the design-system palette
+ * (`globals.css` `--chart-1`..`--chart-5` + `--destructive`, each with a
+ * dark-mode variant — so series colors track light/dark automatically via the
+ * CSS cascade). Replaces the previous ad-hoc Tailwind hexes (blue/violet/pink),
+ * which clashed with the editorial burnt-orange/newsprint palette (PSY-908).
+ *
+ * Series colors only need to be distinguishable WITHIN a single chart, so the
+ * five categorical tokens are reused across charts. Series are assigned
+ * `--chart-1`..`--chart-5` in render order; the Entity Creation chart has a 6th
+ * line (Users) that uses `--foreground` (high-contrast, on-brand neutral).
+ * Approval trends are semantic: approved = `--chart-2` (green), rejected =
+ * `--destructive` (red).
+ */
 const COLORS = {
-  shows: '#3b82f6', // blue-500
-  artists: '#8b5cf6', // violet-500
-  venues: '#f97316', // orange-500
-  releases: '#10b981', // emerald-500
-  labels: '#ec4899', // pink-500
-  users: '#6366f1', // indigo-500
-  // Engagement
-  bookmarks: '#3b82f6',
-  tags_added: '#8b5cf6',
-  tag_votes: '#a78bfa',
-  collection_items: '#f97316',
-  requests: '#10b981',
-  request_votes: '#34d399',
-  revisions: '#ec4899',
-  follows: '#6366f1',
-  attendance: '#f59e0b',
-  // Data quality
-  approved: '#10b981',
-  rejected: '#ef4444',
+  // Entity Creation Trends (6 lines, one chart)
+  shows: 'var(--chart-1)',
+  artists: 'var(--chart-2)',
+  venues: 'var(--chart-3)',
+  releases: 'var(--chart-4)',
+  labels: 'var(--chart-5)',
+  users: 'var(--foreground)',
+  // Content Curation (3 series)
+  tags_added: 'var(--chart-1)',
+  tag_votes: 'var(--chart-2)',
+  collection_items: 'var(--chart-3)',
+  // Requests & Voting (2 series)
+  requests: 'var(--chart-1)',
+  request_votes: 'var(--chart-2)',
+  // Social Engagement (4 series)
+  bookmarks: 'var(--chart-1)',
+  follows: 'var(--chart-2)',
+  attendance: 'var(--chart-3)',
+  revisions: 'var(--chart-4)',
+  // Show Approval Trends (semantic)
+  approved: 'var(--chart-2)',
+  rejected: 'var(--destructive)',
 }
 
 // --- Sub-section labels ---
@@ -212,10 +228,10 @@ function GrowthSection({ months }: { months: MonthRange }) {
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
               contentStyle={{
-                backgroundColor: 'hsl(var(--popover))',
-                border: '1px solid hsl(var(--border))',
+                backgroundColor: 'var(--popover)',
+                border: '1px solid var(--border)',
                 borderRadius: '0.5rem',
-                color: 'hsl(var(--popover-foreground))',
+                color: 'var(--popover-foreground)',
               }}
             />
             <Legend />
@@ -318,10 +334,10 @@ function EngagementSection({ months }: { months: MonthRange }) {
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
               contentStyle={{
-                backgroundColor: 'hsl(var(--popover))',
-                border: '1px solid hsl(var(--border))',
+                backgroundColor: 'var(--popover)',
+                border: '1px solid var(--border)',
                 borderRadius: '0.5rem',
-                color: 'hsl(var(--popover-foreground))',
+                color: 'var(--popover-foreground)',
               }}
             />
             <Legend />
@@ -369,10 +385,10 @@ function EngagementSection({ months }: { months: MonthRange }) {
               <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--popover))',
-                  border: '1px solid hsl(var(--border))',
+                  backgroundColor: 'var(--popover)',
+                  border: '1px solid var(--border)',
                   borderRadius: '0.5rem',
-                  color: 'hsl(var(--popover-foreground))',
+                  color: 'var(--popover-foreground)',
                 }}
               />
               <Legend />
@@ -410,10 +426,10 @@ function EngagementSection({ months }: { months: MonthRange }) {
               <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--popover))',
-                  border: '1px solid hsl(var(--border))',
+                  backgroundColor: 'var(--popover)',
+                  border: '1px solid var(--border)',
                   borderRadius: '0.5rem',
-                  color: 'hsl(var(--popover-foreground))',
+                  color: 'var(--popover-foreground)',
                 }}
               />
               <Legend />
@@ -511,10 +527,10 @@ function CommunityHealthSection() {
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
               contentStyle={{
-                backgroundColor: 'hsl(var(--popover))',
-                border: '1px solid hsl(var(--border))',
+                backgroundColor: 'var(--popover)',
+                border: '1px solid var(--border)',
                 borderRadius: '0.5rem',
-                color: 'hsl(var(--popover-foreground))',
+                color: 'var(--popover-foreground)',
               }}
             />
             <Bar
@@ -625,10 +641,10 @@ function DataQualityTrendsSection({ months }: { months: MonthRange }) {
             <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
             <Tooltip
               contentStyle={{
-                backgroundColor: 'hsl(var(--popover))',
-                border: '1px solid hsl(var(--border))',
+                backgroundColor: 'var(--popover)',
+                border: '1px solid var(--border)',
                 borderRadius: '0.5rem',
-                color: 'hsl(var(--popover-foreground))',
+                color: 'var(--popover-foreground)',
               }}
             />
             <Legend />


### PR DESCRIPTION
Closes PSY-908 (chart half; badge half split to **PSY-943**).

## Summary

Binds the admin **analytics** chart colors to the design-system palette, replacing the ad-hoc Tailwind hexes (blue/violet/pink/emerald/indigo) that clashed with the editorial burnt-orange/newsprint palette.

- **Chart series** → existing editorial tokens. The `--chart-1`..`--chart-5` palette (plus dark-mode variants) already existed in `globals.css` but was unused; the `COLORS` map now binds to it. Each series gets a distinct token *within its chart* (tokens are reused across charts); the 6-line Entity Creation chart uses `--foreground` for its 6th line; approval trends are semantic (approved → `--chart-2` green, rejected → `--destructive` red). Series colors now track light/dark automatically via the CSS cascade.
- **Tooltip box (bug fix found by `/code-review`)** — `contentStyle` wrapped DS tokens in `hsl()` (`hsl(var(--popover))`), but this repo's tokens are raw hex, so the values were invalid CSS and every chart tooltip silently fell back to recharts' default styling. Dropped the `hsl()` wrapper.
- **Tooltip cursor (found by `/adversarial-review`)** — the hover cursor was still the raw recharts default `#ccc` on all 6 charts; bound it to `--border` (line/area guide) / `--muted` (bar highlight), and collapsed the 6 duplicated `contentStyle` objects into a shared constant.

No new tokens were added — this reuses the existing editorial palette per the scoping decision.

## Deferred (per pre-implementation Q&A)

- **Badge color maps** (9 hardcoded per-surface maps: tags category, entity-type, request status/type, radio rotation, streaming worklist, moderation, audit-log, …) — split to **PSY-943**, with the agreed direction recorded there (**muted categorical hue**, not full monochrome). The ticket's "PSY-T3 EntityTypeBadge/StatusBadge" reference points to a non-existent ticket; PSY-943 captures that those are not shared primitives today and proposes consolidating them.

## Adversarial review

`/adversarial-review` — CONCERNS; actionable findings addressed in commit `60cb770c`. Panel: Saboteur · Future-Maintainer · Security · Completeness (fresh sub-agents, no session context, against the branch diff).

- **[MEDIUM] Tooltip cursor was raw recharts `#ccc`** (Completeness) → fixed in `60cb770c` (bound to `--border` / `--muted`).
- **[MEDIUM] Doc comment over-claimed within-chart distinctness** (Future-Maintainer) → fixed in `60cb770c` (comment now states the limitation honestly; see Coverage gaps).
- **[MEDIUM] 6-line editorial palette is perceptually tight** (Saboteur + Future-Maintainer) → **disclosed, not "fixed"**: this is an accepted consequence of the "reuse the editorial palette" decision; palette refinement is the ticket's deferred Figma work. See Coverage gaps.
- **[LOW] No coverage of the color binding** (recharts is mocked) → fixed in `60cb770c` (exported `COLORS` + invariant test).
- **[LOW] `--chart-4` === `--destructive` in light mode** → documented in the `COLORS` comment (never co-occur in one chart; don't pair/dedupe).
- **Security: CLEAN** — static styling, no attacker-reachable values.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run app/admin/analytics lib/hooks/admin/useAnalytics.test.tsx` — 34/34 passing (incl. 7 new `COLORS` invariant tests: per-chart token distinctness, all values are `var()` tokens, approved/rejected semantic pairing)
- [x] `/code-review` — 3 finders; surfaced the `hsl(var())` tooltip bug (fixed in impl commit); no correctness defects
- [x] `/adversarial-review` — CONCERNS; fixes in separate commit `60cb770c` (see above)
- [x] `/psy-self-review` — see result below
- [x] Manual repro against local dev stack (admin `/admin/analytics`): verified via `agent-browser` DOM eval that all 6 Entity Creation lines resolve to the DS tokens in render order — `shows`→`rgb(210,84,27)` (chart-1), `artists`→`rgb(74,124,89)` (chart-2), `venues`→`rgb(200,148,56)` (chart-3), `releases`→`rgb(156,42,26)` (chart-4), `labels`→`rgb(139,115,85)` (chart-5), `users`→`rgb(26,23,20)` (foreground) — and Data Quality approved→`rgb(74,124,89)` / rejected→`rgb(156,42,26)`. Dark-mode token resolution verified deterministically (chart-1→`rgb(232,153,96)`, foreground→`rgb(238,231,217)`, destructive→`rgb(241,77,76)`).

## Screenshots

Growth view (light) — 6 entity series in the editorial palette, no clashing purple/blue/pink:

![analytics growth light](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-7429ac4dd41e3c9bc46c/psy-908-analytics-growth.png)

Data Quality view (light) — semantic approved (green) / rejected (red):

![analytics data quality light](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-7429ac4dd41e3c9bc46c/psy-908-analytics-dataquality.png)

Data Quality view (dark) — semantic colors with contrast on the dark vinyl background:

![analytics data quality dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-7429ac4dd41e3c9bc46c/psy-908-analytics-dataquality-dark.png)

## Coverage gaps

Honest disclosure of what the verification does and does NOT cover:

- **6-line distinctness tradeoff (known limitation):** the editorial palette is intentionally low-chroma and warm-skewed, so the 6 Entity Creation lines are not maximally distinguishable — `--chart-1` and `--chart-3` are close, especially in **dark mode**. The legend (series names) is the primary disambiguator; a richer categorical sub-palette is deferred to the PSY-908 Figma follow-up. If we want a non-color channel (per-series dashes/dots), say so and I'll add it.
- **Engagement view not screenshotted** — the local dev DB had no engagement data over the range, so those area charts rendered empty. The same `COLORS` map + `var()` mechanism applies (proven on the Growth + Data Quality views).
- **Tooltip hover cursor not visually re-screenshotted** — the `var()` resolution is proven and the `cursor` prop type-checks; the rendered hover highlight wasn't captured (would need a live hover pass).
- **Dark-mode Growth chart not screenshotted live** — the in-app dark capture landed on the Data Quality view; Growth's dark-mode token resolution was verified deterministically (values above) rather than visually.
- **CI does not assert rendered pixel colors** — the test suite mocks recharts, so the new invariant test guards the `COLORS` *map* (token names), not the rendered SVG. Rendered colors were verified live via `agent-browser` (values above).
