### PR TITLE
PSY-926: IP-geolocation default city for /explore filter

### DIFF
--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@/features/explore'
 import { API_BASE_URL } from '@/lib/api-base'
 import { queryKeys, getQueryClient } from '@/lib/queryClient'
+import { getGeoDefaultCity } from '@/lib/geo-default'
 
 export const metadata: Metadata = {
   title: 'Explore | Psychic Homily',
@@ -108,6 +109,15 @@ interface ExploreRouteProps {
 export default async function ExploreRoute({ searchParams }: ExploreRouteProps) {
   await searchParams
 
+  // IP-geo soft default for anon visitors (PSY-926). Read the Vercel edge
+  // geo headers at this already-dynamic boundary (the `await searchParams`
+  // above opts the shell into request-time rendering). The data fetches below
+  // keep their ISR `revalidate` hints, so only the per-request shell varies —
+  // ISR is preserved. The detected city is a SUGGESTION the client reconciles
+  // against its has-shows data; it never becomes the canonical `?cities=`
+  // server-side, so shareable URLs and the cached data path are untouched.
+  const geoDefaultCity = await getGeoDefaultCity()
+
   const [featured, upcoming] = await Promise.all([
     getFeatured(),
     getUpcomingShows(),
@@ -135,7 +145,7 @@ export default async function ExploreRoute({ searchParams }: ExploreRouteProps) 
   return (
     <HydrationBoundary state={dehydratedState}>
       <Suspense fallback={<ExploreLoadingFallback />}>
-        <ExplorePage />
+        <ExplorePage geoDefaultCity={geoDefaultCity} />
       </Suspense>
     </HydrationBoundary>
   )

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 }
 
 export default function PrivacyPolicyPage() {
-  const lastUpdated = 'February 15, 2026'
+  const lastUpdated = 'May 31, 2026'
   const effectiveDate = 'February 15, 2026'
 
   return (
@@ -63,6 +63,7 @@ export default function PrivacyPolicyPage() {
               <li><strong>Device Information:</strong> Browser type, operating system, and device identifiers.</li>
               <li><strong>Usage Data:</strong> Pages visited, time spent on pages, and interaction patterns.</li>
               <li><strong>Log Data:</strong> IP address, access times, and referring URLs.</li>
+              <li><strong>Approximate Location:</strong> When you visit the Explore page, the hosting platform (Vercel) infers an approximate, city-level location from your IP address. I use this only to pre-select a nearby city in the upcoming-shows filter, which you can change at any time. This inferred city is read transiently on each request, is not precise, is not stored against your account or any identifier, and is not used to build a profile or track you. See Section 3.</li>
               <li><strong>Cookies:</strong> Session cookies for authentication and preference cookies for your settings. See Section 7 for details.</li>
             </ul>
           </section>
@@ -77,7 +78,7 @@ export default function PrivacyPolicyPage() {
               <li><strong>Provide Services:</strong> To create and manage your account, display your saved shows, and enable show submissions.</li>
               <li><strong>Authentication:</strong> To verify your identity and maintain secure access to your account.</li>
               <li><strong>Communications:</strong> To send you transactional emails (password resets, magic links, email verification) and, with your consent, promotional updates about new features.</li>
-              <li><strong>Personalization:</strong> To remember your preferences such as theme, timezone, and language.</li>
+              <li><strong>Personalization:</strong> To remember your preferences such as theme, timezone, and language, and to pre-select a nearby city in the Explore shows filter based on the approximate, city-level location inferred from your IP address (an overridable default only — see Section 2.3).</li>
               <li><strong>Improvement:</strong> To analyze usage patterns and improve the services.</li>
               <li><strong>Security:</strong> To detect and prevent fraud, abuse, and security incidents.</li>
               <li><strong>Legal Compliance:</strong> To comply with applicable laws and regulations.</li>

--- a/frontend/features/explore/components/ExplorePage.tsx
+++ b/frontend/features/explore/components/ExplorePage.tsx
@@ -22,6 +22,7 @@
  */
 
 import Link from 'next/link'
+import type { CityState } from '@/components/filters/CityFilters'
 import { useExploreFeatured } from '../hooks'
 import { UpcomingShowsList } from './UpcomingShowsList'
 import { FeaturedBillCard } from './FeaturedBillCard'
@@ -29,7 +30,17 @@ import { FeaturedCollectionCard } from './FeaturedCollectionCard'
 import { InlineGraph } from './InlineGraph'
 import { ShuffleCta } from './ShuffleCta'
 
-export function ExplorePage() {
+interface ExplorePageProps {
+  /**
+   * IP-geo soft default for anon visitors (PSY-926), resolved server-side
+   * from the Vercel edge geo headers. A suggestion only — UpcomingShowsList
+   * pre-selects it only when the city has upcoming shows AND the visitor is
+   * anon with no `?cities=` and no favorites. `null` → "All cities".
+   */
+  geoDefaultCity?: CityState | null
+}
+
+export function ExplorePage({ geoDefaultCity = null }: ExplorePageProps) {
   const { data: featured } = useExploreFeatured()
   const bill = featured?.bill ?? null
   const collection = featured?.collection ?? null
@@ -57,7 +68,7 @@ export function ExplorePage() {
               View all shows →
             </Link>
           </div>
-          <UpcomingShowsList limit={5} />
+          <UpcomingShowsList limit={5} geoDefaultCity={geoDefaultCity} />
         </section>
 
         {/* 3. Featured Bill (collapses when null) */}

--- a/frontend/features/explore/components/UpcomingShowsList.test.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { UpcomingShowsList } from './UpcomingShowsList'
 import type { ExploreUpcomingShowsResponse } from '../types'
@@ -24,8 +24,19 @@ vi.mock('../hooks', () => ({
 // (≤1 city, no URL param, anon) so the list-focused tests are unaffected;
 // individual tests override the module-level vars.
 let mockCitiesParam: string | null = null
-const mockReplace = vi.fn()
-const mockPush = vi.fn()
+/** Pull the `cities=` value out of a `/explore?cities=...` href so the
+ * mocked router updates the param a subsequent `rerender` will read. */
+function citiesFromHref(href: string): string | null {
+  const qIndex = href.indexOf('?')
+  if (qIndex === -1) return null
+  return new URLSearchParams(href.slice(qIndex + 1)).get('cities')
+}
+const mockReplace = vi.fn((href: string) => {
+  mockCitiesParam = citiesFromHref(href)
+})
+const mockPush = vi.fn((href: string) => {
+  mockCitiesParam = citiesFromHref(href)
+})
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace, push: mockPush }),
   useSearchParams: () =>
@@ -37,12 +48,19 @@ vi.mock('@/features/shows', () => ({
   useShowCities: () => ({ data: { cities: mockShowCities } }),
 }))
 
+let mockIsAuthenticated = false
+let mockAuthLoading = false
 vi.mock('@/lib/context/AuthContext', () => ({
-  useAuthContext: () => ({ isAuthenticated: false, user: null }),
+  useAuthContext: () => ({
+    isAuthenticated: mockIsAuthenticated,
+    isLoading: mockAuthLoading,
+    user: null,
+  }),
 }))
 
+let mockProfileData: unknown = undefined
 vi.mock('@/features/auth', () => ({
-  useProfile: () => ({ data: undefined }),
+  useProfile: () => ({ data: mockProfileData }),
 }))
 
 // Stub the heavy filter UI (cmdk + Radix popover, dynamic-imported by the
@@ -54,11 +72,14 @@ vi.mock('@/components/filters/CityFilters', () => ({
     selectedCities,
     children,
   }: {
-    selectedCities: unknown[]
+    selectedCities: Array<{ city: string; state: string }>
     children?: ReactNode
   }) => (
     <div data-testid="city-filters">
       <span data-testid="selected-count">{selectedCities.length}</span>
+      <span data-testid="selected-labels">
+        {selectedCities.map(c => `${c.city},${c.state}`).join('|')}
+      </span>
       {children}
     </div>
   ),
@@ -100,8 +121,12 @@ describe('UpcomingShowsList', () => {
     mockUseExploreUpcomingShows.mockReset()
     mockCitiesParam = null
     mockShowCities = []
-    mockReplace.mockReset()
-    mockPush.mockReset()
+    // mockClear (not mockReset) preserves the param-tracking implementation.
+    mockReplace.mockClear()
+    mockPush.mockClear()
+    mockIsAuthenticated = false
+    mockAuthLoading = false
+    mockProfileData = undefined
   })
 
   it('renders a loading spinner while fetching', () => {
@@ -218,5 +243,207 @@ describe('UpcomingShowsList', () => {
     render(<UpcomingShowsList />)
     expect(screen.getByText(/no upcoming shows in the selected city/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /show all cities/i })).toBeInTheDocument()
+  })
+
+  describe('IP-geo default city (PSY-926)', () => {
+    const omahaShow: ExploreUpcomingShowsResponse = {
+      shows: [
+        {
+          id: 1,
+          slug: 'omaha-show',
+          title: 'Omaha Show',
+          event_date: '2026-06-15T03:00:00Z',
+          headliner_name: 'Omaha Headliner',
+          venue_name: 'Reverb',
+          venue_city: 'Omaha',
+          venue_state: 'NE',
+        },
+      ],
+      total: 1,
+      limit: 5,
+      offset: 0,
+    }
+
+    it('seeds the geo city for an anon visitor when it has upcoming shows', async () => {
+      mockShowCities = [
+        { city: 'Phoenix', state: 'AZ', show_count: 5 },
+        { city: 'Omaha', state: 'NE', show_count: 3 },
+      ]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: omahaShow,
+        isLoading: false,
+        error: null,
+      })
+      render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      // The effect seeds via router.replace with the canonical city,state.
+      expect(mockReplace).toHaveBeenCalledWith('/explore?cities=Omaha%2CNE', {
+        scroll: false,
+      })
+    })
+
+    it('does NOT seed when the geo city has no upcoming shows', async () => {
+      // Geo says Tucson, but only Phoenix/Omaha have shows → no seed.
+      mockShowCities = [
+        { city: 'Phoenix', state: 'AZ', show_count: 5 },
+        { city: 'Omaha', state: 'NE', show_count: 3 },
+      ]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: sampleResponse,
+        isLoading: false,
+        error: null,
+      })
+      render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Tucson', state: 'AZ' }} />,
+      )
+      expect(mockReplace).not.toHaveBeenCalled()
+      expect(await screen.findByTestId('selected-count')).toHaveTextContent('0')
+    })
+
+    it('does NOT seed when there is no geo default (null → All cities)', async () => {
+      mockShowCities = [
+        { city: 'Phoenix', state: 'AZ', show_count: 5 },
+        { city: 'Omaha', state: 'NE', show_count: 3 },
+      ]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: sampleResponse,
+        isLoading: false,
+        error: null,
+      })
+      render(<UpcomingShowsList geoDefaultCity={null} />)
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('matches the geo city case/whitespace-insensitively, seeding PH canonical casing', () => {
+      mockShowCities = [{ city: 'Omaha', state: 'NE', show_count: 3 }]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: omahaShow,
+        isLoading: false,
+        error: null,
+      })
+      render(
+        <UpcomingShowsList geoDefaultCity={{ city: ' omaha ', state: 'ne' }} />,
+      )
+      // Seeds the canonical "Omaha,NE" from the cities list, not the raw header.
+      expect(mockReplace).toHaveBeenCalledWith('/explore?cities=Omaha%2CNE', {
+        scroll: false,
+      })
+    })
+
+    it('lets authed favorites win over geo (resolution order)', () => {
+      mockIsAuthenticated = true
+      mockProfileData = {
+        user: { preferences: { favorite_cities: [{ city: 'Phoenix', state: 'AZ' }] } },
+      }
+      mockShowCities = [
+        { city: 'Phoenix', state: 'AZ', show_count: 5 },
+        { city: 'Omaha', state: 'NE', show_count: 3 },
+      ]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: sampleResponse,
+        isLoading: false,
+        error: null,
+      })
+      // Geo says Omaha, but the authed user favorites Phoenix → favorites win.
+      render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      expect(mockReplace).toHaveBeenCalledWith(
+        '/explore?cities=Phoenix%2CAZ',
+        { scroll: false },
+      )
+    })
+
+    it('does NOT apply geo for an authed user with no favorites', () => {
+      mockIsAuthenticated = true
+      mockProfileData = { user: { preferences: { favorite_cities: [] } } }
+      mockShowCities = [{ city: 'Omaha', state: 'NE', show_count: 3 }]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: omahaShow,
+        isLoading: false,
+        error: null,
+      })
+      render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('waits for auth to settle before applying the anon geo default', () => {
+      mockAuthLoading = true
+      mockShowCities = [{ city: 'Omaha', state: 'NE', show_count: 3 }]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: omahaShow,
+        isLoading: false,
+        error: null,
+      })
+      render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('does NOT override an existing ?cities= URL selection', () => {
+      mockCitiesParam = 'Phoenix,AZ'
+      mockShowCities = [
+        { city: 'Phoenix', state: 'AZ', show_count: 5 },
+        { city: 'Omaha', state: 'NE', show_count: 3 },
+      ]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: sampleResponse,
+        isLoading: false,
+        error: null,
+      })
+      render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('renders the "from your location — change" affordance for a geo-seeded city', () => {
+      mockShowCities = [{ city: 'Omaha', state: 'NE', show_count: 3 }]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: omahaShow,
+        isLoading: false,
+        error: null,
+      })
+      const { rerender } = render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      // The seed effect updated mockCitiesParam via the router mock; re-render
+      // so useSearchParams reflects the seeded selection and the affordance
+      // (gated on selection === geo default) shows.
+      rerender(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      const affordance = screen.getByTestId('geo-default-affordance')
+      expect(affordance).toHaveTextContent('Omaha, NE')
+      expect(affordance).toHaveTextContent(/from your location/i)
+    })
+
+    it('clears the geo affordance when the user clicks "change"', () => {
+      mockShowCities = [{ city: 'Omaha', state: 'NE', show_count: 3 }]
+      mockUseExploreUpcomingShows.mockReturnValue({
+        data: omahaShow,
+        isLoading: false,
+        error: null,
+      })
+      const { rerender } = render(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      rerender(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      fireEvent.click(screen.getByTestId('geo-default-change'))
+      // "change" pushes to /explore (all cities) and drops the affordance.
+      expect(mockPush).toHaveBeenCalledWith('/explore', { scroll: false })
+      rerender(
+        <UpcomingShowsList geoDefaultCity={{ city: 'Omaha', state: 'NE' }} />,
+      )
+      expect(
+        screen.queryByTestId('geo-default-affordance'),
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/features/explore/components/UpcomingShowsList.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.tsx
@@ -8,17 +8,27 @@
  * — the same shipped `CityFilters` component the /shows·/venues·/artists
  * lists use, wired here over the discovery teaser.
  *
- * Default city selection:
- *   - authed user with favorite cities → seeded from `favorite_cities`,
- *   - anon / no favorites → "All cities" (chronological).
- * The IP-geolocation smart default for anon visitors is the separate
- * PSY-926 follow-up; this ships the "All cities" baseline.
+ * Default city selection (resolution order):
+ *   1. authed user with favorite cities → seeded from `favorite_cities`,
+ *   2. anon / no favorites → IP-geo city (PSY-926), but ONLY when that city
+ *      has upcoming shows in PH's data; surfaced as an overridable chip with
+ *      a "(from your location) — change" affordance,
+ *   3. geo unavailable / VPN / city-without-shows → "All cities"
+ *      (chronological). NOT a hard Phoenix default.
+ * User override always wins and persists via `?cities=` (PSY-840).
  *
  * The unfiltered list reads from the page-level SSR prefetch (seeded
  * cache) so first paint is synchronous; applying a city refetches.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useTransition } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
@@ -63,15 +73,33 @@ const CityFilters = dynamic(
 
 interface UpcomingShowsListProps {
   limit?: number
+  /**
+   * IP-geo soft default (PSY-926), resolved server-side from the Vercel edge
+   * geo headers in `app/explore/page.tsx`. A suggestion only — applied as the
+   * default selection only for anon visitors with no `?cities=` and no
+   * favorites, AND only when the city has upcoming shows. `null` → no geo
+   * default (→ "All cities").
+   */
+  geoDefaultCity?: CityState | null
 }
 
-export function UpcomingShowsList({ limit = 5 }: UpcomingShowsListProps) {
+export function UpcomingShowsList({
+  limit = 5,
+  geoDefaultCity = null,
+}: UpcomingShowsListProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { isAuthenticated } = useAuthContext()
+  const { isAuthenticated, isLoading: authLoading } = useAuthContext()
   const { data: profileData } = useProfile()
   const [, startTransition] = useTransition()
   const hasAppliedDefaults = useRef(false)
+  // Tracks that the CURRENT selection was auto-applied from the IP-geo
+  // suggestion (vs. a user/favorites/URL choice). Drives the "(from your
+  // location) — change" affordance. Cleared the moment the user touches the
+  // filter, so the affordance never lingers over a manual selection.
+  const [appliedGeoDefault, setAppliedGeoDefault] = useState<CityState | null>(
+    null,
+  )
 
   const citiesParam = searchParams.get('cities')
   const selectedCities = useMemo(
@@ -84,26 +112,75 @@ export function UpcomingShowsList({ limit = 5 }: UpcomingShowsListProps) {
     [profileData?.user?.preferences],
   )
 
-  // Authed default: seed the filter from favorite cities on first load
-  // when the URL carries none yet. Anon visitors get the "All cities"
-  // baseline (no favorites). The IP-geo smart default is PSY-926.
-  useEffect(() => {
-    if (
-      !hasAppliedDefaults.current &&
-      favoriteCities.length > 0 &&
-      !citiesParam
-    ) {
-      hasAppliedDefaults.current = true
-      const params = new URLSearchParams()
-      params.set('cities', buildCitiesParam(favoriteCities))
-      startTransition(() => {
-        router.replace(`/explore?${params.toString()}`, { scroll: false })
-      })
-    }
-  }, [favoriteCities, citiesParam, router])
-
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
   const { data: citiesData } = useShowCities({ timezone })
+
+  // Map ShowCity → CityWithCount; only render the filter when there's
+  // at least one city to choose between (matches the list pages).
+  const cities: CityWithCount[] = useMemo(
+    () =>
+      citiesData?.cities?.map(c => ({
+        city: c.city,
+        state: c.state,
+        count: c.show_count,
+      })) ?? [],
+    [citiesData],
+  )
+
+  // The IP-geo suggestion reconciled against PH's has-shows data: returns the
+  // CANONICAL `{city, state}` from the cities list (so the seeded `?cities=`
+  // matches the backend filter exactly) when the detected city has upcoming
+  // shows, else null. Match is case/whitespace-insensitive because Vercel's
+  // city spelling may differ slightly from PH's stored name.
+  const geoCityWithShows: CityState | null = useMemo(() => {
+    if (!geoDefaultCity || cities.length === 0) return null
+    const norm = (s: string) => s.trim().toLowerCase()
+    const wantCity = norm(geoDefaultCity.city)
+    const wantState = norm(geoDefaultCity.state)
+    const match = cities.find(
+      c => norm(c.city) === wantCity && norm(c.state) === wantState,
+    )
+    return match ? { city: match.city, state: match.state } : null
+  }, [geoDefaultCity, cities])
+
+  // Default selection on first load when the URL carries no `?cities=`:
+  //   1. authed + favorite cities → seed from favorites (unchanged),
+  //   2. anon + geo city that has shows → seed from geo (PSY-926),
+  //   3. otherwise → leave empty ("All cities").
+  // Runs once (guarded by hasAppliedDefaults) and only after the dependent
+  // data (favorites / cities-with-shows) has had a chance to load.
+  useEffect(() => {
+    if (hasAppliedDefaults.current || citiesParam) return
+    // Wait for auth to settle. Applying the anon geo default while auth is
+    // still resolving could wrongly seed geo for a user who turns out to be
+    // authenticated (whose favorites should win, or who gets "All cities").
+    if (authLoading) return
+
+    let seed: CityState[] | null = null
+    let fromGeo = false
+    if (favoriteCities.length > 0) {
+      seed = favoriteCities
+    } else if (!isAuthenticated && geoCityWithShows) {
+      seed = [geoCityWithShows]
+      fromGeo = true
+    }
+    if (!seed) return
+
+    hasAppliedDefaults.current = true
+    if (fromGeo) setAppliedGeoDefault(geoCityWithShows)
+    const params = new URLSearchParams()
+    params.set('cities', buildCitiesParam(seed))
+    startTransition(() => {
+      router.replace(`/explore?${params.toString()}`, { scroll: false })
+    })
+  }, [
+    favoriteCities,
+    geoCityWithShows,
+    isAuthenticated,
+    authLoading,
+    citiesParam,
+    router,
+  ])
 
   const { data, isLoading, isFetching, error } = useExploreUpcomingShows({
     limit,
@@ -112,6 +189,9 @@ export function UpcomingShowsList({ limit = 5 }: UpcomingShowsListProps) {
 
   const handleFilterChange = useCallback(
     (cities: CityState[]) => {
+      // Any manual filter change is an override — the geo affordance must
+      // not linger over a user-chosen selection.
+      setAppliedGeoDefault(null)
       const params = new URLSearchParams()
       if (cities.length > 0) params.set('cities', buildCitiesParam(cities))
       const qs = params.toString()
@@ -122,17 +202,13 @@ export function UpcomingShowsList({ limit = 5 }: UpcomingShowsListProps) {
     [router],
   )
 
-  // Map ShowCity → CityWithCount; only render the filter when there's
-  // more than one city to choose between (matches the list pages).
-  const cities: CityWithCount[] = useMemo(
-    () =>
-      citiesData?.cities?.map(c => ({
-        city: c.city,
-        state: c.state,
-        count: c.show_count,
-      })) ?? [],
-    [citiesData],
-  )
+  // True when the geo default is still the active selection (exactly the one
+  // detected city, unchanged by the user) — drives the "(from your location)"
+  // chip.
+  const showGeoAffordance =
+    appliedGeoDefault !== null &&
+    selectedCities.length === 1 &&
+    citiesEqual(selectedCities, [appliedGeoDefault])
   const selectionDiffersFromFavorites = !citiesEqual(
     selectedCities,
     favoriteCities,
@@ -155,6 +231,23 @@ export function UpcomingShowsList({ limit = 5 }: UpcomingShowsListProps) {
             />
           )}
         </CityFilters>
+        {showGeoAffordance && appliedGeoDefault && (
+          <p
+            className="mt-1.5 text-xs text-muted-foreground"
+            data-testid="geo-default-affordance"
+          >
+            Showing {appliedGeoDefault.city}, {appliedGeoDefault.state} (from
+            your location) —{' '}
+            <button
+              type="button"
+              onClick={() => handleFilterChange([])}
+              className="text-primary hover:underline underline-offset-4"
+              data-testid="geo-default-change"
+            >
+              change
+            </button>
+          </p>
+        )}
       </div>
     ) : null
 

--- a/frontend/lib/geo-default.test.ts
+++ b/frontend/lib/geo-default.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { headers } from 'next/headers'
+import { getGeoDefaultCity } from './geo-default'
+
+// Mock next/headers; each test resolves a header store with the given values.
+vi.mock('next/headers', () => ({
+  headers: vi.fn(),
+}))
+
+const mockHeaders = vi.mocked(headers)
+
+/** Resolve headers() to a store backed by the given (lowercased) map. */
+function setHeaders(map: Record<string, string>) {
+  const store = {
+    get: (key: string) => map[key.toLowerCase()] ?? null,
+  }
+  mockHeaders.mockResolvedValue(
+    store as unknown as Awaited<ReturnType<typeof headers>>,
+  )
+}
+
+describe('getGeoDefaultCity', () => {
+  beforeEach(() => {
+    mockHeaders.mockReset()
+  })
+
+  it('returns {city, state} from US geo headers', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Phoenix',
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Phoenix',
+      state: 'AZ',
+    })
+  })
+
+  it('URL-decodes the city header (e.g. São Paulo) but only for US/CA', async () => {
+    // A US city with an encoded space exercises the decode path.
+    setHeaders({
+      'x-vercel-ip-city': 'San%20Diego',
+      'x-vercel-ip-country-region': 'CA',
+      'x-vercel-ip-country': 'US',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'San Diego',
+      state: 'CA',
+    })
+  })
+
+  it('allows Canada (province codes can match PH data)', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Toronto',
+      'x-vercel-ip-country-region': 'ON',
+      'x-vercel-ip-country': 'CA',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Toronto',
+      state: 'ON',
+    })
+  })
+
+  it('returns null for a non-US/CA country (foreign region cannot match)', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'S%C3%A3o%20Paulo',
+      'x-vercel-ip-country-region': 'SP',
+      'x-vercel-ip-country': 'BR',
+    })
+    await expect(getGeoDefaultCity()).resolves.toBeNull()
+  })
+
+  it('returns null when the city header is missing', async () => {
+    setHeaders({
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+    })
+    await expect(getGeoDefaultCity()).resolves.toBeNull()
+  })
+
+  it('returns null when the city header is empty (truthy-empty trap)', async () => {
+    setHeaders({
+      'x-vercel-ip-city': '',
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+    })
+    await expect(getGeoDefaultCity()).resolves.toBeNull()
+  })
+
+  it('returns null when the region header is missing (bare city is ambiguous)', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Phoenix',
+      'x-vercel-ip-country': 'US',
+    })
+    await expect(getGeoDefaultCity()).resolves.toBeNull()
+  })
+
+  it('returns null when no geo headers are present at all (local dev / VPN)', async () => {
+    setHeaders({})
+    await expect(getGeoDefaultCity()).resolves.toBeNull()
+  })
+
+  it('allows an absent country header through (client has-shows check is the gate)', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Omaha',
+      'x-vercel-ip-country-region': 'NE',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Omaha',
+      state: 'NE',
+    })
+  })
+
+  it('returns null on a malformed percent-encoding rather than throwing', async () => {
+    setHeaders({
+      'x-vercel-ip-city': '%E0%A4%A', // truncated → decodeURIComponent throws
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+    })
+    await expect(getGeoDefaultCity()).resolves.toBeNull()
+  })
+
+  it('trims surrounding whitespace from decoded values', async () => {
+    setHeaders({
+      'x-vercel-ip-city': '%20Phoenix%20',
+      'x-vercel-ip-country-region': '%20AZ%20',
+      'x-vercel-ip-country': 'US',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Phoenix',
+      state: 'AZ',
+    })
+  })
+})

--- a/frontend/lib/geo-default.ts
+++ b/frontend/lib/geo-default.ts
@@ -1,0 +1,109 @@
+/**
+ * IP-geolocation default-city resolver for /explore (PSY-926).
+ *
+ * Why this exists
+ * ---------------
+ * The /explore Upcoming Shows city filter (PSY-840) needs a sensible default
+ * for anonymous / first-visit users who have no `favorite_cities`. A static
+ * Phoenix default wrong-foots the traveler the feature targets. We instead
+ * derive the visitor's metro from Vercel's edge geo-IP headers and surface it
+ * as an *overridable suggestion* — never a hard lock.
+ *
+ * Dynamic-boundary contract
+ * --------------------------
+ * Vercel injects `X-Vercel-IP-City` / `X-Vercel-IP-Country-Region` /
+ * `X-Vercel-IP-Country` onto the incoming request at the edge. This module is
+ * read from `app/explore/page.tsx`, which is ALREADY a request-time (dynamic)
+ * render — it `await`s `searchParams` (PSY-840's URL persistence). Reading one
+ * more request-data source (`headers()`) there does not un-cache the upstream
+ * `fetch(... { next: { revalidate: 300 } })` calls, so ISR on the /explore
+ * *data* is preserved; only the per-request shell varies. This is the
+ * "dynamic boundary" the PSY-926 AC requires, and it avoids touching
+ * `frontend/proxy.ts`'s carefully-tuned soft-404 matcher (the proxy is not
+ * needed because the page is already dynamic).
+ *
+ * Privacy
+ * -------
+ * City + region only, read transiently per request, never stored against an
+ * identity and never written to a cookie. The decoded value flows to the
+ * client as a render prop and is discarded after render. Disclosed in the
+ * privacy policy (§2.3 / §3).
+ *
+ * Importing this from a client component throws at build time (it reads
+ * `next/headers`), so the "server-only" boundary is enforced by the compiler.
+ */
+
+import { headers } from 'next/headers'
+import type { CityState } from '@/components/filters/CityFilters'
+
+/** Vercel edge geo headers (lowercased — Next normalizes header keys). */
+const HEADER_CITY = 'x-vercel-ip-city'
+const HEADER_REGION = 'x-vercel-ip-country-region'
+const HEADER_COUNTRY = 'x-vercel-ip-country'
+
+/**
+ * Read the Vercel edge geo headers and decode them into a `{ city, state }`
+ * suggestion, or `null` when geo is unavailable / ambiguous.
+ *
+ * This is a SUGGESTION only — it is NOT validated against PH's shows data
+ * here (the proxy/server has no cheap access to the cities-with-counts list).
+ * The client (`UpcomingShowsList`) reconciles it against `useShowCities`
+ * data and only pre-selects it when the city actually has upcoming shows;
+ * otherwise it falls back to "All cities". Keeping the has-shows check on the
+ * client reuses PSY-840's existing data source instead of inventing a server
+ * lookup.
+ *
+ * Returns `null` (→ "All cities" fallback) when ANY of these hold:
+ *   - the city header is missing or empty (no geo / proxy stripped it),
+ *   - the region header is missing or empty (we need a state to match PH's
+ *     city,state keying — a bare city is ambiguous),
+ *   - the country is present and not US/CA (PH's city data is US/Canada
+ *     state/province-keyed; a foreign region code can't match, and surfacing
+ *     a foreign city we have no shows for is pointless — the client check
+ *     would drop it anyway, so we short-circuit cheaply here).
+ *
+ * Header values are URL-encoded by Vercel (e.g. "S%C3%A3o%20Paulo"); we
+ * decode them. A malformed encoding yields `null` rather than throwing.
+ */
+export async function getGeoDefaultCity(): Promise<CityState | null> {
+  const headerList = await headers()
+
+  const country = decodeHeader(headerList.get(HEADER_COUNTRY))
+  // Vercel returns ISO 3166-1 alpha-2 country codes. PH's city data is keyed
+  // by US state / Canadian province codes; only US/CA can match, so reject
+  // anything else cheaply. An ABSENT country header (local dev, some edge
+  // configs) is allowed through — the client has-shows check is the real gate.
+  if (country !== null && country !== 'US' && country !== 'CA') {
+    return null
+  }
+
+  const city = decodeHeader(headerList.get(HEADER_CITY))
+  const state = decodeHeader(headerList.get(HEADER_REGION))
+
+  // Both halves are required — PH keys cities by (city, state), and the
+  // `?cities=` wire format (cityParams.ts) drops any segment missing either
+  // half. A bare city with no region is ambiguous → "All cities".
+  if (!city || !state) {
+    return null
+  }
+
+  return { city, state }
+}
+
+/**
+ * Decode a single URL-encoded header value, trimming whitespace. Returns
+ * `null` for a missing, empty, or malformed-encoding value so callers can
+ * treat "no usable value" uniformly (avoids the truthy-empty-string trap).
+ */
+function decodeHeader(raw: string | null): string | null {
+  if (!raw) return null
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(raw)
+  } catch {
+    // Malformed percent-encoding — treat as no value rather than throwing.
+    return null
+  }
+  const trimmed = decoded.trim()
+  return trimmed === '' ? null : trimmed
+}


### PR DESCRIPTION
Closes PSY-926.

## Summary
- Adds a smart **IP-geolocation soft default** for the `/explore` Upcoming Shows city filter (PSY-840), for anonymous / first-visit users with no `favorite_cities`. Replaces the wrong-footing static behavior with a location-aware, fully overridable default.
- **Resolution order** (unchanged for authed users):
  1. authed + `favorite_cities` → seed from favorites (no change),
  2. anon, no favorites → Vercel edge IP-geo city, **only if** that city has upcoming approved shows in PH data → pre-selected as an overridable chip with a "Showing &lt;City&gt;, &lt;ST&gt; (from your location) — change" affordance,
  3. geo unavailable / VPN / foreign country / city-without-shows → **"All cities"** (no hard Phoenix default).
- New server-only resolver `frontend/lib/geo-default.ts` decodes the Vercel edge geo headers (`X-Vercel-IP-City`, `X-Vercel-IP-Country-Region`, `X-Vercel-IP-Country`) — URL-decodes values, handles the truthy-empty / missing-half / malformed-encoding / non-US-CA cases, returns `{city, state} | null`.
- `UpcomingShowsList` reconciles the suggestion against the existing `useShowCities` data (PSY-840's cities-with-counts source — no new endpoint) and only seeds when the detected city actually has shows, writing the **canonical** PH city/state into `?cities=` (case/whitespace-insensitive match).
- Privacy policy: added an IP-location-inference disclosure (§2.3 "Approximate Location" + §3 Personalization), `Last Updated` bumped to May 31, 2026.

## Dynamic-boundary mechanism
The geo city is read in `app/explore/page.tsx` via `next/headers` `headers()` and passed to the client as a serializable `geoDefaultCity` prop (server component → `<ExplorePage>` → `<UpcomingShowsList>`). The client treats it as a **suggestion** and seeds `?cities=` itself (same `router.replace` mechanism PSY-840 uses for authed favorites), so user override + shareable URLs work unchanged.

Why this preserves ISR/PPR for anon visitors: `/explore` was **already** a request-time (dynamic) render before this change — it `await`s `searchParams` (PSY-840's URL persistence), which under Next 16 `cacheComponents: true` opts the shell out of the static prerender. Reading one more request-data source (`headers()`) does not change the route's cacheability profile and does not un-cache the upstream `fetch(... { next: { revalidate: 300 } })` data calls — those keep their ISR hints, so only the per-request shell varies (which it already did). Verified locally: the `/explore` HTML response is `Cache-Control: no-store` and the embedded `geoDefaultCity` prop differs per request (Phoenix vs Chicago) — **no cross-visitor cache poisoning**, and the geo value never becomes the canonical server-side `?cities=`.

Why not `frontend/proxy.ts`: the proxy is unnecessary here because the page is already dynamic. The Vercel edge geo headers are present on the request that reaches the page, so reading them in the (already-dynamic) page is an equivalent dynamic boundary that avoids touching the carefully-tuned soft-404 matcher (PSY-897/913/906). Documented inline in `lib/geo-default.ts`.

## Adversarial review
`/adversarial-review` (inline lenses — dispatched agent, no Agent tool in worktree) — **CLEAN**, no critical/high findings; no fix commit required.
- [Saboteur] Cross-visitor cache poisoning → ruled out: `/explore` shell is per-request (`no-store`), verified Phoenix vs Chicago return distinct geo props; the change adds no new dynamic surface (route already dynamic via `await searchParams`).
- [Saboteur] Wrong-city lock → ruled out: seeded value is overridable (chip X / "change" both revert to All cities, verified in browser); city+state must BOTH match a real PH city, else falls back to All cities.
- [Security] Header injection into URL/DOM → ruled out: the seeded value is the **canonical** PH city/state from backend data (via `geoCityWithShows`), never the raw header; the raw header is only used for a normalized comparison, never rendered. Foreign countries and non-matching cities short-circuit. (Note: Vercel strips inbound client `x-vercel-*` headers in production, so the trust model holds; a spoofed header would only change the spoofer's own soft default.)
- [Completeness] All ACs addressed; the Vercel-preview ISR verification is the only deferred item (requires a preview deploy that exists only after this PR opens) — disclosed below.
Panel lenses: Saboteur · Future-Maintainer · Security · Completeness (run inline; no Agent tool in worktree).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/explore` — 38/38 passing (19 in `UpcomingShowsList`, incl. 11 new geo tests: resolution order, has-shows gating, null/empty geo, case-insensitive canonical match, authed-favorites-win, authed-no-favorites-no-geo, auth-loading wait, no-URL-override, chip render, "change" override)
- [x] `bun run test:run lib/geo-default` — 11/11 passing (header decode, URL-decode, US/CA allow, foreign reject, missing/empty city, missing region, malformed encoding, whitespace trim)
- [x] `bun run test:run components/filters` — 19/19 passing (no regressions in the shared filter)
- [x] Synthetic-header curl repro (local shared stack :51581 → dev backend :8080):
  - `x-vercel-ip-city: Phoenix / AZ / US` → SSR prop `{Phoenix, AZ}`; browser seeds `?cities=Phoenix%2CAZ` + renders "Showing Phoenix, AZ (from your location) — change"
  - no geo header → prop `null`; browser stays on bare `/explore` (All Cities)
  - `Sao Paulo / SP / BR` (foreign) → prop `null`
  - `San%20Diego / CA / US` → prop decoded to `{San Diego, CA}`
  - `Tucson / AZ / US` (US city with no PH shows) → prop set, but browser falls back to All Cities (client has-shows reconciliation)
- [x] Browser repro (agent-browser, headed flow captured): geo-seeded chip renders; "change" reverts to All Cities + drops affordance; no-header and city-without-shows both stay on All Cities
- [ ] Vercel preview verification (authed-browser CDP check that the real geo header is readable + ISR data layer intact) — **deferred post-PR**: requires a Vercel preview deployment, which only exists after this PR opens.

## Coverage gaps
- Real Vercel geo headers cannot be exercised locally (local dev has no edge) — verified with synthetic headers only. Recommend the Vercel-preview check (AC item 5) before merge: load `/explore` on the preview from a geolocatable IP and confirm the chip seeds, AND confirm `/explore`'s ISR data fetches still serve cached data (the shell is intentionally `no-store`; the `revalidate: 300` fetches should not re-hit the backend on every request).
- Canada is allowed through the country gate (province codes can match PH data) but PH has no Canadian-city dogfood data with shows to exercise end-to-end; the unit test covers the decode/allow path.

## Screenshots
Anon visitor geolocated to Phoenix, AZ (which has PH shows) — chip pre-selected with the "Showing Phoenix, AZ (from your location) — change" affordance; the list is filtered to Phoenix shows:

![/explore geo-seeded chip](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-a87dc4ecd3a5cdafc3c0/psy-926-geo-seeded-chip.png)
