### PR TITLE
PSY-917: propose-fulfillment entity picker

### DIFF
--- a/backend/internal/api/handlers/community/request.go
+++ b/backend/internal/api/handlers/community/request.go
@@ -188,6 +188,25 @@ func (h *RequestHandler) GetRequestHandler(ctx context.Context, req *GetRequestH
 	}
 
 	resp := buildRequestResponse(request, userVote)
+
+	// PSY-917: resolve the referenced entity to a linkable slug + name so the
+	// pending-fulfillment review panel can render a "View proposed {entity}"
+	// link. Detail-path only — list responses skip this to avoid an N+1
+	// resolve. Resolution failure is non-fatal: the request still renders,
+	// just without the entity link.
+	if request.RequestedEntityID != nil {
+		if ref, refErr := h.requestService.ResolveEntityRef(request.EntityType, *request.RequestedEntityID); refErr != nil {
+			logger.FromContext(ctx).Warn("request_entity_ref_resolve_failed",
+				"request_id", request.ID, "entity_type", request.EntityType,
+				"entity_id", *request.RequestedEntityID, "error", refErr.Error())
+		} else if ref != nil {
+			resp.RequestedEntitySlug = ref.Slug
+			if ref.Name != "" {
+				resp.RequestedEntityName = &ref.Name
+			}
+		}
+	}
+
 	return &GetRequestHandlerResponse{Body: resp}, nil
 }
 

--- a/backend/internal/api/handlers/community/request_test.go
+++ b/backend/internal/api/handlers/community/request_test.go
@@ -9,6 +9,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // ============================================================================
@@ -222,6 +223,108 @@ func TestRequestHandler_Get_ServiceError(t *testing.T) {
 
 	_, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "1"})
 	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// PSY-917: when the request references an entity, the detail handler resolves
+// it to a slug + name so the review panel can render a "View proposed" link.
+func TestRequestHandler_Get_ResolvesProposedEntity(t *testing.T) {
+	entityID := uint(7)
+	slug := "kendrick-lamar"
+	var resolveCalls int
+	h := NewRequestHandler(&testhelpers.MockRequestService{
+		GetRequestFn: func(requestID uint) (*communitym.Request, error) {
+			return &communitym.Request{
+				ID:                requestID,
+				Title:             "Test Request",
+				EntityType:        "artist",
+				RequestedEntityID: &entityID,
+				Status:            communitym.RequestStatusPendingFulfillment,
+				RequesterID:       1,
+			}, nil
+		},
+		ResolveEntityRefFn: func(entityType string, id uint) (*contracts.EntityRef, error) {
+			resolveCalls++
+			if entityType != "artist" || id != entityID {
+				t.Errorf("expected ResolveEntityRef(artist, %d), got (%s, %d)", entityID, entityType, id)
+			}
+			return &contracts.EntityRef{Slug: &slug, Name: "Kendrick Lamar"}, nil
+		},
+	}, nil)
+
+	resp, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "42"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolveCalls != 1 {
+		t.Errorf("expected ResolveEntityRef to be called once, got %d", resolveCalls)
+	}
+	if resp.Body.RequestedEntitySlug == nil || *resp.Body.RequestedEntitySlug != slug {
+		t.Errorf("expected slug %q, got %v", slug, resp.Body.RequestedEntitySlug)
+	}
+	if resp.Body.RequestedEntityName == nil || *resp.Body.RequestedEntityName != "Kendrick Lamar" {
+		t.Errorf("expected name %q, got %v", "Kendrick Lamar", resp.Body.RequestedEntityName)
+	}
+}
+
+// PSY-917: a NULL-slug entity (catalog slug is nullable) resolves with a name
+// but no slug — the handler leaves the slug nil so the frontend suppresses
+// the broken link.
+func TestRequestHandler_Get_ProposedEntityNullSlug(t *testing.T) {
+	entityID := uint(7)
+	h := NewRequestHandler(&testhelpers.MockRequestService{
+		GetRequestFn: func(requestID uint) (*communitym.Request, error) {
+			return &communitym.Request{
+				ID:                requestID,
+				EntityType:        "artist",
+				RequestedEntityID: &entityID,
+				Status:            communitym.RequestStatusPendingFulfillment,
+				RequesterID:       1,
+			}, nil
+		},
+		ResolveEntityRefFn: func(entityType string, id uint) (*contracts.EntityRef, error) {
+			return &contracts.EntityRef{Slug: nil, Name: "No Slug Artist"}, nil
+		},
+	}, nil)
+
+	resp, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "42"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.RequestedEntitySlug != nil {
+		t.Errorf("expected nil slug, got %v", *resp.Body.RequestedEntitySlug)
+	}
+	if resp.Body.RequestedEntityName == nil || *resp.Body.RequestedEntityName != "No Slug Artist" {
+		t.Errorf("expected name to survive, got %v", resp.Body.RequestedEntityName)
+	}
+}
+
+// PSY-917: a stale RequestedEntityID (entity since deleted → resolver returns
+// nil) must not crash the detail fetch; the request renders link-less.
+func TestRequestHandler_Get_ProposedEntityResolveFailureNonFatal(t *testing.T) {
+	entityID := uint(7)
+	h := NewRequestHandler(&testhelpers.MockRequestService{
+		GetRequestFn: func(requestID uint) (*communitym.Request, error) {
+			return &communitym.Request{
+				ID:                requestID,
+				EntityType:        "artist",
+				RequestedEntityID: &entityID,
+				Status:            communitym.RequestStatusPendingFulfillment,
+				RequesterID:       1,
+			}, nil
+		},
+		ResolveEntityRefFn: func(entityType string, id uint) (*contracts.EntityRef, error) {
+			return nil, fmt.Errorf("db blew up")
+		},
+	}, nil)
+
+	resp, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "42"})
+	if err != nil {
+		t.Fatalf("resolver failure should not fail the request fetch, got: %v", err)
+	}
+	if resp.Body.RequestedEntitySlug != nil || resp.Body.RequestedEntityName != nil {
+		t.Errorf("expected no entity ref on resolver failure, got slug=%v name=%v",
+			resp.Body.RequestedEntitySlug, resp.Body.RequestedEntityName)
+	}
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -2711,6 +2711,7 @@ type MockRequestService struct {
 	NotifyRequesterFulfillmentProposedFn func(uint, uint, uint) error
 	CloseRequestFn                       func(uint, uint, bool) error
 	GetUserVoteFn                        func(uint, uint) (*communitym.RequestVote, error)
+	ResolveEntityRefFn                   func(string, uint) (*contracts.EntityRef, error)
 }
 
 func (m *MockRequestService) CreateRequest(userID uint, title string, description string, entityType string, requestedEntityID *uint) (*communitym.Request, error) {
@@ -2805,6 +2806,12 @@ func (m *MockRequestService) CloseRequest(requestID uint, userID uint, isAdmin b
 func (m *MockRequestService) GetUserVote(requestID uint, userID uint) (*communitym.RequestVote, error) {
 	if m.GetUserVoteFn != nil {
 		return m.GetUserVoteFn(requestID, userID)
+	}
+	return nil, nil
+}
+func (m *MockRequestService) ResolveEntityRef(entityType string, entityID uint) (*contracts.EntityRef, error) {
+	if m.ResolveEntityRefFn != nil {
+		return m.ResolveEntityRefFn(entityType, entityID)
 	}
 	return nil, nil
 }

--- a/backend/internal/services/community/request.go
+++ b/backend/internal/services/community/request.go
@@ -11,6 +11,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	communitym "psychic-homily-backend/internal/models/community"
 	notificationm "psychic-homily-backend/internal/models/notification"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // requestEntityTables maps a request's declared entity_type to the
@@ -26,6 +27,20 @@ var requestEntityTables = map[string]string{
 	communitym.RequestEntityRelease:  "releases",
 	communitym.RequestEntityLabel:    "labels",
 	communitym.RequestEntityFestival: "festivals",
+}
+
+// requestEntityNameColumns maps a request's entity_type to the column that
+// holds the entity's human-readable display name. Most catalog tables use
+// `name`, but releases and shows use `title`. Used by ResolveEntityRef to
+// build the "View proposed {entity}" link label without hardcoding the
+// column per call site. Keep aligned with requestEntityTables. PSY-917.
+var requestEntityNameColumns = map[string]string{
+	communitym.RequestEntityArtist:   "name",
+	communitym.RequestEntityVenue:    "name",
+	communitym.RequestEntityShow:     "title",
+	communitym.RequestEntityRelease:  "title",
+	communitym.RequestEntityLabel:    "name",
+	communitym.RequestEntityFestival: "name",
 }
 
 // RequestService handles community request business logic.
@@ -378,6 +393,49 @@ func (s *RequestService) validateFulfillmentEntity(requestID uint, requestType s
 		return apperrors.ErrRequestEntityNotFound(requestID, requestType, entityID)
 	}
 	return nil
+}
+
+// ResolveEntityRef looks up the slug + display name of the entity a request
+// points at (its RequestedEntityID, which after a fulfillment proposal holds
+// the proposed entity). It powers the "View proposed {entity}" link in the
+// pending-fulfillment review panel — entity detail pages route by slug, so
+// the numeric ID stored on the request isn't enough on its own. PSY-917.
+//
+// Returns (nil, nil) — not an error — when entityType is unknown or the row
+// no longer exists, so a stale or unsupported reference degrades to "no
+// link" rather than failing the whole request fetch. A nil/empty slug on the
+// returned ref signals the row exists but isn't linkable (catalog slug is
+// nullable); the handler still surfaces the name and the frontend suppresses
+// the link.
+func (s *RequestService) ResolveEntityRef(entityType string, entityID uint) (*contracts.EntityRef, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	table, ok := requestEntityTables[entityType]
+	if !ok {
+		// Unknown type — nothing to resolve. Not an error: CreateRequest
+		// already gates entity_type, so this is purely defensive.
+		return nil, nil
+	}
+	nameColumn := requestEntityNameColumns[entityType]
+
+	var row struct {
+		Slug *string
+		Name string
+	}
+	err := s.db.Table(table).
+		Select(fmt.Sprintf("slug AS slug, %s AS name", nameColumn)).
+		Where("id = ?", entityID).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to resolve entity ref: %w", err)
+	}
+
+	return &contracts.EntityRef{Slug: row.Slug, Name: row.Name}, nil
 }
 
 // ApproveFulfillment finalizes a pending_fulfillment request, flipping

