### PR TITLE
PSY-946: extend IP-geo default city to /shows and home

### DIFF
--- a/frontend/app/api/geo/route.test.ts
+++ b/frontend/app/api/geo/route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+/**
+ * Build a NextRequest carrying the given (lowercase) Vercel geo headers.
+ * Header names are normalized by the Headers object, so case is irrelevant.
+ */
+function geoRequest(headers: Record<string, string>): NextRequest {
+  return new NextRequest('https://psychichomily.com/api/geo', { headers })
+}
+
+describe('GET /api/geo', () => {
+  it('decodes US geo headers into { geo: { city, state } }', async () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'Phoenix',
+        'x-vercel-ip-country-region': 'AZ',
+        'x-vercel-ip-country': 'US',
+      }),
+    )
+    await expect(res.json()).resolves.toEqual({
+      geo: { city: 'Phoenix', state: 'AZ' },
+    })
+  })
+
+  it('URL-decodes the city header (e.g. San%20Diego)', async () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'San%20Diego',
+        'x-vercel-ip-country-region': 'CA',
+        'x-vercel-ip-country': 'US',
+      }),
+    )
+    await expect(res.json()).resolves.toEqual({
+      geo: { city: 'San Diego', state: 'CA' },
+    })
+  })
+
+  it('returns { geo: null } for a non-US/CA country', async () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'S%C3%A3o%20Paulo',
+        'x-vercel-ip-country-region': 'SP',
+        'x-vercel-ip-country': 'BR',
+      }),
+    )
+    await expect(res.json()).resolves.toEqual({ geo: null })
+  })
+
+  it('returns { geo: null } when no geo headers are present (local dev / VPN)', async () => {
+    const res = GET(geoRequest({}))
+    await expect(res.json()).resolves.toEqual({ geo: null })
+  })
+
+  it('returns { geo: null } when the region is missing (bare city is ambiguous)', async () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'Phoenix',
+        'x-vercel-ip-country': 'US',
+      }),
+    )
+    await expect(res.json()).resolves.toEqual({ geo: null })
+  })
+
+  it('allows Canada (province codes can match PH data)', async () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'Toronto',
+        'x-vercel-ip-country-region': 'ON',
+        'x-vercel-ip-country': 'CA',
+      }),
+    )
+    await expect(res.json()).resolves.toEqual({
+      geo: { city: 'Toronto', state: 'ON' },
+    })
+  })
+
+  it('sets a non-shared-cacheable Cache-Control header (no cross-visitor poisoning)', () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'Phoenix',
+        'x-vercel-ip-country-region': 'AZ',
+        'x-vercel-ip-country': 'US',
+      }),
+    )
+    const cacheControl = res.headers.get('Cache-Control') ?? ''
+    // `private` forbids shared caches (CDN/proxy); `no-store` forbids storing
+    // at all. Either alone would prevent cross-visitor leakage; we assert both
+    // so a future edit can't quietly weaken the contract to `public`.
+    expect(cacheControl).toContain('private')
+    expect(cacheControl).toContain('no-store')
+    expect(cacheControl).not.toContain('public')
+  })
+})

