### PR TITLE
PSY-942: migrate Pipeline Venue Status table onto AdminTable

### DIFF
--- a/frontend/components/admin/PipelineVenues.test.tsx
+++ b/frontend/components/admin/PipelineVenues.test.tsx
@@ -284,6 +284,78 @@ describe('PipelineVenues — explicit-locale timestamp formatting', () => {
   })
 })
 
+describe('PipelineVenues — Venue Status AdminTable migration (PSY-942)', () => {
+  // The Venue Status table moved onto the shared AdminTable primitive. These
+  // assertions pin the behavior-preserving contract: same six columns, the
+  // ApprovalBadge + notes-tooltip cells, the a11y row label, and the
+  // selected-row highlight — all expressed through AdminTable's config API.
+  it('renders the six Venue Status column headers', () => {
+    render(<PipelineVenues />)
+    for (const header of [
+      'Venue',
+      'Method',
+      'Approval',
+      'Auto',
+      'Last Run',
+      'Notes',
+    ]) {
+      expect(
+        screen.getByRole('columnheader', { name: header })
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('renders the ApprovalBadge percentage and the notes tooltip cell', () => {
+    mockUsePipelineVenues.mockReturnValue({
+      data: {
+        venues: [
+          {
+            ...venueFixture,
+            approval_rate: 0.95,
+            extraction_notes: 'Skip trivia nights',
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+    render(<PipelineVenues />)
+
+    // ApprovalBadge renders the rounded percentage.
+    expect(screen.getByText('95%')).toBeInTheDocument()
+    // Notes cell shows the "Has notes" affordance with the note as a tooltip.
+    const notes = screen.getByText('Has notes')
+    expect(notes).toHaveAttribute('title', 'Skip trivia nights')
+  })
+
+  it('exposes each venue row as a labelled, keyboard-operable button', async () => {
+    const user = userEvent.setup()
+    render(<PipelineVenues />)
+
+    const row = screen.getByRole('button', { name: 'The Rebel Lounge' })
+    expect(row).toBeInTheDocument()
+
+    // The detail panel opens via keyboard activation on the focused row.
+    row.focus()
+    await user.keyboard('{Enter}')
+    expect(
+      screen.getByRole('heading', { name: 'Configuration' })
+    ).toBeInTheDocument()
+  })
+
+  it('applies the selected-row highlight class to the open venue row', async () => {
+    const user = userEvent.setup()
+    render(<PipelineVenues />)
+
+    const row = screen.getByRole('button', { name: 'The Rebel Lounge' })
+    expect(row).not.toHaveClass('bg-muted/50')
+
+    await user.click(row)
+    expect(row).toHaveClass('bg-muted/50')
+  })
+})
+
 describe('PipelineVenues — venue selection', () => {
   it('opens the detail panel when a venue row is clicked', async () => {
     const user = userEvent.setup()

--- a/frontend/components/admin/PipelineVenues.tsx
+++ b/frontend/components/admin/PipelineVenues.tsx
@@ -689,6 +689,68 @@ export function PipelineVenues() {
   const selectedVenue = venues.find((v) => v.venue_id === selectedVenueId)
   const existingVenueIds = new Set(venues.map((v) => v.venue_id))
 
+  const venueColumns: AdminTableColumn<PipelineVenueInfo>[] = [
+    {
+      key: 'venue',
+      header: 'Venue',
+      render: (venue) => (
+        <>
+          <div className="font-medium">{venue.venue_name}</div>
+          {venue.consecutive_failures > 0 && (
+            <span className="text-xs text-red-400">
+              {venue.consecutive_failures} failure(s)
+            </span>
+          )}
+        </>
+      ),
+    },
+    {
+      key: 'method',
+      header: 'Method',
+      cellClassName: 'text-muted-foreground',
+      render: (venue) => venue.render_method ?? '—',
+    },
+    {
+      key: 'approval',
+      header: 'Approval',
+      align: 'center',
+      render: (venue) => <ApprovalBadge rate={venue.approval_rate} />,
+    },
+    {
+      key: 'auto',
+      header: 'Auto',
+      align: 'center',
+      render: (venue) =>
+        venue.auto_approve ? (
+          <span className="text-green-400 text-xs">On</span>
+        ) : (
+          <span className="text-muted-foreground text-xs">Off</span>
+        ),
+    },
+    {
+      key: 'last-run',
+      header: 'Last Run',
+      cellClassName: 'text-muted-foreground text-xs',
+      render: (venue) =>
+        venue.last_run
+          ? `${venue.last_run.events_extracted} events, ${formatShortDate(venue.last_run.created_at)}`
+          : 'Never',
+    },
+    {
+      key: 'notes',
+      header: 'Notes',
+      align: 'center',
+      render: (venue) =>
+        venue.extraction_notes ? (
+          <span className="text-xs text-blue-400" title={venue.extraction_notes}>
+            Has notes
+          </span>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+    },
+  ]
+
   return (
     <div className="space-y-4">
       {/* View toggle */}
@@ -744,71 +806,20 @@ export function PipelineVenues() {
       ) : (
         <>
           {/* Venue table */}
-          <div className="border border-border rounded-lg overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-muted/50">
-                <tr>
-                  <th className="text-left p-3 font-medium">Venue</th>
-                  <th className="text-left p-3 font-medium">Method</th>
-                  <th className="text-center p-3 font-medium">Approval</th>
-                  <th className="text-center p-3 font-medium">Auto</th>
-                  <th className="text-left p-3 font-medium">Last Run</th>
-                  <th className="text-center p-3 font-medium">Notes</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {venues.map((venue) => (
-                  <tr
-                    key={venue.venue_id}
-                    onClick={() =>
-                      setSelectedVenueId(
-                        selectedVenueId === venue.venue_id ? null : venue.venue_id
-                      )
-                    }
-                    className={`cursor-pointer hover:bg-muted/30 ${
-                      selectedVenueId === venue.venue_id ? 'bg-muted/50' : ''
-                    }`}
-                  >
-                    <td className="p-3">
-                      <div className="font-medium">{venue.venue_name}</div>
-                      {venue.consecutive_failures > 0 && (
-                        <span className="text-xs text-red-400">
-                          {venue.consecutive_failures} failure(s)
-                        </span>
-                      )}
-                    </td>
-                    <td className="p-3 text-muted-foreground">
-                      {venue.render_method ?? '—'}
-                    </td>
-                    <td className="p-3 text-center">
-                      <ApprovalBadge rate={venue.approval_rate} />
-                    </td>
-                    <td className="p-3 text-center">
-                      {venue.auto_approve ? (
-                        <span className="text-green-400 text-xs">On</span>
-                      ) : (
-                        <span className="text-muted-foreground text-xs">Off</span>
-                      )}
-                    </td>
-                    <td className="p-3 text-muted-foreground text-xs">
-                      {venue.last_run
-                        ? `${venue.last_run.events_extracted} events, ${formatShortDate(venue.last_run.created_at)}`
-                        : 'Never'}
-                    </td>
-                    <td className="p-3 text-center">
-                      {venue.extraction_notes ? (
-                        <span className="text-xs text-blue-400" title={venue.extraction_notes}>
-                          Has notes
-                        </span>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">—</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <AdminTable
+            columns={venueColumns}
+            rows={venues}
+            rowKey={(venue) => venue.venue_id}
+            onRowClick={(venue) =>
+              setSelectedVenueId(
+                selectedVenueId === venue.venue_id ? null : venue.venue_id
+              )
+            }
+            rowLabel={(venue) => venue.venue_name}
+            rowClassName={(venue) =>
+              selectedVenueId === venue.venue_id ? 'bg-muted/50' : undefined
+            }
+          />
 
           {/* Detail panel */}
           {selectedVenue && (


### PR DESCRIPTION
## Summary
- Migrate the Pipeline **Venue Status** table off its hand-rolled `<table>` onto the shared `AdminTable` primitive (`frontend/components/admin/AdminTable.tsx`) — finishing the PSY-910 cohesion pass. This was the last top-level single-click-to-detail admin entity list still bespoke; its sibling Import History section in the same file already used `AdminTable`.
- Express the six columns (Venue / Method / Approval / Auto / Last Run / Notes) as a `columns` array, with the custom `ApprovalBadge` cell and the "Has notes" tooltip cell as per-column `render`.
- Preserve all behavior: `onRowClick` toggles `selectedVenueId` (re-clicking the open row closes it), `rowClassName` re-applies the `bg-muted/50` selected-row highlight, `rowLabel` gives the a11y row name, and the parent's loading / error / empty-state guards stay put.
- Visual delta is the intended PSY-912/PSY-910 editorial upgrade carried by `AdminTable` (mono-uppercase header band + dense `py-2` rows), matching the already-migrated Import History / Collections / Radio lists.
- Out of scope, left hand-rolled by design: the per-venue extraction-run history table (a nested detail table, not a click-to-detail entity list).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/admin` — 247/247 passing (PipelineVenues 32/32, up from 28 — 4 new migration tests)
- [x] `/code-review` — clean, no findings (9 finder angles + sweep, inline)
- [x] `/adversarial-review` — CLEAN

## Manual repro
Behavior-preserving table migration. Unit-test DOM assertions at `frontend/components/admin/PipelineVenues.test.tsx` cover the migrated table: the six column headers, the ApprovalBadge percentage + notes tooltip (`title=`), the labelled keyboard-operable row (Enter opens the detail panel), and the selected-row highlight class — plus the pre-existing `venue selection` suite (row-click opens / re-click closes the `VenueDetailPanel`). Visual screenshots added by orchestrator post-push.

## Code review
`/code-review` (9 angles + sweep, inline) — no findings; clean behavior-preserving migration onto an existing primitive, all removed row guards/styles re-established by AdminTable's props.

## Adversarial review
`/adversarial-review` — CLEAN. Panel run inline (no Agent tool in a worktree): Saboteur · Future-Maintainer · Security · Completeness. No findings at any severity.

Closes PSY-942