### PR TITLE
PSY-941: blast-radius cascade ISR invalidation for entity renames

### DIFF
--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -119,7 +119,7 @@ func (h *CollectionHandler) ListCollectionsHandler(ctx context.Context, req *Lis
 
 // GetCollectionHandlerRequest represents the request for getting a single collection
 type GetCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug or numeric ID" example:"my-favorite-artists"`
 }
 
 // GetCollectionHandlerResponse represents the response for the get collection endpoint
@@ -127,7 +127,8 @@ type GetCollectionHandlerResponse struct {
 	Body *contracts.CollectionDetailResponse
 }
 
-// GetCollectionHandler handles GET /collections/{slug}
+// GetCollectionHandler handles GET /collections/{slug} - returns a single
+// collection by slug or numeric ID
 func (h *CollectionHandler) GetCollectionHandler(ctx context.Context, req *GetCollectionHandlerRequest) (*GetCollectionHandlerResponse, error) {
 	var viewerID uint
 	user := middleware.GetUserFromContext(ctx)
@@ -135,7 +136,15 @@ func (h *CollectionHandler) GetCollectionHandler(ctx context.Context, req *GetCo
 		viewerID = user.ID
 	}
 
-	collection, err := h.collectionService.GetBySlug(req.Slug, viewerID)
+	// Try to parse as numeric ID first (PSY-940), matching the other entity
+	// GET handlers; fall back to slug lookup.
+	var collection *contracts.CollectionDetailResponse
+	var err error
+	if id, parseErr := strconv.ParseUint(req.Slug, 10, 32); parseErr == nil {
+		collection, err = h.collectionService.GetByID(uint(id), viewerID)
+	} else {
+		collection, err = h.collectionService.GetBySlug(req.Slug, viewerID)
+	}
 	if err != nil {
 		return nil, shared.MapCollectionError(err)
 	}

--- a/backend/internal/api/handlers/community/collection_integration_test.go
+++ b/backend/internal/api/handlers/community/collection_integration_test.go
@@ -151,6 +151,51 @@ func (s *CollectionHandlerIntegrationSuite) TestGetCollection_AuthenticatedViewe
 	s.True(resp.Body.IsSubscribed)
 }
 
