### PR TITLE
PSY-947: categorical chart tokens + dense-chart line dashes

### DIFF
--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
@@ -359,4 +359,14 @@ describe('COLORS palette invariants (PSY-908)', () => {
     expect(COLORS.rejected).toBe('var(--destructive)')
     expect(COLORS.approved).not.toBe(COLORS.rejected)
   })
+
+  it('interleaves cool accents into the dense Entity Creation chart (PSY-947, no all-warm regression)', () => {
+    const entity = chartGroups['Entity Creation'].map((k) => COLORS[k])
+    // each cool accent must appear so the 6 lines don't cluster warm
+    for (const cool of ['var(--chart-6)', 'var(--chart-7)', 'var(--chart-8)']) {
+      expect(entity).toContain(cool)
+    }
+    // no series should fall back to a non-categorical token (e.g. --foreground)
+    expect(entity).not.toContain('var(--foreground)')
+  })
 })

--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
-import { AnalyticsDashboard, COLORS } from './AnalyticsDashboard'
+import { AnalyticsDashboard, COLORS, ENTITY_DASH } from './AnalyticsDashboard'
 
 // Mock recharts to avoid SVG rendering issues in JSDOM
 vi.mock('recharts', () => {
@@ -366,7 +366,23 @@ describe('COLORS palette invariants (PSY-908)', () => {
     for (const cool of ['var(--chart-6)', 'var(--chart-7)', 'var(--chart-8)']) {
       expect(entity).toContain(cool)
     }
-    // no series should fall back to a non-categorical token (e.g. --foreground)
-    expect(entity).not.toContain('var(--foreground)')
+    // every series must be a categorical chart token — not a non-categorical
+    // fallback like --foreground / --muted-foreground (catches any regression,
+    // not just the one retired --foreground string)
+    for (const token of entity) {
+      expect(token).toMatch(/^var\(--chart-[1-8]\)$/)
+    }
+  })
+
+  it('gives each of the 6 Entity Creation lines a DISTINCT dash pattern (PSY-947 disambiguator)', () => {
+    // The muted palette has near-hues (e.g. green vs teal), so the dash pattern
+    // — not color — carries distinctness. Every entity series needs an entry and
+    // all 6 patterns (incl. solid = undefined) must be unique.
+    const entityKeys = chartGroups['Entity Creation']
+    for (const k of entityKeys) {
+      expect(Object.prototype.hasOwnProperty.call(ENTITY_DASH, k)).toBe(true)
+    }
+    const patterns = entityKeys.map((k) => ENTITY_DASH[k])
+    expect(new Set(patterns).size).toBe(entityKeys.length)
   })
 })

