### PR TITLE
PSY-943: bind admin badge colors to DS chart palette

### DIFF
--- a/frontend/app/admin/audit-log/_components/AuditLogEntry.tsx
+++ b/frontend/app/admin/audit-log/_components/AuditLogEntry.tsx
@@ -16,6 +16,14 @@ interface AuditLogEntryProps {
   entry: AuditLogEntryType
 }
 
+/**
+ * Audit-log action → icon color, bound to the DS palette (PSY-943). Semantics
+ * drive the hue: approvals/resolutions = chart-2 (green), rejections =
+ * destructive (red), verify = chart-6 (denim), flagged-resolution = chart-3
+ * (gold, a warning tone), dismissals = muted. The token colors track
+ * light/dark via the CSS cascade, so the prior hand-tuned `dark:` pairs are
+ * gone. These are icon tints only (no badge background).
+ */
 const ACTION_CONFIG: Record<
   string,
   { label: string; icon: React.ReactNode; color: string }
@@ -23,27 +31,27 @@ const ACTION_CONFIG: Record<
   approve_show: {
     label: 'Approved show',
     icon: <CheckCircle className="h-4 w-4" />,
-    color: 'text-green-600 dark:text-green-400',
+    color: 'text-chart-2',
   },
   reject_show: {
     label: 'Rejected show',
     icon: <XCircle className="h-4 w-4" />,
-    color: 'text-red-600 dark:text-red-400',
+    color: 'text-destructive',
   },
   verify_venue: {
     label: 'Verified venue',
     icon: <BadgeCheck className="h-4 w-4" />,
-    color: 'text-blue-600 dark:text-blue-400',
+    color: 'text-chart-6',
   },
   approve_venue_edit: {
     label: 'Approved venue edit',
     icon: <FileEdit className="h-4 w-4" />,
-    color: 'text-green-600 dark:text-green-400',
+    color: 'text-chart-2',
   },
   reject_venue_edit: {
     label: 'Rejected venue edit',
     icon: <XCircle className="h-4 w-4" />,
-    color: 'text-red-600 dark:text-red-400',
+    color: 'text-destructive',
   },
   dismiss_report: {
     label: 'Dismissed report',
@@ -53,12 +61,12 @@ const ACTION_CONFIG: Record<
   resolve_report: {
     label: 'Resolved report',
     icon: <CheckCircle className="h-4 w-4" />,
-    color: 'text-green-600 dark:text-green-400',
+    color: 'text-chart-2',
   },
   resolve_report_with_flag: {
     label: 'Resolved report (flagged show)',
     icon: <Flag className="h-4 w-4" />,
-    color: 'text-amber-600 dark:text-amber-400',
+    color: 'text-chart-3',
   },
 }
 

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -909,7 +909,7 @@ function ImportJobRow({ job }: { job: RadioImportJob }) {
           <div className="h-2 rounded-full bg-muted overflow-hidden">
             <div
               className={`h-full rounded-full transition-all ${
-                job.status === 'completed' ? 'bg-green-500' : 'bg-blue-500'
+                job.status === 'completed' ? 'bg-chart-2' : 'bg-chart-6'
               }`}
               style={{ width: `${progress}%` }}
             />

--- a/frontend/components/admin/CategoryBadge.test.tsx
+++ b/frontend/components/admin/CategoryBadge.test.tsx
@@ -4,25 +4,26 @@ import { render, screen } from '@testing-library/react'
 import { CategoryBadge } from './CategoryBadge'
 
 describe('CategoryBadge', () => {
-  it('renders the Edit kind with its blue tone', () => {
+  // PSY-943: tones bound to the DS categorical chart palette, not raw hues.
+  it('renders the Edit kind with the chart-6 (denim) tone', () => {
     render(<CategoryBadge kind="edit" />)
 
     const badge = screen.getByText('Edit').closest('div')
-    expect(badge).toHaveClass('bg-blue-500/10', 'text-blue-700')
+    expect(badge).toHaveClass('bg-chart-6/10', 'text-chart-6')
   })
 
-  it('renders the Report kind with its amber tone', () => {
+  it('renders the Report kind with the chart-3 (gold) tone', () => {
     render(<CategoryBadge kind="report" />)
 
     const badge = screen.getByText('Report').closest('div')
-    expect(badge).toHaveClass('bg-amber-500/10', 'text-amber-700')
+    expect(badge).toHaveClass('bg-chart-3/10', 'text-chart-3')
   })
 
-  it('renders the Comment kind with its violet tone', () => {
+  it('renders the Comment kind with the chart-7 (plum) tone', () => {
     render(<CategoryBadge kind="comment" />)
 
     const badge = screen.getByText('Comment').closest('div')
-    expect(badge).toHaveClass('bg-violet-500/10', 'text-violet-700')
+    expect(badge).toHaveClass('bg-chart-7/10', 'text-chart-7')
   })
 
   it('renders an icon alongside the label', () => {

--- a/frontend/components/admin/CategoryBadge.tsx
+++ b/frontend/components/admin/CategoryBadge.tsx
@@ -13,9 +13,11 @@ interface KindConfig {
   label: string
   icon: LucideIcon
   /**
-   * Ad-hoc Tailwind tone classes, preserved VERBATIM from the original
-   * inline badges so this extraction is a pure no-visual-change dedup.
-   * PSY-908 will swap these for DS chart/category tokens.
+   * DS-palette tint for the moderation kind (PSY-943). Bound to the shared
+   * categorical `--chart-*` tokens (globals.css, PSY-947) so the three kinds
+   * stay distinct-but-muted and track light/dark via the CSS cascade — no more
+   * raw blue/amber/violet hues with hand-tuned `dark:` overrides. edit =
+   * chart-6 (denim), report = chart-3 (gold, "flag"), comment = chart-7 (plum).
    */
   tone: string
 }
@@ -24,17 +26,17 @@ const KIND_CONFIG: Record<AdminCategoryKind, KindConfig> = {
   edit: {
     label: 'Edit',
     icon: Pencil,
-    tone: 'bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800',
+    tone: 'bg-chart-6/10 text-chart-6 border-chart-6/30',
   },
   report: {
     label: 'Report',
     icon: Flag,
-    tone: 'bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800',
+    tone: 'bg-chart-3/10 text-chart-3 border-chart-3/30',
   },
   comment: {
     label: 'Comment',
     icon: MessageSquare,
-    tone: 'bg-violet-500/10 text-violet-700 dark:text-violet-400 border-violet-200 dark:border-violet-800',
+    tone: 'bg-chart-7/10 text-chart-7 border-chart-7/30',
   },
 }
 

--- a/frontend/components/admin/CollectionManagement.tsx
+++ b/frontend/components/admin/CollectionManagement.tsx
@@ -10,26 +10,8 @@ import {
 } from '@/features/collections'
 import type { Collection } from '@/features/collections'
 import { Switch } from '@/components/ui/switch'
+import { EntityTypeBadge } from '@/components/shared'
 import { AdminTable, type AdminTableColumn } from './AdminTable'
-
-function EntityTypeBadge({ type }: { type: string }) {
-  const colors: Record<string, string> = {
-    artist: 'bg-purple-500/20 text-purple-400',
-    release: 'bg-blue-500/20 text-blue-400',
-    label: 'bg-green-500/20 text-green-400',
-    show: 'bg-amber-500/20 text-amber-400',
-    venue: 'bg-rose-500/20 text-rose-400',
-    festival: 'bg-cyan-500/20 text-cyan-400',
-  }
-
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors[type] || 'bg-muted text-muted-foreground'}`}
-    >
-      {type}
-    </span>
-  )
-}
 
 function CollectionDetailPanel({
   collection,

--- a/frontend/components/shared/EntityTypeBadge.test.tsx
+++ b/frontend/components/shared/EntityTypeBadge.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  EntityTypeBadge,
+  getEntityTypeBadgeClasses,
+} from './EntityTypeBadge'
+
+// The six core entity types and the chart token each is bound to. Mirrors the
+// interleaved warm/cool map in EntityTypeBadge.tsx; the test fails loudly if
+// the single-sourced map drifts off the DS palette.
+const ENTITY_TOKEN: Array<[string, string]> = [
+  ['artist', 'chart-1'],
+  ['venue', 'chart-6'],
+  ['show', 'chart-3'],
+  ['release', 'chart-7'],
+  ['label', 'chart-2'],
+  ['festival', 'chart-8'],
+]
+
+describe('getEntityTypeBadgeClasses', () => {
+  it.each(ENTITY_TOKEN)(
+    'binds %s to the %s DS token (bg + text + border)',
+    (type, token) => {
+      const classes = getEntityTypeBadgeClasses(type)
+      expect(classes).toContain(`bg-${token}/15`)
+      expect(classes).toContain(`text-${token}`)
+      expect(classes).toContain(`border-${token}/30`)
+    }
+  )
+
+  it('never emits a raw off-palette Tailwind hue', () => {
+    for (const [type] of ENTITY_TOKEN) {
+      const classes = getEntityTypeBadgeClasses(type)
+      expect(classes).not.toMatch(
+        /\b(?:bg|text|border)-(?:blue|purple|green|amber|rose|cyan|pink|orange)-\d/
+      )
+    }
+  })
+
+  it('assigns a distinct token to each entity type', () => {
+    const all = ENTITY_TOKEN.map(([type]) => getEntityTypeBadgeClasses(type))
+    expect(new Set(all).size).toBe(ENTITY_TOKEN.length)
+  })
+
+  it('never reuses chart-4 (it equals --destructive in light mode)', () => {
+    for (const [type] of ENTITY_TOKEN) {
+      expect(getEntityTypeBadgeClasses(type)).not.toContain('chart-4')
+    }
+  })
+
+  it('falls back to muted styling for an unknown type', () => {
+    expect(getEntityTypeBadgeClasses('mixtape')).toBe(
+      'bg-muted text-muted-foreground border-border'
+    )
+  })
+})
+
+describe('EntityTypeBadge', () => {
+  it('renders the raw type as the default label', () => {
+    render(<EntityTypeBadge type="artist" testId="b" />)
+    expect(screen.getByTestId('b')).toHaveTextContent('artist')
+  })
+
+  it('applies the type token class to the rendered pill', () => {
+    render(<EntityTypeBadge type="venue" testId="b" />)
+    expect(screen.getByTestId('b').className).toContain('text-chart-6')
+  })
+
+  it('honors a label override', () => {
+    render(<EntityTypeBadge type="show" label="Show" testId="b" />)
+    expect(screen.getByTestId('b')).toHaveTextContent('Show')
+  })
+
+  it('merges an extra className', () => {
+    render(<EntityTypeBadge type="label" className="ml-2" testId="b" />)
+    expect(screen.getByTestId('b').className).toContain('ml-2')
+  })
+})

--- a/frontend/components/shared/EntityTypeBadge.tsx
+++ b/frontend/components/shared/EntityTypeBadge.tsx
@@ -1,0 +1,82 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Single-sourced entity-type → DS-palette color map for the six core
+ * knowledge-graph entity types (PSY-943). Bound to the shared categorical
+ * `--chart-1..8` tokens (globals.css, PSY-947) so badge hues track the
+ * newsprint/vinyl theme in both modes instead of drifting off-palette with
+ * raw Tailwind `blue-500`/`purple-500`/etc.
+ *
+ * Hue assignment is the interleaved warm/cool subset the analytics dashboard
+ * already uses for its entity-creation chart (AnalyticsDashboard `COLORS`):
+ * orange · denim · gold · plum · green · teal. Interleaving warm and cool
+ * keeps adjacent types distinguishable at a glance without the full rainbow.
+ *
+ * `--chart-4` is intentionally absent here: it equals `--destructive` in light
+ * mode (`#9c2a1a`), so reusing it for a neutral entity type would read as an
+ * error tone. Festivals take `--chart-8` (teal) instead.
+ *
+ * Tint convention matches the rest of the badge surfaces: a low-alpha token
+ * background, full-strength token text, and a mid-alpha token border. The
+ * full-strength text keeps adequate contrast against the muted tint in both
+ * light and dark modes (the chart tokens are mid-saturation, not pastel).
+ */
+const ENTITY_TYPE_BADGE_CLASSES: Record<string, string> = {
+  artist: 'bg-chart-1/15 text-chart-1 border-chart-1/30',
+  venue: 'bg-chart-6/15 text-chart-6 border-chart-6/30',
+  show: 'bg-chart-3/15 text-chart-3 border-chart-3/30',
+  release: 'bg-chart-7/15 text-chart-7 border-chart-7/30',
+  label: 'bg-chart-2/15 text-chart-2 border-chart-2/30',
+  festival: 'bg-chart-8/15 text-chart-8 border-chart-8/30',
+}
+
+const ENTITY_TYPE_BADGE_FALLBACK =
+  'bg-muted text-muted-foreground border-border'
+
+/**
+ * Returns the DS-palette tint classes for an entity type, or the muted
+ * fallback for an unknown type. Use this when a caller renders its own badge
+ * element (e.g. an existing custom span with extra layout classes) and only
+ * needs the color slice — it keeps every surface on the SAME map as
+ * {@link EntityTypeBadge}.
+ */
+export function getEntityTypeBadgeClasses(type: string): string {
+  return ENTITY_TYPE_BADGE_CLASSES[type] ?? ENTITY_TYPE_BADGE_FALLBACK
+}
+
+export interface EntityTypeBadgeProps {
+  /** One of artist/venue/show/release/label/festival (others render muted). */
+  type: string
+  /**
+   * Override the visible text. Defaults to the raw `type` string so existing
+   * call sites that showed the lowercase type keep their output unchanged.
+   */
+  label?: string
+  className?: string
+  testId?: string
+}
+
+/**
+ * Small colored pill marking a knowledge-graph entity's type. The hue is
+ * single-sourced via {@link getEntityTypeBadgeClasses} so admin tables, the
+ * request board, and any future surface share one palette.
+ */
+export function EntityTypeBadge({
+  type,
+  label,
+  className,
+  testId,
+}: EntityTypeBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+        getEntityTypeBadgeClasses(type),
+        className
+      )}
+      data-testid={testId}
+    >
+      {label ?? type}
+    </span>
+  )
+}

--- a/frontend/components/shared/index.ts
+++ b/frontend/components/shared/index.ts
@@ -8,6 +8,11 @@ export { TagPill } from './TagPill'
 export type { TagPillProps } from './TagPill'
 export { RelationshipBadge } from './RelationshipBadge'
 export type { RelationshipBadgeProps, RelationshipType } from './RelationshipBadge'
+export {
+  EntityTypeBadge,
+  getEntityTypeBadgeClasses,
+} from './EntityTypeBadge'
+export type { EntityTypeBadgeProps } from './EntityTypeBadge'
 export { DensityToggle } from './DensityToggle'
 export type { DensityToggleProps } from './DensityToggle'
 export { EntityDetailLayout } from './EntityDetailLayout'

--- a/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
@@ -69,12 +69,18 @@ function StatusBadge({ status }: { status: StreamingWorklistEntry['streaming_dis
   // Only non-terminal values appear in the list response, but the type
   // allows the full enum so the badge stays correct if a backend tweak
   // ever widens what's surfaced.
+  //
+  // Bound to the DS categorical palette (`--chart-*`, PSY-943) instead of the
+  // prior dark-only amber/blue/green/zinc hues. Hue follows the triage flow:
+  // unreviewed = chart-3 (gold, needs attention), candidates_pending =
+  // chart-6 (denim, active), linked = chart-2 (green, done), the two terminal
+  // dead-ends (no_links_found / skipped) = muted.
   const palette: Record<typeof status, string> = {
-    unreviewed: 'border-amber-700/50 bg-amber-950/40 text-amber-300',
-    candidates_pending: 'border-blue-700/50 bg-blue-950/40 text-blue-300',
-    linked: 'border-green-700/50 bg-green-950/40 text-green-300',
-    no_links_found: 'border-zinc-600/40 bg-zinc-900/40 text-zinc-300',
-    skipped: 'border-zinc-600/40 bg-zinc-900/40 text-zinc-300',
+    unreviewed: 'border-chart-3/30 bg-chart-3/15 text-chart-3',
+    candidates_pending: 'border-chart-6/30 bg-chart-6/15 text-chart-6',
+    linked: 'border-chart-2/30 bg-chart-2/15 text-chart-2',
+    no_links_found: 'border-border bg-muted text-muted-foreground',
+    skipped: 'border-border bg-muted text-muted-foreground',
   }
   const labels: Record<typeof status, string> = {
     unreviewed: 'Unreviewed',

--- a/frontend/features/radio/types.ts
+++ b/frontend/features/radio/types.ts
@@ -322,11 +322,19 @@ export const ROTATION_STATUS_LABELS: Record<string, string> = {
   library: 'Library',
 }
 
+/**
+ * Rotation-status tint, bound to the DS categorical palette (PSY-943). The
+ * tokens map to a rough play-intensity gradient — heavy = chart-1 (orange,
+ * hottest), medium = chart-3 (gold), light = chart-6 (denim, cooler),
+ * recommended_new = chart-2 (green, "fresh"), library = muted (archival).
+ * `--chart-4` (== --destructive) is intentionally avoided: a red rotation
+ * pill would read as an error, not "heavy rotation".
+ */
 export const ROTATION_STATUS_COLORS: Record<string, string> = {
-  heavy: 'bg-red-500/15 text-red-400 border-red-500/20',
-  medium: 'bg-orange-500/15 text-orange-400 border-orange-500/20',
-  light: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-  recommended_new: 'bg-green-500/15 text-green-400 border-green-500/20',
+  heavy: 'bg-chart-1/15 text-chart-1 border-chart-1/20',
+  medium: 'bg-chart-3/15 text-chart-3 border-chart-3/20',
+  light: 'bg-chart-6/15 text-chart-6 border-chart-6/20',
+  recommended_new: 'bg-chart-2/15 text-chart-2 border-chart-2/20',
   library: 'bg-muted text-muted-foreground border-border',
 }
 

--- a/frontend/features/requests/types.test.ts
+++ b/frontend/features/requests/types.test.ts
@@ -77,35 +77,49 @@ describe('getStatusLabel', () => {
 })
 
 describe('getEntityTypeColor', () => {
-  it('returns a distinct class for each known entity type', () => {
+  it('returns a distinct DS-palette class for each known entity type', () => {
     const colors = REQUEST_ENTITY_TYPES.map(getEntityTypeColor)
     // Every known type maps to a unique, non-muted class.
     expect(new Set(colors).size).toBe(REQUEST_ENTITY_TYPES.length)
     colors.forEach(c => expect(c).not.toContain('text-muted-foreground'))
+    // Bound to the shared chart-* palette, not raw Tailwind hues (PSY-943).
+    colors.forEach(c => {
+      expect(c).toContain('text-chart-')
+      expect(c).not.toMatch(/text-(?:purple|blue|green|orange|pink|amber)-\d/)
+    })
   })
 
   it('falls back to muted styling for an unknown type', () => {
+    // Delegates to the shared map, whose fallback includes a border slice.
     expect(getEntityTypeColor('unknown')).toBe(
-      'bg-muted text-muted-foreground'
+      'bg-muted text-muted-foreground border-border'
     )
   })
 })
 
 describe('getStatusColor', () => {
-  it('returns a yellow class for pending', () => {
-    expect(getStatusColor('pending')).toContain('yellow')
+  it('binds pending to a chart token (gold)', () => {
+    expect(getStatusColor('pending')).toBe('bg-chart-3/15 text-chart-3')
   })
 
   it('returns a primary class for pending_fulfillment', () => {
     expect(getStatusColor('pending_fulfillment')).toContain('primary')
   })
 
-  it('returns a green class for fulfilled', () => {
-    expect(getStatusColor('fulfilled')).toContain('green')
+  it('binds fulfilled to the green chart token', () => {
+    expect(getStatusColor('fulfilled')).toBe('bg-chart-2/15 text-chart-2')
   })
 
-  it('returns a red class for rejected', () => {
-    expect(getStatusColor('rejected')).toContain('red')
+  it('binds rejected to the destructive token', () => {
+    expect(getStatusColor('rejected')).toBe('bg-destructive/15 text-destructive')
+  })
+
+  it('uses no raw off-palette Tailwind hue', () => {
+    for (const status of REQUEST_STATUSES) {
+      expect(getStatusColor(status)).not.toMatch(
+        /(?:bg|text)-(?:yellow|red|blue|green|orange|pink|purple|amber)-\d/
+      )
+    }
   })
 
   it('falls back to muted styling for cancelled and unknown', () => {

--- a/frontend/features/requests/types.ts
+++ b/frontend/features/requests/types.ts
@@ -1,6 +1,7 @@
 // Request types — aligned with backend contracts/request.go response types.
 
 import { formatTimeAgo as sharedFormatTimeAgo } from '@/lib/formatTimeAgo'
+import { getEntityTypeBadgeClasses } from '@/components/shared/EntityTypeBadge'
 
 export const REQUEST_ENTITY_TYPES = [
   'artist',
@@ -121,39 +122,44 @@ export function getStatusLabel(status: string): string {
   }
 }
 
-/** Helper: get a color class for entity type badge */
+/**
+ * Helper: get a color class for an entity-type badge.
+ *
+ * Delegates to the single-sourced DS-palette map shared with the admin
+ * collections table and any future entity-type pill (PSY-943). The request
+ * board renders its own `<span>` without a `border` utility, so the
+ * `border-chart-*` slice the helper returns is inert here — harmless, and it
+ * keeps the map in exactly one place.
+ */
 export function getEntityTypeColor(entityType: string): string {
-  switch (entityType) {
-    case 'artist':
-      return 'bg-purple-500/15 text-purple-700 dark:text-purple-400'
-    case 'venue':
-      return 'bg-blue-500/15 text-blue-700 dark:text-blue-400'
-    case 'show':
-      return 'bg-green-500/15 text-green-700 dark:text-green-400'
-    case 'release':
-      return 'bg-orange-500/15 text-orange-700 dark:text-orange-400'
-    case 'label':
-      return 'bg-pink-500/15 text-pink-700 dark:text-pink-400'
-    case 'festival':
-      return 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
-    default:
-      return 'bg-muted text-muted-foreground'
-  }
+  return getEntityTypeBadgeClasses(entityType)
 }
 
-/** Helper: get a color class for status badge */
+/**
+ * Helper: get a color class for a request status badge (PSY-943).
+ *
+ * Bound to the DS categorical palette (`--chart-*`, globals.css) instead of
+ * raw Tailwind hues. Status semantics drive the hue choice:
+ *   pending             → chart-3 (gold)  — waiting/attention
+ *   in_progress         → chart-6 (denim) — active work
+ *   pending_fulfillment → primary         — needs the owner's review (matches
+ *                                            the app's primary call-to-action)
+ *   fulfilled           → chart-2 (green) — done
+ *   rejected            → destructive     — terminal-negative
+ *   cancelled / unknown → muted           — inert
+ */
 export function getStatusColor(status: string): string {
   switch (status) {
     case 'pending':
-      return 'bg-yellow-500/15 text-yellow-700 dark:text-yellow-400'
+      return 'bg-chart-3/15 text-chart-3'
     case 'in_progress':
-      return 'bg-blue-500/15 text-blue-700 dark:text-blue-400'
+      return 'bg-chart-6/15 text-chart-6'
     case 'pending_fulfillment':
       return 'bg-primary/15 text-primary'
     case 'fulfilled':
-      return 'bg-green-500/15 text-green-700 dark:text-green-400'
+      return 'bg-chart-2/15 text-chart-2'
     case 'rejected':
-      return 'bg-red-500/15 text-red-700 dark:text-red-400'
+      return 'bg-destructive/15 text-destructive'
     case 'cancelled':
       return 'bg-muted text-muted-foreground'
     default:

--- a/frontend/features/tags/types.test.ts
+++ b/frontend/features/tags/types.test.ts
@@ -74,10 +74,18 @@ describe('low-quality signal chips', () => {
 })
 
 describe('getCategoryColor', () => {
-  it('returns a distinct class string per known category', () => {
-    expect(getCategoryColor('genre')).toContain('blue')
-    expect(getCategoryColor('locale')).toContain('cyan')
-    expect(getCategoryColor('other')).toContain('zinc')
+  it('binds each known category to a distinct DS chart token (PSY-943)', () => {
+    expect(getCategoryColor('genre')).toContain('text-chart-6')
+    expect(getCategoryColor('locale')).toContain('text-chart-8')
+    expect(getCategoryColor('other')).toContain('text-muted-foreground')
+  })
+
+  it('uses no raw off-palette Tailwind hue', () => {
+    for (const cat of ['genre', 'locale', 'other']) {
+      expect(getCategoryColor(cat)).not.toMatch(
+        /(?:bg|text|border)-(?:blue|cyan|zinc)-\d/
+      )
+    }
   })
 
   it('falls back to the "other" styling for an unknown category', () => {

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -348,11 +348,18 @@ export interface GenreHierarchyNode extends GenreHierarchyTag {
   parent_name?: string | null
 }
 
+/**
+ * Tag-category tint, bound to the DS categorical palette (PSY-943). Replaces
+ * the raw blue/cyan/zinc hues that drifted off the newsprint/vinyl theme.
+ * Three categories → three distinct-but-muted tokens: genre = chart-6 (denim),
+ * locale = chart-8 (teal), other = muted (the neutral catch-all). The token
+ * tints track light/dark automatically via the CSS cascade.
+ */
 export function getCategoryColor(category: string): string {
   const colors: Record<string, string> = {
-    genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-    locale: 'bg-cyan-500/10 text-cyan-400 border-cyan-500/20',
-    other: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
+    genre: 'bg-chart-6/10 text-chart-6 border-chart-6/20',
+    locale: 'bg-chart-8/10 text-chart-8 border-chart-8/20',
+    other: 'bg-muted text-muted-foreground border-border',
   }
   return colors[category] || colors.other
 }


### PR DESCRIPTION
## Summary
- Migrated 8 hardcoded badge/status color maps off raw Tailwind hues (blue-500/violet/pink/emerald/cyan/yellow/etc.) onto the shared categorical `--chart-1..8` DS tokens (PSY-947), keeping a muted-but-distinct hue per category so at-a-glance scanning survives.
- New shared `EntityTypeBadge` primitive + `getEntityTypeBadgeClasses` helper single-source the 6-entity-type map using the ticket's interleaved warm/cool subset (artist=chart-1, venue=chart-6, show=chart-3, release=chart-7, label=chart-2, festival=chart-8). Admin `CollectionManagement` now renders the primitive; requests `getEntityTypeColor` delegates to the helper.
- Heterogeneous maps bound to `chart-*` tokens in place: tag-category (`getCategoryColor`), request-status (`getStatusColor`), rotation-status (`ROTATION_STATUS_COLORS`), streaming-discovery-status (worklist `StatusBadge`), moderation-kind (`CategoryBadge`), audit-log-action (`ACTION_CONFIG` icon tints).
- `RadioManagement` import progress-bar fill: surgical `bg-green-500`/`bg-blue-500` → `bg-chart-2`/`bg-chart-6` (the single ternary only, per concurrent-scope note).
- `--chart-4` (== `--destructive` in light mode) intentionally avoided for neutral categories; semantic statuses (rejected) map to `destructive` directly.
- `labels` `getLabelStatusVariant` left unchanged — already delegates to DS `<Badge variant>` (verified on-palette).
- Verified `bg/text/border-chart-N` + opacity modifiers compile through Tailwind v4 (`var(--chart-N)` + `color-mix` tint) via a real CLI compile, since these utilities had no prior in-repo consumer.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run` scoped — 130/130 passing across EntityTypeBadge, tags/types, requests/types, CategoryBadge, CollectionManagement, StreamingWorklist
- [x] `bun run test:run features/radio features/requests features/tags` — 557/557 passing (consumers of the changed helpers)
- [x] `/code-review` — no changes
- [x] `/adversarial-review` — CLEAN

## Manual repro
Render-only change. Unit-test DOM assertions at `frontend/components/shared/EntityTypeBadge.test.tsx` (14 cases: per-type token bind, off-palette regression guard, chart-4-avoidance, fallback, rendered-pill class, label override, className merge), `frontend/features/tags/types.test.ts` (getCategoryColor token + off-palette guard), `frontend/features/requests/types.test.ts` (getEntityTypeColor + getStatusColor token binds + off-palette guard), and `frontend/components/admin/CategoryBadge.test.tsx` (3 kind tones) cover the rendered token class per badge category. Visual screenshots added by orchestrator post-push.

## Code review
no changes — 9 finder angles run inline (no Agent tool in a worktree); no CONFIRMED/PLAUSIBLE bugs.

## Adversarial review
`/adversarial-review` — CLEAN, no findings.
Panel: Saboteur · Future-Maintainer · Security · Completeness — run inline (no Agent tool in a worktree). One LOW disclosed: admin entity-type pills gain a subtle on-palette border via the shared primitive (intentional DS alignment, admin-only).

Closes PSY-943