--- a/backend/internal/services/community/request_test.go
+++ b/backend/internal/services/community/request_test.go
@@ -40,6 +40,33 @@ func createTestVenue(db *gorm.DB) uint {
 	return venue.ID
 }
 
+// createTestArtistWithSlug seeds an artist row carrying an explicit name +
+// slug and returns both. PSY-917 ResolveEntityRef tests need a slug to
+// assert the linkable-ref happy path (the plain createTestArtist helper
+// leaves slug NULL, which exercises the suppress-link branch instead).
+func createTestArtistWithSlug(db *gorm.DB) (id uint, name, slug string) {
+	name = fmt.Sprintf("Slug Artist %d", time.Now().UnixNano())
+	slug = fmt.Sprintf("slug-artist-%d", time.Now().UnixNano())
+	artist := &catalogm.Artist{Name: name, Slug: &slug}
+	if err := db.Create(artist).Error; err != nil {
+		panic(fmt.Sprintf("seed artist-with-slug failed: %v", err))
+	}
+	return artist.ID, name, slug
+}
+
+// createTestReleaseWithSlug seeds a release row (title + slug) and returns
+// both. Releases store their display name in `title`, not `name`, so this
+// proves ResolveEntityRef reads the right column for that entity type.
+func createTestReleaseWithSlug(db *gorm.DB) (id uint, title, slug string) {
+	title = fmt.Sprintf("Slug Release %d", time.Now().UnixNano())
+	slug = fmt.Sprintf("slug-release-%d", time.Now().UnixNano())
+	release := &catalogm.Release{Title: title, Slug: &slug}
+	if err := db.Create(release).Error; err != nil {
+		panic(fmt.Sprintf("seed release-with-slug failed: %v", err))
+	}
+	return release.ID, title, slug
+}
+
 // =============================================================================
 // INTEGRATION TESTS (With Real Database)
 // =============================================================================
@@ -73,6 +100,9 @@ func (suite *RequestServiceIntegrationTestSuite) SetupTest() {
 	_, _ = sqlDB.Exec("DELETE FROM requests")
 	_, _ = sqlDB.Exec("DELETE FROM artists")
 	_, _ = sqlDB.Exec("DELETE FROM venues")
+	// PSY-917: ResolveEntityRef tests seed releases; purge them too so IDs
+	// don't drift across runs.
+	_, _ = sqlDB.Exec("DELETE FROM releases")
 	_, _ = sqlDB.Exec("DELETE FROM notification_log")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
@@ -987,6 +1017,63 @@ func (suite *RequestServiceIntegrationTestSuite) TestNotifyRequesterFulfillmentP
 			notificationm.NotificationEntityRequestFulfillmentProposed, created.ID).
 		Count(&n).Error)
 	suite.Assert().Equal(int64(0), n, "zero requesterID should not write a notification row")