--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
@@ -37,39 +37,38 @@ type MonthRange = 3 | 6 | 12 | 24
 const MONTH_OPTIONS: MonthRange[] = [3, 6, 12, 24]
 
 /**
- * Chart series colors, bound to the design-system palette (PSY-908). The token
- * VALUES live in `globals.css` — `--chart-1`..`--chart-5` + `--destructive` +
- * `--foreground`, each with a `:root` (light) and `.dark` override — so series
- * colors track the theme automatically via the CSS cascade. Replaces the prior
- * ad-hoc Tailwind hexes (blue/violet/pink) that clashed with the editorial
- * burnt-orange/newsprint palette.
+ * Chart series colors, bound to the design-system palette. Token VALUES live in
+ * `globals.css` as an 8-hue categorical set — `--chart-1`..`--chart-8` (the 5
+ * editorial hues, warm-skewed, + 3 cool accents: denim/plum/teal, PSY-947) plus `--destructive`,
+ * each with a `:root` (light) and `.dark` override, so series colors track the
+ * theme automatically via the CSS cascade. Replaces the prior ad-hoc Tailwind
+ * hexes (blue/violet/pink) that clashed with the editorial newsprint palette.
  *
- * Within a single chart every series is assigned a DISTINCT token; the five
- * categorical tokens are reused ACROSS charts (a token only has to be unique
- * per chart). The 6-line Entity Creation chart uses `--foreground` for its 6th
- * line (Users). Approval trends are semantic: approved = `--chart-2` (green),
+ * Within a single chart every series gets a DISTINCT token; tokens are reused
+ * ACROSS charts (a token only has to be unique per chart). The dense 6-line
+ * Entity Creation chart uses an INTERLEAVED warm/cool selection
+ * (orange · denim · gold · plum · green · teal) so adjacent lines contrast — the
+ * cool accents break up the warm cluster that read poorly in dark mode before
+ * PSY-947. Approval trends are semantic: approved = `--chart-2` (green),
  * rejected = `--destructive` (red).
  *
- * Caveat — the editorial palette is intentionally low-chroma and warm-skewed,
- * so distinct tokens are not always maximally distinguishable: `--chart-1` and
- * `--chart-3` sit close in dark mode. The legend (series names) is the primary
- * disambiguator for the dense 6-line chart; a richer categorical sub-palette is
- * deferred to the PSY-908 Figma follow-up. Also note `--chart-4` === `--destructive`
- * in light mode (both `#9c2a1a`): they never share a chart today, so don't pair
- * a `--chart-4` series with a `--destructive` series in one chart, and don't
- * "dedupe" the two tokens in `globals.css`.
+ * Note: `--chart-4` === `--destructive` in light mode (both `#9c2a1a`); they
+ * never share a chart, so don't pair a `--chart-4` series with a `--destructive`
+ * series in one chart, and don't "dedupe" the two tokens in `globals.css`. The
+ * full 8-hue set is the shared categorical palette for charts + entity badges
+ * (badge migration: PSY-943).
  *
  * Exported only for the invariant test that guards per-chart distinctness and
  * the approved/rejected semantic pairing.
  */
 export const COLORS = {
-  // Entity Creation Trends (6 lines, one chart)
-  shows: 'var(--chart-1)',
-  artists: 'var(--chart-2)',
-  venues: 'var(--chart-3)',
-  releases: 'var(--chart-4)',
-  labels: 'var(--chart-5)',
-  users: 'var(--foreground)',
+  // Entity Creation Trends (6 lines) — interleaved warm/cool for max contrast
+  shows: 'var(--chart-1)', // orange
+  artists: 'var(--chart-6)', // denim
+  venues: 'var(--chart-3)', // gold
+  releases: 'var(--chart-7)', // plum
+  labels: 'var(--chart-2)', // green
+  users: 'var(--chart-8)', // teal
   // Content Curation (3 series)
   tags_added: 'var(--chart-1)',
   tag_votes: 'var(--chart-2)',

--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
@@ -46,11 +46,12 @@ const MONTH_OPTIONS: MonthRange[] = [3, 6, 12, 24]
  *
  * Within a single chart every series gets a DISTINCT token; tokens are reused
  * ACROSS charts (a token only has to be unique per chart). The dense 6-line
- * Entity Creation chart uses an INTERLEAVED warm/cool selection
- * (orange · denim · gold · plum · green · teal) so adjacent lines contrast — the
- * cool accents break up the warm cluster that read poorly in dark mode before
- * PSY-947. Approval trends are semantic: approved = `--chart-2` (green),
- * rejected = `--destructive` (red).
+ * Entity Creation chart draws from the categorical palette for hue variety
+ * (orange · denim · gold · plum · green · teal), but the muted editorial hues
+ * aren't all far apart (e.g. green vs teal), so per-line DASH PATTERNS — see
+ * `ENTITY_DASH` — are the PRIMARY disambiguator there; color is secondary, and
+ * each plotted line carries both its dash and hue. Approval trends are semantic:
+ * approved = `--chart-2` (green), rejected = `--destructive` (red).
  *
  * Note: `--chart-4` === `--destructive` in light mode (both `#9c2a1a`); they
  * never share a chart, so don't pair a `--chart-4` series with a `--destructive`
@@ -62,7 +63,7 @@ const MONTH_OPTIONS: MonthRange[] = [3, 6, 12, 24]
  * the approved/rejected semantic pairing.
  */
 export const COLORS = {
-  // Entity Creation Trends (6 lines) — interleaved warm/cool for max contrast
+  // Entity Creation Trends (6 lines) — hue variety; dash patterns (ENTITY_DASH) carry distinctness
   shows: 'var(--chart-1)', // orange
   artists: 'var(--chart-6)', // denim
   venues: 'var(--chart-3)', // gold
@@ -84,6 +85,23 @@ export const COLORS = {
   // Show Approval Trends (semantic)
   approved: 'var(--chart-2)',
   rejected: 'var(--destructive)',
+}
+
+/**
+ * Per-line dash patterns for the dense 6-line Entity Creation chart. The
+ * editorial palette is muted, so some series hues sit close (e.g. green vs
+ * teal); the dash pattern — NOT color — is the primary disambiguator here, so
+ * the 6 lines stay tellable apart in both themes and at small legend sizes
+ * (PSY-947, from adversarial review of the color-only first cut).
+ * solid → dashed → dotted → dash-dot → long-dash → short-dash.
+ */
+export const ENTITY_DASH: Record<string, string | undefined> = {
+  shows: undefined, // solid
+  artists: '8 4', // dashed
+  venues: '2 4', // dotted
+  releases: '12 4 2 4', // dash-dot
+  labels: '16 6', // long dash
+  users: '5 3', // short dash
 }
 
 /**
@@ -266,6 +284,8 @@ function GrowthSection({ months }: { months: MonthRange }) {
               stroke={COLORS.shows}
               strokeWidth={2}
               dot={false}
+              strokeDasharray={ENTITY_DASH.shows}
+              legendType="plainline"
               name="Shows"
             />
             <Line
@@ -274,6 +294,8 @@ function GrowthSection({ months }: { months: MonthRange }) {
               stroke={COLORS.artists}
               strokeWidth={2}
               dot={false}
+              strokeDasharray={ENTITY_DASH.artists}
+              legendType="plainline"
               name="Artists"
             />
             <Line
@@ -282,6 +304,8 @@ function GrowthSection({ months }: { months: MonthRange }) {
               stroke={COLORS.venues}
               strokeWidth={2}
               dot={false}
+              strokeDasharray={ENTITY_DASH.venues}
+              legendType="plainline"
               name="Venues"
             />
             <Line
@@ -290,6 +314,8 @@ function GrowthSection({ months }: { months: MonthRange }) {
               stroke={COLORS.releases}
               strokeWidth={2}
               dot={false}
+              strokeDasharray={ENTITY_DASH.releases}
+              legendType="plainline"
               name="Releases"
             />
             <Line
@@ -298,6 +324,8 @@ function GrowthSection({ months }: { months: MonthRange }) {
               stroke={COLORS.labels}
               strokeWidth={2}
               dot={false}
+              strokeDasharray={ENTITY_DASH.labels}
+              legendType="plainline"
               name="Labels"
             />
             <Line
@@ -306,6 +334,8 @@ function GrowthSection({ months }: { months: MonthRange }) {
               stroke={COLORS.users}
               strokeWidth={2}
               dot={false}
+              strokeDasharray={ENTITY_DASH.users}
+              legendType="plainline"
               name="Users"
             />
           </LineChart>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -39,6 +39,9 @@
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
+  --color-chart-8: var(--chart-8);
+  --color-chart-7: var(--chart-7);
+  --color-chart-6: var(--chart-6);
   --color-chart-5: var(--chart-5);
   --color-chart-4: var(--chart-4);
   --color-chart-3: var(--chart-3);
@@ -114,6 +117,11 @@
   --chart-3: #c89438;
   --chart-4: #9c2a1a;
   --chart-5: #8b7355;
+  /* Categorical cool accents (PSY-947) — extend the 5 warm chart tokens into a
+   * shared 8-hue categorical palette for multi-series charts + entity badges. */
+  --chart-6: #3f607f;
+  --chart-7: #6e4f73;
+  --chart-8: #357d74;
   --sidebar: #ede8db;
   --sidebar-foreground: #1a1714;
   --sidebar-primary: #d2541b;
@@ -150,6 +158,10 @@
   --chart-3: #e0b66e;
   --chart-4: #d74745;
   --chart-5: #b59880;
+  /* Categorical cool accents (PSY-947) — dark-mode variants */
+  --chart-6: #80a0c0;
+  --chart-7: #ad8fb0;
+  --chart-8: #6db3a6;
   --sidebar: #120c08;
   --sidebar-foreground: #eee7d9;
   --sidebar-primary: #e89960;


### PR DESCRIPTION
Closes PSY-947. Follow-up to PSY-908/#937 (the "Figma follow-up").

## Summary

Completes the shared 8-hue categorical palette and fixes the dense analytics chart's legibility (the limitation disclosed in #937).

- **DS tokens** — adds `--chart-6` (denim), `--chart-7` (plum), `--chart-8` (teal) to `globals.css` (Light + Dark) + the `--color-chart-6/7/8` Tailwind mappings. Matches the same 3 tokens added to the design-system Figma Color collection (documented on the Foundations/Color page). This is now the shared categorical palette for charts **and** entity badges (badge migration tracked separately in **PSY-943**).
- **Dense Entity-Creation chart** — the 6 lines now use a hue-varied selection from the palette **plus a distinct per-line dash pattern** (`ENTITY_DASH`: solid / dashed / dotted / dash-dot / long-dash / short-dash), with `legendType="plainline"` so the legend icons carry the dash too. Distinctness no longer depends on color, which matters because the editorial palette is intentionally muted (close hues).

## Why dashes, not just color (from adversarial review)

The first cut was color-only (an interleaved warm/cool token assignment). `/adversarial-review` measured that the **muted** Candidate-A accents are RGB-close (denim↔teal ≈ 32, green↔teal ≈ 34), so the color-only interleave actually *regressed* worst-pair separation vs the all-warm baseline and didn't fix the disclosed dark-mode pair. Per-line **dash patterns** are the robust fix — they distinguish the lines regardless of hue closeness, in both themes and in the legend.

## Adversarial review

`/adversarial-review` — 2 rounds → CLEAN; fixes in commit `d2120dde` (panel: Saboteur · Future-Maintainer · Completeness, fresh context).
- **[Round 1 / HIGH] color-only interleave didn't improve distinctness (muted hues are RGB-close)** → reworked to per-line dash patterns as the primary disambiguator; rewrote the overstated "max contrast" comment.
- **[Round 2 / HIGH] dashes didn't reach the legend** (recharts `<Line>` defaults to a solid `legendType="line"` icon) → `legendType="plainline"` on all 6 lines (verified live: legend icons now render the dash).
- **[Round 2 / HIGH] a stale "max contrast" inline comment survived** → corrected.
- **[Round 2 / MEDIUM] the `--foreground` test was a tautology** → replaced with a positive `var(--chart-[1-8])` categorical invariant.
- **Round 3: CLEAN** — all resolved, nothing new.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run app/admin/analytics lib/hooks/admin/useAnalytics.test.tsx` — 36/36 passing (incl. PSY-947 guards: cool-accents present, every entity token is `var(--chart-[1-8])`, and the 6 dash patterns are distinct)
- [x] `/code-review` — clean (fixed one "5 warm hues" comment imprecision in the impl commit; correctness reviewer confirmed no cross-chart side-effects)
- [x] `/adversarial-review` — CLEAN after 2 fix rounds; fixes in separate commit `d2120dde` (see above)
- [x] `/psy-self-review` — see result below
- [x] Manual repro (admin `/admin/analytics`, light **and** dark): DOM-verified all 6 lines resolve to the interleaved tokens (light `shows`→rgb(210,84,27) … `users`→chart-8 rgb(53,125,116); dark variants too), and that each plotted line + its legend icon carries its distinct `stroke-dasharray` (`8 4` / `2 4` / `12 4 2 4` / `16 6` / `5 3` / solid). Screenshots below.

## Screenshots

Growth view, light — 6 lines + legend, each a distinct dash pattern:

![analytics growth light](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-71552612e3d25593b347/psy-947-final-light.png)

Growth view, dark — distinctness holds independent of the muted hues:

![analytics growth dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-71552612e3d25593b347/psy-947-final-dark.png)

## Coverage gaps

- **Engagement view not re-screenshotted** — dev DB has no engagement data over the range (empty areas); the token + dash changes only touch the Growth (Entity Creation) line chart.
- **Dash applied only to the dense 6-line chart** — the other charts (≤4 series) keep their existing color-only assignments (already distinct); not in scope here.
- **Badge migration (PSY-943) not included** — the 8 tokens are now defined and ready for it; this PR is charts-only.
- **CI doesn't assert rendered dashes** — recharts is mocked in unit tests, so the guards cover the `COLORS`/`ENTITY_DASH` data tables (token-categorical + dash-distinct), not the SVG render. Rendered dashes (lines + legend) were verified live via agent-browser (DOM `stroke-dasharray` + screenshots above).