+// PSY-940: GET /collections/{slug} accepts numeric IDs like the other entity
+// GET endpoints, enabling ID→slug lookups for ISR revalidation.
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID() {
+	user := testhelpers.CreateTestUser(s.deps.DB)
+	coll := s.createCollectionViaService(user, "Get By ID", true)
+
+	req := &GetCollectionHandlerRequest{Slug: fmt.Sprintf("%d", coll.ID)}
+	resp, err := s.handler.GetCollectionHandler(context.Background(), req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(coll.ID, resp.Body.ID)
+	s.Equal(coll.Slug, resp.Body.Slug)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID_NotFound() {
+	req := &GetCollectionHandlerRequest{Slug: "999999"}
+	_, err := s.handler.GetCollectionHandler(context.Background(), req)
+	testhelpers.AssertHumaError(s.T(), err, 404)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID_PrivateForbiddenForNonOwner() {
+	owner := testhelpers.CreateTestUser(s.deps.DB)
+	viewer := testhelpers.CreateTestUser(s.deps.DB)
+	coll := s.createCollectionViaService(owner, "Private By ID", false)
+
+	// ID lookups must enforce the same privacy gate as slug lookups.
+	ctx := testhelpers.CtxWithUser(viewer)
+	req := &GetCollectionHandlerRequest{Slug: fmt.Sprintf("%d", coll.ID)}
+	_, err := s.handler.GetCollectionHandler(ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 403)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID_PrivateVisibleToOwner() {
+	owner := testhelpers.CreateTestUser(s.deps.DB)
+	coll := s.createCollectionViaService(owner, "Private Own By ID", false)
+
+	ctx := testhelpers.CtxWithUser(owner)
+	req := &GetCollectionHandlerRequest{Slug: fmt.Sprintf("%d", coll.ID)}
+	resp, err := s.handler.GetCollectionHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(coll.ID, resp.Body.ID)
+}
+
 // ============================================================================
 // GetCollectionStatsHandler
 // ============================================================================

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -695,6 +695,7 @@ type MockCollectionService struct {
 	CreateCollectionFn                   func(uint, *contracts.CreateCollectionRequest) (*contracts.CollectionDetailResponse, error)
 	CloneCollectionFn                    func(string, uint) (*contracts.CollectionDetailResponse, error)
 	GetBySlugFn                          func(string, uint) (*contracts.CollectionDetailResponse, error)
+	GetByIDFn                            func(uint, uint) (*contracts.CollectionDetailResponse, error)
 	ListCollectionsFn                    func(contracts.CollectionFilters, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	UpdateCollectionFn                   func(string, uint, bool, *contracts.UpdateCollectionRequest) (*contracts.CollectionDetailResponse, error)
 	DeleteCollectionFn                   func(string, uint, bool) error
@@ -736,6 +737,12 @@ func (m *MockCollectionService) CloneCollection(srcSlug string, callerID uint) (
 func (m *MockCollectionService) GetBySlug(slug string, viewerID uint) (*contracts.CollectionDetailResponse, error) {
 	if m.GetBySlugFn != nil {
 		return m.GetBySlugFn(slug, viewerID)
+	}
+	return nil, nil
+}
+func (m *MockCollectionService) GetByID(id uint, viewerID uint) (*contracts.CollectionDetailResponse, error) {
+	if m.GetByIDFn != nil {
+		return m.GetByIDFn(id, viewerID)
 	}
 	return nil, nil
 }

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -431,6 +431,29 @@ func (s *CollectionService) CloneCollection(srcSlug string, callerID uint) (*con
 	return s.GetBySlug(newSlug, callerID)
 }
 
+// GetByID retrieves a collection by numeric ID with full detail.
+//
+// Resolves the slug first and delegates to GetBySlug so the access-control
+// and detail-building logic lives in exactly one place. Added so
+// GET /collections/{slug} can accept ID-or-slug like the other entity GET
+// endpoints (PSY-940 — enables ID→slug lookups for ISR revalidation).
+func (s *CollectionService) GetByID(id uint, viewerID uint) (*contracts.CollectionDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var collection communitym.Collection
+	err := s.db.Select("slug").Where("id = ?", id).First(&collection).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrCollectionNotFound(strconv.FormatUint(uint64(id), 10))
+		}
+		return nil, fmt.Errorf("failed to get collection: %w", err)
+	}
+
+	return s.GetBySlug(collection.Slug, viewerID)
+}
+
 // GetBySlug retrieves a collection by slug with full detail
 func (s *CollectionService) GetBySlug(slug string, viewerID uint) (*contracts.CollectionDetailResponse, error) {
 	if s.db == nil {

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -460,6 +460,11 @@ type CollectionServiceInterface interface {
 	CreateCollection(creatorID uint, req *CreateCollectionRequest) (*CollectionDetailResponse, error)
 	CloneCollection(srcSlug string, callerID uint) (*CollectionDetailResponse, error)
 	GetBySlug(slug string, viewerID uint) (*CollectionDetailResponse, error)
+	// GetByID retrieves a collection by numeric ID with the same
+	// access-control semantics as GetBySlug. Lets GET /collections/{slug}
+	// accept ID-or-slug like the other entity GET endpoints (PSY-940 —
+	// enables ID→slug lookups for ISR revalidation).
+	GetByID(id uint, viewerID uint) (*CollectionDetailResponse, error)
 	ListCollections(filters CollectionFilters, limit, offset int) ([]*CollectionListResponse, int64, error)
 	UpdateCollection(slug string, userID uint, isAdmin bool, req *UpdateCollectionRequest) (*CollectionDetailResponse, error)
 	DeleteCollection(slug string, userID uint, isAdmin bool) error

--- a/frontend/lib/proxy-revalidation.test.ts
+++ b/frontend/lib/proxy-revalidation.test.ts
@@ -108,18 +108,20 @@ describe('show rules', () => {
     '/explore',
     '/artists',
     '/venues',
+    '/scenes/[slug]',
     '/artists/bright-eyes',
     '/artists/cursive',
   ]
 
-  it('show create revalidates the show, list surfaces, and billed artists', async () => {
+  it('show create revalidates the show, list surfaces, scenes, and billed artists', async () => {
     await run({ method: 'POST', path: '/shows', responseText: showBody })
     expect(revalidated()).toEqual(expectedShowPages)
   })
 
-  it('show update revalidates the same set', async () => {
+  it('show update revalidates the same set plus the collection cascade', async () => {
     await run({ method: 'PUT', path: '/shows/7', responseText: showBody })
-    expect(revalidated()).toEqual(expectedShowPages)
+    // Title edits stale collection pages embedding the show's name.
+    expect(revalidated()).toEqual([...expectedShowPages, '/collections/[slug]'])
   })
 
   it('show status ops revalidate the same set', async () => {
@@ -149,14 +151,52 @@ describe('show rules', () => {
     expect(revalidated()).toEqual(expectedShowPages)
   })
 
-  it('show delete revalidates list surfaces only (empty response)', async () => {
+  it('batch approve/reject blasts the show route (response has counts, not slugs)', async () => {
+    const expectedBatchPages = [
+      '/shows/[slug]',
+      '/shows',
+      '/explore',
+      '/artists',
+      '/venues',
+      '/scenes/[slug]',
+    ]
+    await run({
+      method: 'POST',
+      path: '/admin/shows/batch-approve',
+      responseText: JSON.stringify({ approved: 50, errors: [] }),
+    })
+    expect(revalidated()).toEqual(expectedBatchPages)
+
+    mockRevalidatePath.mockClear()
+    await run({
+      method: 'POST',
+      path: '/admin/shows/batch-reject',
+      responseText: JSON.stringify({ rejected: 3, errors: [] }),
+    })
+    expect(revalidated()).toEqual(expectedBatchPages)
+  })
+
+  it('show delete revalidates list surfaces, scenes, and the collection cascade', async () => {
     await run({ method: 'DELETE', path: '/shows/7' })
-    expect(revalidated()).toEqual(['/shows', '/explore', '/artists', '/venues'])
+    expect(revalidated()).toEqual([
+      '/shows',
+      '/explore',
+      '/artists',
+      '/venues',
+      '/scenes/[slug]',
+      '/collections/[slug]',
+    ])
   })
 
   it('degrades to list surfaces when the response body is not JSON', async () => {
     await run({ method: 'POST', path: '/shows', responseText: 'created' })
-    expect(revalidated()).toEqual(['/shows', '/explore', '/artists', '/venues'])
+    expect(revalidated()).toEqual([
+      '/shows',
+      '/explore',
+      '/artists',
+      '/venues',
+      '/scenes/[slug]',
+    ])
   })
 })
 
@@ -174,13 +214,19 @@ describe('suggest-edit rules', () => {
     })
   }
 
-  it('revalidates the entity + list page when the edit was auto-applied', async () => {
+  it('revalidates the entity + list page + rename cascade when the edit was auto-applied', async () => {
     await run({
       method: 'PUT',
       path: '/artists/10/suggest-edit',
       responseText: suggestEditBody(true, 'bright-eyes'),
     })
-    expect(revalidated()).toEqual(['/artists/bright-eyes', '/artists'])
+    expect(revalidated()).toEqual([
+      '/artists/bright-eyes',
+      '/artists',
+      '/shows/[slug]',
+      '/releases/[slug]',
+      '/collections/[slug]',
+    ])
   })
 
   it('does nothing when the edit went to the pending queue (applied: false)', async () => {
@@ -192,13 +238,18 @@ describe('suggest-edit rules', () => {
     expect(mockRevalidatePath).not.toHaveBeenCalled()
   })
 
-  it('revalidates only the list page when the slug is missing', async () => {
+  it('revalidates the list page + cascade when the slug is missing', async () => {
     await run({
       method: 'PUT',
       path: '/artists/10/suggest-edit',
       responseText: suggestEditBody(true, undefined),
     })
-    expect(revalidated()).toEqual(['/artists'])
+    expect(revalidated()).toEqual([
+      '/artists',
+      '/shows/[slug]',
+      '/releases/[slug]',
+      '/collections/[slug]',
+    ])
   })
 
   it('uses the entity type from the path (venue)', async () => {
@@ -207,7 +258,12 @@ describe('suggest-edit rules', () => {
       path: '/venues/4/suggest-edit',
       responseText: suggestEditBody(true, 'the-rebel-lounge'),
     })
-    expect(revalidated()).toEqual(['/venues/the-rebel-lounge', '/venues'])
+    expect(revalidated()).toEqual([
+      '/venues/the-rebel-lounge',
+      '/venues',
+      '/shows/[slug]',
+      '/collections/[slug]',
+    ])
   })
 
   it('skips the list page for entity types without an ISR list route (release)', async () => {
@@ -216,12 +272,15 @@ describe('suggest-edit rules', () => {
       path: '/releases/9/suggest-edit',
       responseText: suggestEditBody(true, 'fevers-and-mirrors'),
     })
-    expect(revalidated()).toEqual(['/releases/fevers-and-mirrors'])
+    expect(revalidated()).toEqual([
+      '/releases/fevers-and-mirrors',
+      '/collections/[slug]',
+    ])
   })
 })
 
 describe('pending-edit moderation rules', () => {
-  it('approve revalidates the affected entity + list page', async () => {
+  it('approve revalidates the affected entity + list page + rename cascade', async () => {
     await run({
       method: 'POST',
       path: '/admin/pending-edits/55/approve',
@@ -231,7 +290,13 @@ describe('pending-edit moderation rules', () => {
         entity_slug: 'bright-eyes',
       }),
     })
-    expect(revalidated()).toEqual(['/artists/bright-eyes', '/artists'])
+    expect(revalidated()).toEqual([
+      '/artists/bright-eyes',
+      '/artists',
+      '/shows/[slug]',
+      '/releases/[slug]',
+      '/collections/[slug]',
+    ])
   })
 
   it('approve maps singular entity types without ISR list pages (label)', async () => {
@@ -244,7 +309,11 @@ describe('pending-edit moderation rules', () => {
         entity_slug: 'saddle-creek',
       }),
     })
-    expect(revalidated()).toEqual(['/labels/saddle-creek'])
+    expect(revalidated()).toEqual([
+      '/labels/saddle-creek',
+      '/releases/[slug]',
+      '/collections/[slug]',
+    ])
   })
 
   it('approve does nothing for unknown entity types', async () => {
@@ -284,18 +353,26 @@ describe('artist rules', () => {
     expect(revalidated()).toEqual(['/artists/new-artist', '/artists'])
   })
 
-  it('admin update revalidates the artist + list', async () => {
+  // Renames/merges/deletes change the artist name embedded in show, release,
+  // and collection ISR payloads → the artist cascade.
+  const artistCascade = ['/shows/[slug]', '/releases/[slug]', '/collections/[slug]']
+
+  it('admin update revalidates the artist + list + rename cascade', async () => {
     await run({
       method: 'PATCH',
       path: '/admin/artists/1',
       responseText: JSON.stringify({ id: 1, slug: 'renamed-artist' }),
     })
-    expect(revalidated()).toEqual(['/artists/renamed-artist', '/artists'])
+    expect(revalidated()).toEqual([
+      '/artists/renamed-artist',
+      '/artists',
+      ...artistCascade,
+    ])
   })
 
-  it('delete revalidates the list only', async () => {
+  it('delete revalidates the list + rename cascade', async () => {
     await run({ method: 'DELETE', path: '/artists/1' })
-    expect(revalidated()).toEqual(['/artists'])
+    expect(revalidated()).toEqual(['/artists', ...artistCascade])
   })
 
   it('merge resolves the canonical artist slug via backend lookup', async () => {
@@ -312,17 +389,21 @@ describe('artist rules', () => {
       `${BACKEND}/artists/42`,
       expect.objectContaining({ cache: 'no-store' })
     )
-    expect(revalidated()).toEqual(['/artists/bright-eyes', '/artists'])
+    expect(revalidated()).toEqual([
+      '/artists/bright-eyes',
+      '/artists',
+      ...artistCascade,
+    ])
   })
 
-  it('merge falls back to the list page when the lookup fails', async () => {
+  it('merge falls back to the list page + cascade when the lookup fails', async () => {
     fetchSpy.mockResolvedValueOnce(new Response('gone', { status: 404 }))
     await run({
       method: 'POST',
       path: '/admin/artists/merge',
       responseText: JSON.stringify({ canonical_artist_id: 42 }),
     })
-    expect(revalidated()).toEqual(['/artists'])
+    expect(revalidated()).toEqual(['/artists', ...artistCascade])
     // Lookup failures are observable so the staleness gap is visible.
     expect(mockCaptureMessage).toHaveBeenCalledWith(
       'isr-revalidation: slug lookup failed',
@@ -341,21 +422,29 @@ describe('venue rules', () => {
     expect(revalidated()).toEqual(['/venues/new-venue', '/venues'])
   })
 
-  it('update revalidates the venue + list', async () => {
+  // Venue renames/deletes change the venue name embedded in show and
+  // collection ISR payloads (releases don't credit venues).
+  const venueCascade = ['/shows/[slug]', '/collections/[slug]']
+
+  it('update revalidates the venue + list + rename cascade', async () => {
     await run({
       method: 'PUT',
       path: '/venues/3',
       responseText: JSON.stringify({ id: 3, slug: 'the-rebel-lounge' }),
     })
-    expect(revalidated()).toEqual(['/venues/the-rebel-lounge', '/venues'])
+    expect(revalidated()).toEqual([
+      '/venues/the-rebel-lounge',
+      '/venues',
+      ...venueCascade,
+    ])
   })
 
-  it('delete revalidates the list only', async () => {
+  it('delete revalidates the list + rename cascade', async () => {
     await run({ method: 'DELETE', path: '/venues/3' })
-    expect(revalidated()).toEqual(['/venues'])
+    expect(revalidated()).toEqual(['/venues', ...venueCascade])
   })
 
-  it('verify revalidates the venue + list', async () => {
+  it('verify revalidates the venue + list with NO cascade (name unchanged)', async () => {
     await run({
       method: 'POST',
       path: '/admin/venues/3/verify',
@@ -382,7 +471,7 @@ describe('release rules', () => {
     ])
   })
 
-  it('update revalidates the release + credited artist pages', async () => {
+  it('update revalidates the release + credited artist pages + collection cascade', async () => {
     await run({
       method: 'PUT',
       path: '/releases/9',
@@ -395,7 +484,13 @@ describe('release rules', () => {
     expect(revalidated()).toEqual([
       '/releases/fevers-and-mirrors',
       '/artists/bright-eyes',
+      '/collections/[slug]',
     ])
+  })
+
+  it('delete revalidates the collection cascade (no ISR list page for releases)', async () => {
+    await run({ method: 'DELETE', path: '/releases/9' })
+    expect(revalidated()).toEqual(['/collections/[slug]'])
   })
 
   it('link add resolves the release slug from the path ID', async () => {
@@ -425,13 +520,23 @@ describe('label rules', () => {
     expect(revalidated()).toEqual(['/labels/saddle-creek'])
   })
 
-  it('update revalidates the label page', async () => {
+  it('update revalidates the label page + rename cascade', async () => {
     await run({
       method: 'PUT',
       path: '/labels/5',
       responseText: JSON.stringify({ id: 5, slug: 'saddle-creek' }),
     })
-    expect(revalidated()).toEqual(['/labels/saddle-creek'])
+    // Release pages credit labels by name; collections may list the label.
+    expect(revalidated()).toEqual([
+      '/labels/saddle-creek',
+      '/releases/[slug]',
+      '/collections/[slug]',
+    ])
+  })
+
+  it('delete revalidates the rename cascade', async () => {
+    await run({ method: 'DELETE', path: '/labels/5' })
+    expect(revalidated()).toEqual(['/releases/[slug]', '/collections/[slug]'])
   })
 
   it('roster ops resolve the label slug from the path ID', async () => {
@@ -458,13 +563,21 @@ describe('festival rules', () => {
     expect(revalidated()).toEqual(['/festivals/riot-fest-2026'])
   })
 
-  it('update revalidates the festival page', async () => {
+  it('update revalidates the festival page + collection cascade', async () => {
     await run({
       method: 'PUT',
       path: '/festivals/6',
       responseText: JSON.stringify({ id: 6, slug: 'riot-fest-2026' }),
     })
-    expect(revalidated()).toEqual(['/festivals/riot-fest-2026'])
+    expect(revalidated()).toEqual([
+      '/festivals/riot-fest-2026',
+      '/collections/[slug]',
+    ])
+  })
+
+  it('delete revalidates the collection cascade', async () => {
+    await run({ method: 'DELETE', path: '/festivals/6' })
+    expect(revalidated()).toEqual(['/collections/[slug]'])
   })
 
   it('lineup ops resolve the festival slug from the path ID', async () => {
@@ -623,6 +736,49 @@ describe('explore curation rules', () => {
   })
 })
 
+describe('cascade invalidation (PSY-941)', () => {
+  it('revalidates route patterns with type page and concrete paths without', async () => {
+    await run({
+      method: 'PATCH',
+      path: '/admin/artists/1',
+      responseText: JSON.stringify({ id: 1, slug: 'renamed-artist' }),
+    })
+
+    // Concrete paths: single-argument revalidatePath calls.
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/renamed-artist')
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/artists')
+    // Route patterns: type 'page' so Next invalidates every page under the route.
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/shows/[slug]', 'page')
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/releases/[slug]', 'page')
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/collections/[slug]', 'page')
+  })
+
+  it('does not cascade on creates (nothing embeds a brand-new entity)', async () => {
+    const creates: Array<[string, string, string]> = [
+      ['POST', '/admin/artists', JSON.stringify({ id: 1, slug: 'new-artist' })],
+      ['POST', '/admin/venues', JSON.stringify({ id: 2, slug: 'new-venue' })],
+      ['POST', '/labels', JSON.stringify({ id: 3, slug: 'new-label' })],
+      ['POST', '/festivals', JSON.stringify({ id: 4, slug: 'new-fest' })],
+    ]
+    for (const [method, path, responseText] of creates) {
+      mockRevalidatePath.mockClear()
+      await run({ method, path, responseText })
+      expect(revalidated()).not.toContain('/shows/[slug]')
+      expect(revalidated()).not.toContain('/releases/[slug]')
+      expect(revalidated()).not.toContain('/collections/[slug]')
+    }
+  })
+
+  it('collection mutations do not cascade (collections are not embedded elsewhere)', async () => {
+    await run({
+      method: 'PUT',
+      path: '/collections/my-list',
+      responseText: JSON.stringify({ id: 1, slug: 'my-list' }),
+    })
+    expect(revalidated()).toEqual(['/collections/my-list'])
+  })
+})
+
 describe('resilience', () => {
   it('never throws when revalidatePath throws — reports each failure to Sentry', async () => {
     mockRevalidatePath.mockImplementation(() => {
@@ -632,8 +788,9 @@ describe('resilience', () => {
     await expect(
       run({ method: 'DELETE', path: '/shows/7' })
     ).resolves.toBeUndefined()
-    // show-delete touches 4 list pages; each failure is captured separately.
-    expect(mockCaptureException).toHaveBeenCalledTimes(4)
+    // show-delete touches 4 list pages + scenes + the collection cascade;
+    // each failure is captured separately.
+    expect(mockCaptureException).toHaveBeenCalledTimes(6)
   })
 
   it('never throws when the lookup fetch rejects — skips the page and reports', async () => {

--- a/frontend/lib/proxy-revalidation.test.ts
+++ b/frontend/lib/proxy-revalidation.test.ts
@@ -725,6 +725,94 @@ describe('tag rules', () => {
   })
 })
 
+describe('collection tagging via the generic entities path (PSY-940)', () => {
+  /** Route lookup GETs to per-URL responses (tag 3 + collection 9). */
+  function mockLookups() {
+    fetchSpy.mockImplementation(((url: string | URL | Request) => {
+      const target = String(url)
+      if (target === `${BACKEND}/tags/3`) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 3, slug: 'post-punk' }), {
+            status: 200,
+          })
+        )
+      }
+      if (target === `${BACKEND}/collections/9`) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 9, slug: 'desert-punk-essentials' }), {
+            status: 200,
+          })
+        )
+      }
+      return Promise.resolve(new Response('not found', { status: 404 }))
+    }) as typeof fetch)
+  }
+
+  it('tag add on a collection revalidates BOTH the tag page and the collection page', async () => {
+    mockLookups()
+    await run({
+      method: 'POST',
+      path: '/entities/collection/9/tags',
+      requestText: JSON.stringify({ tag_id: 3 }),
+    })
+    // Collection ISR payloads embed tags[], unlike every other entity type.
+    expect(revalidated()).toEqual([
+      '/tags/post-punk',
+      '/collections/desert-punk-essentials',
+    ])
+  })
+
+  it('tag add by tag_name on a collection still revalidates the collection page', async () => {
+    mockLookups()
+    await run({
+      method: 'POST',
+      path: '/entities/collection/9/tags',
+      requestText: JSON.stringify({ tag_name: 'desert rock', category: 'genre' }),
+    })
+    expect(revalidated()).toEqual(['/collections/desert-punk-essentials'])
+  })
+
+  it('tag remove on a collection revalidates BOTH pages', async () => {
+    mockLookups()
+    await run({ method: 'DELETE', path: '/entities/collection/9/tags/3' })
+    expect(revalidated()).toEqual([
+      '/tags/post-punk',
+      '/collections/desert-punk-essentials',
+    ])
+  })
+
+  it('falls back to the tag page only when the collection lookup fails', async () => {
+    fetchSpy.mockImplementation(((url: string | URL | Request) => {
+      const target = String(url)
+      if (target === `${BACKEND}/tags/3`) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 3, slug: 'post-punk' }), {
+            status: 200,
+          })
+        )
+      }
+      return Promise.resolve(new Response('error', { status: 500 }))
+    }) as typeof fetch)
+
+    await run({ method: 'DELETE', path: '/entities/collection/9/tags/3' })
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+    // The skipped collection page is observable via the lookup-failure warning.
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'isr-revalidation: slug lookup failed',
+      expect.objectContaining({ level: 'warning' })
+    )
+  })
+
+  it('non-collection entity tagging never looks up the entity', async () => {
+    mockLookupResponse('post-punk')
+    await run({ method: 'DELETE', path: '/entities/artist/10/tags/3' })
+    // Exactly one lookup (the tag) — never a second for the artist.
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith(`${BACKEND}/tags/3`, expect.anything())
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+  })
+})
+
 describe('explore curation rules', () => {
   it('featured slot set/delete revalidates /explore', async () => {
     await run({ method: 'POST', path: '/admin/featured-slots' })

--- a/frontend/lib/proxy-revalidation.ts
+++ b/frontend/lib/proxy-revalidation.ts
@@ -28,8 +28,6 @@ import { safeRevalidatePath } from './revalidate-entity'
  * pages), via dynamic route patterns — see RENAME_CASCADES below.
  *
  * Known gaps (follow-up tickets):
- *   - PSY-940: collections tagged via the generic /entities/collection/...
- *     path (collections GET is slug-only; no ID→slug lookup possible)
  *   - Deletes by numeric ID can't revalidate the deleted entity's own detail
  *     page (empty response, entity gone); the soft-404 proxy handles dead
  *     slugs (PSY-897/913/906)
@@ -242,6 +240,25 @@ function releasePages(body: unknown): Array<string | undefined> {
     ...entityPages('releases', slugOf(body)),
     ...nestedSlugs(body, 'artists').map((artistSlug) => `/artists/${artistSlug}`),
   ]
+}
+
+/**
+ * The tagged entity's own detail page, when its ISR payload embeds tags.
+ *
+ * Only collections do (CollectionDetailResponse.tags) — every other entity
+ * type client-fetches its tags, so tagging them never stales their pages.
+ * The generic tagging path carries a numeric entity ID; resolving it to a
+ * slug requires the collection GET to accept IDs (backend change shipped
+ * with PSY-940).
+ */
+async function taggedEntityPages(
+  entityType: string,
+  entityId: string,
+  lookupSlug: RuleContext['lookupSlug']
+): Promise<Array<string | undefined>> {
+  if (entityType !== 'collection') return []
+  const slug = await lookupSlug('collections', entityId)
+  return [slug ? `/collections/${slug}` : undefined]
 }
 
 // ---------------------------------------------------------------------------
@@ -571,26 +588,35 @@ const RULES: readonly RevalidationRule[] = [
   {
     name: 'entity-tag-add',
     methods: ['POST'],
-    pattern: /^\/entities\/[a-z]+\/\d+\/tags$/,
-    // Entity detail pages client-fetch their tags, so they are NOT affected.
-    // The /tags/{slug} page IS affected (usage_breakdown is ISR-cached). The
-    // response body is empty; the tag reference lives in the REQUEST body —
-    // tag_id for existing tags. (tag_name-only requests create a brand-new
-    // tag, which has no cached ISR page yet, so nothing to revalidate.)
-    paths: async ({ requestBody, lookupSlug }) => {
+    pattern: /^\/entities\/([a-z]+)\/(\d+)\/tags$/,
+    // Two pages can be affected:
+    //   1. The /tags/{slug} page (usage_breakdown is ISR-cached). The
+    //      response body is empty; the tag reference lives in the REQUEST
+    //      body — tag_id for existing tags. (tag_name-only requests create a
+    //      brand-new tag, which has no cached ISR page yet.)
+    //   2. The tagged entity's own page, but ONLY for collections — every
+    //      other entity type client-fetches its tags (PSY-940).
+    paths: async ({ match, requestBody, lookupSlug }) => {
       const tagId = asRecord(requestBody)?.tag_id
-      if (typeof tagId !== 'number' || tagId === 0) return []
-      const slug = await lookupSlug('tags', String(tagId))
-      return [slug ? `/tags/${slug}` : undefined]
+      const [tagSlug, entityOwnPages] = await Promise.all([
+        typeof tagId === 'number' && tagId !== 0
+          ? lookupSlug('tags', String(tagId))
+          : Promise.resolve(undefined),
+        taggedEntityPages(match[1], match[2], lookupSlug),
+      ])
+      return [tagSlug ? `/tags/${tagSlug}` : undefined, ...entityOwnPages]
     },
   },
   {
     name: 'entity-tag-remove',
     methods: ['DELETE'],
-    pattern: /^\/entities\/[a-z]+\/\d+\/tags\/(\d+)$/,
+    pattern: /^\/entities\/([a-z]+)\/(\d+)\/tags\/(\d+)$/,
     paths: async ({ match, lookupSlug }) => {
-      const slug = await lookupSlug('tags', match[1])
-      return [slug ? `/tags/${slug}` : undefined]
+      const [tagSlug, entityOwnPages] = await Promise.all([
+        lookupSlug('tags', match[3]),
+        taggedEntityPages(match[1], match[2], lookupSlug),
+      ])
+      return [tagSlug ? `/tags/${tagSlug}` : undefined, ...entityOwnPages]
     },
   },
 
@@ -684,9 +710,10 @@ function parseJson(text: string | null | undefined): unknown {
  * Resolve an entity's slug from its numeric ID via the backend GET endpoint.
  *
  * Every URL segment used by the rules above (artists, releases, labels,
- * festivals, tags) has a GET that accepts ID-or-slug. Returns undefined on
- * any failure — the caller then skips that page, which means it stays stale
- * until its ISR window expires; failures are reported so the gap is visible.
+ * festivals, tags, collections — the last as of PSY-940) has a GET that
+ * accepts ID-or-slug. Returns undefined on any failure — the caller then
+ * skips that page, which means it stays stale until its ISR window expires;
+ * failures are reported so the gap is visible.
  *
  * Lookups run synchronously before the mutation response returns, adding one
  * backend GET to the rules that need them (admin sub-resource ops, entity

--- a/frontend/lib/proxy-revalidation.ts
+++ b/frontend/lib/proxy-revalidation.ts
@@ -23,11 +23,13 @@ import { safeRevalidatePath } from './revalidate-entity'
  * surfaces, and entity tagging → *entity* pages (entity pages client-fetch
  * their tags; only the /tags/{slug} page ISR-caches usage counts).
  *
+ * Cascades (PSY-941): mutations that change or remove an entity's NAME also
+ * invalidate every page that embeds that name (show/release/collection
+ * pages), via dynamic route patterns — see RENAME_CASCADES below.
+ *
  * Known gaps (follow-up tickets):
  *   - PSY-940: collections tagged via the generic /entities/collection/...
  *     path (collections GET is slug-only; no ID→slug lookup possible)
- *   - PSY-941: cascade renames (artist rename → show pages embedding the
- *     name) need revalidateTag; out of reach for path-based rules
  *   - Deletes by numeric ID can't revalidate the deleted entity's own detail
  *     page (empty response, entity gone); the soft-404 proxy handles dead
  *     slugs (PSY-897/913/906)
@@ -70,7 +72,9 @@ interface RevalidationRule {
    */
   paths: (
     ctx: RuleContext
-  ) => Promise<Array<string | undefined>> | Array<string | undefined>
+  ) =>
+    | Promise<ReadonlyArray<string | undefined>>
+    | ReadonlyArray<string | undefined>
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +140,48 @@ const SINGULAR_TO_SEGMENT: Readonly<Record<string, string>> = {
   collection: 'collections',
 }
 
+// ---------------------------------------------------------------------------
+// Cascade invalidation (PSY-941)
+// ---------------------------------------------------------------------------
+
+// Dynamic route patterns. safeRevalidatePath revalidates these with type
+// 'page', invalidating every cached page under the route on its next visit.
+const ALL_SHOW_PAGES = '/shows/[slug]'
+const ALL_RELEASE_PAGES = '/releases/[slug]'
+const ALL_COLLECTION_PAGES = '/collections/[slug]'
+const ALL_SCENE_PAGES = '/scenes/[slug]'
+
+/**
+ * Route patterns made stale when an entity of the given segment is renamed,
+ * merged, or deleted — the pages that embed the entity's NAME in their own
+ * ISR payload (verified against backend contracts):
+ *
+ *   - Show pages embed artist + venue names (ShowResponse.artists/venues)
+ *   - Release pages embed artist + label names (ReleaseDetailResponse)
+ *   - Collection pages embed item entity names of every entity type
+ *     (CollectionItemResponse.entity_name)
+ *   - Scene + tag pages embed only counts → no rename cascade
+ *
+ * Path-based rules can't enumerate the specific affected pages (that would
+ * need revalidateTag with tagged fetches), so the whole route pattern is
+ * invalidated. Rename-class mutations are rare admin/trusted events and
+ * pages regenerate lazily on their next visit, so the over-invalidation is
+ * cheap.
+ */
+const RENAME_CASCADES: Readonly<Record<string, readonly string[]>> = {
+  artists: [ALL_SHOW_PAGES, ALL_RELEASE_PAGES, ALL_COLLECTION_PAGES],
+  venues: [ALL_SHOW_PAGES, ALL_COLLECTION_PAGES],
+  shows: [ALL_COLLECTION_PAGES],
+  releases: [ALL_COLLECTION_PAGES],
+  labels: [ALL_RELEASE_PAGES, ALL_COLLECTION_PAGES],
+  festivals: [ALL_COLLECTION_PAGES],
+}
+
+/** Cascade route patterns for a segment; empty for types nothing embeds. */
+function cascadePages(segment: string): readonly string[] {
+  return RENAME_CASCADES[segment] ?? []
+}
+
 /** Detail page (when the slug is known) + ISR list page (when one exists). */
 function entityPages(
   segment: string,
@@ -154,9 +200,24 @@ function bodySlugPages(segment: string): RevalidationRule['paths'] {
 }
 
 /**
+ * bodySlugPages + the segment's rename cascade — for update-class rules
+ * where the mutation may have changed the entity's name (which other pages
+ * embed in their ISR payloads).
+ */
+function bodySlugPagesWithCascade(
+  segment: string
+): RevalidationRule['paths'] {
+  return ({ body }) => [
+    ...entityPages(segment, slugOf(body)),
+    ...cascadePages(segment),
+  ]
+}
+
+/**
  * Pages affected by a show mutation: the show itself, the upcoming-show
  * surfaces (/shows, /explore), the /artists and /venues lists (both embed
- * upcoming-show data), and each billed artist's detail page (artist pages
+ * upcoming-show data), every scene page (per-city show counts in
+ * SceneStats), and each billed artist's detail page (artist pages
  * ISR-cache stats.shows_tracked).
  */
 function showPages(body: unknown): Array<string | undefined> {
@@ -167,6 +228,7 @@ function showPages(body: unknown): Array<string | undefined> {
     '/explore',
     '/artists',
     '/venues',
+    ALL_SCENE_PAGES,
     ...nestedSlugs(body, 'artists').map((artistSlug) => `/artists/${artistSlug}`),
   ]
 }
@@ -201,15 +263,23 @@ const RULES: readonly RevalidationRule[] = [
     name: 'show-update',
     methods: ['PUT'],
     pattern: /^\/shows\/\d+$/,
-    paths: ({ body }) => showPages(body),
+    // A title edit also stales collection pages embedding the show's name.
+    paths: ({ body }) => [...showPages(body), ...cascadePages('shows')],
   },
   {
     name: 'show-delete',
     methods: ['DELETE'],
     pattern: /^\/shows\/\d+$/,
     // Empty response body — the show's own page can't be resolved, but every
-    // list surface that embedded it can.
-    paths: () => ['/shows', '/explore', '/artists', '/venues'],
+    // list surface that embedded it can, plus collection pages that listed it.
+    paths: () => [
+      '/shows',
+      '/explore',
+      '/artists',
+      '/venues',
+      ALL_SCENE_PAGES,
+      ...cascadePages('shows'),
+    ],
   },
   {
     name: 'show-status',
@@ -223,6 +293,22 @@ const RULES: readonly RevalidationRule[] = [
     pattern: /^\/admin\/shows\/\d+\/(approve|reject)$/,
     paths: ({ body }) => showPages(body),
   },
+  {
+    name: 'show-batch-moderation',
+    methods: ['POST'],
+    pattern: /^\/admin\/shows\/(batch-approve|batch-reject)$/,
+    // The response carries only counts ({approved/rejected, errors}) — no
+    // slugs — so the affected show pages can't be enumerated. Blast the show
+    // route along with every list surface a (de)published show appears on.
+    paths: () => [
+      ALL_SHOW_PAGES,
+      '/shows',
+      '/explore',
+      '/artists',
+      '/venues',
+      ALL_SCENE_PAGES,
+    ],
+  },
 
   // --- suggest-edit pipeline + moderation --------------------------------
   {
@@ -235,7 +321,8 @@ const RULES: readonly RevalidationRule[] = [
       const record = asRecord(body)
       if (record?.applied !== true) return []
       const slug = stringField(record.pending_edit, 'entity_slug')
-      return entityPages(match[1], slug)
+      // Applied edits may rename the entity → cascade to embedding pages.
+      return [...entityPages(match[1], slug), ...cascadePages(match[1])]
     },
   },
   {
@@ -247,7 +334,11 @@ const RULES: readonly RevalidationRule[] = [
       const entityType = stringField(body, 'entity_type')
       const segment = entityType ? SINGULAR_TO_SEGMENT[entityType] : undefined
       if (!segment) return []
-      return entityPages(segment, stringField(body, 'entity_slug'))
+      // Approved edits may rename the entity → cascade to embedding pages.
+      return [
+        ...entityPages(segment, stringField(body, 'entity_slug')),
+        ...cascadePages(segment),
+      ]
     },
   },
 
@@ -262,26 +353,30 @@ const RULES: readonly RevalidationRule[] = [
     name: 'artist-update',
     methods: ['PATCH'],
     pattern: /^\/admin\/artists\/\d+$/,
-    paths: bodySlugPages('artists'),
+    paths: bodySlugPagesWithCascade('artists'),
   },
   {
     name: 'artist-delete',
     methods: ['DELETE'],
     pattern: /^\/artists\/\d+$/,
-    paths: () => ['/artists'],
+    // The deleted artist disappears from show bills, release credits, and
+    // collection items → cascade to every embedding page.
+    paths: () => ['/artists', ...cascadePages('artists')],
   },
   {
     name: 'artist-merge',
     methods: ['POST'],
     pattern: /^\/admin\/artists\/merge$/,
     // MergeArtistResult carries IDs only; resolve the canonical artist's slug.
+    // Shows/releases/collections that credited the merged artist now show the
+    // canonical one → cascade.
     paths: async ({ body, lookupSlug }) => {
       const canonicalId = asRecord(body)?.canonical_artist_id
       const slug =
         typeof canonicalId === 'number'
           ? await lookupSlug('artists', String(canonicalId))
           : undefined
-      return entityPages('artists', slug)
+      return [...entityPages('artists', slug), ...cascadePages('artists')]
     },
   },
 
@@ -296,13 +391,13 @@ const RULES: readonly RevalidationRule[] = [
     name: 'venue-update',
     methods: ['PUT'],
     pattern: /^\/venues\/\d+$/,
-    paths: bodySlugPages('venues'),
+    paths: bodySlugPagesWithCascade('venues'),
   },
   {
     name: 'venue-delete',
     methods: ['DELETE'],
     pattern: /^\/venues\/\d+$/,
-    paths: () => ['/venues'],
+    paths: () => ['/venues', ...cascadePages('venues')],
   },
   {
     name: 'venue-verify',
@@ -322,7 +417,15 @@ const RULES: readonly RevalidationRule[] = [
     name: 'release-update',
     methods: ['PUT'],
     pattern: /^\/releases\/\d+$/,
-    paths: ({ body }) => releasePages(body),
+    // A title edit also stales collection pages embedding the release's name.
+    paths: ({ body }) => [...releasePages(body), ...cascadePages('releases')],
+  },
+  {
+    name: 'release-delete',
+    methods: ['DELETE'],
+    pattern: /^\/releases\/\d+$/,
+    // No ISR list page for releases; collection pages listing it go stale.
+    paths: () => cascadePages('releases'),
   },
   {
     name: 'release-links',
@@ -347,7 +450,14 @@ const RULES: readonly RevalidationRule[] = [
     name: 'label-update',
     methods: ['PUT'],
     pattern: /^\/labels\/\d+$/,
-    paths: bodySlugPages('labels'),
+    paths: bodySlugPagesWithCascade('labels'),
+  },
+  {
+    name: 'label-delete',
+    methods: ['DELETE'],
+    pattern: /^\/labels\/\d+$/,
+    // Release pages list label credits; collection pages may list the label.
+    paths: () => cascadePages('labels'),
   },
   {
     name: 'label-roster',
@@ -372,7 +482,14 @@ const RULES: readonly RevalidationRule[] = [
     name: 'festival-update',
     methods: ['PUT'],
     pattern: /^\/festivals\/\d+$/,
-    paths: bodySlugPages('festivals'),
+    paths: bodySlugPagesWithCascade('festivals'),
+  },
+  {
+    name: 'festival-delete',
+    methods: ['DELETE'],
+    pattern: /^\/festivals\/\d+$/,
+    // Collection pages may list the festival as an item.
+    paths: () => cascadePages('festivals'),
   },
   {
     name: 'festival-lineup',

--- a/frontend/lib/revalidate-entity.test.ts
+++ b/frontend/lib/revalidate-entity.test.ts
@@ -51,11 +51,19 @@ describe('revalidateArtistDetail', () => {
 })
 
 describe('safeRevalidatePath', () => {
-  it('revalidates the given path', () => {
+  it('revalidates a concrete path with no type argument', () => {
     safeRevalidatePath('/collections/my-list', 'collection-engagement')
 
     expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
     expect(mockRevalidatePath).toHaveBeenCalledWith('/collections/my-list')
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('revalidates a dynamic route pattern with type page (cascade invalidation)', () => {
+    safeRevalidatePath('/shows/[slug]', 'artist-update')
+
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/shows/[slug]', 'page')
     expect(mockCaptureException).not.toHaveBeenCalled()
   })
 

--- a/frontend/lib/revalidate-entity.ts
+++ b/frontend/lib/revalidate-entity.ts
@@ -9,11 +9,20 @@ import * as Sentry from '@sentry/nextjs'
  * the dedicated admin routes (PSY-936) and the proxy revalidation rules
  * engine (PSY-939, lib/proxy-revalidation.ts).
  *
+ * Accepts either a concrete URL path (`/artists/bright-eyes`) or a dynamic
+ * route pattern (`/shows/[slug]`). Patterns invalidate every cached page
+ * under that route on its next visit — used for cascade invalidation when
+ * the affected pages can't be enumerated from the mutation (PSY-941).
+ *
  * `source` identifies the caller in Sentry (an entity type or rule name).
  */
 export function safeRevalidatePath(path: string, source: string): void {
   try {
-    revalidatePath(path)
+    if (isRoutePattern(path)) {
+      revalidatePath(path, 'page')
+    } else {
+      revalidatePath(path)
+    }
   } catch (error) {
     Sentry.captureException(error, {
       level: 'error',
@@ -21,6 +30,16 @@ export function safeRevalidatePath(path: string, source: string): void {
       extra: { path },
     })
   }
+}
+
+/**
+ * Dynamic route patterns (containing a `[segment]`) must pass type 'page' to
+ * revalidatePath; concrete URLs must not pass a type. Real slugs never
+ * contain brackets (backend slugs are kebab-case alphanumerics), so the
+ * bracket is an unambiguous discriminator.
+ */
+function isRoutePattern(path: string): boolean {
+  return path.includes('[')
 }
 
 /**


### PR DESCRIPTION
Closes PSY-941

Fixes the cascade-rename gap left open by PSY-939: an artist/venue/label rename (or merge/delete) left every show, release, and collection page embedding the old name stale for up to 1 hour. Approach chosen over the `cacheTag`/`"use cache"` migration: **blast-radius revalidation** via Next's dynamic-route form `revalidatePath('/shows/[slug]', 'page')` — invalidates every page under a route in one call.

## Why blast-radius (decision context)

- The "precise" alternative (`cacheTag` + data-dependent tags) requires migrating all 9 entity pages from `fetch(next:{revalidate})` to `'use cache'` + `cacheLife()` + `cacheTag()`, with interaction risk against PPR/AuthHydrator (PSY-841), `React.cache` dedup (PSY-796), and the soft-404 proxy (PSY-897). It remains the long-term direction.
- The cascade-lookup alternative is non-viable without backend changes: `ArtistShowResponse`/`VenueShowResponse` carry no slugs, and the shows endpoints cap at `limit=50`.
- Rename-class mutations are rare admin/trusted events; pages regenerate **lazily on next visit** (no regeneration storm). Over-invalidation costs cache misses, never correctness.
- `revalidatePath(path, type?: 'layout' | 'page')` verified against the installed Next 16.1.4 type declarations.

## What's here

**`lib/revalidate-entity.ts`** — `safeRevalidatePath` accepts dynamic route patterns (`/shows/[slug]`) and passes `type: 'page'` for them; concrete paths unchanged. Brackets are an unambiguous discriminator (backend slugs are kebab-case alphanumerics).

**`lib/proxy-revalidation.ts`**:
- `RENAME_CASCADES` map — which route patterns embed which entity type's name, **verified against backend contracts**: show pages embed artist+venue names; release pages embed artist+label names; collection pages embed every item's entity name (`CollectionItemResponse.entity_name`); scene/tag pages embed only counts (no cascade)
- Cascades added to every update/delete/merge/applied-suggest-edit/approved-pending-edit rule
- 3 new delete rules (release/label/festival) — previously nothing to revalidate, now their collection cascade
- Scene pages (`/scenes/[slug]`, per-city show counts) added to all show-mutation rules
- **New `show-batch-moderation` rule** — `POST /admin/shows/batch-(approve|reject)` previously matched no rule (coverage gap found by `/code-review`); responses carry only counts so the rule blasts the show route + list surfaces

## What deliberately does NOT cascade

- Creates (nothing embeds a brand-new entity)
- Venue verify, show status ops (sold-out/cancelled/publish) — no name change
- Collection/tag mutations — collections and tags aren't embedded by name in other ISR pages
- The dedicated admin Bandcamp/Spotify routes — they change URLs, not names (verified: cascade not needed)

## Precision note

Cascades fire on every update-class mutation, not just renames — the engine can't see the old value to detect a rename. Request-body name-field gating was considered and rejected: PUT endpoints may carry unchanged names (no precision gain) and a wrong gate under-invalidates, which is the bug class this fixes. Documented in code.

## Test plan

- [x] `bun run typecheck` clean
- [x] 135 tests pass in affected scopes (8 new: cascade behavior, route-pattern type forwarding, batch moderation, new delete rules)
- [x] Full frontend suite: first run had 1 failure in an unrelated test file (output truncated before the name was captured); immediate re-run passed 5,396/5,396 — consistent with a pre-existing flake, not these changes (affected scopes pass deterministically across 3 runs)
- [x] `/code-review` (5 finder agents) — 2 of 3 correctness angles zero findings; the third's findings verified as intentional conservative over-invalidation; coverage gap (batch-approve) and cleanup findings folded in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
