### PR TITLE
PSY-940: collection tagging revalidates the collection ISR page

### DIFF
--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -119,7 +119,7 @@ func (h *CollectionHandler) ListCollectionsHandler(ctx context.Context, req *Lis
 
 // GetCollectionHandlerRequest represents the request for getting a single collection
 type GetCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug or numeric ID" example:"my-favorite-artists"`
 }
 
 // GetCollectionHandlerResponse represents the response for the get collection endpoint
@@ -127,7 +127,8 @@ type GetCollectionHandlerResponse struct {
 	Body *contracts.CollectionDetailResponse
 }
 
-// GetCollectionHandler handles GET /collections/{slug}
+// GetCollectionHandler handles GET /collections/{slug} - returns a single
+// collection by slug or numeric ID
 func (h *CollectionHandler) GetCollectionHandler(ctx context.Context, req *GetCollectionHandlerRequest) (*GetCollectionHandlerResponse, error) {
 	var viewerID uint
 	user := middleware.GetUserFromContext(ctx)
@@ -135,7 +136,15 @@ func (h *CollectionHandler) GetCollectionHandler(ctx context.Context, req *GetCo
 		viewerID = user.ID
 	}
 
-	collection, err := h.collectionService.GetBySlug(req.Slug, viewerID)
+	// Try to parse as numeric ID first (PSY-940), matching the other entity
+	// GET handlers; fall back to slug lookup.
+	var collection *contracts.CollectionDetailResponse
+	var err error
+	if id, parseErr := strconv.ParseUint(req.Slug, 10, 32); parseErr == nil {
+		collection, err = h.collectionService.GetByID(uint(id), viewerID)
+	} else {
+		collection, err = h.collectionService.GetBySlug(req.Slug, viewerID)
+	}
 	if err != nil {
 		return nil, shared.MapCollectionError(err)
 	}

--- a/backend/internal/api/handlers/community/collection_integration_test.go
+++ b/backend/internal/api/handlers/community/collection_integration_test.go
@@ -151,6 +151,51 @@ func (s *CollectionHandlerIntegrationSuite) TestGetCollection_AuthenticatedViewe
 	s.True(resp.Body.IsSubscribed)
 }
 
