### PR TITLE
PSY-949: fix artist graph dialog canvas-width balloon loop

### DIFF
--- a/frontend/features/artists/components/RelatedArtists.tsx
+++ b/frontend/features/artists/components/RelatedArtists.tsx
@@ -227,7 +227,18 @@ export function ArtistGraphDialog({
         <DialogHeader>
           <DialogTitle>Similar artists · {artistName}</DialogTitle>
         </DialogHeader>
-        <div ref={containerRefCallback}>
+        {/*
+          PSY-949: `min-w-0` is load-bearing — do NOT remove it.
+          DialogContent is `display: grid`, so this div is a grid item whose
+          default `min-width: auto` resolves to its min-content width. The
+          ResizeObserver below feeds the measured width to ForceGraph2D as an
+          explicit pixel `width`; without `min-w-0` the canvas's min-content
+          width forces this item to grow past `max-w-5xl`, the observer fires
+          larger, and the canvas balloons every tick (measured 3036px→11254px).
+          `min-w-0` lets the item shrink to the grid track instead, capping the
+          measured width at the real dialog inner width and breaking the loop.
+        */}
+        <div ref={containerRefCallback} className="min-w-0 w-full overflow-hidden">
           {containerWidth !== null && (
             <RecenteringGraph
               originalArtistId={artistId}


### PR DESCRIPTION
Closes PSY-949.

## Summary
- Add `min-w-0 w-full overflow-hidden` to the ResizeObserver-measured graph container in `ArtistGraphDialog` (`RelatedArtists.tsx`). `min-w-0` is the load-bearing class: it lets the grid item shrink to its track instead of expanding to the canvas's min-content width, breaking the measure → render → grow feedback loop. A code comment documents *why* it must not be removed.

## Root cause
`DialogContent` is `display: grid`, so the measured `<div>` was a grid item with the default `min-width: auto` (= min-content sizing). The ResizeObserver fed the measured width to `ForceGraph2D` as an explicit pixel `width`; the canvas's min-content width then forced the grid item to grow past `max-w-5xl`, the observer fired with a larger `contentRect.width`, and the canvas ballooned every animation tick. `min-w-0` removes the min-content floor so the item is capped at the real dialog inner width.

## Fix verification (local repro: Chloe Tang / artist 373, VIVA PHX 2026 festival graph — 30 nodes / 465 festival_cobill links)
Viewport 1280px. Measured `canvas.style.width` at two timepoints after opening `#graph`:

| | canvas width @ ~2.5s | canvas width @ ~7.5s | horizontal scroll | legend |
| --- | --- | --- | --- | --- |
| Before (this branch, stashed) | 1578px | 2756px (growing) | n/a* | cluster + legend pushed off-screen right |
| Before (from ticket) | 3036px | 11254px (growing) | yes | off-screen |
| After (this PR) | 974px | 974px (equal/stable) | no | visible top-right |

\* In my local DOM nesting the `overflow-auto` on DialogContent clipped the dialog scroll-width readout in the before-state, but the canvas growth across ticks (1578 → 2756) is the unambiguous bug signature; the absolute magnitude varies with d3 simulation seed/timing. The after-state is stable to the pixel.

Mobile sanity check (390px viewport, no mobile gate on the artist dialog): canvas stable at **340px** across both timepoints, no horizontal scroll, no collapse to 0-width.

## Peer-host audit
All other `ForceGraph2D` / `ForceGraphView` hosts spot-checked for the same grid/flex + `min-width:auto` + ResizeObserver-measured-width shape:
- **InlineGraph** (`/explore`): measured div is `<div className="w-full">` in column flow — already bounded. Immune (matches ticket). Not changed.
- **SceneGraph / SceneGraphVisualization**: inline measured div is a block in `SceneDetail`'s normal column flow (`className="mt-2 scroll-mt-20"`, not a grid/flex item). Fullscreen overlay measures `window.innerWidth`, not a DOM container, so it cannot feedback-loop. Immune. Not changed.
- **CollectionGraph**: inline measured div is a block (`className="mt-6 scroll-mt-20"`); overlay uses `window.innerWidth`. Immune. Not changed.
- **VenueBillNetwork / VenueBillNetworkAdapter**: inline measured div is a block (`className="mt-8 px-4 md:px-0 scroll-mt-20"`); overlay uses `window.innerWidth`. Immune. Not changed.

Only `ArtistGraphDialog` hosts the graph inside a `grid` `DialogContent` with an un-classed measured child, so only it exhibited the bug. No speculative changes to the healthy hosts (scope discipline).

## Adversarial review
`/adversarial-review` (inline lenses — dispatched agent, no Agent tool in worktree) — **PASS**.
Panel lenses: Saboteur · Future-Maintainer · Security · Completeness.
- Saboteur: probed mobile-collapse / 0-width / window-resize-while-open. Empirically closed — `w-full` keeps the canvas filling the track (974px desktop, 340px mobile), `min-w-0` only removes the min-content floor; resize re-measures the bounded track instead of looping.
- Future-Maintainer: comment explicitly marks `min-w-0` as load-bearing with the measured failure numbers so it is not deleted as "unnecessary."
- Security: n/a (CSS layout change).
- Completeness: peer-host audit + before/after + mobile measurements captured.
No findings required code changes, so there is no separate adversarial-fixes commit.

## Test plan
- [x] `bun run typecheck` — clean (`tsc --noEmit`, no output)
- [x] `bun run test:run features/artists` — 266/266 passing (22 files, incl. `RelatedArtists.test.tsx` 12/12)
- [x] `bun run test:run components/graph` — 16/16 passing (2 files)
- [x] Local browser repro: canvas width stable across ticks (974px @ 2.5s == 974px @ 7.5s; was growing 1578→2756 / ticket 3036→11254), no horizontal scrollbar, legend visible, cluster centered
- [x] Mobile (390px): canvas stable at 340px, no balloon, no collapse
- [x] Peer-host audit complete (4 hosts confirmed immune; none changed)

## Screenshots
- Before (no fix): canvas ballooned wide → cluster + legend pushed off-screen, dialog appears empty
  https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-f9e60d9af58f64f04281/psy-949-before.png
- After (this PR, 1280px): cluster centered, full legend visible top-right, no horizontal scroll
  https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-f9e60d9af58f64f04281/psy-949-fixed.png
- After (this PR, 390px mobile): canvas bounded, cluster centered
  https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-f9e60d9af58f64f04281/psy-949-fixed-mobile.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)