+}
+
+// ============================================================================
+// Test: ResolveEntityRef (PSY-917)
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestResolveEntityRef_ArtistWithSlug() {
+	artistID, name, slug := createTestArtistWithSlug(suite.db)
+
+	ref, err := suite.requestService.ResolveEntityRef("artist", artistID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(ref)
+	suite.Require().NotNil(ref.Slug)
+	suite.Assert().Equal(slug, *ref.Slug)
+	suite.Assert().Equal(name, ref.Name)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestResolveEntityRef_ReleaseUsesTitleColumn() {
+	// Releases store their display name in `title`, not `name`. Proves the
+	// per-type name-column map resolves the right column.
+	releaseID, title, slug := createTestReleaseWithSlug(suite.db)
+
+	ref, err := suite.requestService.ResolveEntityRef("release", releaseID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(ref)
+	suite.Require().NotNil(ref.Slug)
+	suite.Assert().Equal(slug, *ref.Slug)
+	suite.Assert().Equal(title, ref.Name)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestResolveEntityRef_NullSlugSuppressesLink() {
+	// createTestArtist seeds an artist with a NULL slug (no service-level
+	// slug generation in the helper). The ref should still resolve with the
+	// name but a nil Slug so the frontend omits the broken link.
+	artistID := createTestArtist(suite.db)
+
+	ref, err := suite.requestService.ResolveEntityRef("artist", artistID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(ref)
+	suite.Assert().Nil(ref.Slug)
+	suite.Assert().NotEmpty(ref.Name)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestResolveEntityRef_MissingRowReturnsNil() {
+	// A stale RequestedEntityID (entity since deleted) degrades to "no link"
+	// rather than an error.
+	ref, err := suite.requestService.ResolveEntityRef("artist", 999999)
+	suite.Require().NoError(err)
+	suite.Assert().Nil(ref)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestResolveEntityRef_UnknownTypeReturnsNil() {
+	// Defensive: an unsupported entity_type can't be resolved, but it must
+	// not error — CreateRequest already gates the type.
+	ref, err := suite.requestService.ResolveEntityRef("mixtape", 1)
+	suite.Require().NoError(err)
+	suite.Assert().Nil(ref)
 }
 
 // ============================================================================

--- a/backend/internal/services/contracts/request.go
+++ b/backend/internal/services/contracts/request.go
@@ -16,9 +16,23 @@ type RequestResponse struct {
 	Description       *string `json:"description,omitempty"`
 	EntityType        string  `json:"entity_type"`
 	RequestedEntityID *uint   `json:"requested_entity_id,omitempty"`
-	Status            string  `json:"status"`
-	RequesterID       uint    `json:"requester_id"`
-	RequesterName     string  `json:"requester_name"`
+	// RequestedEntitySlug / RequestedEntityName resolve RequestedEntityID to
+	// the linkable slug + display name of the referenced entity. Populated
+	// only by the single-request detail path (GetRequestHandler) when
+	// RequestedEntityID is set and the row still exists — list responses
+	// leave them nil to avoid an N+1 resolve per row. PSY-917.
+	//
+	// Why this is needed: entity detail pages route by SLUG
+	// (/artists/<slug>), not by numeric ID, and the requests table only
+	// stores the ID. Without the resolved slug the "View proposed {entity}"
+	// link in the fulfillment review panel can't be built. Slug is a pointer
+	// because catalog rows can have a NULL slug — when it's nil the frontend
+	// omits the link rather than emitting a broken /artists/<id> href.
+	RequestedEntitySlug *string `json:"requested_entity_slug,omitempty"`
+	RequestedEntityName *string `json:"requested_entity_name,omitempty"`
+	Status              string  `json:"status"`
+	RequesterID         uint    `json:"requester_id"`
+	RequesterName       string  `json:"requester_name"`
 	// RequesterUsername is the requester's username when set — pointer so
 	// the JSON encodes null (not "") for accounts that never set a username.
 	// Frontend uses this to render the byline as a link to /users/:username
@@ -36,6 +50,16 @@ type RequestResponse struct {
 	UserVote          *int       `json:"user_vote,omitempty"`
 	CreatedAt         time.Time  `json:"created_at"`
 	UpdatedAt         time.Time  `json:"updated_at"`
+}
+
+// EntityRef is the resolved, linkable identity of a knowledge-graph entity
+// referenced by a request — the slug used to build its detail-page URL plus
+// its display name. Returned by ResolveEntityRef. Slug is a pointer so the
+// caller can distinguish "row exists but has no slug" (link suppressed) from
+// "resolved with a slug" (link rendered). PSY-917.
+type EntityRef struct {
+	Slug *string
+	Name string
 }
 
 // RequestServiceInterface defines the contract for community request operations.
@@ -74,4 +98,9 @@ type RequestServiceInterface interface {
 	NotifyRequesterFulfillmentProposed(requestID, requesterID, fulfillerID uint) error
 	CloseRequest(requestID, userID uint, isAdmin bool) error
 	GetUserVote(requestID, userID uint) (*communitym.RequestVote, error)
+	// ResolveEntityRef looks up the slug + display name of the entity
+	// referenced by a request (entityType + entityID). Returns nil (no
+	// error) when the row doesn't exist, so a stale RequestedEntityID
+	// degrades to "no link" rather than a 500. PSY-917.
+	ResolveEntityRef(entityType string, entityID uint) (*EntityRef, error)
 }

--- a/frontend/features/requests/components/FulfillmentEntityPicker.test.tsx
+++ b/frontend/features/requests/components/FulfillmentEntityPicker.test.tsx
@@ -1,0 +1,234 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { EntitySearchResult } from '@/lib/hooks/common/useEntitySearch'
+
+// ── Mocks ──────────────────────────────────────────
+
+vi.mock('@/components/shared', () => ({
+  InlineErrorBanner: ({
+    children,
+    testId,
+  }: {
+    children: React.ReactNode
+    testId?: string
+  }) => (
+    <div role="alert" data-testid={testId ?? 'inline-error'}>
+      {children}
+    </div>
+  ),
+}))
+
+const emptyResults = {
+  artists: [] as EntitySearchResult[],
+  venues: [] as EntitySearchResult[],
+  shows: [] as EntitySearchResult[],
+  releases: [] as EntitySearchResult[],
+  labels: [] as EntitySearchResult[],
+  festivals: [] as EntitySearchResult[],
+  tags: [] as EntitySearchResult[],
+}
+
+const mockUseEntitySearch = vi.fn(() => ({
+  data: emptyResults,
+  isSearching: false,
+  searchError: false,
+}))
+vi.mock('@/lib/hooks/common/useEntitySearch', () => ({
+  useEntitySearch: () => mockUseEntitySearch(),
+  ENTITY_SEARCH_UNAVAILABLE_MESSAGE: 'Search is temporarily unavailable.',
+}))
+
+import { FulfillmentEntityPicker } from './FulfillmentEntityPicker'
+
+function artistRow(
+  overrides: Partial<EntitySearchResult> = {}
+): EntitySearchResult {
+  return {
+    id: 1,
+    slug: 'slowdive',
+    name: 'Slowdive',
+    subtitle: 'Reading, UK',
+    entityType: 'artist',
+    href: '/artists/slowdive',
+    ...overrides,
+  }
+}
+
+function setResults(partial: Partial<typeof emptyResults>) {
+  mockUseEntitySearch.mockReturnValue({
+    data: { ...emptyResults, ...partial },
+    isSearching: false,
+    searchError: false,
+  })
+}
+
+describe('FulfillmentEntityPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseEntitySearch.mockReturnValue({
+      data: emptyResults,
+      isSearching: false,
+      searchError: false,
+    })
+  })
+
+  it('confirm is disabled until an entity is selected', async () => {
+    const user = userEvent.setup()
+    setResults({ artists: [artistRow()] })
+    render(
+      <FulfillmentEntityPicker
+        entityType="artist"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByTestId('fulfillment-entity-picker-confirm')
+    ).toBeDisabled()
+
+    await user.type(
+      screen.getByTestId('fulfillment-entity-picker-search-input'),
+      'slow'
+    )
+    await user.click(screen.getByTestId('fulfillment-entity-picker-result-row'))
+
+    expect(
+      screen.getByTestId('fulfillment-entity-picker-confirm')
+    ).toBeEnabled()
+  })
+
+  it('calls onSubmit with the selected entity id', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    setResults({ artists: [artistRow({ id: 777 })] })
+    render(
+      <FulfillmentEntityPicker
+        entityType="artist"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(
+      screen.getByTestId('fulfillment-entity-picker-search-input'),
+      'slow'
+    )
+    await user.click(screen.getByTestId('fulfillment-entity-picker-result-row'))
+    await user.click(screen.getByTestId('fulfillment-entity-picker-confirm'))
+
+    expect(onSubmit).toHaveBeenCalledWith(777)
+  })
+
+  it('scopes results to the request entity_type (ignores other-type matches)', async () => {
+    const user = userEvent.setup()
+    // The hook returns a venue too, but a venue request must only show venues.
+    setResults({
+      artists: [artistRow({ name: 'Should Not Show' })],
+      venues: [
+        {
+          id: 9,
+          slug: 'valley-bar',
+          name: 'Valley Bar',
+          subtitle: 'Phoenix, AZ',
+          entityType: 'venue',
+          href: '/venues/valley-bar',
+        },
+      ],
+    })
+    render(
+      <FulfillmentEntityPicker
+        entityType="venue"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(
+      screen.getByTestId('fulfillment-entity-picker-search-input'),
+      'val'
+    )
+
+    expect(screen.getByText('Valley Bar')).toBeInTheDocument()
+    expect(screen.queryByText('Should Not Show')).not.toBeInTheDocument()
+  })
+
+  it('renders an inline submitError (e.g. backend type-mismatch 400)', () => {
+    render(
+      <FulfillmentEntityPicker
+        entityType="artist"
+        submitError="Entity type does not match the request"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(
+      screen.getByTestId('fulfillment-entity-picker-submit-error')
+    ).toHaveTextContent('Entity type does not match the request')
+  })
+
+  it('surfaces the search-unavailable banner when search errors', async () => {
+    const user = userEvent.setup()
+    mockUseEntitySearch.mockReturnValue({
+      data: emptyResults,
+      isSearching: false,
+      searchError: true,
+    })
+    render(
+      <FulfillmentEntityPicker
+        entityType="artist"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(
+      screen.getByTestId('fulfillment-entity-picker-search-input'),
+      'slow'
+    )
+    expect(
+      screen.getByTestId('fulfillment-entity-picker-search-error')
+    ).toBeInTheDocument()
+  })
+
+  it('clears the selection when the query changes', async () => {
+    const user = userEvent.setup()
+    setResults({ artists: [artistRow()] })
+    render(
+      <FulfillmentEntityPicker
+        entityType="artist"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const input = screen.getByTestId('fulfillment-entity-picker-search-input')
+    await user.type(input, 'slow')
+    await user.click(screen.getByTestId('fulfillment-entity-picker-result-row'))
+    expect(
+      screen.getByTestId('fulfillment-entity-picker-confirm')
+    ).toBeEnabled()
+
+    // Typing again invalidates the prior pick — confirm goes back to disabled.
+    await user.type(input, 'x')
+    expect(
+      screen.getByTestId('fulfillment-entity-picker-confirm')
+    ).toBeDisabled()
+  })
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+    render(
+      <FulfillmentEntityPicker
+        entityType="artist"
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /Cancel/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/frontend/features/requests/components/FulfillmentEntityPicker.tsx
+++ b/frontend/features/requests/components/FulfillmentEntityPicker.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+/**
+ * FulfillmentEntityPicker — PSY-917
+ *
+ * Mandatory entity picker for the "Propose a fulfillment" flow. Proposing a
+ * fulfillment REQUIRES naming a concrete entity (decision locked in PSY-917):
+ * every proposal points at a real graph entity so the requester's review
+ * panel always has a "View proposed {entity}" link. There is no skip/optional
+ * path.
+ *
+ * Scope: results are filtered to the request's own `entity_type` — you can't
+ * propose a venue to fulfill an artist request (the backend rejects the
+ * mismatch with a 400; PSY-748). Scoping the picker up front keeps the user
+ * from picking something that'll only fail on submit.
+ *
+ * Reuses the shared `useEntitySearch` hook (same search surface as the
+ * collections Add-Items picker and the Cmd+K palette) rather than rolling a
+ * parallel search. The hook returns results grouped by type; we read only the
+ * group matching `entityType`.
+ *
+ * The component is selection-only. It calls `onSubmit(entityId)` with the
+ * chosen id; the parent owns the mutation, its pending/error state, and the
+ * surrounding dialog. The backend's type-mismatch / not-found validation
+ * error is passed back in via `submitError` so it renders inline beneath the
+ * confirm button.
+ */
+
+import { useMemo, useState } from 'react'
+import { Search, Check, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { InlineErrorBanner } from '@/components/shared'
+import {
+  useEntitySearch,
+  ENTITY_SEARCH_UNAVAILABLE_MESSAGE,
+  type EntitySearchResult,
+  type EntitySearchResults,
+} from '@/lib/hooks/common/useEntitySearch'
+import { getEntityTypeLabel } from '../types'
+
+/**
+ * Maps a request entity_type to the matching result group on
+ * EntitySearchResults. `tag` is intentionally absent — tags aren't a
+ * requestable entity type (REQUEST_ENTITY_TYPES in ../types).
+ */
+const ENTITY_TYPE_TO_GROUP: Record<
+  string,
+  keyof Omit<EntitySearchResults, 'tags'>
+> = {
+  artist: 'artists',
+  venue: 'venues',
+  show: 'shows',
+  release: 'releases',
+  label: 'labels',
+  festival: 'festivals',
+}
+
+export interface FulfillmentEntityPickerProps {
+  /** The request's entity_type — scopes search results to this type only. */
+  entityType: string
+  /** Disable the confirm button + inputs while the parent mutation is in flight. */
+  isSubmitting?: boolean
+  /**
+   * Backend validation / submit error to surface inline (e.g. the PSY-748
+   * type-mismatch 400). Null when there's nothing to show.
+   */
+  submitError?: string | null
+  /** Fired with the chosen entity's numeric id when the user confirms. */
+  onSubmit: (entityId: number) => void
+  /** Fired when the user backs out without proposing. */
+  onCancel: () => void
+}
+
+export function FulfillmentEntityPicker({
+  entityType,
+  isSubmitting = false,
+  submitError = null,
+  onSubmit,
+  onCancel,
+}: FulfillmentEntityPickerProps) {
+  const [query, setQuery] = useState('')
+  const [selected, setSelected] = useState<EntitySearchResult | null>(null)
+
+  const {
+    data: searchResults,
+    isSearching,
+    searchError,
+  } = useEntitySearch({ query, enabled: true })
+
+  // Only surface results of the request's own entity type. A request for an
+  // unmapped type (shouldn't happen — CreateRequest gates the enum) yields no
+  // rows rather than crashing.
+  const rows: EntitySearchResult[] = useMemo(() => {
+    const group = ENTITY_TYPE_TO_GROUP[entityType]
+    if (!group) return []
+    return searchResults[group]
+  }, [searchResults, entityType])
+
+  const typeLabel = getEntityTypeLabel(entityType).toLowerCase()
+  const trimmedQuery = query.trim()
+
+  return (
+    <div className="space-y-3" data-testid="fulfillment-entity-picker">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder={`Search ${typeLabel}s…`}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            // A new query invalidates the prior selection — the user is
+            // looking for something else.
+            setSelected(null)
+          }}
+          className="pl-9"
+          autoFocus
+          disabled={isSubmitting}
+          data-testid="fulfillment-entity-picker-search-input"
+        />
+      </div>
+
+      {trimmedQuery.length === 0 ? (
+        <p className="py-3 text-center text-sm text-muted-foreground">
+          Search for the {typeLabel} that fulfills this request.
+        </p>
+      ) : trimmedQuery.length < 2 ? (
+        <p className="py-3 text-center text-sm text-muted-foreground">
+          Keep typing to search…
+        </p>
+      ) : isSearching ? (
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : searchError ? (
+        <InlineErrorBanner testId="fulfillment-entity-picker-search-error">
+          {ENTITY_SEARCH_UNAVAILABLE_MESSAGE}
+        </InlineErrorBanner>
+      ) : rows.length === 0 ? (
+        <p className="py-3 text-center text-sm text-muted-foreground">
+          No {typeLabel}s found for &quot;{trimmedQuery}&quot;.
+        </p>
+      ) : (
+        <div
+          className="max-h-64 space-y-1 overflow-y-auto"
+          data-testid="fulfillment-entity-picker-results"
+        >
+          {rows.map((row) => {
+            const isSelected =
+              selected?.entityType === row.entityType && selected?.id === row.id
+            return (
+              <button
+                key={`${row.entityType}-${row.id}`}
+                type="button"
+                onClick={() => setSelected(row)}
+                disabled={isSubmitting}
+                aria-pressed={isSelected}
+                className={cnPickerRow(isSelected)}
+                data-testid="fulfillment-entity-picker-result-row"
+              >
+                <div className="min-w-0 flex-1 text-left">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium">
+                      {row.name}
+                    </span>
+                    <Badge
+                      variant="secondary"
+                      className="shrink-0 px-1.5 py-0 text-[10px]"
+                    >
+                      {getEntityTypeLabel(row.entityType)}
+                    </Badge>
+                  </div>
+                  {row.subtitle && (
+                    <p className="truncate text-xs text-muted-foreground">
+                      {row.subtitle}
+                    </p>
+                  )}
+                </div>
+                {isSelected && (
+                  <Check className="h-4 w-4 shrink-0 text-primary" />
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {selected && (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="fulfillment-entity-picker-selection"
+        >
+          Proposing:{' '}
+          <span className="font-medium text-foreground">{selected.name}</span>
+        </p>
+      )}
+
+      {submitError && (
+        <p
+          className="text-sm text-destructive"
+          data-testid="fulfillment-entity-picker-submit-error"
+        >
+          {submitError}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={() => selected && onSubmit(selected.id)}
+          disabled={!selected || isSubmitting}
+          data-testid="fulfillment-entity-picker-confirm"
+        >
+          {isSubmitting && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+          Propose this {typeLabel}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onCancel}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Row styling kept in a tiny helper so the long conditional className doesn't
+ * bury the JSX. Selected rows get a primary ring + tint; the rest get the
+ * standard hover affordance.
+ */
+function cnPickerRow(isSelected: boolean): string {
+  const base =
+    'flex w-full items-center gap-3 rounded-md p-2 transition-colors disabled:opacity-60'
+  return isSelected
+    ? `${base} bg-primary/10 ring-1 ring-primary`
+    : `${base} hover:bg-muted/50`
+}

--- a/frontend/features/requests/components/RequestDetail.test.tsx
+++ b/frontend/features/requests/components/RequestDetail.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { Request } from '../types'
+import type { EntitySearchResults } from '@/lib/hooks/common/useEntitySearch'
 
 // ── Mocks ──────────────────────────────────────────
 
@@ -62,6 +63,38 @@ vi.mock('@/components/shared', () => ({
     ) : (
       <span>{name}</span>
     ),
+  // PSY-917: FulfillmentEntityPicker renders InlineErrorBanner on a search
+  // outage. Provide a passthrough so the picker mounts in these tests.
+  InlineErrorBanner: ({ children }: { children: React.ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}))
+
+// PSY-917: the propose-fulfillment picker reuses the shared entity-search
+// hook. Mock it so the dialog renders deterministically without real network
+// calls — individual tests override the return value to drive results.
+type EntitySearchStub = {
+  data: EntitySearchResults
+  isSearching: boolean
+  searchError: boolean
+}
+const emptyEntitySearchResults: EntitySearchResults = {
+  artists: [],
+  venues: [],
+  shows: [],
+  releases: [],
+  labels: [],
+  festivals: [],
+  tags: [],
+}
+const mockUseEntitySearch = vi.fn<() => EntitySearchStub>(() => ({
+  data: emptyEntitySearchResults,
+  isSearching: false,
+  searchError: false,
+}))
+vi.mock('@/lib/hooks/common/useEntitySearch', () => ({
+  useEntitySearch: () => mockUseEntitySearch(),
+  ENTITY_SEARCH_UNAVAILABLE_MESSAGE: 'Search is temporarily unavailable.',
 }))
 
 // Hooks — query + mutation stubs. The mutation factories are reset per-test
@@ -82,7 +115,13 @@ type MutationStub = {
   isPending: boolean
   isError?: boolean
   error?: Error | null
+  reset?: ReturnType<typeof vi.fn>
 }
+
+// PSY-917: openProposeModal() calls fulfillMutation.reset() to clear stale
+// error state before opening the picker dialog, so the fulfill stub needs a
+// no-op reset. Shared so the factory + beforeEach agree.
+const mockFulfillReset = vi.fn()
 const mockDeleteMutation = vi.fn<() => MutationStub>(() => ({
   mutate: mockDeleteMutate,
   isPending: false,
@@ -98,6 +137,8 @@ const mockRemoveVoteMutation = vi.fn<() => MutationStub>(() => ({
 const mockFulfillMutation = vi.fn<() => MutationStub>(() => ({
   mutate: mockFulfillMutate,
   isPending: false,
+  error: null,
+  reset: mockFulfillReset,
 }))
 const mockApproveMutation = vi.fn<() => MutationStub>(() => ({
   mutate: mockApproveMutate,
@@ -192,6 +233,8 @@ describe('RequestDetail', () => {
     mockFulfillMutation.mockReturnValue({
       mutate: mockFulfillMutate,
       isPending: false,
+      error: null,
+      reset: mockFulfillReset,
     })
     mockApproveMutation.mockReturnValue({
       mutate: mockApproveMutate,
@@ -211,6 +254,11 @@ describe('RequestDetail', () => {
       mutate: mockUpdateMutate,
       isPending: false,
       error: null,
+    })
+    mockUseEntitySearch.mockReturnValue({
+      data: emptyEntitySearchResults,
+      isSearching: false,
+      searchError: false,
     })
   })
 
@@ -276,17 +324,61 @@ describe('RequestDetail', () => {
       expect(screen.getByText('Shoegaze legends.')).toBeInTheDocument()
     })
 
-    it('links to the requested entity when one is attached', () => {
+    it('links to the requested entity by slug when one is attached (PSY-917)', () => {
+      // Entity pages route by slug, not id, so the link must use the
+      // server-resolved requested_entity_slug. The name is the link label.
       mockUseRequest.mockReturnValue(
         queryResult({
-          data: makeRequest({ entity_type: 'artist', requested_entity_id: 99 }),
+          data: makeRequest({
+            entity_type: 'artist',
+            requested_entity_id: 99,
+            requested_entity_slug: 'slowdive',
+            requested_entity_name: 'Slowdive',
+          }),
+        })
+      )
+      render(<RequestDetail requestId={42} />)
+      const link = screen.getByText(/View requested Slowdive/i).closest('a')
+      expect(link).toHaveAttribute('href', '/artists/slowdive')
+    })
+
+    it('suppresses the entity link when no slug resolved (PSY-917)', () => {
+      // A legacy request with only an id (no slug) must NOT render a dead
+      // /artists/<id> link.
+      mockUseRequest.mockReturnValue(
+        queryResult({
+          data: makeRequest({
+            entity_type: 'artist',
+            requested_entity_id: 99,
+            requested_entity_slug: null,
+          }),
+        })
+      )
+      render(<RequestDetail requestId={42} />)
+      expect(screen.queryByText(/View requested/i)).not.toBeInTheDocument()
+    })
+
+    it('shows a "View proposed {entity}" link in the review panel (PSY-917)', () => {
+      // Requester reviewing a pending_fulfillment proposal sees a link to the
+      // proposed entity, keyed off the resolved slug.
+      mockUseRequest.mockReturnValue(
+        queryResult({
+          data: makeRequest({
+            entity_type: 'artist',
+            status: 'pending_fulfillment',
+            fulfiller_name: 'contributor-cara',
+            requested_entity_id: 99,
+            requested_entity_slug: 'slowdive',
+            requested_entity_name: 'Slowdive',
+          }),
         })
       )
       render(<RequestDetail requestId={42} />)
       const link = screen
-        .getByText(/View requested artist/i)
+        .getByTestId('review-panel-proposed-entity-link')
         .closest('a')
-      expect(link).toHaveAttribute('href', '/artists/99')
+      expect(link).toHaveAttribute('href', '/artists/slowdive')
+      expect(link).toHaveTextContent(/View proposed Slowdive/i)
     })
 
     it('renders fulfillment info for a fulfilled request', () => {
@@ -441,9 +533,8 @@ describe('RequestDetail', () => {
       confirmSpy.mockRestore()
     })
 
-    it('fulfills immediately without a confirm prompt', async () => {
+    it('opens the entity picker instead of submitting immediately (PSY-917)', async () => {
       const user = userEvent.setup()
-      const confirmSpy = vi.spyOn(window, 'confirm')
       mockAuthContext.mockReturnValue({
         user: { id: '99', is_admin: true },
         isAuthenticated: true,
@@ -452,10 +543,107 @@ describe('RequestDetail', () => {
       })
       render(<RequestDetail requestId={42} />)
 
-      await user.click(screen.getByRole('button', { name: /Fulfill/i }))
-      expect(mockFulfillMutate).toHaveBeenCalledWith({ requestId: 42 })
-      expect(confirmSpy).not.toHaveBeenCalled()
-      confirmSpy.mockRestore()
+      // Clicking "Propose a fulfillment" must NOT submit — it opens the
+      // mandatory-entity picker. The mutation only fires after a pick.
+      await user.click(
+        screen.getByRole('button', { name: /Propose a fulfillment/i })
+      )
+      expect(mockFulfillMutate).not.toHaveBeenCalled()
+      expect(
+        screen.getByTestId('fulfillment-entity-picker')
+      ).toBeInTheDocument()
+    })
+
+    it('submits the picked entity id as fulfilled_entity_id (PSY-917)', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      // One artist result so the picker has something to select.
+      mockUseEntitySearch.mockReturnValue({
+        data: {
+          ...emptyEntitySearchResults,
+          artists: [
+            {
+              id: 555,
+              slug: 'slowdive',
+              name: 'Slowdive',
+              subtitle: 'Reading, UK',
+              entityType: 'artist',
+              href: '/artists/slowdive',
+            },
+          ],
+        },
+        isSearching: false,
+        searchError: false,
+      })
+      render(<RequestDetail requestId={42} />)
+
+      await user.click(
+        screen.getByRole('button', { name: /Propose a fulfillment/i })
+      )
+      // Type to trigger the results render (the picker gates rows behind a
+      // 2-char query even though the hook is mocked).
+      await user.type(
+        screen.getByTestId('fulfillment-entity-picker-search-input'),
+        'slow'
+      )
+      await user.click(screen.getByTestId('fulfillment-entity-picker-result-row'))
+      await user.click(
+        screen.getByTestId('fulfillment-entity-picker-confirm')
+      )
+
+      expect(mockFulfillMutate).toHaveBeenCalledWith(
+        { requestId: 42, fulfilled_entity_id: 555 },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      )
+    })
+
+    it('disables the confirm button until an entity is picked (PSY-917)', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestDetail requestId={42} />)
+
+      await user.click(
+        screen.getByRole('button', { name: /Propose a fulfillment/i })
+      )
+      // Nothing selected yet — confirm is disabled (mandatory picker).
+      expect(
+        screen.getByTestId('fulfillment-entity-picker-confirm')
+      ).toBeDisabled()
+    })
+
+    it('surfaces the backend type-mismatch error inline in the picker (PSY-917)', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      // Fulfill mutation is in an error state (e.g. PSY-748 400 mismatch).
+      mockFulfillMutation.mockReturnValue({
+        mutate: mockFulfillMutate,
+        isPending: false,
+        error: new Error('Entity type does not match the request'),
+        reset: mockFulfillReset,
+      })
+      render(<RequestDetail requestId={42} />)
+
+      await user.click(
+        screen.getByRole('button', { name: /Propose a fulfillment/i })
+      )
+      expect(
+        screen.getByTestId('fulfillment-entity-picker-submit-error')
+      ).toHaveTextContent('Entity type does not match the request')
     })
 
     it('closes the request after confirmation', async () => {

--- a/frontend/features/requests/components/RequestDetail.test.tsx
+++ b/frontend/features/requests/components/RequestDetail.test.tsx
@@ -379,6 +379,41 @@ describe('RequestDetail', () => {
         .closest('a')
       expect(link).toHaveAttribute('href', '/artists/slowdive')
       expect(link).toHaveTextContent(/View proposed Slowdive/i)
+      // The main entity-link block is suppressed for the requester while the
+      // review panel owns the link — so exactly ONE "View proposed" link
+      // renders, not two.
+      expect(screen.getAllByText(/View proposed Slowdive/i)).toHaveLength(1)
+    })
+
+    it('shows the proposed link in the main block for a non-reviewer (PSY-917)', () => {
+      // A viewer who is NOT the requester/admin sees the proposed entity via
+      // the main block (no review panel for them).
+      mockAuthContext.mockReturnValue({
+        user: { id: '77', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockUseRequest.mockReturnValue(
+        queryResult({
+          data: makeRequest({
+            entity_type: 'artist',
+            status: 'pending_fulfillment',
+            requester_id: 1,
+            fulfiller_name: 'contributor-cara',
+            requested_entity_id: 99,
+            requested_entity_slug: 'slowdive',
+            requested_entity_name: 'Slowdive',
+          }),
+        })
+      )
+      render(<RequestDetail requestId={42} />)
+      // No review panel for a non-reviewer; the main block carries the link.
+      expect(
+        screen.queryByTestId('review-panel-proposed-entity-link')
+      ).not.toBeInTheDocument()
+      const link = screen.getByText(/View proposed Slowdive/i).closest('a')
+      expect(link).toHaveAttribute('href', '/artists/slowdive')
     })
 
     it('renders fulfillment info for a fulfilled request', () => {

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -42,13 +42,15 @@ import {
 } from '../hooks'
 import {
   getEntityTypeLabel,
+  getEntityTypeArticle,
   getEntityTypeColor,
   getStatusLabel,
   getStatusColor,
-  getEntityUrl,
+  getEntityUrlBySlug,
   formatTimeAgo,
   formatDate,
 } from '../types'
+import { FulfillmentEntityPicker } from './FulfillmentEntityPicker'
 
 interface RequestDetailProps {
   requestId: number
@@ -68,6 +70,10 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
 
   const [isEditing, setIsEditing] = useState(false)
   const [isRejectModalOpen, setIsRejectModalOpen] = useState(false)
+  // PSY-917: the "Propose a fulfillment" picker dialog. Proposing requires
+  // naming a concrete entity, so the button opens this picker rather than
+  // submitting directly.
+  const [isProposeModalOpen, setIsProposeModalOpen] = useState(false)
 
   if (isLoading) {
     return (
@@ -169,8 +175,19 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
     }
   }
 
-  const handleFulfill = () => {
-    fulfillMutation.mutate({ requestId: request.id })
+  // PSY-917: a proposal MUST name a concrete entity (picker is mandatory).
+  // The selected entity id flows through as fulfilled_entity_id; the backend
+  // validates type-match (PSY-748) and any 400 surfaces inline in the picker.
+  const handleProposeFulfillment = (entityId: number) => {
+    fulfillMutation.mutate(
+      { requestId: request.id, fulfilled_entity_id: entityId },
+      { onSuccess: () => setIsProposeModalOpen(false) }
+    )
+  }
+
+  const openProposeModal = () => {
+    fulfillMutation.reset()
+    setIsProposeModalOpen(true)
   }
 
   const handleApprove = () => {
@@ -303,21 +320,41 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                     </p>
                   )}
 
-                  {/* Requested entity link */}
-                  {request.requested_entity_id && (
-                    <div className="mt-4">
-                      <Link
-                        href={getEntityUrl(
-                          request.entity_type,
-                          request.requested_entity_id
-                        )}
-                        className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
-                      >
-                        <ExternalLink className="h-3.5 w-3.5" />
-                        View requested {getEntityTypeLabel(request.entity_type).toLowerCase()}
-                      </Link>
-                    </div>
-                  )}
+                  {/*
+                    Linked entity. The requests table reuses requested_entity_id
+                    for BOTH the originally-requested entity AND (after a
+                    proposal) the fulfiller's proposed entity, so the link's
+                    label depends on status: "proposed" while pending review,
+                    "requested" otherwise. We key off the server-resolved slug
+                    (PSY-917) — entity pages route by slug, not id — and render
+                    nothing when the slug is null (entity has no slug / was
+                    deleted) so we never emit a dead link.
+                    The dedicated review panel below ALSO surfaces this link for
+                    the requester; this block covers every other viewer.
+                  */}
+                  {(() => {
+                    const entityUrl = getEntityUrlBySlug(
+                      request.entity_type,
+                      request.requested_entity_slug
+                    )
+                    if (!entityUrl) return null
+                    const isProposed =
+                      request.status === 'pending_fulfillment'
+                    const label =
+                      request.requested_entity_name ??
+                      getEntityTypeLabel(request.entity_type).toLowerCase()
+                    return (
+                      <div className="mt-4">
+                        <Link
+                          href={entityUrl}
+                          className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                          View {isProposed ? 'proposed' : 'requested'} {label}
+                        </Link>
+                      </div>
+                    )
+                  })()}
 
                   {/* Fulfillment info */}
                   {request.status === 'fulfilled' && (
@@ -357,13 +394,34 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                         </p>
                       )}
                       {/*
-                        PSY-891: no "view proposed entity" link here yet — the
-                        current "Propose a fulfillment" flow doesn't capture a
-                        distinct entity (it submits without fulfilled_entity_id),
-                        so request.requested_entity_id holds the ORIGINAL request
-                        target, not what the fulfiller proposed. A propose-with-
-                        entity-picker flow is the follow-up (see PSY-891 comment).
+                        PSY-917: the propose flow now captures a concrete entity
+                        (fulfilled_entity_id), stored on the request and resolved
+                        server-side to a slug + name. Surface it as a "View
+                        proposed {entity}" link so the requester can inspect what
+                        was proposed before approving. Suppressed only when the
+                        slug didn't resolve (legacy proposals from before this
+                        shipped carried no entity; entity since deleted).
                       */}
+                      {(() => {
+                        const proposedUrl = getEntityUrlBySlug(
+                          request.entity_type,
+                          request.requested_entity_slug
+                        )
+                        if (!proposedUrl) return null
+                        const label =
+                          request.requested_entity_name ??
+                          getEntityTypeLabel(request.entity_type).toLowerCase()
+                        return (
+                          <Link
+                            href={proposedUrl}
+                            className="mt-2 inline-flex items-center gap-1.5 text-sm text-primary transition-colors hover:text-primary/80"
+                            data-testid="review-panel-proposed-entity-link"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                            View proposed {label}
+                          </Link>
+                        )
+                      })()}
                       <div className="mt-3 flex items-center gap-2">
                         <Button
                           size="sm"
@@ -418,7 +476,7 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                       </p>
                       <Button
                         size="sm"
-                        onClick={handleFulfill}
+                        onClick={openProposeModal}
                         disabled={fulfillMutation.isPending}
                       >
                         {fulfillMutation.isPending && (
@@ -511,6 +569,40 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
               Reject fulfillment
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* PSY-917: propose-fulfillment entity picker. Mandatory entity selection
+          — the request can only enter pending_fulfillment with a concrete
+          proposed entity so the requester's review always has something to
+          inspect. */}
+      <Dialog open={isProposeModalOpen} onOpenChange={setIsProposeModalOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Propose {getEntityTypeArticle(request.entity_type)}{' '}
+              {getEntityTypeLabel(request.entity_type).toLowerCase()}
+            </DialogTitle>
+            <DialogDescription>
+              Pick the{' '}
+              {getEntityTypeLabel(request.entity_type).toLowerCase()} in the
+              graph that fulfills this request. The requester reviews and
+              approves your proposal.
+            </DialogDescription>
+          </DialogHeader>
+          <FulfillmentEntityPicker
+            entityType={request.entity_type}
+            isSubmitting={fulfillMutation.isPending}
+            submitError={
+              fulfillMutation.error
+                ? fulfillMutation.error instanceof Error
+                  ? fulfillMutation.error.message
+                  : 'Failed to propose a fulfillment'
+                : null
+            }
+            onSubmit={handleProposeFulfillment}
+            onCancel={() => setIsProposeModalOpen(false)}
+          />
         </DialogContent>
       </Dialog>
     </div>

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -139,6 +139,21 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
   // original requester or an admin, and only when one is pending review.
   const canReviewFulfillment =
     request.status === 'pending_fulfillment' && (isRequester || isAdmin)
+
+  // PSY-917: the linkable identity of the entity this request references. The
+  // requests table reuses requested_entity_id for both the originally-requested
+  // entity and (after a proposal) the fulfiller's proposed entity; the backend
+  // resolves it to a slug + name on the detail fetch. `url` is null when no
+  // slug resolved (entity has no slug / was deleted) so callers suppress the
+  // link rather than emit a dead /type/<id> href. Single-sourced so the main
+  // entity-link block and the review panel can't drift.
+  const proposedEntityUrl = getEntityUrlBySlug(
+    request.entity_type,
+    request.requested_entity_slug
+  )
+  const proposedEntityLabel =
+    request.requested_entity_name ??
+    getEntityTypeLabel(request.entity_type).toLowerCase()
   const canClose = isAdmin && request.status !== 'cancelled' && request.status !== 'fulfilled'
 
   const userVote = request.user_vote ?? 0
@@ -335,30 +350,21 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                     Every OTHER viewer of a pending_fulfillment request gets the
                     link here.
                   */}
-                  {!canReviewFulfillment &&
-                    (() => {
-                      const entityUrl = getEntityUrlBySlug(
-                        request.entity_type,
-                        request.requested_entity_slug
-                      )
-                      if (!entityUrl) return null
-                      const isProposed =
-                        request.status === 'pending_fulfillment'
-                      const label =
-                        request.requested_entity_name ??
-                        getEntityTypeLabel(request.entity_type).toLowerCase()
-                      return (
-                        <div className="mt-4">
-                          <Link
-                            href={entityUrl}
-                            className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                            View {isProposed ? 'proposed' : 'requested'} {label}
-                          </Link>
-                        </div>
-                      )
-                    })()}
+                  {!canReviewFulfillment && proposedEntityUrl && (
+                    <div className="mt-4">
+                      <Link
+                        href={proposedEntityUrl}
+                        className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                        View{' '}
+                        {request.status === 'pending_fulfillment'
+                          ? 'proposed'
+                          : 'requested'}{' '}
+                        {proposedEntityLabel}
+                      </Link>
+                    </div>
+                  )}
 
                   {/* Fulfillment info */}
                   {request.status === 'fulfilled' && (
@@ -406,26 +412,16 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                         slug didn't resolve (legacy proposals from before this
                         shipped carried no entity; entity since deleted).
                       */}
-                      {(() => {
-                        const proposedUrl = getEntityUrlBySlug(
-                          request.entity_type,
-                          request.requested_entity_slug
-                        )
-                        if (!proposedUrl) return null
-                        const label =
-                          request.requested_entity_name ??
-                          getEntityTypeLabel(request.entity_type).toLowerCase()
-                        return (
-                          <Link
-                            href={proposedUrl}
-                            className="mt-2 inline-flex items-center gap-1.5 text-sm text-primary transition-colors hover:text-primary/80"
-                            data-testid="review-panel-proposed-entity-link"
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                            View proposed {label}
-                          </Link>
-                        )
-                      })()}
+                      {proposedEntityUrl && (
+                        <Link
+                          href={proposedEntityUrl}
+                          className="mt-2 inline-flex items-center gap-1.5 text-sm text-primary transition-colors hover:text-primary/80"
+                          data-testid="review-panel-proposed-entity-link"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                          View proposed {proposedEntityLabel}
+                        </Link>
+                      )}
                       <div className="mt-3 flex items-center gap-2">
                         <Button
                           size="sm"

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -329,32 +329,36 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
                     (PSY-917) — entity pages route by slug, not id — and render
                     nothing when the slug is null (entity has no slug / was
                     deleted) so we never emit a dead link.
-                    The dedicated review panel below ALSO surfaces this link for
-                    the requester; this block covers every other viewer.
+                    Suppressed for the requester/admin while a proposal is under
+                    review: the dedicated review panel below owns the "View
+                    proposed" link for them, so this block would duplicate it.
+                    Every OTHER viewer of a pending_fulfillment request gets the
+                    link here.
                   */}
-                  {(() => {
-                    const entityUrl = getEntityUrlBySlug(
-                      request.entity_type,
-                      request.requested_entity_slug
-                    )
-                    if (!entityUrl) return null
-                    const isProposed =
-                      request.status === 'pending_fulfillment'
-                    const label =
-                      request.requested_entity_name ??
-                      getEntityTypeLabel(request.entity_type).toLowerCase()
-                    return (
-                      <div className="mt-4">
-                        <Link
-                          href={entityUrl}
-                          className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
-                        >
-                          <ExternalLink className="h-3.5 w-3.5" />
-                          View {isProposed ? 'proposed' : 'requested'} {label}
-                        </Link>
-                      </div>
-                    )
-                  })()}
+                  {!canReviewFulfillment &&
+                    (() => {
+                      const entityUrl = getEntityUrlBySlug(
+                        request.entity_type,
+                        request.requested_entity_slug
+                      )
+                      if (!entityUrl) return null
+                      const isProposed =
+                        request.status === 'pending_fulfillment'
+                      const label =
+                        request.requested_entity_name ??
+                        getEntityTypeLabel(request.entity_type).toLowerCase()
+                      return (
+                        <div className="mt-4">
+                          <Link
+                            href={entityUrl}
+                            className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                            View {isProposed ? 'proposed' : 'requested'} {label}
+                          </Link>
+                        </div>
+                      )
+                    })()}
 
                   {/* Fulfillment info */}
                   {request.status === 'fulfilled' && (

--- a/frontend/features/requests/components/index.ts
+++ b/frontend/features/requests/components/index.ts
@@ -1,3 +1,4 @@
 export { RequestCard } from './RequestCard'
 export { RequestDetail } from './RequestDetail'
 export { RequestList } from './RequestList'
+export { FulfillmentEntityPicker } from './FulfillmentEntityPicker'

--- a/frontend/features/requests/index.ts
+++ b/frontend/features/requests/index.ts
@@ -11,10 +11,12 @@ export {
   REQUEST_STATUSES,
   REQUEST_SORT_OPTIONS,
   getEntityTypeLabel,
+  getEntityTypeArticle,
   getStatusLabel,
   getEntityTypeColor,
   getStatusColor,
   getEntityUrl,
+  getEntityUrlBySlug,
   formatTimeAgo,
   formatDate,
 } from './types'

--- a/frontend/features/requests/types.test.ts
+++ b/frontend/features/requests/types.test.ts
@@ -4,10 +4,12 @@ import {
   REQUEST_STATUSES,
   REQUEST_SORT_OPTIONS,
   getEntityTypeLabel,
+  getEntityTypeArticle,
   getStatusLabel,
   getEntityTypeColor,
   getStatusColor,
   getEntityUrl,
+  getEntityUrlBySlug,
   formatTimeAgo,
   formatDate,
 } from './types'
@@ -126,6 +128,42 @@ describe('getEntityUrl', () => {
 
   it('returns "#" for an unknown entity type', () => {
     expect(getEntityUrl('mixtape', 7)).toBe('#')
+  })
+})
+
+describe('getEntityTypeArticle', () => {
+  it('returns "an" for the vowel-initial label (artist)', () => {
+    expect(getEntityTypeArticle('artist')).toBe('an')
+  })
+
+  it.each(['venue', 'show', 'release', 'label', 'festival'])(
+    'returns "a" for consonant-initial label (%s)',
+    (type) => {
+      expect(getEntityTypeArticle(type)).toBe('a')
+    }
+  )
+})
+
+describe('getEntityUrlBySlug', () => {
+  it.each([
+    ['artist', 'slowdive', '/artists/slowdive'],
+    ['venue', 'valley-bar', '/venues/valley-bar'],
+    ['show', 'a-show', '/shows/a-show'],
+    ['release', 'souvlaki', '/releases/souvlaki'],
+    ['label', 'creation', '/labels/creation'],
+    ['festival', 'fyf', '/festivals/fyf'],
+  ])('builds %s url from slug', (type, slug, expected) => {
+    expect(getEntityUrlBySlug(type, slug)).toBe(expected)
+  })
+
+  it('returns null for an unknown entity type', () => {
+    expect(getEntityUrlBySlug('mixtape', 'foo')).toBeNull()
+  })
+
+  it('returns null for an empty/nullish slug so the caller can suppress the link', () => {
+    expect(getEntityUrlBySlug('artist', null)).toBeNull()
+    expect(getEntityUrlBySlug('artist', undefined)).toBeNull()
+    expect(getEntityUrlBySlug('artist', '')).toBeNull()
   })
 })
 

--- a/frontend/features/requests/types.ts
+++ b/frontend/features/requests/types.ts
@@ -29,6 +29,17 @@ export interface Request {
   description?: string
   entity_type: string
   requested_entity_id?: number
+  /**
+   * PSY-917: slug + display name of the entity `requested_entity_id` points
+   * at, resolved server-side on the single-request detail fetch (null on
+   * list rows). After a fulfillment is proposed with an entity, this is the
+   * PROPOSED entity. Entity detail pages route by slug, so the slug — not the
+   * numeric id — is what builds a working "View proposed {entity}" link. Slug
+   * is nullable because catalog rows can lack a slug; when null, suppress the
+   * link. Name is the label for the link text.
+   */
+  requested_entity_slug?: string | null
+  requested_entity_name?: string | null
   status: string
   requester_id: number
   requester_name: string
@@ -76,6 +87,18 @@ export function getEntityTypeLabel(entityType: string): string {
     default:
       return entityType
   }
+}
+
+/**
+ * Helper: the indefinite article ("a"/"an") for an entity type's label, so UI
+ * copy reads "Propose an artist" / "Propose a venue" instead of the
+ * always-"a" version. Of the six request entity types only "artist" starts
+ * with a vowel sound, but we check the resolved label's first letter so the
+ * helper stays correct if the label set grows. PSY-917.
+ */
+export function getEntityTypeArticle(entityType: string): 'a' | 'an' {
+  const first = getEntityTypeLabel(entityType).charAt(0).toLowerCase()
+  return 'aeiou'.includes(first) ? 'an' : 'a'
 }
 
 /** Helper: get a display label for a request status */
@@ -158,7 +181,15 @@ export function formatDate(dateString: string): string {
   })
 }
 
-/** Helper: build entity URL from entity type and ID */
+/**
+ * Helper: build an entity URL from entity type and ID.
+ *
+ * @deprecated PSY-917 — entity detail pages route by SLUG, not numeric ID, so
+ * a `/artists/<id>` URL doesn't resolve (the backend looks rows up by slug).
+ * Use {@link getEntityUrlBySlug} with the resolved `requested_entity_slug`
+ * instead. Retained only so the historical signature stays covered; not used
+ * for any live link.
+ */
 export function getEntityUrl(entityType: string, entityId: number): string {
   switch (entityType) {
     case 'artist':
@@ -175,5 +206,36 @@ export function getEntityUrl(entityType: string, entityId: number): string {
       return `/festivals/${entityId}`
     default:
       return '#'
+  }
+}
+
+/**
+ * Helper: build an entity detail URL from entity type and SLUG.
+ *
+ * This is the correct way to link to a knowledge-graph entity — detail pages
+ * are `/<type>/[slug]` routes resolved against the slug column. Returns null
+ * for an unknown type or an empty slug so callers can suppress the link
+ * rather than emit a dead `#` href. PSY-917.
+ */
+export function getEntityUrlBySlug(
+  entityType: string,
+  slug: string | null | undefined
+): string | null {
+  if (!slug) return null
+  switch (entityType) {
+    case 'artist':
+      return `/artists/${slug}`
+    case 'venue':
+      return `/venues/${slug}`
+    case 'show':
+      return `/shows/${slug}`
+    case 'release':
+      return `/releases/${slug}`
+    case 'label':
+      return `/labels/${slug}`
+    case 'festival':
+      return `/festivals/${slug}`
+    default:
+      return null
   }
 }


### PR DESCRIPTION
## Summary
- Proposing a fulfillment now REQUIRES naming a concrete entity via a mandatory picker (`FulfillmentEntityPicker`), scoped to the request's `entity_type` and reusing the shared `useEntitySearch` hook. Confirm is disabled until an entity is selected.
- The selected entity id flows through `useFulfillRequest` as `fulfilled_entity_id`; the backend's PSY-748 type-mismatch / not-found 400 surfaces inline in the picker.
- Restored the "View proposed {entity}" link in the review panel, keyed off the actual proposed entity.
- **Bug found + fixed along the way:** entity detail pages route by SLUG, not numeric id, so the prior `getEntityUrl(entity_type, id)` link (`/artists/123`) never resolved. Added `getEntityUrlBySlug` + a server-resolved `requested_entity_slug` / `requested_entity_name` on the Request contract; live links now use the slug and suppress when none resolved.
- Backend: `RequestResponse` gains `requested_entity_slug` + `requested_entity_name`, resolved by `GetRequest` (detail path only — list paths skip it to avoid an N+1) via new `RequestService.ResolveEntityRef`, which reads `title` vs `name` per entity type and degrades to "no link" on a missing/unknown/null-slug row. Resolution failure is non-fatal to the request fetch.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/community/... ./internal/api/handlers/community/...` — passed (incl. new `ResolveEntityRef` integration + handler tests)
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run features/requests` — 131 passed (picker, RequestDetail flow, types helpers)
- [x] `/adversarial-review` — CONCERNS (1 MEDIUM addressed in a separate commit)

## Manual repro
Brought up the isolated dispatch stack, seeded an open artist request, and exercised the full flow end-to-end via agent-browser. Screenshots in `dogfood-output/PSY-917/screenshots/`:
- `01-picker-open-disabled.png` — picker opens scoped to artists, "Propose this artist" disabled (mandatory selection).
- `03-picker-selected-enabled.png` — Calexico selected, confirm enabled, "Proposing: Calexico".
- `04-review-panel-with-proposed-link.png` — requester/admin review panel showing the restored **"View proposed Calexico"** link + Approve/Reject.
- `05-proposed-entity-page-resolves.png` — the proposed link target (`/artists/calexico`) resolves to the real Calexico artist page, proving the slug-based link works.

DB after proposal: `status=pending_fulfillment, requested_entity_id=1 (Calexico), fulfiller_id=2`. Both rendered "View proposed" links resolved to `/artists/calexico`.

## Code review
`/code-review` (9 angles + sweep, inline) — 1 CONFIRMED finding: the requester saw the "View proposed" link twice (main block + review panel); fixed by suppressing the main block when the review panel owns it. SQL-injection concern on `ResolveEntityRef`'s `fmt.Sprintf` refuted (table/column from hardcoded internal maps).

## Adversarial review
`/adversarial-review` — CONCERNS, 1 finding addressed in separate commit `945bb1d8`.
- [MEDIUM] Future-Maintainer: proposed-entity slug→url + name→label logic duplicated across two link blocks → extracted to single `proposedEntityUrl` / `proposedEntityLabel` derivations.
Saboteur · Security · Completeness returned CLEAN (no SQL injection — hardcoded maps; resolved slug/name are public catalog fields; PSY-748 still gates the id; all 5 acceptance criteria met). Run inline (no Agent tool in a worktree).

Closes PSY-917


## Screenshots

**1. Mandatory picker, nothing selected** — "Propose a fulfillment" opens the picker scoped to artists; the confirm button is disabled until an entity is picked.

![Picker open with confirm disabled](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-029ba63ec9ab1e5cb79d/01-picker-open-disabled.png)

**2. Entity selected** — Calexico searched and selected; "Proposing: Calexico" with the confirm button now enabled.

![Picker with Calexico selected and confirm enabled](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-029ba63ec9ab1e5cb79d/03-picker-selected-enabled.png)

**3. Requester's review panel** — the restored "View proposed Calexico" link alongside Approve fulfillment / Reject. *Note: this capture predates the code-review fix commit — it shows the proposed-entity link twice (main block + review panel); the shipped code suppresses the main-block copy when the review panel owns it.*

![Review panel with View proposed Calexico link](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-029ba63ec9ab1e5cb79d/04-review-panel-with-proposed-link.png)

**4. The proposed link resolves** — clicking through lands on the real `/artists/calexico` page, proving the new slug-based link works (the old numeric-id link `/artists/123` never resolved).

![Calexico artist page resolved from the proposed link](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-029ba63ec9ab1e5cb79d/05-proposed-entity-page-resolves.png)