--- a/frontend/app/api/geo/route.ts
+++ b/frontend/app/api/geo/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { decodeGeoHeaders } from '@/lib/geo-default'
+import type { CityState } from '@/components/filters/CityFilters'
+
+/**
+ * IP-geo default-city route handler (PSY-946).
+ *
+ * Returns the visitor's `{ city, state }` suggestion decoded from the Vercel
+ * edge geo headers, or `null` when geo is unavailable / ambiguous / non-US-CA.
+ * This is the CLIENT-FETCH transport for the geo default on `/shows` (ISR) and
+ * home (static), which can't read `next/headers` server-side without
+ * un-ISR-ing themselves. /explore uses the server `next/headers()` path
+ * instead — see the two-read-paths note in `lib/geo-default.ts`.
+ *
+ * The response echoes only the geo HEADERS Vercel already injected for THIS
+ * request through the same US/CA gate /explore uses; it exposes nothing the
+ * caller's own request didn't already carry, so the unauthenticated public
+ * endpoint leaks nothing and needs no rate limiting (it's strictly cheaper
+ * than the page render it precedes).
+ *
+ * Dynamic without segment configs: reading `request.headers` already opts this
+ * handler into per-request (dynamic) rendering. We CANNOT set
+ * `export const runtime = 'edge'` or `export const dynamic = 'force-dynamic'`
+ * — Next 16's `cacheComponents: true` (this repo's PPR mode, next.config.ts)
+ * REJECTS those route-segment configs at build time ("not compatible with
+ * nextConfig.cacheComponents"). The header read plus the no-store Cache-Control
+ * below give the same guarantee (dynamic, never cached) without the configs.
+ */
+
+interface GeoResponse {
+  geo: CityState | null
+}
+
+export function GET(request: NextRequest): NextResponse<GeoResponse> {
+  const geo = decodeGeoHeaders(request.headers)
+
+  return NextResponse.json(
+    { geo },
+    {
+      // CRITICAL: one visitor's city must NEVER be served to another. The
+      // response varies by the caller's IP-derived geo headers, which are not
+      // part of the cache key, so any shared cache (Vercel CDN, a corporate
+      // proxy, the browser bfcache) could poison a different visitor.
+      // `private` forbids shared caches; `no-store` forbids storing at all
+      // (incl. the browser's own disk cache) — the client's sessionStorage
+      // layer in `useGeoDefaultCity` provides the intended per-session reuse,
+      // so we don't rely on HTTP caching at all.
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+      },
+    },
+  )
+}

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -63,7 +63,7 @@ export default function PrivacyPolicyPage() {
               <li><strong>Device Information:</strong> Browser type, operating system, and device identifiers.</li>
               <li><strong>Usage Data:</strong> Pages visited, time spent on pages, and interaction patterns.</li>
               <li><strong>Log Data:</strong> IP address, access times, and referring URLs.</li>
-              <li><strong>Approximate Location:</strong> When you visit the Explore page, the hosting platform (Vercel) infers an approximate, city-level location from your IP address. I use this only to pre-select a nearby city in the upcoming-shows filter, which you can change at any time. This inferred city is read transiently on each request, is not precise, is not stored against your account or any identifier, and is not used to build a profile or track you. See Section 3.</li>
+              <li><strong>Approximate Location:</strong> When you browse pages with an upcoming-shows city filter (such as the home page, the Shows listing, and the Explore page), the hosting platform (Vercel) infers an approximate, city-level location from your IP address. I use this only to pre-select a nearby city in that filter, which you can change at any time. This inferred city is read transiently on each request, is not precise, is not stored against your account or any identifier, and is not used to build a profile or track you. See Section 3.</li>
               <li><strong>Cookies:</strong> Session cookies for authentication and preference cookies for your settings. See Section 7 for details.</li>
             </ul>
           </section>
@@ -78,7 +78,7 @@ export default function PrivacyPolicyPage() {
               <li><strong>Provide Services:</strong> To create and manage your account, display your saved shows, and enable show submissions.</li>
               <li><strong>Authentication:</strong> To verify your identity and maintain secure access to your account.</li>
               <li><strong>Communications:</strong> To send you transactional emails (password resets, magic links, email verification) and, with your consent, promotional updates about new features.</li>
-              <li><strong>Personalization:</strong> To remember your preferences such as theme, timezone, and language, and to pre-select a nearby city in the Explore shows filter based on the approximate, city-level location inferred from your IP address (an overridable default only — see Section 2.3).</li>
+              <li><strong>Personalization:</strong> To remember your preferences such as theme, timezone, and language, and to pre-select a nearby city in the upcoming-shows filters (on the home page, the Shows listing, and the Explore page) based on the approximate, city-level location inferred from your IP address (an overridable default only — see Section 2.3).</li>
               <li><strong>Improvement:</strong> To analyze usage patterns and improve the services.</li>
               <li><strong>Security:</strong> To detect and prevent fraud, abuse, and security incidents.</li>
               <li><strong>Legal Compliance:</strong> To comply with applicable laws and regulations.</li>

--- a/frontend/components/filters/GeoDefaultAffordance.tsx
+++ b/frontend/components/filters/GeoDefaultAffordance.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import type { CityState } from './CityFilters'
+
+/**
+ * The overridable "Showing {City}, {ST} (from your location) — change" chip
+ * shown under the city filter when a selection was auto-applied from the IP-geo
+ * default (PSY-926 /explore, PSY-946 /shows + home). Rendered identically on
+ * all three surfaces; the parent decides WHEN via `shouldShowGeoAffordance` and
+ * supplies the override handler.
+ */
+export function GeoDefaultAffordance({
+  city,
+  onChange,
+}: {
+  city: CityState
+  onChange: () => void
+}) {
+  return (
+    <p
+      className="mt-1.5 text-xs text-muted-foreground"
+      data-testid="geo-default-affordance"
+    >
+      Showing {city.city}, {city.state} (from your location) —{' '}
+      <button
+        type="button"
+        onClick={onChange}
+        className="text-primary hover:underline underline-offset-4"
+        data-testid="geo-default-change"
+      >
+        change
+      </button>
+    </p>
+  )
+}

--- a/frontend/components/filters/useGeoDefaultCity.test.tsx
+++ b/frontend/components/filters/useGeoDefaultCity.test.tsx
@@ -323,4 +323,23 @@ describe('useGeoDefaultCity — client-fetch path (/shows + home)', () => {
     await waitFor(() => expect(window.sessionStorage.getItem('ph-geo-default-city')).not.toBeNull())
     expect(onSeed).not.toHaveBeenCalled()
   })
+
+  it('ignores a malformed cached value without crashing (defensive shape check)', () => {
+    // A non-string city would throw on .trim() in geoCityWithShows if it
+    // reached reconciliation. The shape check coerces it to null instead.
+    window.sessionStorage.setItem(
+      'ph-geo-default-city',
+      JSON.stringify({ geo: { city: 123, state: 'AZ' } }),
+    )
+    const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+    const onSeed = vi.fn()
+    expect(() =>
+      renderHook(() =>
+        useGeoDefaultCity(baseParams({ enableClientFetch: true, onSeed })),
+      ),
+    ).not.toThrow()
+    // Cache hit short-circuits the fetch; the malformed value yields no seed.
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(onSeed).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/components/filters/useGeoDefaultCity.test.tsx
+++ b/frontend/components/filters/useGeoDefaultCity.test.tsx
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import {
+  useGeoDefaultCity,
+  shouldShowGeoAffordance,
+} from './useGeoDefaultCity'
+import type { CityState, CityWithCount } from './CityFilters'
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+const PHOENIX: CityWithCount = { city: 'Phoenix', state: 'AZ', count: 5 }
+const OMAHA: CityWithCount = { city: 'Omaha', state: 'NE', count: 3 }
+const ALL_CITIES: CityWithCount[] = [PHOENIX, OMAHA]
+
+type HookParams = Parameters<typeof useGeoDefaultCity>[0]
+
+/** Base params for an anon visitor with no favorites, no existing selection. */
+function baseParams(overrides: Partial<HookParams> = {}): HookParams {
+  return {
+    cities: ALL_CITIES,
+    isAuthenticated: false,
+    authLoading: false,
+    favoriteCities: [],
+    hasExistingSelection: false,
+    onSeed: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('shouldShowGeoAffordance', () => {
+  it('is true when the single selected city equals the applied geo default', () => {
+    expect(
+      shouldShowGeoAffordance({ city: 'Omaha', state: 'NE' }, [
+        { city: 'Omaha', state: 'NE' },
+      ]),
+    ).toBe(true)
+  })
+
+  it('is false when nothing is applied', () => {
+    expect(shouldShowGeoAffordance(null, [{ city: 'Omaha', state: 'NE' }])).toBe(
+      false,
+    )
+  })
+
+  it('is false when the selection differs from the applied default', () => {
+    expect(
+      shouldShowGeoAffordance({ city: 'Omaha', state: 'NE' }, [
+        { city: 'Phoenix', state: 'AZ' },
+      ]),
+    ).toBe(false)
+  })
+
+  it('is false when more than one city is selected', () => {
+    expect(
+      shouldShowGeoAffordance({ city: 'Omaha', state: 'NE' }, [
+        { city: 'Omaha', state: 'NE' },
+        { city: 'Phoenix', state: 'AZ' },
+      ]),
+    ).toBe(false)
+  })
+})
+
+describe('useGeoDefaultCity — server-prop path (/explore)', () => {
+  it('seeds the canonical geo city for an anon visitor when it has shows', () => {
+    const onSeed = vi.fn()
+    const { result } = renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({ geoFromServer: { city: 'Omaha', state: 'NE' }, onSeed }),
+      ),
+    )
+    expect(onSeed).toHaveBeenCalledWith({ city: 'Omaha', state: 'NE' })
+    expect(result.current.appliedGeoDefault).toEqual({
+      city: 'Omaha',
+      state: 'NE',
+    })
+  })
+
+  it('matches case/whitespace-insensitively and seeds the PH canonical casing', () => {
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({ geoFromServer: { city: ' omaha ', state: 'ne' }, onSeed }),
+      ),
+    )
+    // Seeds the canonical "Omaha,NE" from the cities list, not the raw header.
+    expect(onSeed).toHaveBeenCalledWith({ city: 'Omaha', state: 'NE' })
+  })
+
+  it('does NOT seed when the geo city has no shows', () => {
+    const onSeed = vi.fn()
+    const { result } = renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({ geoFromServer: { city: 'Tucson', state: 'AZ' }, onSeed }),
+      ),
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+    expect(result.current.appliedGeoDefault).toBeNull()
+  })
+
+  it('does NOT seed when there is no geo default (null)', () => {
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(baseParams({ geoFromServer: null, onSeed })),
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+  })
+
+  it('does NOT seed for an authed user (favorites are the caller’s concern)', () => {
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          isAuthenticated: true,
+          geoFromServer: { city: 'Omaha', state: 'NE' },
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+  })
+
+  it('does NOT seed when favorites are present (favorites win)', () => {
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          isAuthenticated: true,
+          favoriteCities: [{ city: 'Phoenix', state: 'AZ' }],
+          geoFromServer: { city: 'Omaha', state: 'NE' },
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+  })
+
+  it('waits for auth to settle before seeding the anon geo default', () => {
+    const onSeed = vi.fn()
+    const { rerender } = renderHook(
+      (props: HookParams) => useGeoDefaultCity(props),
+      {
+        initialProps: baseParams({
+          authLoading: true,
+          geoFromServer: { city: 'Omaha', state: 'NE' },
+          onSeed,
+        }),
+      },
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+    // Auth settles → now it seeds.
+    rerender(
+      baseParams({
+        authLoading: false,
+        geoFromServer: { city: 'Omaha', state: 'NE' },
+        onSeed,
+      }),
+    )
+    expect(onSeed).toHaveBeenCalledWith({ city: 'Omaha', state: 'NE' })
+  })
+
+  it('does NOT seed when a selection already exists (hasExistingSelection)', () => {
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          hasExistingSelection: true,
+          geoFromServer: { city: 'Omaha', state: 'NE' },
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+  })
+
+  it('seeds only once even as inputs change', () => {
+    const onSeed = vi.fn()
+    const { rerender } = renderHook(
+      (props: HookParams) => useGeoDefaultCity(props),
+      {
+        initialProps: baseParams({
+          geoFromServer: { city: 'Omaha', state: 'NE' },
+          onSeed,
+        }),
+      },
+    )
+    rerender(
+      baseParams({ geoFromServer: { city: 'Omaha', state: 'NE' }, onSeed }),
+    )
+    expect(onSeed).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops the affordance after notifyUserInteracted', () => {
+    const { result } = renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({ geoFromServer: { city: 'Omaha', state: 'NE' } }),
+      ),
+    )
+    expect(result.current.appliedGeoDefault).toEqual({
+      city: 'Omaha',
+      state: 'NE',
+    })
+    act(() => result.current.notifyUserInteracted())
+    expect(result.current.appliedGeoDefault).toBeNull()
+  })
+})
+
+describe('useGeoDefaultCity — client-fetch path (/shows + home)', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    window.sessionStorage.clear()
+  })
+
+  function mockGeoFetch(geo: CityState | null) {
+    return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ geo }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  }
+
+  it('fetches /api/geo and seeds the canonical city on mount', async () => {
+    const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(baseParams({ enableClientFetch: true, onSeed })),
+    )
+    await waitFor(() =>
+      expect(onSeed).toHaveBeenCalledWith({ city: 'Omaha', state: 'NE' }),
+    )
+    expect(fetchSpy).toHaveBeenCalledWith('/api/geo')
+  })
+
+  it('caches the response in sessionStorage (cross-page reuse, no re-fetch)', async () => {
+    const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+    const onSeed1 = vi.fn()
+    const first = renderHook(() =>
+      useGeoDefaultCity(baseParams({ enableClientFetch: true, onSeed: onSeed1 })),
+    )
+    await waitFor(() => expect(onSeed1).toHaveBeenCalled())
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    first.unmount()
+
+    // A second mount (simulating navigation to another surface) reads the
+    // cached value synchronously — no second fetch.
+    const onSeed2 = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(baseParams({ enableClientFetch: true, onSeed: onSeed2 })),
+    )
+    await waitFor(() =>
+      expect(onSeed2).toHaveBeenCalledWith({ city: 'Omaha', state: 'NE' }),
+    )
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT fetch when enableClientFetch is false (e.g. authed up front)', () => {
+    const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+    renderHook(() => useGeoDefaultCity(baseParams({ enableClientFetch: false })))
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fetch for an authed visitor (efficiency: no wasted edge request)', () => {
+    const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({ isAuthenticated: true, enableClientFetch: true, onSeed }),
+      ),
+    )
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(onSeed).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fetch for an anon visitor with favorites (efficiency gate)', () => {
+    const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          favoriteCities: [{ city: 'Phoenix', state: 'AZ' }],
+          enableClientFetch: true,
+        }),
+      ),
+    )
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fetch while auth is still loading, then fetches once it settles to anon', async () => {
+    const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+    const onSeed = vi.fn()
+    const { rerender } = renderHook(
+      (props: HookParams) => useGeoDefaultCity(props),
+      {
+        initialProps: baseParams({
+          authLoading: true,
+          enableClientFetch: true,
+          onSeed,
+        }),
+      },
+    )
+    expect(fetchSpy).not.toHaveBeenCalled()
+    rerender(
+      baseParams({ authLoading: false, enableClientFetch: true, onSeed }),
+    )
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith('/api/geo'))
+    await waitFor(() =>
+      expect(onSeed).toHaveBeenCalledWith({ city: 'Omaha', state: 'NE' }),
+    )
+  })
+
+  it('does not seed when the fetched city has no shows', async () => {
+    mockGeoFetch({ city: 'Tucson', state: 'AZ' })
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(baseParams({ enableClientFetch: true, onSeed })),
+    )
+    // Give the effect a tick; assert no seed.
+    await waitFor(() => expect(window.sessionStorage.getItem('ph-geo-default-city')).not.toBeNull())
+    expect(onSeed).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/components/filters/useGeoDefaultCity.ts
+++ b/frontend/components/filters/useGeoDefaultCity.ts
@@ -44,6 +44,21 @@ interface GeoApiResponse {
   geo: CityState | null
 }
 
+/**
+ * Narrow an arbitrary parsed value to a `CityState` (two non-empty string
+ * halves), else null. Defensive: the only writer of the cache / the route
+ * handler always emits this shape, but a malformed value (corrupted
+ * sessionStorage, a future route-handler change) must not reach
+ * `geoCityWithShows`, where `.trim()` on a non-string would throw mid-render.
+ */
+function toCityState(value: unknown): CityState | null {
+  if (typeof value !== 'object' || value === null) return null
+  const { city, state } = value as Record<string, unknown>
+  if (typeof city !== 'string' || typeof state !== 'string') return null
+  if (city.trim() === '' || state.trim() === '') return null
+  return { city, state }
+}
+
 interface UseGeoDefaultCityParams {
   /** Cities that currently have shows (from `useShowCities`); the has-shows gate. */
   cities: CityWithCount[]
@@ -120,7 +135,7 @@ function useGeoSource(
       const cached = window.sessionStorage.getItem(GEO_CACHE_KEY)
       if (cached !== null) {
         const parsed = JSON.parse(cached) as GeoApiResponse
-        setFetched(parsed.geo ?? null)
+        setFetched(toCityState(parsed?.geo))
         return
       }
     } catch {
@@ -132,7 +147,7 @@ function useGeoSource(
       .then(res => (res.ok ? (res.json() as Promise<GeoApiResponse>) : null))
       .then(body => {
         if (cancelled) return
-        const geo = body?.geo ?? null
+        const geo = toCityState(body?.geo)
         setFetched(geo)
         try {
           window.sessionStorage.setItem(GEO_CACHE_KEY, JSON.stringify({ geo }))

--- a/frontend/components/filters/useGeoDefaultCity.ts
+++ b/frontend/components/filters/useGeoDefaultCity.ts
@@ -1,0 +1,267 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import * as Sentry from '@sentry/nextjs'
+import type { CityState, CityWithCount } from './CityFilters'
+import { citiesEqual } from './cityParams'
+
+/**
+ * Shared IP-geo default-city hook (PSY-946).
+ *
+ * Extracted from /explore's `UpcomingShowsList` reconciliation logic (PSY-926)
+ * so the SAME resolution-order, has-shows gate, canonical-city match, and
+ * "from your location — change" affordance run on all three city-filter
+ * surfaces: /explore, /shows, and home. The seeding MECHANISM differs per
+ * surface (URL `?cities=` vs local state), so the hook decides WHAT to seed
+ * and the caller wires its own `onSeed`.
+ *
+ * Two geo SOURCES, one hook (see the two-read-paths note in
+ * `lib/geo-default.ts`):
+ *   - /explore passes `geoFromServer` (already read server-side via
+ *     `next/headers` at its dynamic boundary) and sets `enableClientFetch:
+ *     false` → zero extra client requests there.
+ *   - /shows + home set `enableClientFetch: true` (and no `geoFromServer`) →
+ *     the hook fetches the `/api/geo` edge route handler on mount, cached in
+ *     sessionStorage so cross-page navigation doesn't re-fetch.
+ *
+ * Resolution order (mirrors PSY-926, unchanged):
+ *   1. authed user with `favoriteCities` → seed favorites (caller's concern;
+ *      pass `favoriteCities` so the hook stands down — it never overrides
+ *      favorites),
+ *   2. anon + geo city that HAS upcoming shows in PH's data → seed the
+ *      CANONICAL city from `cities` (never the raw header — injection-safe),
+ *   3. otherwise → no default ("All cities").
+ *
+ * The seeded value is always the canonical PH `{city,state}` from `cities`, so
+ * the `?cities=` it produces matches the backend filter exactly.
+ */
+
+/** sessionStorage key for the cached `/api/geo` response (per-session reuse). */
+const GEO_CACHE_KEY = 'ph-geo-default-city'
+
+/** Shape of the `/api/geo` route-handler response. */
+interface GeoApiResponse {
+  geo: CityState | null
+}
+
+interface UseGeoDefaultCityParams {
+  /** Cities that currently have shows (from `useShowCities`); the has-shows gate. */
+  cities: CityWithCount[]
+  /** Whether the visitor is authenticated. Geo applies to anon visitors only. */
+  isAuthenticated: boolean
+  /** Whether auth is still resolving. The hook waits — seeding geo while auth
+   *  is in-flight could wrongly seed a user whose favorites should win. */
+  authLoading: boolean
+  /** The authed user's favorite cities. Non-empty → the hook stands down
+   *  entirely (favorites win; the caller seeds them). */
+  favoriteCities: CityState[]
+  /** True when a selection is already present that geo must NOT override —
+   *  e.g. /shows has a `?cities=` URL param, or the caller already seeded
+   *  favorites. When true the hook never seeds and shows no affordance. */
+  hasExistingSelection: boolean
+  /** The geo value read server-side (/explore). When provided, the client
+   *  fetch is skipped. `undefined` (not passed) → use the client fetch. */
+  geoFromServer?: CityState | null
+  /** Fetch `/api/geo` client-side (/shows + home). Mutually exclusive in
+   *  practice with `geoFromServer`. */
+  enableClientFetch?: boolean
+  /** Called once with the canonical city the hook decides to seed. The caller
+   *  wires its surface's mechanism (router.replace for URL surfaces,
+   *  setSelectedCities for state surfaces). */
+  onSeed: (city: CityState) => void
+}
+
+interface UseGeoDefaultCityResult {
+  /** The geo city currently seeded (and not yet overridden by the user), or
+   *  null. Drives the "Showing {City}, {ST} (from your location)" affordance.
+   *  Null whenever the selection isn't the geo default. */
+  appliedGeoDefault: CityState | null
+  /** Call from the surface's filter-change / "change" handler so the
+   *  affordance never lingers over a user-chosen selection. Also permanently
+   *  blocks a still-in-flight geo fetch from seeding AFTER the user has acted
+   *  (the client-fetch surfaces resolve geo async, so this race is real;
+   *  /explore's server prop resolves before mount, so it's a no-op there). */
+  notifyUserInteracted: () => void
+}
+
+/**
+ * Resolve the raw geo suggestion (`{city,state} | null`) for the client-fetch
+ * surfaces, caching the `/api/geo` response in sessionStorage so cross-page
+ * navigation within a session doesn't re-hit the edge.
+ *
+ * Returns `geoFromServer` verbatim when the caller already has a server-read
+ * value (/explore) — no fetch, no cache.
+ */
+function useGeoSource(
+  geoFromServer: CityState | null | undefined,
+  enableClientFetch: boolean,
+  eligible: boolean,
+): CityState | null {
+  // Seed synchronously from sessionStorage so a cached value is available on
+  // first render (no flash, no redundant fetch). Server render + first
+  // hydration return null (sessionStorage is client-only) — the value arrives
+  // post-mount, same beat as today's authed-favorites seeding.
+  const [fetched, setFetched] = useState<CityState | null>(null)
+  const hasFetched = useRef(false)
+
+  useEffect(() => {
+    if (!enableClientFetch || geoFromServer !== undefined) return
+    // Only hit the edge route when the visitor could actually use the result
+    // (anon, no favorites, auth settled, no existing selection). This is the
+    // efficiency gate: an authed / favorited visitor NEVER triggers the geo
+    // request. We re-check on each render until eligible, so a fetch fires the
+    // moment auth settles to "anon, no favorites".
+    if (!eligible) return
+    if (hasFetched.current) return
+    hasFetched.current = true
+
+    // sessionStorage cache: a prior page in this session already resolved geo.
+    try {
+      const cached = window.sessionStorage.getItem(GEO_CACHE_KEY)
+      if (cached !== null) {
+        const parsed = JSON.parse(cached) as GeoApiResponse
+        setFetched(parsed.geo ?? null)
+        return
+      }
+    } catch {
+      // Corrupted cache / sessionStorage unavailable — fall through to fetch.
+    }
+
+    let cancelled = false
+    fetch('/api/geo')
+      .then(res => (res.ok ? (res.json() as Promise<GeoApiResponse>) : null))
+      .then(body => {
+        if (cancelled) return
+        const geo = body?.geo ?? null
+        setFetched(geo)
+        try {
+          window.sessionStorage.setItem(GEO_CACHE_KEY, JSON.stringify({ geo }))
+        } catch {
+          // sessionStorage unavailable (private mode / quota) — degrade to
+          // re-fetching on the next page; the geo default still works here.
+        }
+      })
+      .catch(error => {
+        if (cancelled) return
+        // A geo-default failure is non-critical (the filter just defaults to
+        // "All cities"), but capture it so a broken edge route is visible.
+        Sentry.captureException(error, {
+          level: 'warning',
+          tags: { service: 'geo-default-city' },
+        })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [enableClientFetch, geoFromServer, eligible])
+
+  // Server-prop path wins when provided; otherwise the client-fetched value.
+  return geoFromServer !== undefined ? (geoFromServer ?? null) : fetched
+}
+
+export function useGeoDefaultCity({
+  cities,
+  isAuthenticated,
+  authLoading,
+  favoriteCities,
+  hasExistingSelection,
+  geoFromServer,
+  enableClientFetch = false,
+  onSeed,
+}: UseGeoDefaultCityParams): UseGeoDefaultCityResult {
+  const hasAppliedDefaults = useRef(false)
+  // Set once the user interacts with the filter. Permanently blocks seeding —
+  // guards the async race where the `/api/geo` fetch resolves AFTER the user
+  // has already chosen (or cleared) a city on the client-fetch surfaces.
+  const userInteracted = useRef(false)
+
+  // Eligibility for the geo lookup: only anon visitors with no favorites, no
+  // existing selection, and no prior interaction, once auth has settled. Gates
+  // BOTH the client fetch (efficiency: an authed / favorited visitor never
+  // hits the edge) and the seed effect below.
+  const eligible =
+    !authLoading &&
+    !isAuthenticated &&
+    favoriteCities.length === 0 &&
+    !hasExistingSelection &&
+    !userInteracted.current
+
+  const rawGeo = useGeoSource(geoFromServer, enableClientFetch, eligible)
+  // Tracks that the CURRENT selection was auto-applied from the IP-geo
+  // suggestion (vs. a user / favorites / URL choice). Drives the affordance;
+  // cleared the moment the user touches the filter.
+  const [appliedGeoDefault, setAppliedGeoDefault] = useState<CityState | null>(
+    null,
+  )
+
+  // The geo suggestion reconciled against PH's has-shows data: returns the
+  // CANONICAL {city,state} from `cities` (so the seed matches the backend
+  // filter exactly) when the detected city has upcoming shows, else null.
+  // Match is case/whitespace-insensitive because Vercel's city spelling may
+  // differ slightly from PH's stored name.
+  const geoCityWithShows: CityState | null = useMemo(() => {
+    if (!rawGeo || cities.length === 0) return null
+    const norm = (s: string) => s.trim().toLowerCase()
+    const wantCity = norm(rawGeo.city)
+    const wantState = norm(rawGeo.state)
+    const match = cities.find(
+      c => norm(c.city) === wantCity && norm(c.state) === wantState,
+    )
+    return match ? { city: match.city, state: match.state } : null
+  }, [rawGeo, cities])
+
+  // Seed once when: no existing selection, auth settled, anon, favorites empty,
+  // and the geo city has shows. Guarded by hasAppliedDefaults so it runs once.
+  useEffect(() => {
+    if (hasAppliedDefaults.current) return
+    // The user already acted (possibly before the async geo fetch resolved) —
+    // never seed over their intent.
+    if (userInteracted.current) return
+    if (hasExistingSelection) return
+    // Wait for auth to settle — seeding the anon geo default while auth is
+    // still resolving could wrongly seed geo for a user who turns out to be
+    // authenticated (whose favorites should win, or who gets "All cities").
+    if (authLoading) return
+    // Favorites win (caller seeds them) and authed-no-favorites gets no geo.
+    if (isAuthenticated || favoriteCities.length > 0) return
+    if (!geoCityWithShows) return
+
+    hasAppliedDefaults.current = true
+    setAppliedGeoDefault(geoCityWithShows)
+    onSeed(geoCityWithShows)
+  }, [
+    hasExistingSelection,
+    authLoading,
+    isAuthenticated,
+    favoriteCities,
+    geoCityWithShows,
+    onSeed,
+  ])
+
+  const notifyUserInteracted = useCallback(() => {
+    userInteracted.current = true
+    // Also block a later seed pass and drop the affordance immediately.
+    hasAppliedDefaults.current = true
+    setAppliedGeoDefault(null)
+  }, [])
+
+  return { appliedGeoDefault, notifyUserInteracted }
+}
+
+/**
+ * True when the geo default is still the active selection (exactly the one
+ * detected city, unchanged by the user) — drives whether the surface renders
+ * the "(from your location) — change" chip. Extracted so all three surfaces
+ * gate the chip identically.
+ */
+export function shouldShowGeoAffordance(
+  appliedGeoDefault: CityState | null,
+  selectedCities: CityState[],
+): appliedGeoDefault is CityState {
+  return (
+    appliedGeoDefault !== null &&
+    selectedCities.length === 1 &&
+    citiesEqual(selectedCities, [appliedGeoDefault])
+  )
+}

--- a/frontend/features/explore/components/UpcomingShowsList.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.tsx
@@ -26,7 +26,6 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState,
   useTransition,
 } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -44,6 +43,11 @@ import {
   buildCitiesParam,
   citiesEqual,
 } from '@/components/filters/cityParams'
+import {
+  useGeoDefaultCity,
+  shouldShowGeoAffordance,
+} from '@/components/filters/useGeoDefaultCity'
+import { GeoDefaultAffordance } from '@/components/filters/GeoDefaultAffordance'
 import type { CityState, CityWithCount } from '@/components/filters/CityFilters'
 
 // CityFilters pulls in cmdk (Command) + Radix Popover. Those bytes are
@@ -92,14 +96,7 @@ export function UpcomingShowsList({
   const { isAuthenticated, isLoading: authLoading } = useAuthContext()
   const { data: profileData } = useProfile()
   const [, startTransition] = useTransition()
-  const hasAppliedDefaults = useRef(false)
-  // Tracks that the CURRENT selection was auto-applied from the IP-geo
-  // suggestion (vs. a user/favorites/URL choice). Drives the "(from your
-  // location) — change" affordance. Cleared the moment the user touches the
-  // filter, so the affordance never lingers over a manual selection.
-  const [appliedGeoDefault, setAppliedGeoDefault] = useState<CityState | null>(
-    null,
-  )
+  const hasAppliedFavorites = useRef(false)
 
   const citiesParam = searchParams.get('cities')
   const selectedCities = useMemo(
@@ -127,60 +124,45 @@ export function UpcomingShowsList({
     [citiesData],
   )
 
-  // The IP-geo suggestion reconciled against PH's has-shows data: returns the
-  // CANONICAL `{city, state}` from the cities list (so the seeded `?cities=`
-  // matches the backend filter exactly) when the detected city has upcoming
-  // shows, else null. Match is case/whitespace-insensitive because Vercel's
-  // city spelling may differ slightly from PH's stored name.
-  const geoCityWithShows: CityState | null = useMemo(() => {
-    if (!geoDefaultCity || cities.length === 0) return null
-    const norm = (s: string) => s.trim().toLowerCase()
-    const wantCity = norm(geoDefaultCity.city)
-    const wantState = norm(geoDefaultCity.state)
-    const match = cities.find(
-      c => norm(c.city) === wantCity && norm(c.state) === wantState,
-    )
-    return match ? { city: match.city, state: match.state } : null
-  }, [geoDefaultCity, cities])
-
-  // Default selection on first load when the URL carries no `?cities=`:
-  //   1. authed + favorite cities → seed from favorites (unchanged),
-  //   2. anon + geo city that has shows → seed from geo (PSY-926),
-  //   3. otherwise → leave empty ("All cities").
-  // Runs once (guarded by hasAppliedDefaults) and only after the dependent
-  // data (favorites / cities-with-shows) has had a chance to load.
+  // Seed authed favorites onto the URL on first load (when no `?cities=`).
+  // Geo seeding for anon visitors is delegated to the shared hook below;
+  // favorites win because the hook stands down whenever favorites are present.
   useEffect(() => {
-    if (hasAppliedDefaults.current || citiesParam) return
-    // Wait for auth to settle. Applying the anon geo default while auth is
-    // still resolving could wrongly seed geo for a user who turns out to be
-    // authenticated (whose favorites should win, or who gets "All cities").
+    if (hasAppliedFavorites.current || citiesParam) return
     if (authLoading) return
+    if (favoriteCities.length === 0) return
 
-    let seed: CityState[] | null = null
-    let fromGeo = false
-    if (favoriteCities.length > 0) {
-      seed = favoriteCities
-    } else if (!isAuthenticated && geoCityWithShows) {
-      seed = [geoCityWithShows]
-      fromGeo = true
-    }
-    if (!seed) return
-
-    hasAppliedDefaults.current = true
-    if (fromGeo) setAppliedGeoDefault(geoCityWithShows)
+    hasAppliedFavorites.current = true
     const params = new URLSearchParams()
-    params.set('cities', buildCitiesParam(seed))
+    params.set('cities', buildCitiesParam(favoriteCities))
     startTransition(() => {
       router.replace(`/explore?${params.toString()}`, { scroll: false })
     })
-  }, [
-    favoriteCities,
-    geoCityWithShows,
+  }, [favoriteCities, authLoading, citiesParam, router])
+
+  // IP-geo soft default for anon visitors (PSY-926, shared hook PSY-946). The
+  // hook reconciles the server-read `geoDefaultCity` against the has-shows
+  // data and seeds the canonical city via router.replace. /explore reads geo
+  // server-side, so no client fetch here (enableClientFetch defaults false).
+  const onSeedGeo = useCallback(
+    (city: CityState) => {
+      const params = new URLSearchParams()
+      params.set('cities', buildCitiesParam([city]))
+      startTransition(() => {
+        router.replace(`/explore?${params.toString()}`, { scroll: false })
+      })
+    },
+    [router],
+  )
+  const { appliedGeoDefault, notifyUserInteracted } = useGeoDefaultCity({
+    cities,
     isAuthenticated,
     authLoading,
-    citiesParam,
-    router,
-  ])
+    favoriteCities,
+    hasExistingSelection: !!citiesParam,
+    geoFromServer: geoDefaultCity,
+    onSeed: onSeedGeo,
+  })
 
   const { data, isLoading, isFetching, error } = useExploreUpcomingShows({
     limit,
@@ -191,7 +173,7 @@ export function UpcomingShowsList({
     (cities: CityState[]) => {
       // Any manual filter change is an override — the geo affordance must
       // not linger over a user-chosen selection.
-      setAppliedGeoDefault(null)
+      notifyUserInteracted()
       const params = new URLSearchParams()
       if (cities.length > 0) params.set('cities', buildCitiesParam(cities))
       const qs = params.toString()
@@ -199,16 +181,16 @@ export function UpcomingShowsList({
         router.push(qs ? `/explore?${qs}` : '/explore', { scroll: false })
       })
     },
-    [router],
+    [router, notifyUserInteracted],
   )
 
   // True when the geo default is still the active selection (exactly the one
   // detected city, unchanged by the user) — drives the "(from your location)"
   // chip.
-  const showGeoAffordance =
-    appliedGeoDefault !== null &&
-    selectedCities.length === 1 &&
-    citiesEqual(selectedCities, [appliedGeoDefault])
+  const showGeoAffordance = shouldShowGeoAffordance(
+    appliedGeoDefault,
+    selectedCities,
+  )
   const selectionDiffersFromFavorites = !citiesEqual(
     selectedCities,
     favoriteCities,
@@ -231,22 +213,11 @@ export function UpcomingShowsList({
             />
           )}
         </CityFilters>
-        {showGeoAffordance && appliedGeoDefault && (
-          <p
-            className="mt-1.5 text-xs text-muted-foreground"
-            data-testid="geo-default-affordance"
-          >
-            Showing {appliedGeoDefault.city}, {appliedGeoDefault.state} (from
-            your location) —{' '}
-            <button
-              type="button"
-              onClick={() => handleFilterChange([])}
-              className="text-primary hover:underline underline-offset-4"
-              data-testid="geo-default-change"
-            >
-              change
-            </button>
-          </p>
+        {showGeoAffordance && (
+          <GeoDefaultAffordance
+            city={appliedGeoDefault}
+            onChange={() => handleFilterChange([])}
+          />
         )}
       </div>
     ) : null

--- a/frontend/features/shows/components/HomeShowList.test.tsx
+++ b/frontend/features/shows/components/HomeShowList.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
 import { HomeShowList } from './HomeShowList'
 import type { ShowResponse } from '../types'
+
+// Mock Sentry so a geo-fetch rejection in tests is observable & offline.
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
 
 // Mock AuthContext.
 // Return type widened so individual tests can override `user`/`isAuthenticated`
@@ -57,8 +62,19 @@ vi.mock('./ShowCard', () => ({
 }))
 
 vi.mock('@/components/filters', () => ({
-  CityFilters: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="city-filters">{children}</div>
+  CityFilters: ({
+    selectedCities,
+    children,
+  }: {
+    selectedCities?: Array<{ city: string; state: string }>
+    children?: React.ReactNode
+  }) => (
+    <div data-testid="city-filters">
+      <span data-testid="selected-labels">
+        {(selectedCities ?? []).map(c => `${c.city},${c.state}`).join('|')}
+      </span>
+      {children}
+    </div>
   ),
 }))
 
@@ -269,6 +285,83 @@ describe('HomeShowList', () => {
       // With no selected cities and no favorites, selectionDiffersFromFavorites is false (both empty)
       // so SaveDefaultsButton should NOT show
       expect(screen.queryByTestId('save-defaults')).not.toBeInTheDocument()
+    })
+  })
+
+  // IP-geo soft default (PSY-946). Home seeds the geo city into local
+  // selection state (no URL) via the real useGeoDefaultCity hook, driven here
+  // by a mocked /api/geo fetch + the useShowCities has-shows list.
+  describe('IP-geo default city (PSY-946)', () => {
+    function mockGeoFetch(geo: { city: string; state: string } | null) {
+      return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ geo }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    }
+
+    beforeEach(() => {
+      window.sessionStorage.clear()
+      mockUseShowCities.mockReturnValue({
+        data: {
+          cities: [
+            { city: 'Phoenix', state: 'AZ', show_count: 5 },
+            { city: 'Omaha', state: 'NE', show_count: 3 },
+          ],
+        },
+      })
+      mockUseUpcomingShows.mockReturnValue({
+        data: { shows: [makeShow()] },
+        isLoading: false,
+        isFetching: false,
+        error: null,
+      })
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+      window.sessionStorage.clear()
+    })
+
+    it('seeds the canonical geo city into local selection state for an anon visitor', async () => {
+      mockGeoFetch({ city: 'Omaha', state: 'NE' })
+      render(<HomeShowList />)
+      await waitFor(() =>
+        expect(screen.getByTestId('selected-labels')).toHaveTextContent(
+          'Omaha,NE',
+        ),
+      )
+      // The overridable affordance renders for the geo-seeded selection.
+      expect(screen.getByTestId('geo-default-affordance')).toHaveTextContent(
+        'Omaha, NE',
+      )
+    })
+
+    it('does NOT seed when the geo city has no shows', async () => {
+      mockGeoFetch({ city: 'Tucson', state: 'AZ' })
+      render(<HomeShowList />)
+      await waitFor(() =>
+        expect(
+          window.sessionStorage.getItem('ph-geo-default-city'),
+        ).not.toBeNull(),
+      )
+      expect(screen.getByTestId('selected-labels')).toHaveTextContent('')
+      expect(
+        screen.queryByTestId('geo-default-affordance'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('does NOT fetch geo for an authed visitor (no wasted edge request)', () => {
+      const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+      mockAuthContext.mockReturnValue({
+        user: { id: '1' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<HomeShowList />)
+      expect(fetchSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/features/shows/components/HomeShowList.tsx
+++ b/frontend/features/shows/components/HomeShowList.tsx
@@ -12,10 +12,15 @@ import type { CityState } from '@/components/filters'
 import { ShowCard } from './ShowCard'
 import { CityFilters, type CityWithCount } from '@/components/filters'
 import { citiesEqual } from '@/components/filters/cityParams'
+import {
+  useGeoDefaultCity,
+  shouldShowGeoAffordance,
+} from '@/components/filters/useGeoDefaultCity'
+import { GeoDefaultAffordance } from '@/components/filters/GeoDefaultAffordance'
 import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
 
 export function HomeShowList() {
-  const { user, isAuthenticated } = useAuthContext()
+  const { user, isAuthenticated, isLoading: authLoading } = useAuthContext()
   const isAdmin = user?.is_admin ?? false
   const { data: profileData } = useProfile()
   const [selectedCities, setSelectedCities] = useState<CityState[]>([])
@@ -35,17 +40,51 @@ export function HomeShowList() {
     }
   }, [favoriteCities])
 
-  const handleFilterChange = useCallback((cities: CityState[]) => {
-    hasManuallyInteracted.current = true
-    setSelectedCities(cities)
-  }, [])
-
   const timezone =
     typeof window !== 'undefined'
       ? Intl.DateTimeFormat().resolvedOptions().timeZone
       : 'America/Phoenix'
 
   const { data: citiesData } = useShowCities({ timezone })
+
+  const cities: CityWithCount[] = useMemo(
+    () =>
+      citiesData?.cities?.map(c => ({
+        city: c.city,
+        state: c.state,
+        count: c.show_count,
+      })) ?? [],
+    [citiesData?.cities]
+  )
+
+  // IP-geo soft default for anon visitors (PSY-946). Home has no URL
+  // persistence, so geo seeds the local selection state — the same mechanism
+  // favorites use. The page stays fully static; geo arrives via the `/api/geo`
+  // edge route handler client-side. Favorites win (the hook stands down when
+  // favoriteCities is non-empty); a user interaction blocks any in-flight seed.
+  const onSeedGeo = useCallback((city: CityState) => {
+    setSelectedCities([city])
+  }, [])
+  const { appliedGeoDefault, notifyUserInteracted } = useGeoDefaultCity({
+    cities,
+    isAuthenticated,
+    authLoading,
+    favoriteCities,
+    // Home seeds favorites into the same local state; once that has happened
+    // (or the user picks a city), a non-empty selection means geo stands down.
+    hasExistingSelection: selectedCities.length > 0,
+    enableClientFetch: true,
+    onSeed: onSeedGeo,
+  })
+
+  const handleFilterChange = useCallback(
+    (cities: CityState[]) => {
+      hasManuallyInteracted.current = true
+      notifyUserInteracted()
+      setSelectedCities(cities)
+    },
+    [notifyUserInteracted]
+  )
 
   const { data, isLoading, isFetching, error } = useUpcomingShows({
     timezone,
@@ -63,18 +102,13 @@ export function HomeShowList() {
   const { data: savedShowIds } = useSavedShowBatch(showIds, isAuthenticated)
   const { data: batchAttendance } = useBatchAttendance(showIds)
 
-  const cities: CityWithCount[] = useMemo(
-    () =>
-      citiesData?.cities?.map(c => ({
-        city: c.city,
-        state: c.state,
-        count: c.show_count,
-      })) ?? [],
-    [citiesData?.cities]
-  )
-
   // Determine if "Save as default" / "Clear defaults" should show
   const selectionDiffersFromFavorites = !citiesEqual(selectedCities, favoriteCities)
+
+  const showGeoAffordance = shouldShowGeoAffordance(
+    appliedGeoDefault,
+    selectedCities
+  )
 
   if (isLoading) {
     return (
@@ -110,6 +144,12 @@ export function HomeShowList() {
               />
             )}
           </CityFilters>
+          {showGeoAffordance && (
+            <GeoDefaultAffordance
+              city={appliedGeoDefault}
+              onChange={() => handleFilterChange([])}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/features/shows/components/ShowList.test.tsx
+++ b/frontend/features/shows/components/ShowList.test.tsx
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ShowList } from './ShowList'
 import type { ShowResponse, ArtistResponse } from '../types'
+
+// Mock Sentry so a geo-fetch rejection in tests is observable & offline.
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
 
 // Mock AuthContext
 const mockAuthContext = vi.fn(() => ({
@@ -409,6 +414,95 @@ describe('ShowList', () => {
       })
       render(<ShowList />)
       expect(screen.queryByTestId('city-filters')).not.toBeInTheDocument()
+    })
+  })
+
+  // IP-geo soft default (PSY-946). ShowList consumes the real
+  // useGeoDefaultCity hook, driven here via a mocked /api/geo fetch + the
+  // useShowCities has-shows list, and seeds `?cities=` via router.replace.
+  describe('IP-geo default city (PSY-946)', () => {
+    function mockGeoFetch(geo: { city: string; state: string } | null) {
+      return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ geo }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    }
+
+    beforeEach(() => {
+      window.sessionStorage.clear()
+      mockUseShowCities.mockReturnValue({
+        data: {
+          cities: [
+            { city: 'Phoenix', state: 'AZ', show_count: 5 },
+            { city: 'Omaha', state: 'NE', show_count: 3 },
+          ],
+        },
+        isLoading: false,
+        isFetching: false,
+      })
+      mockUseUpcomingShows.mockReturnValue({
+        data: {
+          shows: [makeShow()],
+          pagination: { has_more: false, next_cursor: null, limit: 20 },
+        },
+        isLoading: false,
+        isFetching: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+      window.sessionStorage.clear()
+    })
+
+    it('seeds the canonical geo city onto ?cities= for an anon visitor with shows', async () => {
+      mockGeoFetch({ city: 'Omaha', state: 'NE' })
+      render(<ShowList />)
+      await waitFor(() =>
+        expect(mockReplace).toHaveBeenCalledWith('/shows?cities=Omaha%2CNE', {
+          scroll: false,
+        }),
+      )
+    })
+
+    it('does NOT seed when the geo city has no shows', async () => {
+      mockGeoFetch({ city: 'Tucson', state: 'AZ' })
+      render(<ShowList />)
+      // Let the fetch resolve, then assert no replace.
+      await waitFor(() =>
+        expect(
+          window.sessionStorage.getItem('ph-geo-default-city'),
+        ).not.toBeNull(),
+      )
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fetch geo or seed when ?cities= is already present', () => {
+      const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+      mockSearchParams.mockReturnValue({
+        get: vi.fn((key: string): string | null =>
+          key === 'cities' ? 'Phoenix,AZ' : null,
+        ),
+      })
+      render(<ShowList />)
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fetch geo for an authed user (no wasted edge request)', () => {
+      const fetchSpy = mockGeoFetch({ city: 'Omaha', state: 'NE' })
+      mockAuthContext.mockReturnValue({
+        user: { id: 1 } as never,
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<ShowList />)
+      expect(fetchSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -21,6 +21,11 @@ import {
   buildCitiesParam,
   citiesEqual,
 } from '@/components/filters/cityParams'
+import {
+  useGeoDefaultCity,
+  shouldShowGeoAffordance,
+} from '@/components/filters/useGeoDefaultCity'
+import { GeoDefaultAffordance } from '@/components/filters/GeoDefaultAffordance'
 import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
 import {
   TagFacetPanel,
@@ -32,7 +37,7 @@ import {
 export function ShowList() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { user, isAuthenticated } = useAuthContext()
+  const { user, isAuthenticated, isLoading: authLoading } = useAuthContext()
   const isAdmin = user?.is_admin ?? false
   const [isPending, startTransition] = useTransition()
   const { data: profileData } = useProfile()
@@ -82,6 +87,11 @@ export function ShowList() {
   }, [favoriteCities, citiesParam, legacyCity, legacyState, router])
 
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+  // Any explicit selection already present (URL param or legacy single-city)
+  // means geo must not seed. Authed favorites also stand the geo hook down
+  // (handled inside the hook via favoriteCities + isAuthenticated).
+  const hasExistingSelection = !!citiesParam || !!(legacyCity && legacyState)
   const [cursor, setCursor] = useState<string | undefined>(undefined)
   const [accumulatedShows, setAccumulatedShows] = useState<ShowResponse[]>([])
 
@@ -91,6 +101,43 @@ export function ShowList() {
     isFetching: citiesFetching,
   } = useShowCities({
     timezone,
+  })
+
+  // Map ShowCity → CityWithCount (the has-shows list). Lifted above the early
+  // returns so the geo hook can read it unconditionally.
+  const cities: CityWithCount[] = useMemo(
+    () =>
+      citiesData?.cities?.map(c => ({
+        city: c.city,
+        state: c.state,
+        count: c.show_count,
+      })) ?? [],
+    [citiesData?.cities]
+  )
+
+  // IP-geo soft default for anon visitors (PSY-946). /shows reads geo via the
+  // `/api/geo` edge route handler client-side (the page stays ISR — it must
+  // not read `next/headers`). Seeds the canonical city onto `?cities=` via the
+  // same router.replace mechanism favorites use; favorites and an existing
+  // `?cities=`/legacy selection both win (the hook stands down).
+  const onSeedGeo = useCallback(
+    (city: CityState) => {
+      const params = new URLSearchParams()
+      params.set('cities', buildCitiesParam([city]))
+      startTransition(() => {
+        router.replace(`/shows?${params.toString()}`, { scroll: false })
+      })
+    },
+    [router]
+  )
+  const { appliedGeoDefault, notifyUserInteracted } = useGeoDefaultCity({
+    cities,
+    isAuthenticated,
+    authLoading,
+    favoriteCities,
+    hasExistingSelection,
+    enableClientFetch: true,
+    onSeed: onSeedGeo,
   })
 
   const { data, isLoading, isFetching, error, refetch } = useUpcomingShows({
@@ -146,6 +193,9 @@ export function ShowList() {
   )
 
   const handleFilterChange = (cities: CityState[]) => {
+    // Any manual city change is an override — block a still-in-flight geo seed
+    // and drop the affordance.
+    notifyUserInteracted()
     writeParams(cities, selectedTags, tagMatch)
   }
 
@@ -181,13 +231,10 @@ export function ShowList() {
     )
   }
 
-  // Map ShowCity to CityWithCount
-  const cities: CityWithCount[] =
-    citiesData?.cities?.map(c => ({
-      city: c.city,
-      state: c.state,
-      count: c.show_count,
-    })) ?? []
+  const showGeoAffordance = shouldShowGeoAffordance(
+    appliedGeoDefault,
+    selectedCities
+  )
 
   return (
     <section className="w-full max-w-6xl">
@@ -207,6 +254,12 @@ export function ShowList() {
               />
             )}
           </CityFilters>
+          {showGeoAffordance && (
+            <GeoDefaultAffordance
+              city={appliedGeoDefault}
+              onChange={() => handleFilterChange([])}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/lib/geo-default.ts
+++ b/frontend/lib/geo-default.ts
@@ -1,36 +1,55 @@
 /**
- * IP-geolocation default-city resolver for /explore (PSY-926).
+ * IP-geolocation default-city resolver (PSY-926 /explore, PSY-946 /shows + home).
  *
  * Why this exists
  * ---------------
- * The /explore Upcoming Shows city filter (PSY-840) needs a sensible default
- * for anonymous / first-visit users who have no `favorite_cities`. A static
- * Phoenix default wrong-foots the traveler the feature targets. We instead
- * derive the visitor's metro from Vercel's edge geo-IP headers and surface it
- * as an *overridable suggestion* — never a hard lock.
+ * The city filter (PSY-840 /explore, PSY-932 list pages) needs a sensible
+ * default for anonymous / first-visit users who have no `favorite_cities`. A
+ * static Phoenix default wrong-foots the traveler the feature targets. We
+ * instead derive the visitor's metro from Vercel's edge geo-IP headers and
+ * surface it as an *overridable suggestion* — never a hard lock.
  *
- * Dynamic-boundary contract
- * --------------------------
- * Vercel injects `X-Vercel-IP-City` / `X-Vercel-IP-Country-Region` /
- * `X-Vercel-IP-Country` onto the incoming request at the edge. This module is
- * read from `app/explore/page.tsx`, which is ALREADY a request-time (dynamic)
- * render — it `await`s `searchParams` (PSY-840's URL persistence). Reading one
- * more request-data source (`headers()`) there does not un-cache the upstream
- * `fetch(... { next: { revalidate: 300 } })` calls, so ISR on the /explore
- * *data* is preserved; only the per-request shell varies. This is the
- * "dynamic boundary" the PSY-926 AC requires, and it avoids touching
- * `frontend/proxy.ts`'s carefully-tuned soft-404 matcher (the proxy is not
- * needed because the page is already dynamic).
+ * Two read paths — both through `decodeGeoHeaders` (PSY-946)
+ * ----------------------------------------------------------
+ * The SAME decode logic (`decodeGeoHeaders`) feeds two transports, chosen per
+ * surface by its rendering mode. DO NOT "unify" these into one — the split is
+ * deliberate and load-bearing (each preserves a different route's cache mode):
+ *
+ *   1. `getGeoDefaultCity()` — server `next/headers()` read, used by
+ *      `app/explore/page.tsx`. /explore is ALREADY a request-time (dynamic)
+ *      render (it `await`s `searchParams`, PSY-840), so reading one more
+ *      request-data source there is free: the upstream
+ *      `fetch(... { revalidate: 300 })` calls keep their ISR hints, only the
+ *      per-request shell varies. Moving /explore to the route-handler path
+ *      would ADD a client request it doesn't need.
+ *
+ *   2. The edge route handler `app/api/geo/route.ts` — calls
+ *      `decodeGeoHeaders(request.headers)` and is fetched CLIENT-SIDE by
+ *      `useGeoDefaultCity`. Used by `/shows` (ISR, `app/shows/page.tsx`) and
+ *      home (`app/page.tsx`, fully static). Those PAGES must NOT read
+ *      `next/headers` — doing so opts the whole route into dynamic rendering
+ *      and defeats ISR/static (the anti-pattern that got PSY-834 cancelled).
+ *      A separate route handler is inherently dynamic without touching the
+ *      page's cache mode. ⚠️ If you ever try to make /shows or home read geo
+ *      server-side, you will silently un-ISR them — keep the client fetch.
+ *
+ * Either way the decoded value is a SUGGESTION only — it is reconciled against
+ * PH's has-shows data on the client (`useGeoDefaultCity` →
+ * `geoCityWithShows`) and only ever pre-selected as the canonical PH city,
+ * never the raw header (injection-safe).
  *
  * Privacy
  * -------
  * City + region only, read transiently per request, never stored against an
  * identity and never written to a cookie. The decoded value flows to the
- * client as a render prop and is discarded after render. Disclosed in the
- * privacy policy (§2.3 / §3).
+ * client as a render prop (/explore) or a no-store JSON response (route
+ * handler) and is discarded after use. Disclosed in the privacy policy
+ * (§2.3 / §3).
  *
- * Importing this from a client component throws at build time (it reads
- * `next/headers`), so the "server-only" boundary is enforced by the compiler.
+ * `getGeoDefaultCity` imports `next/headers`, so importing IT from a client
+ * component throws at build time — the "server-only" boundary is enforced by
+ * the compiler. `decodeGeoHeaders` is pure (takes a `Headers`) and is safe to
+ * call from the edge route handler.
  */
 
 import { headers } from 'next/headers'
@@ -42,16 +61,21 @@ const HEADER_REGION = 'x-vercel-ip-country-region'
 const HEADER_COUNTRY = 'x-vercel-ip-country'
 
 /**
- * Read the Vercel edge geo headers and decode them into a `{ city, state }`
- * suggestion, or `null` when geo is unavailable / ambiguous.
+ * Decode a `Headers`-like object carrying the Vercel edge geo headers into a
+ * `{ city, state }` suggestion, or `null` when geo is unavailable / ambiguous.
+ *
+ * Pure (no `next/headers`) so BOTH read paths share it (see file header):
+ * `getGeoDefaultCity` passes the server `headers()` store; the edge route
+ * handler passes `request.headers`. Anything with a `.get(name) => string |
+ * null` shape works.
  *
  * This is a SUGGESTION only — it is NOT validated against PH's shows data
- * here (the proxy/server has no cheap access to the cities-with-counts list).
- * The client (`UpcomingShowsList`) reconciles it against `useShowCities`
- * data and only pre-selects it when the city actually has upcoming shows;
- * otherwise it falls back to "All cities". Keeping the has-shows check on the
- * client reuses PSY-840's existing data source instead of inventing a server
- * lookup.
+ * here (neither the server nor the edge has cheap access to the
+ * cities-with-counts list). The client (`useGeoDefaultCity`) reconciles it
+ * against `useShowCities` data and only pre-selects it when the city actually
+ * has upcoming shows; otherwise it falls back to "All cities". Keeping the
+ * has-shows check on the client reuses PSY-840's existing data source instead
+ * of inventing a server lookup.
  *
  * Returns `null` (→ "All cities" fallback) when ANY of these hold:
  *   - the city header is missing or empty (no geo / proxy stripped it),
@@ -65,9 +89,9 @@ const HEADER_COUNTRY = 'x-vercel-ip-country'
  * Header values are URL-encoded by Vercel (e.g. "S%C3%A3o%20Paulo"); we
  * decode them. A malformed encoding yields `null` rather than throwing.
  */
-export async function getGeoDefaultCity(): Promise<CityState | null> {
-  const headerList = await headers()
-
+export function decodeGeoHeaders(
+  headerList: { get(name: string): string | null },
+): CityState | null {
   const country = decodeHeader(headerList.get(HEADER_COUNTRY))
   // Vercel returns ISO 3166-1 alpha-2 country codes. PH's city data is keyed
   // by US state / Canadian province codes; only US/CA can match, so reject
@@ -88,6 +112,17 @@ export async function getGeoDefaultCity(): Promise<CityState | null> {
   }
 
   return { city, state }
+}
+
+/**
+ * Server-side geo read for the /explore page (path 1 above). Reads the Vercel
+ * edge geo headers via `next/headers()` and decodes them with
+ * `decodeGeoHeaders`. Throws at build time if imported from a client component
+ * (compiler-enforced server-only boundary).
+ */
+export async function getGeoDefaultCity(): Promise<CityState | null> {
+  const headerList = await headers()
+  return decodeGeoHeaders(headerList)
 }
 
 /**


### PR DESCRIPTION
Closes PSY-946.

## Summary
- New edge-class route handler `frontend/app/api/geo/route.ts` returns `{geo: {city, state} | null}` from the Vercel geo headers via the shared `decodeGeoHeaders` in `lib/geo-default.ts`. Response is non-shared-cacheable (`Cache-Control: private, no-store, max-age=0, must-revalidate`).
- Extracted the `/explore` reconciliation logic into a shared `useGeoDefaultCity` hook (`frontend/components/filters/useGeoDefaultCity.ts`): canonical-city match against `useShowCities` + has-shows gate + resolution-order + don't-seed-after-user-action guard + sessionStorage cache. One implementation across `/explore`, `/shows`, and home.
- Wired `ShowList.tsx` (seeds `?cities=` via its existing `router.replace`) and `HomeShowList.tsx` (seeds its local `useState`) to the hook for anon-no-favorites visitors.
- `/explore` refactored to use the hook with **zero behavior change** (its geo value still arrives via the server prop; its 19 existing tests pass with no assertion edits).
- Extracted the shared "Showing {City}, {ST} (from your location) — change" chip into `GeoDefaultAffordance.tsx` (was duplicated 3×).
- Privacy policy §2.3 + §3 generalized beyond "the Explore page".

## Design (per PSY-946 decision comment, 2026-05-31)
Option B: edge route handler + client fetch; home in scope. The geo value flows through `decodeGeoHeaders` on two read paths — `/explore`'s existing server `next/headers()` read (already dynamic, no extra request) and the new `/api/geo` client fetch for `/shows` + home (which must stay ISR/static and so cannot read `next/headers` server-side). Both paths and the "don't unify them" rationale are documented in `lib/geo-default.ts`. The seeded value is always the canonical PH city from `useShowCities`, never the raw header (injection-safe). The hook gates the client fetch on eligibility (anon, no favorites, auth settled, no existing selection), so **authed/favorited visitors never trigger the edge request**.

**Justified deviation from the decision comment:** the comment specified `export const runtime = 'edge'` + `export const dynamic = 'force-dynamic'` on the route handler. Both are **rejected at build time** under this repo's `cacheComponents: true` (Next 16 PPR): `Route segment config "runtime"/"dynamic" is not compatible with nextConfig.cacheComponents. Please remove it.` Reading `request.headers` already makes the handler dynamic (build classifies it `ƒ`), and the explicit `Cache-Control: private, no-store` gives the same never-cached guarantee — so the handler satisfies the AC without the incompatible segment configs. Documented inline in `route.ts`.

## ISR/static verification
From `bun run build` (exit 0). `◐` = Partial Prerender (the static/ISR mode under cacheComponents), `ƒ` = Dynamic. Neither page became `ƒ`; `/shows` kept its `1h` revalidate:

```
Route (app)                                                             Revalidate  Expire
┌ ◐ /
├ ƒ /api/geo
├ ◐ /explore
├ ◐ /shows                                                                      1h      1y
```

- `/` → `◐` (static preserved — not `ƒ`)
- `/shows` → `◐` with `1h 1y` (ISR `revalidate: 3600` preserved)
- `/api/geo` → `ƒ` (the route handler is correctly dynamic)
- `/explore` → `◐` (unchanged)

The page route files (`app/page.tsx`, `app/shows/page.tsx`, `app/explore/page.tsx`) were not modified at all — render mode is structurally guaranteed unchanged; only client components + a separate route handler were added.

## Adversarial review
`/adversarial-review` (inline lenses — dispatched agent, no Agent tool in worktree) — **CLEAN** after one LOW fix.
- [LOW] Saboteur: a malformed cached/route value (non-string `city`) would throw on `.trim()` in `geoCityWithShows` mid-render → added `toCityState()` shape-check on both the sessionStorage-cache and fetch paths (coerces a bad value to null) + regression test. Fixed in commit `PSY-946: adversarial-review fixes`.
- Security: `/api/geo` is public/unauthenticated but only echoes the caller's own per-request geo headers through the US/CA gate — no cross-visitor read, no PII beyond already-disclosed city level, no injection (canonical reconciliation client-side). No rate limiting needed (cheaper than the page it precedes). Held up.
- Completeness: all 8 ACs met or disclosed (see deviation above).
Panel lenses: Saboteur · Future-Maintainer · Security · Completeness (run inline; no Agent tool in worktree).

## Test plan
- [x] `bun run typecheck` — clean (post-rebase)
- [x] `bun run test:run features/shows` — all pass (ShowList 20 incl. 4 new geo; HomeShowList 14 incl. 3 new geo)
- [x] `bun run test:run features/explore` — 49/49 (UpcomingShowsList 19/19, no assertion changes — hook extraction is behavior-preserving)
- [x] `bun run test:run lib/geo-default` — 11/11 (existing tests unchanged; `decodeGeoHeaders` extraction is transparent)
- [x] `bun run test:run components/filters` — all pass (useGeoDefaultCity 22, incl. server-prop + client-fetch + sessionStorage + eligibility + malformed-cache branches; CityFilters 19)
- [x] `bun run test:run app/api/geo` — 7/7 (header decode, null cases, US/CA gate, Cache-Control non-shared assertion)
- [x] Full scoped suite (`features/shows features/explore lib/geo-default components/filters app/api/geo`) — 474/474, 45 files
- [x] `bun run build` — exit 0; route table captured above
- [x] Synthetic-header curl against `/api/geo` (live dev stack): `Phoenix/AZ/US` → `{"geo":{"city":"Phoenix","state":"AZ"}}` + `cache-control: private, no-store, max-age=0, must-revalidate`; no headers → `{"geo":null}`; `BR` → `{"geo":null}`
- [x] Browser repro via sessionStorage seam (agent-browser): /shows seeds `?cities=Phoenix%2CAZ` + overridable chip; "change" clears chip + URL, no re-seed; home seeds local state + chip, "change" clears, no re-seed; fresh session (real `/api/geo` → `{"geo":null}` locally) → no affordance on both surfaces
- [ ] Vercel preview verification with real geo headers — **deferred post-PR** (preview exists only after this PR opens)

## Coverage gaps
- Real Vercel geo headers can't be exercised locally — local requests carry no `x-vercel-ip-*`, so the live path was verified via synthetic-header curl (route handler) + the sessionStorage seam (client seeding). Recommend a Vercel-preview check with a real geolocatable IP before merge.
- The "home query transiently errored on first cold load then recovered on retry" was observed once in the dev stack (pre-existing `useUpcomingShows` error path, not geo-related); the geo affordance rendered correctly on the successful render.

## Screenshots
- [/shows seeded](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2661a714dd44d1f48188/psy-946-shows-seeded.png) — Phoenix pre-selected with the "from your location — change" chip + `?cities=` URL.
- [/shows no-geo](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2661a714dd44d1f48188/psy-946-shows-nogeo.png) — clean session, no default, bare `/shows`.
- [home seeded](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2661a714dd44d1f48188/psy-946-home-seeded.png) — Phoenix seeded into local state + chip.
- [home no-geo](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2661a714dd44d1f48188/psy-946-home-nogeo.png) — clean session, no default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