+// PSY-940: GET /collections/{slug} accepts numeric IDs like the other entity
+// GET endpoints, enabling ID→slug lookups for ISR revalidation.
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID() {
+	user := testhelpers.CreateTestUser(s.deps.DB)
+	coll := s.createCollectionViaService(user, "Get By ID", true)
+
+	req := &GetCollectionHandlerRequest{Slug: fmt.Sprintf("%d", coll.ID)}
+	resp, err := s.handler.GetCollectionHandler(context.Background(), req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(coll.ID, resp.Body.ID)
+	s.Equal(coll.Slug, resp.Body.Slug)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID_NotFound() {
+	req := &GetCollectionHandlerRequest{Slug: "999999"}
+	_, err := s.handler.GetCollectionHandler(context.Background(), req)
+	testhelpers.AssertHumaError(s.T(), err, 404)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID_PrivateForbiddenForNonOwner() {
+	owner := testhelpers.CreateTestUser(s.deps.DB)
+	viewer := testhelpers.CreateTestUser(s.deps.DB)
+	coll := s.createCollectionViaService(owner, "Private By ID", false)
+
+	// ID lookups must enforce the same privacy gate as slug lookups.
+	ctx := testhelpers.CtxWithUser(viewer)
+	req := &GetCollectionHandlerRequest{Slug: fmt.Sprintf("%d", coll.ID)}
+	_, err := s.handler.GetCollectionHandler(ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 403)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_ByNumericID_PrivateVisibleToOwner() {
+	owner := testhelpers.CreateTestUser(s.deps.DB)
+	coll := s.createCollectionViaService(owner, "Private Own By ID", false)
+
+	ctx := testhelpers.CtxWithUser(owner)
+	req := &GetCollectionHandlerRequest{Slug: fmt.Sprintf("%d", coll.ID)}
+	resp, err := s.handler.GetCollectionHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(coll.ID, resp.Body.ID)
+}
+
 // ============================================================================
 // GetCollectionStatsHandler
 // ============================================================================

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -695,6 +695,7 @@ type MockCollectionService struct {
 	CreateCollectionFn                   func(uint, *contracts.CreateCollectionRequest) (*contracts.CollectionDetailResponse, error)
 	CloneCollectionFn                    func(string, uint) (*contracts.CollectionDetailResponse, error)
 	GetBySlugFn                          func(string, uint) (*contracts.CollectionDetailResponse, error)
+	GetByIDFn                            func(uint, uint) (*contracts.CollectionDetailResponse, error)
 	ListCollectionsFn                    func(contracts.CollectionFilters, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	UpdateCollectionFn                   func(string, uint, bool, *contracts.UpdateCollectionRequest) (*contracts.CollectionDetailResponse, error)
 	DeleteCollectionFn                   func(string, uint, bool) error
@@ -736,6 +737,12 @@ func (m *MockCollectionService) CloneCollection(srcSlug string, callerID uint) (
 func (m *MockCollectionService) GetBySlug(slug string, viewerID uint) (*contracts.CollectionDetailResponse, error) {
 	if m.GetBySlugFn != nil {
 		return m.GetBySlugFn(slug, viewerID)
+	}
+	return nil, nil
+}
+func (m *MockCollectionService) GetByID(id uint, viewerID uint) (*contracts.CollectionDetailResponse, error) {
+	if m.GetByIDFn != nil {
+		return m.GetByIDFn(id, viewerID)
 	}
 	return nil, nil
 }

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -431,6 +431,29 @@ func (s *CollectionService) CloneCollection(srcSlug string, callerID uint) (*con
 	return s.GetBySlug(newSlug, callerID)
 }
 
+// GetByID retrieves a collection by numeric ID with full detail.
+//
+// Resolves the slug first and delegates to GetBySlug so the access-control
+// and detail-building logic lives in exactly one place. Added so
+// GET /collections/{slug} can accept ID-or-slug like the other entity GET
+// endpoints (PSY-940 — enables ID→slug lookups for ISR revalidation).
+func (s *CollectionService) GetByID(id uint, viewerID uint) (*contracts.CollectionDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var collection communitym.Collection
+	err := s.db.Select("slug").Where("id = ?", id).First(&collection).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrCollectionNotFound(strconv.FormatUint(uint64(id), 10))
+		}
+		return nil, fmt.Errorf("failed to get collection: %w", err)
+	}
+
+	return s.GetBySlug(collection.Slug, viewerID)
+}
+
 // GetBySlug retrieves a collection by slug with full detail
 func (s *CollectionService) GetBySlug(slug string, viewerID uint) (*contracts.CollectionDetailResponse, error) {
 	if s.db == nil {

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -460,6 +460,11 @@ type CollectionServiceInterface interface {
 	CreateCollection(creatorID uint, req *CreateCollectionRequest) (*CollectionDetailResponse, error)
 	CloneCollection(srcSlug string, callerID uint) (*CollectionDetailResponse, error)
 	GetBySlug(slug string, viewerID uint) (*CollectionDetailResponse, error)
+	// GetByID retrieves a collection by numeric ID with the same
+	// access-control semantics as GetBySlug. Lets GET /collections/{slug}
+	// accept ID-or-slug like the other entity GET endpoints (PSY-940 —
+	// enables ID→slug lookups for ISR revalidation).
+	GetByID(id uint, viewerID uint) (*CollectionDetailResponse, error)
 	ListCollections(filters CollectionFilters, limit, offset int) ([]*CollectionListResponse, int64, error)
 	UpdateCollection(slug string, userID uint, isAdmin bool, req *UpdateCollectionRequest) (*CollectionDetailResponse, error)
 	DeleteCollection(slug string, userID uint, isAdmin bool) error

--- a/frontend/lib/proxy-revalidation.test.ts
+++ b/frontend/lib/proxy-revalidation.test.ts
@@ -725,6 +725,94 @@ describe('tag rules', () => {
   })
 })
 
+describe('collection tagging via the generic entities path (PSY-940)', () => {
+  /** Route lookup GETs to per-URL responses (tag 3 + collection 9). */
+  function mockLookups() {
+    fetchSpy.mockImplementation(((url: string | URL | Request) => {
+      const target = String(url)
+      if (target === `${BACKEND}/tags/3`) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 3, slug: 'post-punk' }), {
+            status: 200,
+          })
+        )
+      }
+      if (target === `${BACKEND}/collections/9`) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 9, slug: 'desert-punk-essentials' }), {
+            status: 200,
+          })
+        )
+      }
+      return Promise.resolve(new Response('not found', { status: 404 }))
+    }) as typeof fetch)
+  }
+
+  it('tag add on a collection revalidates BOTH the tag page and the collection page', async () => {
+    mockLookups()
+    await run({
+      method: 'POST',
+      path: '/entities/collection/9/tags',
+      requestText: JSON.stringify({ tag_id: 3 }),
+    })
+    // Collection ISR payloads embed tags[], unlike every other entity type.
+    expect(revalidated()).toEqual([
+      '/tags/post-punk',
+      '/collections/desert-punk-essentials',
+    ])
+  })
+
+  it('tag add by tag_name on a collection still revalidates the collection page', async () => {
+    mockLookups()
+    await run({
+      method: 'POST',
+      path: '/entities/collection/9/tags',
+      requestText: JSON.stringify({ tag_name: 'desert rock', category: 'genre' }),
+    })
+    expect(revalidated()).toEqual(['/collections/desert-punk-essentials'])
+  })
+
+  it('tag remove on a collection revalidates BOTH pages', async () => {
+    mockLookups()
+    await run({ method: 'DELETE', path: '/entities/collection/9/tags/3' })
+    expect(revalidated()).toEqual([
+      '/tags/post-punk',
+      '/collections/desert-punk-essentials',
+    ])
+  })
+
+  it('falls back to the tag page only when the collection lookup fails', async () => {
+    fetchSpy.mockImplementation(((url: string | URL | Request) => {
+      const target = String(url)
+      if (target === `${BACKEND}/tags/3`) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 3, slug: 'post-punk' }), {
+            status: 200,
+          })
+        )
+      }
+      return Promise.resolve(new Response('error', { status: 500 }))
+    }) as typeof fetch)
+
+    await run({ method: 'DELETE', path: '/entities/collection/9/tags/3' })
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+    // The skipped collection page is observable via the lookup-failure warning.
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'isr-revalidation: slug lookup failed',
+      expect.objectContaining({ level: 'warning' })
+    )
+  })
+
+  it('non-collection entity tagging never looks up the entity', async () => {
+    mockLookupResponse('post-punk')
+    await run({ method: 'DELETE', path: '/entities/artist/10/tags/3' })
+    // Exactly one lookup (the tag) — never a second for the artist.
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith(`${BACKEND}/tags/3`, expect.anything())
+    expect(revalidated()).toEqual(['/tags/post-punk'])
+  })
+})
+
 describe('explore curation rules', () => {
   it('featured slot set/delete revalidates /explore', async () => {
     await run({ method: 'POST', path: '/admin/featured-slots' })

--- a/frontend/lib/proxy-revalidation.ts
+++ b/frontend/lib/proxy-revalidation.ts
@@ -28,8 +28,6 @@ import { safeRevalidatePath } from './revalidate-entity'
  * pages), via dynamic route patterns — see RENAME_CASCADES below.
  *
  * Known gaps (follow-up tickets):
- *   - PSY-940: collections tagged via the generic /entities/collection/...
- *     path (collections GET is slug-only; no ID→slug lookup possible)
  *   - Deletes by numeric ID can't revalidate the deleted entity's own detail
  *     page (empty response, entity gone); the soft-404 proxy handles dead
  *     slugs (PSY-897/913/906)
@@ -242,6 +240,25 @@ function releasePages(body: unknown): Array<string | undefined> {
     ...entityPages('releases', slugOf(body)),
     ...nestedSlugs(body, 'artists').map((artistSlug) => `/artists/${artistSlug}`),
   ]
+}
+
+/**
+ * The tagged entity's own detail page, when its ISR payload embeds tags.
+ *
+ * Only collections do (CollectionDetailResponse.tags) — every other entity
+ * type client-fetches its tags, so tagging them never stales their pages.
+ * The generic tagging path carries a numeric entity ID; resolving it to a
+ * slug requires the collection GET to accept IDs (backend change shipped
+ * with PSY-940).
+ */
+async function taggedEntityPages(
+  entityType: string,
+  entityId: string,
+  lookupSlug: RuleContext['lookupSlug']
+): Promise<Array<string | undefined>> {
+  if (entityType !== 'collection') return []
+  const slug = await lookupSlug('collections', entityId)
+  return [slug ? `/collections/${slug}` : undefined]
 }
 
 // ---------------------------------------------------------------------------
@@ -571,26 +588,35 @@ const RULES: readonly RevalidationRule[] = [
   {
     name: 'entity-tag-add',
     methods: ['POST'],
-    pattern: /^\/entities\/[a-z]+\/\d+\/tags$/,
-    // Entity detail pages client-fetch their tags, so they are NOT affected.
-    // The /tags/{slug} page IS affected (usage_breakdown is ISR-cached). The
-    // response body is empty; the tag reference lives in the REQUEST body —
-    // tag_id for existing tags. (tag_name-only requests create a brand-new
-    // tag, which has no cached ISR page yet, so nothing to revalidate.)
-    paths: async ({ requestBody, lookupSlug }) => {
+    pattern: /^\/entities\/([a-z]+)\/(\d+)\/tags$/,
+    // Two pages can be affected:
+    //   1. The /tags/{slug} page (usage_breakdown is ISR-cached). The
+    //      response body is empty; the tag reference lives in the REQUEST
+    //      body — tag_id for existing tags. (tag_name-only requests create a
+    //      brand-new tag, which has no cached ISR page yet.)
+    //   2. The tagged entity's own page, but ONLY for collections — every
+    //      other entity type client-fetches its tags (PSY-940).
+    paths: async ({ match, requestBody, lookupSlug }) => {
       const tagId = asRecord(requestBody)?.tag_id
-      if (typeof tagId !== 'number' || tagId === 0) return []
-      const slug = await lookupSlug('tags', String(tagId))
-      return [slug ? `/tags/${slug}` : undefined]
+      const [tagSlug, entityOwnPages] = await Promise.all([
+        typeof tagId === 'number' && tagId !== 0
+          ? lookupSlug('tags', String(tagId))
+          : Promise.resolve(undefined),
+        taggedEntityPages(match[1], match[2], lookupSlug),
+      ])
+      return [tagSlug ? `/tags/${tagSlug}` : undefined, ...entityOwnPages]
     },
   },
   {
     name: 'entity-tag-remove',
     methods: ['DELETE'],
-    pattern: /^\/entities\/[a-z]+\/\d+\/tags\/(\d+)$/,
+    pattern: /^\/entities\/([a-z]+)\/(\d+)\/tags\/(\d+)$/,
     paths: async ({ match, lookupSlug }) => {
-      const slug = await lookupSlug('tags', match[1])
-      return [slug ? `/tags/${slug}` : undefined]
+      const [tagSlug, entityOwnPages] = await Promise.all([
+        lookupSlug('tags', match[3]),
+        taggedEntityPages(match[1], match[2], lookupSlug),
+      ])
+      return [tagSlug ? `/tags/${tagSlug}` : undefined, ...entityOwnPages]
     },
   },
 
@@ -684,9 +710,10 @@ function parseJson(text: string | null | undefined): unknown {
  * Resolve an entity's slug from its numeric ID via the backend GET endpoint.
  *
  * Every URL segment used by the rules above (artists, releases, labels,
- * festivals, tags) has a GET that accepts ID-or-slug. Returns undefined on
- * any failure — the caller then skips that page, which means it stays stale
- * until its ISR window expires; failures are reported so the gap is visible.
+ * festivals, tags, collections — the last as of PSY-940) has a GET that
+ * accepts ID-or-slug. Returns undefined on any failure — the caller then
+ * skips that page, which means it stays stale until its ISR window expires;
+ * failures are reported so the gap is visible.
  *
  * Lookups run synchronously before the mutation response returns, adding one
  * backend GET to the rules that need them (admin sub-resource ops, entity


### PR DESCRIPTION
Closes PSY-940

> **Stacked on #939** (PSY-941) — both PRs touch `lib/proxy-revalidation.ts`. Merge #939 first; GitHub will retarget this PR to `main` automatically.

Fixes the last documented gap from PSY-939: tagging a collection through the tag widget left `/collections/{slug}` stale for up to 1 hour, because the generic tagging path carries a numeric collection ID and the collection GET endpoint was slug-only — no ID→slug lookup was possible.

## What's here

### Backend — `GET /collections/{slug}` accepts ID-or-slug

- `CollectionService.GetByID(id, viewerID)` — resolves the slug with a single-column query, then **delegates to `GetBySlug`** so the access-control and detail-building logic stays in exactly one place
- `GetCollectionHandler` does the same `ParseUint`-then-fallback the other six entity GET handlers do
- Privacy semantics identical for ID lookups: 404 unknown, **403 private non-owner**, 200 owner (all covered by new integration tests)
- Mocks regenerated via `go generate ./...`

### Frontend — collection tagging revalidates the collection page

- `entity-tag-add` / `entity-tag-remove` rules now also revalidate `/collections/{slug}` when the tagged entity is a collection — the **only** entity type whose ISR payload embeds tags (`CollectionDetailResponse.tags`); every other type client-fetches tags, so their rules deliberately stay tag-page-only
- Tag-page and collection-page lookups run in parallel (`Promise.all`)
- Known-gaps doc updated: PSY-940 removed from the list

## Review notes

- One reviewer finding deliberately not taken: `ParseUint(..., 10, 32)` bit-width vs 64-bit IDs. All six existing entity handlers use bit-width 32; this app's IDs will not approach 2^32, and deviating in one handler would break pattern consistency. A coordinated change across all seven handlers can be its own ticket if ever needed.

## Test plan

- [x] Backend: `go build ./...` + `go vet` clean; collection handler integration suite passes including 4 new ID-lookup tests (by-ID success, unknown-ID 404, private-non-owner 403, private-owner 200)
- [x] Frontend: typecheck clean; 140 tests pass in affected scopes (5 new: collection tag add/remove both pages, tag_name-only case, lookup-failure fallback, non-collection entities never trigger entity lookups)
- [x] Full frontend suite: 5,401/5,401 pass
- [x] Review: 3 agents (Go correctness / TS correctness / cleanup+altitude) — TS and cleanup angles zero findings; Go finding addressed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
