### PR TITLE
PSY-934: fix dead pending-venue-edits admin links via nav SSOT

### DIFF
--- a/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
+++ b/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
@@ -281,7 +281,11 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
               value={stats.pending_venue_edits}
               icon={MapPin}
               highlight
-              onClick={onNavigate ? () => onNavigate('pending-venue-edits') : undefined}
+              // PSY-934: pending entity edits (incl. venue edits) render under
+              // the Moderation queue, not a standalone tab. 'pending-venue-edits'
+              // is not a valid section (see VALID_TABS in adminNav.ts), so it fell
+              // back to Dashboard — a dead quick-link. Route to the real section.
+              onClick={onNavigate ? () => onNavigate('moderation') : undefined}
             />
             <StatCard
               label="Pending Reports"

--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { screen, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
-import { CommandPalette } from './CommandPalette'
+import { CommandPalette, adminRoutes } from './CommandPalette'
+import { isValidTab, adminNavGroups, adminTabHref } from './adminNav'
 
 // jsdom does not implement scrollIntoView
 beforeAll(() => {
@@ -598,5 +599,49 @@ describe('CommandPalette — search outage banner (PSY-725)', () => {
     // Palette open with searchError=true but no query yet — banner must
     // stay hidden so users see the static routes, not a stale outage flag.
     expect(screen.queryByTestId('entity-search-error-banner')).not.toBeInTheDocument()
+  })
+})
+
+// PSY-934: the palette's admin routes are now DERIVED from the nav SSOT
+// (adminNavGroups + adminTabHref in adminNav.ts) instead of a third hardcoded
+// copy. This guards that coupling: every admin href must resolve to a real
+// section, so a dead link like the old `?tab=pending-venue-edits` (which fell
+// back to the Dashboard) can never ship again, and every nav section stays
+// reachable via Cmd-K.
+describe('CommandPalette — admin routes derived from nav SSOT (PSY-934)', () => {
+  // The `?tab=` value an admin href resolves to. Dashboard is the bare /admin
+  // (resolves to 'dashboard' in page.tsx via the isValidTab fallback).
+  const tabOf = (href: string): string => {
+    const url = new URL(href, 'https://x.test')
+    return url.searchParams.get('tab') ?? 'dashboard'
+  }
+
+  it('every admin href resolves to a valid section (⊆ VALID_TABS)', () => {
+    for (const route of adminRoutes) {
+      expect(route.href.startsWith('/admin')).toBe(true)
+      // isValidTab accepts the resolved tab — no Dashboard fallback for a
+      // stale/typo'd tab. This is what the dead `pending-venue-edits` link
+      // failed before this fix.
+      expect(isValidTab(tabOf(route.href))).toBe(true)
+    }
+  })
+
+  it('has no dead `pending-venue-edits` link (the PSY-934 regression)', () => {
+    expect(adminRoutes.some(r => r.href.includes('pending-venue-edits'))).toBe(false)
+  })
+
+  it('covers exactly the nav SSOT sections, in order (Radio reachable via Cmd-K)', () => {
+    const expectedTabs = adminNavGroups.flatMap(g => g.items.map(i => i.tab))
+    expect(adminRoutes.map(r => tabOf(r.href))).toEqual(expectedTabs)
+    // Radio was missing from the prior hardcoded copy; the SSOT includes it.
+    expect(adminRoutes.some(r => r.href === adminTabHref('radio'))).toBe(true)
+  })
+
+  it('every admin route is admin-gated and prefixed', () => {
+    for (const route of adminRoutes) {
+      expect(route.requireAdmin).toBe(true)
+      expect(route.label.startsWith('Admin: ')).toBe(true)
+      expect(route.keywords).toContain('admin')
+    }
   })
 })

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -14,11 +14,12 @@ import {
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
   Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe,
-  TrendingUp, LayoutDashboard, Upload, BadgeCheck, Flag, ScrollText, Users, Workflow,
-  ClipboardCheck, BarChart3, Music, Bell, HeartHandshake, ShieldCheck, Loader2, Trophy, Radio,
+  TrendingUp, Music, Bell, HeartHandshake, Loader2, Trophy, Radio,
   Hash, Network,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
+import { adminNavGroups, adminTabHref } from '@/components/layout/adminNav'
+import type { AdminTab } from '@/components/layout/adminNav'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useCommandPalette } from '@/lib/hooks/common/useCommandPalette'
 import {
@@ -187,134 +188,51 @@ const routes: RouteItem[] = [
   },
 ]
 
-const adminRoutes: RouteItem[] = [
-  {
-    label: 'Admin: Dashboard',
-    href: '/admin',
-    icon: LayoutDashboard,
-    keywords: ['admin', 'dashboard', 'overview', 'stats'],
+/**
+ * Cmd-K search keywords per admin section, keyed by AdminTab so a new section
+ * (added to VALID_TABS in adminNav.ts) is a compile error here until it gets
+ * search terms — the palette can never silently ship a keyword-less admin entry.
+ * 'admin' is prepended to every entry by the derivation below, so it's omitted here.
+ */
+const ADMIN_ROUTE_KEYWORDS: Record<AdminTab, string[]> = {
+  dashboard: ['dashboard', 'overview', 'stats'],
+  moderation: ['moderation', 'queue', 'review', 'pending', 'edits', 'reports', 'moderate', 'venue'],
+  'pending-shows': ['pending', 'shows', 'approve', 'review', 'moderate'],
+  'unverified-venues': ['unverified', 'venues', 'verify'],
+  reports: ['reports', 'flags', 'flagged', 'issues'],
+  'import-show': ['import', 'show', 'add', 'upload'],
+  releases: ['releases', 'albums', 'manage'],
+  labels: ['labels', 'record labels', 'manage'],
+  festivals: ['festivals', 'manage'],
+  pipeline: ['pipeline', 'extraction', 'scraping', 'venues', 'data', 'import'],
+  collections: ['collections', 'manage', 'featured'],
+  tags: ['tags', 'manage', 'genres'],
+  'data-quality': ['data', 'quality', 'health', 'issues'],
+  analytics: ['analytics', 'metrics', 'growth', 'engagement'],
+  'artists-admin': ['artists', 'manage', 'merge', 'aliases'],
+  radio: ['radio', 'stations', 'matching', 'kexp', 'wfmu', 'nts', 'manage'],
+  users: ['users', 'accounts', 'manage'],
+  'audit-log': ['audit', 'log', 'history', 'actions'],
+}
+
+// PSY-934: derive the admin palette entries from the nav SSOT (adminNavGroups +
+// adminTabHref in adminNav.ts) rather than maintaining a third hardcoded copy of
+// the admin route list. The prior copy carried a dead `?tab=pending-venue-edits`
+// link (not a valid section — pending edits live under Moderation) and was
+// MISSING the Radio section. Deriving from the SSOT makes a stale/missing tab a
+// compile error and keeps icons + coverage in lockstep with the sidebar.
+// adminNav.test.ts asserts the derived hrefs ⊆ VALID_TABS.
+// Exported for the parity test (adminNav hrefs ⊆ VALID_TABS) in
+// CommandPalette.test.tsx — not consumed elsewhere.
+export const adminRoutes: RouteItem[] = adminNavGroups.flatMap(group =>
+  group.items.map(item => ({
+    label: `Admin: ${item.label}`,
+    href: adminTabHref(item.tab),
+    icon: item.icon,
+    keywords: ['admin', ...ADMIN_ROUTE_KEYWORDS[item.tab]],
     requireAdmin: true,
-  },
-  {
-    label: 'Admin: Moderation Queue',
-    href: '/admin?tab=moderation',
-    icon: ShieldCheck,
-    keywords: ['admin', 'moderation', 'queue', 'review', 'pending', 'edits', 'reports', 'moderate'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Pending Shows',
-    href: '/admin?tab=pending-shows',
-    icon: Clock,
-    keywords: ['admin', 'pending', 'shows', 'approve', 'review', 'moderate'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Venue Edits',
-    href: '/admin?tab=pending-venue-edits',
-    icon: MapPin,
-    keywords: ['admin', 'venue', 'edits', 'pending', 'approve'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Unverified Venues',
-    href: '/admin?tab=unverified-venues',
-    icon: BadgeCheck,
-    keywords: ['admin', 'unverified', 'venues', 'verify'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Reports',
-    href: '/admin?tab=reports',
-    icon: Flag,
-    keywords: ['admin', 'reports', 'flags', 'flagged', 'issues'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Import Show',
-    href: '/admin?tab=import-show',
-    icon: Upload,
-    keywords: ['admin', 'import', 'show', 'add', 'upload'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Releases',
-    href: '/admin?tab=releases',
-    icon: Disc3,
-    keywords: ['admin', 'releases', 'albums', 'manage'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Labels',
-    href: '/admin?tab=labels',
-    icon: Tag,
-    keywords: ['admin', 'labels', 'record labels', 'manage'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Festivals',
-    href: '/admin?tab=festivals',
-    icon: Tent,
-    keywords: ['admin', 'festivals', 'manage'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Data Pipeline',
-    href: '/admin?tab=pipeline',
-    icon: Workflow,
-    keywords: ['admin', 'pipeline', 'extraction', 'scraping', 'venues', 'data', 'import'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Collections',
-    href: '/admin?tab=collections',
-    icon: Library,
-    keywords: ['admin', 'collections', 'manage', 'featured'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Tags',
-    href: '/admin?tab=tags',
-    icon: Tags,
-    keywords: ['admin', 'tags', 'manage', 'genres'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Data Quality',
-    href: '/admin?tab=data-quality',
-    icon: ClipboardCheck,
-    keywords: ['admin', 'data', 'quality', 'health', 'issues'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Analytics',
-    href: '/admin?tab=analytics',
-    icon: BarChart3,
-    keywords: ['admin', 'analytics', 'metrics', 'growth', 'engagement'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Artists',
-    href: '/admin?tab=artists-admin',
-    icon: Music,
-    keywords: ['admin', 'artists', 'manage', 'merge', 'aliases'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Users',
-    href: '/admin?tab=users',
-    icon: Users,
-    keywords: ['admin', 'users', 'accounts', 'manage'],
-    requireAdmin: true,
-  },
-  {
-    label: 'Admin: Audit Log',
-    href: '/admin?tab=audit-log',
-    icon: ScrollText,
-    keywords: ['admin', 'audit', 'log', 'history', 'actions'],
-    requireAdmin: true,
-  },
-]
+  }))
+)
 
 const allRoutes = [...routes, ...adminRoutes]
 


### PR DESCRIPTION
## Summary
- Two admin entry points navigated to `?tab=pending-venue-edits`, which is NOT a valid section (`VALID_TABS` in `adminNav.ts` — pending entity edits render under the **Moderation** queue). After PSY-933's URL-derive change, both fell back to the Dashboard — dead no-ops.
- `CommandPalette.tsx` was a THIRD independent copy of the admin route list (separate from `adminNav.ts` and `page.tsx`), uncovered by `adminNav.test.ts`. Beyond the dead Venue Edits link it was MISSING a Radio entry (only the public `/radio` existed). Now **derived from `adminNavGroups` + `adminTabHref(tab)`** (single source of truth) — a stale/missing tab is a compile error, and Radio is reachable via Cmd-K.
- Per-tab Cmd-K search keywords live in an exhaustive `Record<AdminTab, string[]>` so a new section forces a keyword entry (compile error if missing).
- `AdminDashboard` quick-link: the Pending Venue Edits card now routes to `moderation` (the real section) instead of the dead `pending-venue-edits`.
- Net -33 lines (the SSOT derivation collapses ~80 lines of hardcoded routes).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/layout` — 216/216 passing across 14 files (incl. the new PSY-934 parity block: CommandPalette.test.tsx 22→26 tests)
- [x] `bun run test:run app/admin` — 110/110 passing (dashboard + moderation + radio unaffected)
- [x] `/code-review` (xhigh, inline 9-angle) — no findings; both ESLint warnings in the file pre-date this change and are out of scope
- [x] `/adversarial-review` — CLEAN

## Manual repro
The parity block in `frontend/components/layout/CommandPalette.test.tsx` (describe "admin routes derived from nav SSOT (PSY-934)") locks the behavior:
- `every admin href resolves to a valid section (⊆ VALID_TABS)` — every derived href passes `isValidTab` (no Dashboard fallback).
- `has no dead pending-venue-edits link (the PSY-934 regression)`.
- `covers exactly the nav SSOT sections, in order (Radio reachable via Cmd-K)` — asserts `adminTabHref('radio')` is present.
- `every admin route is admin-gated and prefixed`.

Visual screenshots added by orchestrator post-push.

## Code review
`/code-review` (xhigh, 9 angles inline — no Agent tool in a worktree): no correctness/cleanup findings. The change IS the reuse/altitude fix (SSOT derivation replaces a hardcoded duplicate).

## Adversarial review
`/adversarial-review` — CLEAN. Panel run inline (no Agent tool in a worktree): Saboteur · Future-Maintainer · Security · Completeness. Only a LOW note (stale recent-search label after rename is a guarded no-op, self-healing, admin-only — same pre-existing fragility, no fix warranted). All ticket ACs met; the dead link is now structurally impossible to reintroduce (parity test + compile-time `AdminTab` typing).

Closes PSY-934

🤖 Generated with [Claude Code](https://claude.com/claude-code)