### PR TITLE
PSY-930: migrate admin long entity forms to AdminFormLayout

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.editStation.test.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.editStation.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { RadioStationDetail } from '@/lib/hooks/admin/useAdminRadio'
+
+// EditStationFormFields calls useUpdateRadioStation; stub just that hook so the
+// fields render without a real mutation/QueryClient. Other module exports load
+// as-is so AdminFormLayout, the Sheet primitives, etc. are the real ones.
+const updateMutate = vi.fn()
+vi.mock('@/lib/hooks/admin/useAdminRadio', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/hooks/admin/useAdminRadio')>()
+  return {
+    ...actual,
+    useUpdateRadioStation: () => ({ mutate: updateMutate, isPending: false }),
+  }
+})
+
+import { EditStationFormFields } from './RadioManagement'
+
+const noop = () => {}
+
+function makeStation(
+  overrides: Partial<RadioStationDetail> = {}
+): RadioStationDetail {
+  return {
+    id: 1,
+    name: 'KEXP',
+    slug: 'kexp',
+    description: null,
+    city: 'Seattle',
+    state: 'WA',
+    country: 'US',
+    timezone: 'America/Los_Angeles',
+    stream_url: null,
+    stream_urls: null,
+    website: null,
+    donation_url: null,
+    donation_embed_url: null,
+    logo_url: null,
+    social: null,
+    broadcast_type: 'both',
+    frequency_mhz: 90.3,
+    playlist_source: null,
+    playlist_config: null,
+    last_playlist_fetch_at: null,
+    is_active: true,
+    show_count: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// Pins the PSY-930 Radio Edit Station migration: the AdminFormLayout (Sheet)
+// initializes its fields from the loaded station detail, and a station switch
+// re-initializes the fields when callers pass `key={station.id}` (the
+// init-from-props-inline + key-reset contract, no useEffect ratchet).
+describe('EditStationFormFields (PSY-930 Edit Station -> AdminFormLayout Sheet)', () => {
+  beforeEach(() => updateMutate.mockClear())
+
+  it('initializes the fields from the loaded station detail', () => {
+    render(
+      <EditStationFormFields
+        key={1}
+        station={makeStation()}
+        open
+        onOpenChange={noop}
+        onSuccess={noop}
+      />
+    )
+
+    expect(screen.getByLabelText('Name *')).toHaveValue('KEXP')
+    expect(screen.getByLabelText('City')).toHaveValue('Seattle')
+    expect(screen.getByLabelText('State')).toHaveValue('WA')
+    expect(screen.getByLabelText('Frequency (MHz)')).toHaveValue(90.3)
+    // The Sheet renders as a dialog with the Edit Station title + Save action.
+    expect(
+      screen.getByRole('heading', { name: 'Edit Station' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /save changes/i })
+    ).toBeInTheDocument()
+  })
+
+  it('re-initializes the fields when the station switches (via key prop)', () => {
+    const { rerender } = render(
+      <EditStationFormFields
+        key={1}
+        station={makeStation({ id: 1, name: 'KEXP', city: 'Seattle' })}
+        open
+        onOpenChange={noop}
+        onSuccess={noop}
+      />
+    )
+    expect(screen.getByLabelText('Name *')).toHaveValue('KEXP')
+
+    rerender(
+      <EditStationFormFields
+        key={2}
+        station={makeStation({ id: 2, name: 'WFMU', city: 'Jersey City' })}
+        open
+        onOpenChange={noop}
+        onSuccess={noop}
+      />
+    )
+    expect(screen.getByLabelText('Name *')).toHaveValue('WFMU')
+    expect(screen.getByLabelText('City')).toHaveValue('Jersey City')
+  })
+})

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -335,9 +335,9 @@ export function CreateStationForm({
 // Migrated to AdminFormLayout (Sheet) in PSY-930. The station detail loads
 // async (useRadioStationDetail), so per the PSY-930 decision the Sheet opens
 // IMMEDIATELY on click and shows a spinner in the body until the detail
-// resolves, then the fields populate — "state-init-on-async-load inside one
-// AdminFormLayout" (not render-when-loaded). EditStationFormFields owns the
-// single AdminFormLayout and the field state; the wrapper just gates loading.
+// resolves, then the fields populate (not render-when-the-whole-thing-loads).
+// EditStationFormFields owns the AdminFormLayout and the field state;
+// EditStationFormWrapper gates loading vs loaded.
 
 // Exported only for direct regression-test access (rerender-with-different-key
 // resets fields; rerender-with-same-key preserves dirty edits). Production
@@ -1796,7 +1796,7 @@ export function RadioManagement() {
             open={dialogMode === 'delete-station'}
             onOpenChange={(open) => !open && setDialogMode(null)}
             title="Delete Station"
-            description={`Are you sure you want to delete "${selectedStation?.name ?? ''}"? This will also delete all shows, episodes, and plays. This action cannot be undone.`}
+            description="This action is permanent and cannot be undone."
             onSubmit={(e) => {
               e.preventDefault()
               if (selectedStation) handleDeleteStation(selectedStation)
@@ -1813,7 +1813,10 @@ export function RadioManagement() {
               </>
             }
           >
-            {null}
+            <p className="text-sm text-muted-foreground">
+              Are you sure you want to delete &quot;{selectedStation?.name}&quot;? This will
+              also delete all shows, episodes, and plays. This action cannot be undone.
+            </p>
           </AdminFormLayout>
         </TabsContent>
 
@@ -1910,12 +1913,11 @@ export function RadioManagement() {
 // Edit Station Form Wrapper (loads station detail)
 // ============================================================================
 
-// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
-// opens immediately on click; while the station detail loads we render the
-// SAME <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
-// across the loading->loaded swap — no flicker), then mount
-// EditStationFormFields with `key={station.id}` so the fields initialize from
-// the resolved detail.
+// Per the PSY-930 decision the Edit Station Sheet opens immediately on click:
+// while the station detail loads this wrapper renders an AdminFormLayout (open)
+// with a spinner body — `open` stays true throughout, so the Sheet stays open
+// — then swaps to EditStationFormFields (keyed on station.id) once the detail
+// resolves, initializing the fields from it.
 function EditStationFormWrapper({
   stationId,
   open,

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -332,20 +332,26 @@ export function CreateStationForm({
 // Edit Station Form
 // ============================================================================
 //
-// NOTE: still on the raw <form> + Dialog pattern. CreateStationForm migrated to
-// AdminFormLayout (Sheet) in PSY-911; the Edit migration is deferred to PSY-930
-// because it loads through EditStationFormWrapper (async detail fetch) and needs
-// careful state-init-on-load handling. Create = Sheet / Edit = Modal is a
-// temporary split until PSY-930 lands.
+// Migrated to AdminFormLayout (Sheet) in PSY-930. The station detail loads
+// async (useRadioStationDetail), so per the PSY-930 decision the Sheet opens
+// IMMEDIATELY on click and shows a spinner in the body until the detail
+// resolves, then the fields populate — "state-init-on-async-load inside one
+// AdminFormLayout" (not render-when-loaded). EditStationFormFields owns the
+// single AdminFormLayout and the field state; the wrapper just gates loading.
 
-function EditStationForm({
+// Exported only for direct regression-test access (rerender-with-different-key
+// resets fields; rerender-with-same-key preserves dirty edits). Production
+// callers go through EditStationFormWrapper.
+export function EditStationFormFields({
   station,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   station: RadioStationDetail
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const updateMutation = useUpdateRadioStation()
 
@@ -416,43 +422,51 @@ function EditStationForm({
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
-      )}
-
-      <div>
-        <Label htmlFor="edit-station-name">Name *</Label>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit Station"
+      description="Update station details."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={updateMutation.isPending}>
+            {updateMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Save Changes
+          </Button>
+        </>
+      }
+    >
+      <AdminFormField label="Name *" htmlFor="edit-station-name">
         <Input id="edit-station-name" value={name} onChange={(e) => setName(e.target.value)} />
-      </div>
+      </AdminFormField>
 
-      <div>
-        <Label htmlFor="edit-station-description">Description</Label>
+      <AdminFormField label="Description" htmlFor="edit-station-description">
         <Textarea id="edit-station-description" value={description} onChange={(e) => setDescription(e.target.value)} rows={2} />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-4 gap-4">
-        <div>
-          <Label htmlFor="edit-station-city">City</Label>
+      <AdminFormRow cols={4}>
+        <AdminFormField label="City" htmlFor="edit-station-city">
           <Input id="edit-station-city" value={city} onChange={(e) => setCity(e.target.value)} />
-        </div>
-        <div>
-          <Label htmlFor="edit-station-state">State</Label>
+        </AdminFormField>
+        <AdminFormField label="State" htmlFor="edit-station-state">
           <Input id="edit-station-state" value={state} onChange={(e) => setState(e.target.value)} />
-        </div>
-        <div>
-          <Label htmlFor="edit-station-country">Country</Label>
+        </AdminFormField>
+        <AdminFormField label="Country" htmlFor="edit-station-country">
           <Input id="edit-station-country" value={country} onChange={(e) => setCountry(e.target.value)} />
-        </div>
-        <div>
-          <Label htmlFor="edit-station-timezone">Timezone</Label>
+        </AdminFormField>
+        <AdminFormField label="Timezone" htmlFor="edit-station-timezone">
           <Input id="edit-station-timezone" value={timezone} onChange={(e) => setTimezone(e.target.value)} />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="edit-station-broadcast-type">Broadcast Type</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Broadcast Type" htmlFor="edit-station-broadcast-type">
           <Select value={broadcastType} onValueChange={setBroadcastType}>
             <SelectTrigger id="edit-station-broadcast-type" className="w-full">
               <SelectValue />
@@ -463,38 +477,32 @@ function EditStationForm({
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div>
-          <Label htmlFor="edit-station-frequency">Frequency (MHz)</Label>
+        </AdminFormField>
+        <AdminFormField label="Frequency (MHz)" htmlFor="edit-station-frequency">
           <Input id="edit-station-frequency" type="number" step="0.1" value={frequencyMHz} onChange={(e) => setFrequencyMHz(e.target.value)} />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="edit-station-stream-url">Stream URL</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Stream URL" htmlFor="edit-station-stream-url">
           <Input id="edit-station-stream-url" value={streamUrl} onChange={(e) => setStreamUrl(e.target.value)} />
-        </div>
-        <div>
-          <Label htmlFor="edit-station-website">Website</Label>
+        </AdminFormField>
+        <AdminFormField label="Website" htmlFor="edit-station-website">
           <Input id="edit-station-website" value={website} onChange={(e) => setWebsite(e.target.value)} />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="edit-station-donation-url">Donation URL</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Donation URL" htmlFor="edit-station-donation-url">
           <Input id="edit-station-donation-url" value={donationUrl} onChange={(e) => setDonationUrl(e.target.value)} />
-        </div>
-        <div>
-          <Label htmlFor="edit-station-logo-url">Logo URL</Label>
+        </AdminFormField>
+        <AdminFormField label="Logo URL" htmlFor="edit-station-logo-url">
           <Input id="edit-station-logo-url" value={logoUrl} onChange={(e) => setLogoUrl(e.target.value)} />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="edit-station-playlist-source">Playlist Source</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Playlist Source" htmlFor="edit-station-playlist-source">
           <Select
             value={toPlaylistSelectValue(playlistSource)}
             onValueChange={(v) => setPlaylistSource(fromPlaylistSelectValue(v))}
@@ -509,26 +517,17 @@ function EditStationForm({
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div>
-          <Label htmlFor="edit-station-playlist-config">Playlist Config (JSON)</Label>
+        </AdminFormField>
+        <AdminFormField label="Playlist Config (JSON)" htmlFor="edit-station-playlist-config">
           <Input id="edit-station-playlist-config" value={playlistConfigJson} onChange={(e) => setPlaylistConfigJson(e.target.value)} />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
       <div className="flex items-center gap-2">
         <Switch id="edit-station-active" checked={isActive} onCheckedChange={setIsActive} />
         <Label htmlFor="edit-station-active">Active</Label>
       </div>
-
-      <DialogFooter>
-        <Button type="button" variant="outline" onClick={onCancel}>Cancel</Button>
-        <Button type="submit" disabled={updateMutation.isPending}>
-          {updateMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          Save Changes
-        </Button>
-      </DialogFooter>
-    </form>
+    </AdminFormLayout>
   )
 }
 
@@ -1777,50 +1776,45 @@ export function RadioManagement() {
             }}
           />
 
-          {/* Edit Station Dialog */}
-          <Dialog open={dialogMode === 'edit-station'} onOpenChange={(open) => !open && setDialogMode(null)}>
-            <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-              <DialogHeader>
-                <DialogTitle>Edit Station</DialogTitle>
-                <DialogDescription>Update station details.</DialogDescription>
-              </DialogHeader>
-              {selectedStation && (
-                <EditStationFormWrapper
-                  stationId={selectedStation.id}
-                  onSuccess={() => {
-                    setDialogMode(null)
-                    // Refresh detail view
-                    setDetailStation({ ...detailStation })
-                  }}
-                  onCancel={() => setDialogMode(null)}
-                />
-              )}
-            </DialogContent>
-          </Dialog>
+          {/* Edit Station — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+          {selectedStation && (
+            <EditStationFormWrapper
+              stationId={selectedStation.id}
+              open={dialogMode === 'edit-station'}
+              onOpenChange={(open) => !open && setDialogMode(null)}
+              onSuccess={() => {
+                setDialogMode(null)
+                // Refresh detail view
+                setDetailStation({ ...detailStation })
+              }}
+            />
+          )}
 
-          {/* Delete Station Dialog */}
-          <Dialog open={dialogMode === 'delete-station'} onOpenChange={(open) => !open && setDialogMode(null)}>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Delete Station</DialogTitle>
-                <DialogDescription>
-                  Are you sure you want to delete &quot;{selectedStation?.name}&quot;? This will also delete all shows, episodes, and plays.
-                  This action cannot be undone.
-                </DialogDescription>
-              </DialogHeader>
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setDialogMode(null)}>Cancel</Button>
-                <Button
-                  variant="destructive"
-                  disabled={deleteMutation.isPending}
-                  onClick={() => selectedStation && handleDeleteStation(selectedStation)}
-                >
+          {/* Delete Station — centered Modal (PSY-930, first modal-variant consumer) */}
+          <AdminFormLayout
+            variant="modal"
+            open={dialogMode === 'delete-station'}
+            onOpenChange={(open) => !open && setDialogMode(null)}
+            title="Delete Station"
+            description={`Are you sure you want to delete "${selectedStation?.name ?? ''}"? This will also delete all shows, episodes, and plays. This action cannot be undone.`}
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (selectedStation) handleDeleteStation(selectedStation)
+            }}
+            footer={
+              <>
+                <Button type="button" variant="outline" onClick={() => setDialogMode(null)}>
+                  Cancel
+                </Button>
+                <Button type="submit" variant="destructive" disabled={deleteMutation.isPending}>
                   {deleteMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   Delete Station
                 </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+              </>
+            }
+          >
+            {null}
+          </AdminFormLayout>
         </TabsContent>
 
         <TabsContent value="matching">
@@ -1916,24 +1910,59 @@ export function RadioManagement() {
 // Edit Station Form Wrapper (loads station detail)
 // ============================================================================
 
+// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
+// opens immediately on click; while the station detail loads we render the
+// SAME <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
+// across the loading->loaded swap — no flicker), then mount
+// EditStationFormFields with `key={station.id}` so the fields initialize from
+// the resolved detail.
 function EditStationFormWrapper({
   stationId,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   stationId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const { data: station, isLoading } = useRadioStationDetail(stationId)
 
   if (isLoading || !station) {
     return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
+      <AdminFormLayout
+        variant="sheet"
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Edit Station"
+        description="Update station details."
+        onSubmit={(e) => e.preventDefault()}
+        footer={
+          <>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled>
+              Save Changes
+            </Button>
+          </>
+        }
+      >
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      </AdminFormLayout>
     )
   }
 
-  return <EditStationForm station={station} onSuccess={onSuccess} onCancel={onCancel} />
+  return (
+    <EditStationFormFields
+      key={station.id}
+      station={station}
+      open={open}
+      onOpenChange={onOpenChange}
+      onSuccess={onSuccess}
+    />
+  )
 }

--- a/frontend/features/festivals/admin/FestivalManagement.test.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.test.tsx
@@ -40,7 +40,11 @@ vi.mock('@/features/venues', () => ({
   useVenueSearch: () => ({ data: { venues: [] as unknown[] }, isLoading: false }),
 }))
 
-import { FestivalManagement, EditFestivalFormFields } from './FestivalManagement'
+import {
+  FestivalManagement,
+  CreateFestivalForm,
+  EditFestivalFormFields,
+} from './FestivalManagement'
 
 function makeFestival(overrides: Partial<FestivalListItem> = {}): FestivalListItem {
   return {
@@ -350,8 +354,9 @@ describe('FestivalManagement', () => {
         <EditFestivalFormFields
           key={festivalA.id}
           festival={festivalA}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -366,8 +371,9 @@ describe('FestivalManagement', () => {
         <EditFestivalFormFields
           key={festivalB.id}
           festival={festivalB}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -384,8 +390,9 @@ describe('FestivalManagement', () => {
         <EditFestivalFormFields
           key={festival.id}
           festival={festival}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -397,12 +404,40 @@ describe('FestivalManagement', () => {
         <EditFestivalFormFields
           key={festival.id}
           festival={festival}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
       expect(screen.getByLabelText('Name *')).toHaveValue('Dirty Edit')
+    })
+  })
+
+  // Pins the PSY-930 Dialog->Sheet migration: AdminFormLayout keeps the create
+  // form mounted across the Sheet close animation, so the form must clear its
+  // own state when it (re)opens. Mirrors CreateStationForm's reset-on-open test.
+  describe('CreateFestivalForm reset-on-open (PSY-930)', () => {
+    it('clears entered field values when the Sheet is closed and reopened', async () => {
+      const user = userEvent.setup()
+      const { rerender } = renderWithProviders(
+        <CreateFestivalForm open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+
+      rerender(
+        <CreateFestivalForm open onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      const nameInput = screen.getByLabelText('Name *')
+      await user.type(nameInput, 'M3F Festival')
+      expect(nameInput).toHaveValue('M3F Festival')
+
+      rerender(
+        <CreateFestivalForm open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      rerender(
+        <CreateFestivalForm open onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      expect(screen.getByLabelText('Name *')).toHaveValue('')
     })
   })
 })

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -390,12 +390,12 @@ export function CreateFestivalForm({
 // Edit Festival Form
 // ============================================================================
 
-// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
-// opens immediately on click; while the festival detail loads we render the
-// SAME <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
-// across the loading->loaded swap), then mount EditFestivalFormFields with
-// `key={festival.id}` so a switch-festival-without-closing-dialog scenario
-// remounts with fresh state. The inner component initializes local state from
+// Per the PSY-930 decision the Edit Sheet opens immediately on click: while the
+// festival detail loads this wrapper renders an AdminFormLayout (open) with a
+// spinner body — `open` stays true throughout, so the Sheet stays open — then
+// swaps to EditFestivalFormFields (keyed on festival.id, so a
+// switch-festival-without-closing-dialog scenario remounts with fresh state)
+// once the detail resolves. The inner component initializes local state from
 // props inline (React's preferred "calculate during render" path — see
 // https://react.dev/learn/you-might-not-need-an-effect). No useEffect, no
 // `initialized` ratchet.

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -35,6 +35,11 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
+import {
+  AdminFormLayout,
+  AdminFormRow,
+  AdminFormField,
+} from '@/components/admin/AdminFormLayout'
 import { InlineErrorBanner } from '@/components/shared'
 import { useFestivals, useFestival, useFestivalLineup, useFestivalVenues } from '../hooks/useFestivals'
 import { useArtistSearch } from '@/features/artists'
@@ -76,12 +81,16 @@ type ManageMode = 'lineup' | 'venues' | null
 // Create Festival Form
 // ============================================================================
 
-function CreateFestivalForm({
+// Exported only for direct regression-test access (reset-on-open). Production
+// callers render it from FestivalManagement.
+export function CreateFestivalForm({
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const createMutation = useCreateFestival()
 
@@ -100,6 +109,31 @@ function CreateFestivalForm({
   const [flyerUrl, setFlyerUrl] = useState('')
   const [status, setStatus] = useState<string>('announced')
   const [error, setError] = useState<string | null>(null)
+
+  // Reset on (re)open — AdminFormLayout keeps the form mounted across the Sheet
+  // close animation. Adjust state during render (not in an effect) per the
+  // canonical CreateStationForm pattern (PSY-911/930).
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setName('')
+      setSeriesSlug('')
+      setEditionYear('')
+      setDescription('')
+      setLocationName('')
+      setCity('')
+      setState('')
+      setCountry('')
+      setStartDate('')
+      setEndDate('')
+      setWebsite('')
+      setTicketUrl('')
+      setFlyerUrl('')
+      setStatus('announced')
+      setError(null)
+    }
+  }
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -164,33 +198,56 @@ function CreateFestivalForm({
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
-      <div className="space-y-2">
-        <Label htmlFor="create-name">Name *</Label>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Create Festival"
+      description="Add a new music festival with location and dates."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={createMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={createMutation.isPending}>
+            {createMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              'Create Festival'
+            )}
+          </Button>
+        </>
+      }
+    >
+      <AdminFormField label="Name *" htmlFor="create-name">
         <Input
           id="create-name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="M3F Festival"
         />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="create-series-slug">Series Slug *</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Series Slug *" htmlFor="create-series-slug">
           <Input
             id="create-series-slug"
             value={seriesSlug}
             onChange={(e) => setSeriesSlug(e.target.value)}
             placeholder="m3f"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-edition-year">Edition Year *</Label>
+        </AdminFormField>
+        <AdminFormField label="Edition Year *" htmlFor="create-edition-year">
           <Input
             id="create-edition-year"
             type="number"
@@ -200,32 +257,29 @@ function CreateFestivalForm({
             min="1900"
             max="2100"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="create-start-date">Start Date *</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Start Date *" htmlFor="create-start-date">
           <Input
             id="create-start-date"
             type="date"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-end-date">End Date *</Label>
+        </AdminFormField>
+        <AdminFormField label="End Date *" htmlFor="create-end-date">
           <Input
             id="create-end-date"
             type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="space-y-2">
-        <Label htmlFor="create-status">Status</Label>
+      <AdminFormField label="Status" htmlFor="create-status">
         <Select value={status} onValueChange={setStatus}>
           <SelectTrigger id="create-status" className="w-full">
             <SelectValue />
@@ -238,50 +292,45 @@ function CreateFestivalForm({
             ))}
           </SelectContent>
         </Select>
-      </div>
+      </AdminFormField>
 
-      <div className="space-y-2">
-        <Label htmlFor="create-location-name">Location Name</Label>
+      <AdminFormField label="Location Name" htmlFor="create-location-name">
         <Input
           id="create-location-name"
           value={locationName}
           onChange={(e) => setLocationName(e.target.value)}
           placeholder="Margaret T. Hance Park"
         />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="create-city">City</Label>
+      <AdminFormRow cols={3}>
+        <AdminFormField label="City" htmlFor="create-city">
           <Input
             id="create-city"
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="Phoenix"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-state">State</Label>
+        </AdminFormField>
+        <AdminFormField label="State" htmlFor="create-state">
           <Input
             id="create-state"
             value={state}
             onChange={(e) => setState(e.target.value)}
             placeholder="AZ"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-country">Country</Label>
+        </AdminFormField>
+        <AdminFormField label="Country" htmlFor="create-country">
           <Input
             id="create-country"
             value={country}
             onChange={(e) => setCountry(e.target.value)}
             placeholder="US"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="space-y-2">
-        <Label htmlFor="create-desc">Description</Label>
+      <AdminFormField label="Description" htmlFor="create-desc">
         <Textarea
           id="create-desc"
           value={description}
@@ -289,69 +338,51 @@ function CreateFestivalForm({
           placeholder="Optional description..."
           rows={3}
         />
-      </div>
+      </AdminFormField>
 
       {/* Links */}
       <div className="space-y-3">
         <Label>Links</Label>
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="create-website" className="text-xs text-muted-foreground">
-              Website
-            </Label>
+        <AdminFormRow cols={2} className="gap-3">
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Website</span>}
+            htmlFor="create-website"
+          >
             <Input
               id="create-website"
               value={website}
               onChange={(e) => setWebsite(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-ticket-url" className="text-xs text-muted-foreground">
-              Ticket URL
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Ticket URL</span>}
+            htmlFor="create-ticket-url"
+          >
             <Input
               id="create-ticket-url"
               value={ticketUrl}
               onChange={(e) => setTicketUrl(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-flyer-url" className="text-xs text-muted-foreground">
-              Flyer URL
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Flyer URL</span>}
+            htmlFor="create-flyer-url"
+          >
             <Input
               id="create-flyer-url"
               value={flyerUrl}
               onChange={(e) => setFlyerUrl(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-        </div>
+          </AdminFormField>
+        </AdminFormRow>
       </div>
-
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          disabled={createMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled={createMutation.isPending}>
-          {createMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Creating...
-            </>
-          ) : (
-            'Create Festival'
-          )}
-        </Button>
-      </DialogFooter>
-    </form>
+    </AdminFormLayout>
   )
 }
 
@@ -359,39 +390,61 @@ function CreateFestivalForm({
 // Edit Festival Form
 // ============================================================================
 
-// Outer fetches the festival; once loaded, mounts EditFestivalFormFields
-// with `key={festival.id}` so a switch-festival-without-closing-dialog
-// scenario remounts with fresh state. The inner component initializes
-// local state from props inline (React's preferred "calculate during
-// render" path — see https://react.dev/learn/you-might-not-need-an-effect).
-// No useEffect, no `initialized` ratchet.
+// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
+// opens immediately on click; while the festival detail loads we render the
+// SAME <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
+// across the loading->loaded swap), then mount EditFestivalFormFields with
+// `key={festival.id}` so a switch-festival-without-closing-dialog scenario
+// remounts with fresh state. The inner component initializes local state from
+// props inline (React's preferred "calculate during render" path — see
+// https://react.dev/learn/you-might-not-need-an-effect). No useEffect, no
+// `initialized` ratchet.
 function EditFestivalForm({
   festivalId,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   festivalId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const { data: festival, isLoading } = useFestival({
     idOrSlug: festivalId,
     enabled: festivalId > 0,
   })
 
-  if (isLoading) {
+  if (isLoading || !festival) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (!festival) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        Festival not found.
-      </div>
+      <AdminFormLayout
+        variant="sheet"
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Edit Festival"
+        description="Update festival details, location, and dates."
+        onSubmit={(e) => e.preventDefault()}
+        footer={
+          <>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled>
+              Save Changes
+            </Button>
+          </>
+        }
+      >
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="text-center py-8 text-muted-foreground">
+            Festival not found.
+          </div>
+        )}
+      </AdminFormLayout>
     )
   }
 
@@ -399,8 +452,9 @@ function EditFestivalForm({
     <EditFestivalFormFields
       key={festival.id}
       festival={festival}
+      open={open}
+      onOpenChange={onOpenChange}
       onSuccess={onSuccess}
-      onCancel={onCancel}
     />
   )
 }
@@ -410,12 +464,14 @@ function EditFestivalForm({
 // the surface's public API — production callers use EditFestivalForm.
 export function EditFestivalFormFields({
   festival,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   festival: FestivalDetail
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const updateMutation = useUpdateFestival()
 
@@ -489,33 +545,56 @@ export function EditFestivalFormFields({
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
-      <div className="space-y-2">
-        <Label htmlFor="edit-name">Name *</Label>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit Festival"
+      description="Update festival details, location, and dates."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={updateMutation.isPending}>
+            {updateMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Changes'
+            )}
+          </Button>
+        </>
+      }
+    >
+      <AdminFormField label="Name *" htmlFor="edit-name">
         <Input
           id="edit-name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Festival name"
         />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="edit-series-slug">Series Slug</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Series Slug" htmlFor="edit-series-slug">
           <Input
             id="edit-series-slug"
             value={seriesSlug}
             onChange={(e) => setSeriesSlug(e.target.value)}
             placeholder="m3f"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="edit-edition-year">Edition Year</Label>
+        </AdminFormField>
+        <AdminFormField label="Edition Year" htmlFor="edit-edition-year">
           <Input
             id="edit-edition-year"
             type="number"
@@ -525,32 +604,29 @@ export function EditFestivalFormFields({
             min="1900"
             max="2100"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="edit-start-date">Start Date</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Start Date" htmlFor="edit-start-date">
           <Input
             id="edit-start-date"
             type="date"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="edit-end-date">End Date</Label>
+        </AdminFormField>
+        <AdminFormField label="End Date" htmlFor="edit-end-date">
           <Input
             id="edit-end-date"
             type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="space-y-2">
-        <Label htmlFor="edit-status">Status</Label>
+      <AdminFormField label="Status" htmlFor="edit-status">
         <Select value={status} onValueChange={setStatus}>
           <SelectTrigger id="edit-status" className="w-full">
             <SelectValue />
@@ -563,50 +639,45 @@ export function EditFestivalFormFields({
             ))}
           </SelectContent>
         </Select>
-      </div>
+      </AdminFormField>
 
-      <div className="space-y-2">
-        <Label htmlFor="edit-location-name">Location Name</Label>
+      <AdminFormField label="Location Name" htmlFor="edit-location-name">
         <Input
           id="edit-location-name"
           value={locationName}
           onChange={(e) => setLocationName(e.target.value)}
           placeholder="Margaret T. Hance Park"
         />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="edit-city">City</Label>
+      <AdminFormRow cols={3}>
+        <AdminFormField label="City" htmlFor="edit-city">
           <Input
             id="edit-city"
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="Phoenix"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="edit-state">State</Label>
+        </AdminFormField>
+        <AdminFormField label="State" htmlFor="edit-state">
           <Input
             id="edit-state"
             value={state}
             onChange={(e) => setState(e.target.value)}
             placeholder="AZ"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="edit-country">Country</Label>
+        </AdminFormField>
+        <AdminFormField label="Country" htmlFor="edit-country">
           <Input
             id="edit-country"
             value={country}
             onChange={(e) => setCountry(e.target.value)}
             placeholder="US"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="space-y-2">
-        <Label htmlFor="edit-desc">Description</Label>
+      <AdminFormField label="Description" htmlFor="edit-desc">
         <Textarea
           id="edit-desc"
           value={description}
@@ -614,69 +685,51 @@ export function EditFestivalFormFields({
           placeholder="Optional description..."
           rows={3}
         />
-      </div>
+      </AdminFormField>
 
       {/* Links */}
       <div className="space-y-3">
         <Label>Links</Label>
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="edit-website" className="text-xs text-muted-foreground">
-              Website
-            </Label>
+        <AdminFormRow cols={2} className="gap-3">
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Website</span>}
+            htmlFor="edit-website"
+          >
             <Input
               id="edit-website"
               value={website}
               onChange={(e) => setWebsite(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-ticket-url" className="text-xs text-muted-foreground">
-              Ticket URL
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Ticket URL</span>}
+            htmlFor="edit-ticket-url"
+          >
             <Input
               id="edit-ticket-url"
               value={ticketUrl}
               onChange={(e) => setTicketUrl(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-flyer-url" className="text-xs text-muted-foreground">
-              Flyer URL
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Flyer URL</span>}
+            htmlFor="edit-flyer-url"
+          >
             <Input
               id="edit-flyer-url"
               value={flyerUrl}
               onChange={(e) => setFlyerUrl(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-        </div>
+          </AdminFormField>
+        </AdminFormRow>
       </div>
-
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          disabled={updateMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled={updateMutation.isPending}>
-          {updateMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Saving...
-            </>
-          ) : (
-            'Save Changes'
-          )}
-        </Button>
-      </DialogFooter>
-    </form>
+    </AdminFormLayout>
   )
 }
 
@@ -684,16 +737,20 @@ export function EditFestivalFormFields({
 // Delete Confirmation
 // ============================================================================
 
+// Short confirm form -> centered Modal (variant="modal"), per the PSY-912
+// Hybrid decision.
 function DeleteConfirmation({
   festivalName,
   festivalId,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   festivalName: string
   festivalId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const deleteMutation = useDeleteFestival()
   const [error, setError] = useState<string | null>(null)
@@ -713,11 +770,44 @@ function DeleteConfirmation({
   }, [festivalId, deleteMutation, onSuccess])
 
   return (
-    <div className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
+    <AdminFormLayout
+      variant="modal"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Delete Festival"
+      description="This action is permanent and cannot be undone."
+      error={error || undefined}
+      onSubmit={(e) => {
+        e.preventDefault()
+        handleDelete()
+      }}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={deleteMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="destructive"
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              'Delete Festival'
+            )}
+          </Button>
+        </>
+      }
+    >
       <p className="text-sm text-muted-foreground">
         Are you sure you want to delete{' '}
         <span className="font-semibold text-foreground">
@@ -726,31 +816,7 @@ function DeleteConfirmation({
         ? This action cannot be undone. All lineup and venue associations will
         also be removed.
       </p>
-
-      <DialogFooter>
-        <Button
-          variant="outline"
-          onClick={onCancel}
-          disabled={deleteMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button
-          variant="destructive"
-          onClick={handleDelete}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Deleting...
-            </>
-          ) : (
-            'Delete Festival'
-          )}
-        </Button>
-      </DialogFooter>
-    </div>
+    </AdminFormLayout>
   )
 }
 
@@ -1668,66 +1734,33 @@ export function FestivalManagement() {
         </>
       )}
 
-      {/* Create Dialog */}
-      <Dialog
+      {/* Create — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+      <CreateFestivalForm
         open={dialogMode === 'create'}
         onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Create Festival</DialogTitle>
-            <DialogDescription>
-              Add a new music festival with location and dates.
-            </DialogDescription>
-          </DialogHeader>
-          <CreateFestivalForm onSuccess={closeDialog} onCancel={closeDialog} />
-        </DialogContent>
-      </Dialog>
+        onSuccess={closeDialog}
+      />
 
-      {/* Edit Dialog */}
-      <Dialog
-        open={dialogMode === 'edit'}
-        onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Edit Festival</DialogTitle>
-            <DialogDescription>
-              Update festival details, location, and dates.
-            </DialogDescription>
-          </DialogHeader>
-          {selectedFestivalId && (
-            <EditFestivalForm
-              festivalId={selectedFestivalId}
-              onSuccess={closeDialog}
-              onCancel={closeDialog}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {/* Edit — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+      {selectedFestivalId && (
+        <EditFestivalForm
+          festivalId={selectedFestivalId}
+          open={dialogMode === 'edit'}
+          onOpenChange={(open) => !open && closeDialog()}
+          onSuccess={closeDialog}
+        />
+      )}
 
-      {/* Delete Dialog */}
-      <Dialog
-        open={dialogMode === 'delete'}
-        onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Delete Festival</DialogTitle>
-            <DialogDescription>
-              This action is permanent and cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {selectedFestivalId && (
-            <DeleteConfirmation
-              festivalName={selectedFestivalName}
-              festivalId={selectedFestivalId}
-              onSuccess={closeDialog}
-              onCancel={closeDialog}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {/* Delete — centered Modal (PSY-930 AdminFormLayout) */}
+      {selectedFestivalId && (
+        <DeleteConfirmation
+          festivalName={selectedFestivalName}
+          festivalId={selectedFestivalId}
+          open={dialogMode === 'delete'}
+          onOpenChange={(open) => !open && closeDialog()}
+          onSuccess={closeDialog}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -1495,10 +1495,13 @@ export function FestivalManagement() {
     setSelectedFestivalName(name)
   }, [])
 
+  // Close by clearing dialogMode only. The selected id/name persist so the
+  // mounted Edit/Delete AdminFormLayout can animate closed (its `open` is
+  // driven by dialogMode); openEdit/openDelete overwrite them on the next open.
+  // Nulling the id here would unmount the form mid-animation and flash its
+  // empty/not-found state. (PSY-930)
   const closeDialog = useCallback(() => {
     setDialogMode(null)
-    setSelectedFestivalId(null)
-    setSelectedFestivalName('')
   }, [])
 
   const openManage = useCallback(

--- a/frontend/features/labels/admin/LabelManagement.test.tsx
+++ b/frontend/features/labels/admin/LabelManagement.test.tsx
@@ -22,7 +22,11 @@ vi.mock('../hooks/useAdminLabels', () => ({
   useDeleteLabel: () => ({ mutate: mockDeleteMutate, isPending: false }),
 }))
 
-import { LabelManagement, EditLabelFormFields } from './LabelManagement'
+import {
+  LabelManagement,
+  CreateLabelForm,
+  EditLabelFormFields,
+} from './LabelManagement'
 
 function makeLabelDetail(overrides: Partial<LabelDetail> = {}): LabelDetail {
   return {
@@ -259,8 +263,9 @@ describe('LabelManagement', () => {
         <EditLabelFormFields
           key={labelA.id}
           label={labelA}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -275,8 +280,9 @@ describe('LabelManagement', () => {
         <EditLabelFormFields
           key={labelB.id}
           label={labelB}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -293,8 +299,9 @@ describe('LabelManagement', () => {
         <EditLabelFormFields
           key={label.id}
           label={label}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -306,12 +313,41 @@ describe('LabelManagement', () => {
         <EditLabelFormFields
           key={label.id}
           label={label}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
       expect(screen.getByLabelText('Name *')).toHaveValue('Dirty Edit')
+    })
+  })
+
+  // Pins the PSY-930 Dialog->Sheet migration: AdminFormLayout keeps the create
+  // form mounted across the Sheet close animation, so the form must clear its
+  // own state when it (re)opens — otherwise the next "New Label" shows stale
+  // input. Mirrors CreateStationForm's reset-on-open test (PSY-911).
+  describe('CreateLabelForm reset-on-open (PSY-930)', () => {
+    it('clears entered field values when the Sheet is closed and reopened', async () => {
+      const user = userEvent.setup()
+      const { rerender } = renderWithProviders(
+        <CreateLabelForm open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+
+      rerender(
+        <CreateLabelForm open onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      const nameInput = screen.getByLabelText('Name *')
+      await user.type(nameInput, 'Hardly Art')
+      expect(nameInput).toHaveValue('Hardly Art')
+
+      rerender(
+        <CreateLabelForm open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      rerender(
+        <CreateLabelForm open onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      expect(screen.getByLabelText('Name *')).toHaveValue('')
     })
   })
 })

--- a/frontend/features/labels/admin/LabelManagement.tsx
+++ b/frontend/features/labels/admin/LabelManagement.tsx
@@ -23,13 +23,10 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from '@/components/ui/dialog'
+  AdminFormLayout,
+  AdminFormRow,
+  AdminFormField,
+} from '@/components/admin/AdminFormLayout'
 import { InlineErrorBanner } from '@/components/shared'
 import { useLabels, useLabel } from '../hooks/useLabels'
 import {
@@ -57,12 +54,16 @@ type DialogMode = 'create' | 'edit' | 'delete' | null
 // Create Label Form
 // ============================================================================
 
-function CreateLabelForm({
+// Exported only for direct regression-test access (reset-on-open). Production
+// callers render it from LabelManagement.
+export function CreateLabelForm({
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const createMutation = useCreateLabel()
 
@@ -82,6 +83,33 @@ function CreateLabelForm({
   const [bandcamp, setBandcamp] = useState('')
   const [website, setWebsite] = useState('')
   const [error, setError] = useState<string | null>(null)
+
+  // Reset on (re)open. AdminFormLayout keeps the form mounted across the Sheet's
+  // close animation, so without this the next "New Label" would show stale input.
+  // Adjusting state during render (not in an effect) avoids a cascading re-render
+  // and an extra paint — the canonical CreateStationForm pattern (PSY-911/930).
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setName('')
+      setCity('')
+      setState('')
+      setCountry('')
+      setFoundedYear('')
+      setStatus('active')
+      setDescription('')
+      setInstagram('')
+      setFacebook('')
+      setTwitter('')
+      setYoutube('')
+      setSpotify('')
+      setSoundcloud('')
+      setBandcamp('')
+      setWebsite('')
+      setError(null)
+    }
+  }
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -145,54 +173,75 @@ function CreateLabelForm({
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
-      <div className="space-y-2">
-        <Label htmlFor="create-name">Name *</Label>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Create Label"
+      description="Add a new record label with location and social links."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={createMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={createMutation.isPending}>
+            {createMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              'Create Label'
+            )}
+          </Button>
+        </>
+      }
+    >
+      <AdminFormField label="Name *" htmlFor="create-name">
         <Input
           id="create-name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Label name"
         />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="create-city">City</Label>
+      <AdminFormRow cols={3}>
+        <AdminFormField label="City" htmlFor="create-city">
           <Input
             id="create-city"
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="Seattle"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-state">State</Label>
+        </AdminFormField>
+        <AdminFormField label="State" htmlFor="create-state">
           <Input
             id="create-state"
             value={state}
             onChange={(e) => setState(e.target.value)}
             placeholder="WA"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-country">Country</Label>
+        </AdminFormField>
+        <AdminFormField label="Country" htmlFor="create-country">
           <Input
             id="create-country"
             value={country}
             onChange={(e) => setCountry(e.target.value)}
             placeholder="US"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="create-status">Status</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Status" htmlFor="create-status">
           <Select value={status} onValueChange={setStatus}>
             <SelectTrigger id="create-status" className="w-full">
               <SelectValue />
@@ -205,9 +254,8 @@ function CreateLabelForm({
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-founded-year">Founded Year</Label>
+        </AdminFormField>
+        <AdminFormField label="Founded Year" htmlFor="create-founded-year">
           <Input
             id="create-founded-year"
             type="number"
@@ -217,11 +265,10 @@ function CreateLabelForm({
             min="1900"
             max="2100"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="space-y-2">
-        <Label htmlFor="create-desc">Description</Label>
+      <AdminFormField label="Description" htmlFor="create-desc">
         <Textarea
           id="create-desc"
           value={description}
@@ -229,124 +276,111 @@ function CreateLabelForm({
           placeholder="Optional description..."
           rows={3}
         />
-      </div>
+      </AdminFormField>
 
       {/* Social Links */}
       <div className="space-y-3">
         <Label>Social Links</Label>
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="create-website" className="text-xs text-muted-foreground">
-              Website
-            </Label>
+        <AdminFormRow cols={2} className="gap-3">
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Website</span>}
+            htmlFor="create-website"
+          >
             <Input
               id="create-website"
               value={website}
               onChange={(e) => setWebsite(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-bandcamp" className="text-xs text-muted-foreground">
-              Bandcamp
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Bandcamp</span>}
+            htmlFor="create-bandcamp"
+          >
             <Input
               id="create-bandcamp"
               value={bandcamp}
               onChange={(e) => setBandcamp(e.target.value)}
               placeholder="https://label.bandcamp.com"
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-instagram" className="text-xs text-muted-foreground">
-              Instagram
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Instagram</span>}
+            htmlFor="create-instagram"
+          >
             <Input
               id="create-instagram"
               value={instagram}
               onChange={(e) => setInstagram(e.target.value)}
               placeholder="@handle"
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-twitter" className="text-xs text-muted-foreground">
-              Twitter
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Twitter</span>}
+            htmlFor="create-twitter"
+          >
             <Input
               id="create-twitter"
               value={twitter}
               onChange={(e) => setTwitter(e.target.value)}
               placeholder="@handle"
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-spotify" className="text-xs text-muted-foreground">
-              Spotify
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Spotify</span>}
+            htmlFor="create-spotify"
+          >
             <Input
               id="create-spotify"
               value={spotify}
               onChange={(e) => setSpotify(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-facebook" className="text-xs text-muted-foreground">
-              Facebook
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Facebook</span>}
+            htmlFor="create-facebook"
+          >
             <Input
               id="create-facebook"
               value={facebook}
               onChange={(e) => setFacebook(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-youtube" className="text-xs text-muted-foreground">
-              YouTube
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">YouTube</span>}
+            htmlFor="create-youtube"
+          >
             <Input
               id="create-youtube"
               value={youtube}
               onChange={(e) => setYoutube(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="create-soundcloud" className="text-xs text-muted-foreground">
-              SoundCloud
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">SoundCloud</span>}
+            htmlFor="create-soundcloud"
+          >
             <Input
               id="create-soundcloud"
               value={soundcloud}
               onChange={(e) => setSoundcloud(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-        </div>
+          </AdminFormField>
+        </AdminFormRow>
       </div>
-
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          disabled={createMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled={createMutation.isPending}>
-          {createMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Creating...
-            </>
-          ) : (
-            'Create Label'
-          )}
-        </Button>
-      </DialogFooter>
-    </form>
+    </AdminFormLayout>
   )
 }
 
@@ -354,39 +388,61 @@ function CreateLabelForm({
 // Edit Label Form
 // ============================================================================
 
-// Outer fetches the label; once loaded, mounts EditLabelFormFields with
-// `key={label.id}` so a switch-label-without-closing-dialog scenario
-// remounts with fresh state. The inner component initializes local state
-// from props inline (React's preferred "calculate during render" path —
-// see https://react.dev/learn/you-might-not-need-an-effect). No useEffect,
-// no `initialized` ratchet.
+// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
+// opens immediately on click; while the label detail loads we render the SAME
+// <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
+// across the loading->loaded swap), then mount EditLabelFormFields with
+// `key={label.id}` so a switch-label-without-closing-dialog scenario remounts
+// with fresh state. The inner component initializes local state from props
+// inline (React's preferred "calculate during render" path — see
+// https://react.dev/learn/you-might-not-need-an-effect). No useEffect, no
+// `initialized` ratchet.
 function EditLabelForm({
   labelId,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   labelId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const { data: label, isLoading } = useLabel({
     idOrSlug: labelId,
     enabled: labelId > 0,
   })
 
-  if (isLoading) {
+  if (isLoading || !label) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (!label) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        Label not found.
-      </div>
+      <AdminFormLayout
+        variant="sheet"
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Edit Label"
+        description="Update label details and social links."
+        onSubmit={(e) => e.preventDefault()}
+        footer={
+          <>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled>
+              Save Changes
+            </Button>
+          </>
+        }
+      >
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="text-center py-8 text-muted-foreground">
+            Label not found.
+          </div>
+        )}
+      </AdminFormLayout>
     )
   }
 
@@ -394,8 +450,9 @@ function EditLabelForm({
     <EditLabelFormFields
       key={label.id}
       label={label}
+      open={open}
+      onOpenChange={onOpenChange}
       onSuccess={onSuccess}
-      onCancel={onCancel}
     />
   )
 }
@@ -405,12 +462,14 @@ function EditLabelForm({
 // the surface's public API — production callers use EditLabelForm.
 export function EditLabelFormFields({
   label,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   label: LabelDetail
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const updateMutation = useUpdateLabel()
 
@@ -501,54 +560,75 @@ export function EditLabelFormFields({
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
-      <div className="space-y-2">
-        <Label htmlFor="edit-name">Name *</Label>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit Label"
+      description="Update label details and social links."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={updateMutation.isPending}>
+            {updateMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Changes'
+            )}
+          </Button>
+        </>
+      }
+    >
+      <AdminFormField label="Name *" htmlFor="edit-name">
         <Input
           id="edit-name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Label name"
         />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="edit-city">City</Label>
+      <AdminFormRow cols={3}>
+        <AdminFormField label="City" htmlFor="edit-city">
           <Input
             id="edit-city"
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="Seattle"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="edit-state">State</Label>
+        </AdminFormField>
+        <AdminFormField label="State" htmlFor="edit-state">
           <Input
             id="edit-state"
             value={state}
             onChange={(e) => setState(e.target.value)}
             placeholder="WA"
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="edit-country">Country</Label>
+        </AdminFormField>
+        <AdminFormField label="Country" htmlFor="edit-country">
           <Input
             id="edit-country"
             value={country}
             onChange={(e) => setCountry(e.target.value)}
             placeholder="US"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="edit-status">Status</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Status" htmlFor="edit-status">
           <Select value={status} onValueChange={setStatus}>
             <SelectTrigger id="edit-status" className="w-full">
               <SelectValue />
@@ -561,9 +641,8 @@ export function EditLabelFormFields({
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="edit-founded-year">Founded Year</Label>
+        </AdminFormField>
+        <AdminFormField label="Founded Year" htmlFor="edit-founded-year">
           <Input
             id="edit-founded-year"
             type="number"
@@ -573,11 +652,10 @@ export function EditLabelFormFields({
             min="1900"
             max="2100"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="space-y-2">
-        <Label htmlFor="edit-desc">Description</Label>
+      <AdminFormField label="Description" htmlFor="edit-desc">
         <Textarea
           id="edit-desc"
           value={description}
@@ -585,124 +663,111 @@ export function EditLabelFormFields({
           placeholder="Optional description..."
           rows={3}
         />
-      </div>
+      </AdminFormField>
 
       {/* Social Links */}
       <div className="space-y-3">
         <Label>Social Links</Label>
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="edit-website" className="text-xs text-muted-foreground">
-              Website
-            </Label>
+        <AdminFormRow cols={2} className="gap-3">
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Website</span>}
+            htmlFor="edit-website"
+          >
             <Input
               id="edit-website"
               value={website}
               onChange={(e) => setWebsite(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-bandcamp" className="text-xs text-muted-foreground">
-              Bandcamp
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Bandcamp</span>}
+            htmlFor="edit-bandcamp"
+          >
             <Input
               id="edit-bandcamp"
               value={bandcamp}
               onChange={(e) => setBandcamp(e.target.value)}
               placeholder="https://label.bandcamp.com"
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-instagram" className="text-xs text-muted-foreground">
-              Instagram
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Instagram</span>}
+            htmlFor="edit-instagram"
+          >
             <Input
               id="edit-instagram"
               value={instagram}
               onChange={(e) => setInstagram(e.target.value)}
               placeholder="@handle"
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-twitter" className="text-xs text-muted-foreground">
-              Twitter
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Twitter</span>}
+            htmlFor="edit-twitter"
+          >
             <Input
               id="edit-twitter"
               value={twitter}
               onChange={(e) => setTwitter(e.target.value)}
               placeholder="@handle"
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-spotify" className="text-xs text-muted-foreground">
-              Spotify
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Spotify</span>}
+            htmlFor="edit-spotify"
+          >
             <Input
               id="edit-spotify"
               value={spotify}
               onChange={(e) => setSpotify(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-facebook" className="text-xs text-muted-foreground">
-              Facebook
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">Facebook</span>}
+            htmlFor="edit-facebook"
+          >
             <Input
               id="edit-facebook"
               value={facebook}
               onChange={(e) => setFacebook(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-youtube" className="text-xs text-muted-foreground">
-              YouTube
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">YouTube</span>}
+            htmlFor="edit-youtube"
+          >
             <Input
               id="edit-youtube"
               value={youtube}
               onChange={(e) => setYoutube(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="edit-soundcloud" className="text-xs text-muted-foreground">
-              SoundCloud
-            </Label>
+          </AdminFormField>
+          <AdminFormField
+            className="space-y-1"
+            label={<span className="text-xs text-muted-foreground">SoundCloud</span>}
+            htmlFor="edit-soundcloud"
+          >
             <Input
               id="edit-soundcloud"
               value={soundcloud}
               onChange={(e) => setSoundcloud(e.target.value)}
               placeholder="https://..."
             />
-          </div>
-        </div>
+          </AdminFormField>
+        </AdminFormRow>
       </div>
-
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          disabled={updateMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled={updateMutation.isPending}>
-          {updateMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Saving...
-            </>
-          ) : (
-            'Save Changes'
-          )}
-        </Button>
-      </DialogFooter>
-    </form>
+    </AdminFormLayout>
   )
 }
 
@@ -710,16 +775,21 @@ export function EditLabelFormFields({
 // Delete Confirmation
 // ============================================================================
 
+// Short confirm form -> centered Modal (variant="modal"), per the PSY-912
+// Hybrid decision: long entity forms use the Sheet, short confirm/delete forms
+// stay a centered Dialog.
 function DeleteConfirmation({
   labelName,
   labelId,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   labelName: string
   labelId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const deleteMutation = useDeleteLabel()
   const [error, setError] = useState<string | null>(null)
@@ -739,11 +809,44 @@ function DeleteConfirmation({
   }, [labelId, deleteMutation, onSuccess])
 
   return (
-    <div className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
+    <AdminFormLayout
+      variant="modal"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Delete Label"
+      description="This action is permanent and cannot be undone."
+      error={error || undefined}
+      onSubmit={(e) => {
+        e.preventDefault()
+        handleDelete()
+      }}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={deleteMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="destructive"
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              'Delete Label'
+            )}
+          </Button>
+        </>
+      }
+    >
       <p className="text-sm text-muted-foreground">
         Are you sure you want to delete{' '}
         <span className="font-semibold text-foreground">
@@ -752,31 +855,7 @@ function DeleteConfirmation({
         ? This action cannot be undone. All artist and release associations will
         also be removed.
       </p>
-
-      <DialogFooter>
-        <Button
-          variant="outline"
-          onClick={onCancel}
-          disabled={deleteMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button
-          variant="destructive"
-          onClick={handleDelete}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Deleting...
-            </>
-          ) : (
-            'Delete Label'
-          )}
-        </Button>
-      </DialogFooter>
-    </div>
+    </AdminFormLayout>
   )
 }
 
@@ -996,66 +1075,33 @@ export function LabelManagement() {
         </>
       )}
 
-      {/* Create Dialog */}
-      <Dialog
+      {/* Create — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+      <CreateLabelForm
         open={dialogMode === 'create'}
         onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Create Label</DialogTitle>
-            <DialogDescription>
-              Add a new record label with location and social links.
-            </DialogDescription>
-          </DialogHeader>
-          <CreateLabelForm onSuccess={closeDialog} onCancel={closeDialog} />
-        </DialogContent>
-      </Dialog>
+        onSuccess={closeDialog}
+      />
 
-      {/* Edit Dialog */}
-      <Dialog
-        open={dialogMode === 'edit'}
-        onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Edit Label</DialogTitle>
-            <DialogDescription>
-              Update label details and social links.
-            </DialogDescription>
-          </DialogHeader>
-          {selectedLabelId && (
-            <EditLabelForm
-              labelId={selectedLabelId}
-              onSuccess={closeDialog}
-              onCancel={closeDialog}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {/* Edit — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+      {selectedLabelId && (
+        <EditLabelForm
+          labelId={selectedLabelId}
+          open={dialogMode === 'edit'}
+          onOpenChange={(open) => !open && closeDialog()}
+          onSuccess={closeDialog}
+        />
+      )}
 
-      {/* Delete Dialog */}
-      <Dialog
-        open={dialogMode === 'delete'}
-        onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Delete Label</DialogTitle>
-            <DialogDescription>
-              This action is permanent and cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {selectedLabelId && (
-            <DeleteConfirmation
-              labelName={selectedLabelName}
-              labelId={selectedLabelId}
-              onSuccess={closeDialog}
-              onCancel={closeDialog}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {/* Delete — centered Modal (PSY-930 AdminFormLayout) */}
+      {selectedLabelId && (
+        <DeleteConfirmation
+          labelName={selectedLabelName}
+          labelId={selectedLabelId}
+          open={dialogMode === 'delete'}
+          onOpenChange={(open) => !open && closeDialog()}
+          onSuccess={closeDialog}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/features/labels/admin/LabelManagement.tsx
+++ b/frontend/features/labels/admin/LabelManagement.tsx
@@ -388,12 +388,12 @@ export function CreateLabelForm({
 // Edit Label Form
 // ============================================================================
 
-// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
-// opens immediately on click; while the label detail loads we render the SAME
-// <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
-// across the loading->loaded swap), then mount EditLabelFormFields with
-// `key={label.id}` so a switch-label-without-closing-dialog scenario remounts
-// with fresh state. The inner component initializes local state from props
+// Per the PSY-930 decision the Edit Sheet opens immediately on click: while the
+// label detail loads this wrapper renders an AdminFormLayout (open) with a
+// spinner body — `open` stays true throughout, so the Sheet stays open — then
+// swaps to EditLabelFormFields (keyed on label.id, so a
+// switch-label-without-closing-dialog scenario remounts with fresh state) once
+// the detail resolves. The inner component initializes local state from props
 // inline (React's preferred "calculate during render" path — see
 // https://react.dev/learn/you-might-not-need-an-effect). No useEffect, no
 // `initialized` ratchet.

--- a/frontend/features/labels/admin/LabelManagement.tsx
+++ b/frontend/features/labels/admin/LabelManagement.tsx
@@ -913,10 +913,13 @@ export function LabelManagement() {
     setSelectedLabelName(name)
   }, [])
 
+  // Close by clearing dialogMode only. The selected id/name persist so the
+  // mounted Edit/Delete AdminFormLayout can animate closed (its `open` is
+  // driven by dialogMode); openEdit/openDelete overwrite them on the next open.
+  // Nulling the id here would unmount the form mid-animation and flash its
+  // empty/not-found state. (PSY-930)
   const closeDialog = useCallback(() => {
     setDialogMode(null)
-    setSelectedLabelId(null)
-    setSelectedLabelName('')
   }, [])
 
   return (
@@ -1082,7 +1085,10 @@ export function LabelManagement() {
         onSuccess={closeDialog}
       />
 
-      {/* Edit — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+      {/* Edit — right-anchored Sheet (PSY-930 AdminFormLayout). Gated on the
+          selected id; closeDialog keeps the id set so the form stays mounted
+          and the Sheet animates closed (open driven by dialogMode), matching
+          CreateLabelForm. The id is overwritten on the next open. */}
       {selectedLabelId && (
         <EditLabelForm
           labelId={selectedLabelId}

--- a/frontend/features/releases/admin/ReleaseManagement.test.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.test.tsx
@@ -32,7 +32,11 @@ vi.mock('../hooks/useAdminReleases', () => ({
   useRemoveReleaseLink: () => ({ mutate: mockRemoveLink, isPending: false }),
 }))
 
-import { ReleaseManagement, EditReleaseFormFields } from './ReleaseManagement'
+import {
+  ReleaseManagement,
+  CreateReleaseForm,
+  EditReleaseFormFields,
+} from './ReleaseManagement'
 
 function makeListItem(
   overrides: Partial<ReleaseListItem> = {}
@@ -338,8 +342,9 @@ describe('ReleaseManagement', () => {
         <EditReleaseFormFields
           key={releaseA.id}
           release={releaseA}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -354,8 +359,9 @@ describe('ReleaseManagement', () => {
         <EditReleaseFormFields
           key={releaseB.id}
           release={releaseB}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -373,8 +379,9 @@ describe('ReleaseManagement', () => {
         <EditReleaseFormFields
           key={release.id}
           release={release}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
@@ -386,12 +393,40 @@ describe('ReleaseManagement', () => {
         <EditReleaseFormFields
           key={release.id}
           release={release}
+          open
+          onOpenChange={vi.fn()}
           onSuccess={vi.fn()}
-          onCancel={vi.fn()}
         />
       )
 
       expect(screen.getByLabelText(/Title \*/i)).toHaveValue('Dirty Edit')
+    })
+  })
+
+  // Pins the PSY-930 Dialog->Sheet migration: AdminFormLayout keeps the create
+  // form mounted across the Sheet close animation, so the form must clear its
+  // own state when it (re)opens. Mirrors CreateStationForm's reset-on-open test.
+  describe('CreateReleaseForm reset-on-open (PSY-930)', () => {
+    it('clears entered field values when the Sheet is closed and reopened', async () => {
+      const user = userEvent.setup()
+      const { rerender } = renderWithProviders(
+        <CreateReleaseForm open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+
+      rerender(
+        <CreateReleaseForm open onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      const titleInput = screen.getByLabelText(/Title \*/i)
+      await user.type(titleInput, 'My Album')
+      expect(titleInput).toHaveValue('My Album')
+
+      rerender(
+        <CreateReleaseForm open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      rerender(
+        <CreateReleaseForm open onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      )
+      expect(screen.getByLabelText(/Title \*/i)).toHaveValue('')
     })
   })
 })

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -1095,10 +1095,13 @@ export function ReleaseManagement() {
     setSelectedReleaseTitle(title)
   }, [])
 
+  // Close by clearing dialogMode only. The selected id/title persist so the
+  // mounted Edit/Delete AdminFormLayout can animate closed (its `open` is
+  // driven by dialogMode); openEdit/openDelete overwrite them on the next open.
+  // Nulling the id here would unmount the form mid-animation and flash its
+  // empty/not-found state. (PSY-930)
   const closeDialog = useCallback(() => {
     setDialogMode(null)
-    setSelectedReleaseId(null)
-    setSelectedReleaseTitle('')
   }, [])
 
   return (

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -26,13 +26,10 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from '@/components/ui/dialog'
+  AdminFormLayout,
+  AdminFormRow,
+  AdminFormField,
+} from '@/components/admin/AdminFormLayout'
 import { InlineErrorBanner } from '@/components/shared'
 import { useReleases, useRelease } from '../hooks/useReleases'
 import { useArtistSearch } from '@/features/artists'
@@ -455,12 +452,16 @@ function ExistingLinkManager({
 // Release Form (Create)
 // ============================================================================
 
-function CreateReleaseForm({
+// Exported only for direct regression-test access (reset-on-open). Production
+// callers render it from ReleaseManagement.
+export function CreateReleaseForm({
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const createMutation = useCreateRelease()
 
@@ -473,6 +474,27 @@ function CreateReleaseForm({
   const [artists, setArtists] = useState<ArtistEntry[]>([])
   const [links, setLinks] = useState<LinkEntry[]>([])
   const [error, setError] = useState<string | null>(null)
+
+  // Reset on (re)open — AdminFormLayout keeps the form mounted across the Sheet
+  // close animation. Adjust state during render (not in an effect) per the
+  // canonical CreateStationForm pattern (PSY-911/930). Note the embedded
+  // ArtistPicker / LinkEditor hold their own draft state and remount with the
+  // form, so the artists/links arrays here are the load-bearing reset.
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setTitle('')
+      setReleaseType('lp')
+      setReleaseYear('')
+      setReleaseDate('')
+      setCoverArtUrl('')
+      setDescription('')
+      setArtists([])
+      setLinks([])
+      setError(null)
+    }
+  }
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -532,24 +554,48 @@ function CreateReleaseForm({
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
-      <div className="space-y-2">
-        <Label htmlFor="create-title">Title *</Label>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Create Release"
+      description="Add a new music release with artist associations and external links."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={createMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={createMutation.isPending}>
+            {createMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              'Create Release'
+            )}
+          </Button>
+        </>
+      }
+    >
+      <AdminFormField label="Title *" htmlFor="create-title">
         <Input
           id="create-title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Album title"
         />
-      </div>
+      </AdminFormField>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="create-type">Release Type</Label>
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Release Type" htmlFor="create-type">
           <Select value={releaseType} onValueChange={setReleaseType}>
             <SelectTrigger id="create-type" className="w-full">
               <SelectValue />
@@ -562,9 +608,8 @@ function CreateReleaseForm({
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="create-year">Year</Label>
+        </AdminFormField>
+        <AdminFormField label="Year" htmlFor="create-year">
           <Input
             id="create-year"
             type="number"
@@ -574,31 +619,28 @@ function CreateReleaseForm({
             min="1900"
             max="2100"
           />
-        </div>
-      </div>
+        </AdminFormField>
+      </AdminFormRow>
 
-      <div className="space-y-2">
-        <Label htmlFor="create-date">Release Date</Label>
+      <AdminFormField label="Release Date" htmlFor="create-date">
         <Input
           id="create-date"
           type="date"
           value={releaseDate}
           onChange={(e) => setReleaseDate(e.target.value)}
         />
-      </div>
+      </AdminFormField>
 
-      <div className="space-y-2">
-        <Label htmlFor="create-cover">Cover Art URL</Label>
+      <AdminFormField label="Cover Art URL" htmlFor="create-cover">
         <Input
           id="create-cover"
           value={coverArtUrl}
           onChange={(e) => setCoverArtUrl(e.target.value)}
           placeholder="https://..."
         />
-      </div>
+      </AdminFormField>
 
-      <div className="space-y-2">
-        <Label htmlFor="create-desc">Description</Label>
+      <AdminFormField label="Description" htmlFor="create-desc">
         <Textarea
           id="create-desc"
           value={description}
@@ -606,7 +648,7 @@ function CreateReleaseForm({
           placeholder="Optional description..."
           rows={3}
         />
-      </div>
+      </AdminFormField>
 
       <ArtistPicker
         artists={artists}
@@ -628,28 +670,7 @@ function CreateReleaseForm({
           setLinks((prev) => prev.filter((_, i) => i !== index))
         }
       />
-
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          disabled={createMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled={createMutation.isPending}>
-          {createMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Creating...
-            </>
-          ) : (
-            'Create Release'
-          )}
-        </Button>
-      </DialogFooter>
-    </form>
+    </AdminFormLayout>
   )
 }
 
@@ -657,39 +678,61 @@ function CreateReleaseForm({
 // Edit Release Form
 // ============================================================================
 
-// Outer fetches the release; once loaded, mounts EditReleaseFormFields with
+// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
+// opens immediately on click; while the release detail loads we render the SAME
+// <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
+// across the loading->loaded swap), then mount EditReleaseFormFields with
 // `key={release.id}` so a switch-release-without-closing-dialog scenario
-// remounts with fresh state. The inner component initializes local state
-// from props inline (React's preferred "calculate during render" path —
-// see https://react.dev/learn/you-might-not-need-an-effect). No useEffect,
-// no `initialized` ratchet.
+// remounts with fresh state. The inner component initializes local state from
+// props inline (React's preferred "calculate during render" path — see
+// https://react.dev/learn/you-might-not-need-an-effect). No useEffect, no
+// `initialized` ratchet.
 function EditReleaseForm({
   releaseId,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   releaseId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const { data: release, isLoading } = useRelease({
     idOrSlug: releaseId,
     enabled: releaseId > 0,
   })
 
-  if (isLoading) {
+  if (isLoading || !release) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (!release) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        Release not found.
-      </div>
+      <AdminFormLayout
+        variant="sheet"
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Edit Release"
+        description="Update release details and manage external links."
+        onSubmit={(e) => e.preventDefault()}
+        footer={
+          <>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled>
+              Save Changes
+            </Button>
+          </>
+        }
+      >
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="text-center py-8 text-muted-foreground">
+            Release not found.
+          </div>
+        )}
+      </AdminFormLayout>
     )
   }
 
@@ -697,8 +740,9 @@ function EditReleaseForm({
     <EditReleaseFormFields
       key={release.id}
       release={release}
+      open={open}
+      onOpenChange={onOpenChange}
       onSuccess={onSuccess}
-      onCancel={onCancel}
     />
   )
 }
@@ -708,12 +752,14 @@ function EditReleaseForm({
 // the surface's public API — production callers use EditReleaseForm.
 export function EditReleaseFormFields({
   release,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   release: ReleaseDetail
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const updateMutation = useUpdateRelease()
 
@@ -779,88 +825,20 @@ export function EditReleaseFormFields({
   )
 
   return (
-    <div className="space-y-4">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {error && (
-          <InlineErrorBanner>{error}</InlineErrorBanner>
-        )}
-
-        <div className="space-y-2">
-          <Label htmlFor="edit-title">Title *</Label>
-          <Input
-            id="edit-title"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="Album title"
-          />
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="edit-type">Release Type</Label>
-            <Select value={releaseType} onValueChange={setReleaseType}>
-              <SelectTrigger id="edit-type" className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {RELEASE_TYPES.map((type) => (
-                  <SelectItem key={type} value={type}>
-                    {RELEASE_TYPE_LABELS[type]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="edit-year">Year</Label>
-            <Input
-              id="edit-year"
-              type="number"
-              value={releaseYear}
-              onChange={(e) => setReleaseYear(e.target.value)}
-              placeholder="2024"
-              min="1900"
-              max="2100"
-            />
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="edit-date">Release Date</Label>
-          <Input
-            id="edit-date"
-            type="date"
-            value={releaseDate}
-            onChange={(e) => setReleaseDate(e.target.value)}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="edit-cover">Cover Art URL</Label>
-          <Input
-            id="edit-cover"
-            value={coverArtUrl}
-            onChange={(e) => setCoverArtUrl(e.target.value)}
-            placeholder="https://..."
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="edit-desc">Description</Label>
-          <Textarea
-            id="edit-desc"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Optional description..."
-            rows={3}
-          />
-        </div>
-
-        <DialogFooter>
+    <AdminFormLayout
+      variant="sheet"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit Release"
+      description="Update release details and manage external links."
+      error={error || undefined}
+      onSubmit={handleSubmit}
+      footer={
+        <>
           <Button
             type="button"
             variant="outline"
-            onClick={onCancel}
+            onClick={() => onOpenChange(false)}
             disabled={updateMutation.isPending}
           >
             Cancel
@@ -875,8 +853,73 @@ export function EditReleaseFormFields({
               'Save Changes'
             )}
           </Button>
-        </DialogFooter>
-      </form>
+        </>
+      }
+    >
+      <AdminFormField label="Title *" htmlFor="edit-title">
+        <Input
+          id="edit-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Album title"
+        />
+      </AdminFormField>
+
+      <AdminFormRow cols={2}>
+        <AdminFormField label="Release Type" htmlFor="edit-type">
+          <Select value={releaseType} onValueChange={setReleaseType}>
+            <SelectTrigger id="edit-type" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RELEASE_TYPES.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {RELEASE_TYPE_LABELS[type]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </AdminFormField>
+        <AdminFormField label="Year" htmlFor="edit-year">
+          <Input
+            id="edit-year"
+            type="number"
+            value={releaseYear}
+            onChange={(e) => setReleaseYear(e.target.value)}
+            placeholder="2024"
+            min="1900"
+            max="2100"
+          />
+        </AdminFormField>
+      </AdminFormRow>
+
+      <AdminFormField label="Release Date" htmlFor="edit-date">
+        <Input
+          id="edit-date"
+          type="date"
+          value={releaseDate}
+          onChange={(e) => setReleaseDate(e.target.value)}
+        />
+      </AdminFormField>
+
+      <AdminFormField label="Cover Art URL" htmlFor="edit-cover">
+        <Input
+          id="edit-cover"
+          value={coverArtUrl}
+          onChange={(e) => setCoverArtUrl(e.target.value)}
+          placeholder="https://..."
+        />
+      </AdminFormField>
+
+      <AdminFormField label="Description" htmlFor="edit-desc">
+        <Textarea
+          id="edit-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Optional description..."
+          rows={3}
+        />
+      </AdminFormField>
 
       {/* Artists (read-only in edit mode — artists are set at creation) */}
       {release.artists.length > 0 && (
@@ -905,7 +948,7 @@ export function EditReleaseFormFields({
           links={release.external_links || []}
         />
       </div>
-    </div>
+    </AdminFormLayout>
   )
 }
 
@@ -913,16 +956,20 @@ export function EditReleaseFormFields({
 // Delete Confirmation
 // ============================================================================
 
+// Short confirm form -> centered Modal (variant="modal"), per the PSY-912
+// Hybrid decision.
 function DeleteConfirmation({
   releaseTitle,
   releaseId,
+  open,
+  onOpenChange,
   onSuccess,
-  onCancel,
 }: {
   releaseTitle: string
   releaseId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSuccess: () => void
-  onCancel: () => void
 }) {
   const deleteMutation = useDeleteRelease()
   const [error, setError] = useState<string | null>(null)
@@ -942,11 +989,44 @@ function DeleteConfirmation({
   }, [releaseId, deleteMutation, onSuccess])
 
   return (
-    <div className="space-y-4">
-      {error && (
-        <InlineErrorBanner>{error}</InlineErrorBanner>
-      )}
-
+    <AdminFormLayout
+      variant="modal"
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Delete Release"
+      description="This action is permanent and cannot be undone."
+      error={error || undefined}
+      onSubmit={(e) => {
+        e.preventDefault()
+        handleDelete()
+      }}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={deleteMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="destructive"
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              'Delete Release'
+            )}
+          </Button>
+        </>
+      }
+    >
       <p className="text-sm text-muted-foreground">
         Are you sure you want to delete{' '}
         <span className="font-semibold text-foreground">
@@ -955,31 +1035,7 @@ function DeleteConfirmation({
         ? This action cannot be undone. All artist associations and external
         links will also be removed.
       </p>
-
-      <DialogFooter>
-        <Button
-          variant="outline"
-          onClick={onCancel}
-          disabled={deleteMutation.isPending}
-        >
-          Cancel
-        </Button>
-        <Button
-          variant="destructive"
-          onClick={handleDelete}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Deleting...
-            </>
-          ) : (
-            'Delete Release'
-          )}
-        </Button>
-      </DialogFooter>
-    </div>
+    </AdminFormLayout>
   )
 }
 
@@ -1199,67 +1255,33 @@ export function ReleaseManagement() {
         </>
       )}
 
-      {/* Create Dialog */}
-      <Dialog
+      {/* Create — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+      <CreateReleaseForm
         open={dialogMode === 'create'}
         onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Create Release</DialogTitle>
-            <DialogDescription>
-              Add a new music release with artist associations and external
-              links.
-            </DialogDescription>
-          </DialogHeader>
-          <CreateReleaseForm onSuccess={closeDialog} onCancel={closeDialog} />
-        </DialogContent>
-      </Dialog>
+        onSuccess={closeDialog}
+      />
 
-      {/* Edit Dialog */}
-      <Dialog
-        open={dialogMode === 'edit'}
-        onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Edit Release</DialogTitle>
-            <DialogDescription>
-              Update release details and manage external links.
-            </DialogDescription>
-          </DialogHeader>
-          {selectedReleaseId && (
-            <EditReleaseForm
-              releaseId={selectedReleaseId}
-              onSuccess={closeDialog}
-              onCancel={closeDialog}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {/* Edit — right-anchored Sheet (PSY-930 AdminFormLayout) */}
+      {selectedReleaseId && (
+        <EditReleaseForm
+          releaseId={selectedReleaseId}
+          open={dialogMode === 'edit'}
+          onOpenChange={(open) => !open && closeDialog()}
+          onSuccess={closeDialog}
+        />
+      )}
 
-      {/* Delete Dialog */}
-      <Dialog
-        open={dialogMode === 'delete'}
-        onOpenChange={(open) => !open && closeDialog()}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Delete Release</DialogTitle>
-            <DialogDescription>
-              This action is permanent and cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {selectedReleaseId && (
-            <DeleteConfirmation
-              releaseTitle={selectedReleaseTitle}
-              releaseId={selectedReleaseId}
-              onSuccess={closeDialog}
-              onCancel={closeDialog}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {/* Delete — centered Modal (PSY-930 AdminFormLayout) */}
+      {selectedReleaseId && (
+        <DeleteConfirmation
+          releaseTitle={selectedReleaseTitle}
+          releaseId={selectedReleaseId}
+          open={dialogMode === 'delete'}
+          onOpenChange={(open) => !open && closeDialog()}
+          onSuccess={closeDialog}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -678,12 +678,12 @@ export function CreateReleaseForm({
 // Edit Release Form
 // ============================================================================
 
-// Owns the single AdminFormLayout Sheet. Per the PSY-930 decision the Sheet
-// opens immediately on click; while the release detail loads we render the SAME
-// <AdminFormLayout> with a spinner body (so React keeps one Sheet mounted
-// across the loading->loaded swap), then mount EditReleaseFormFields with
-// `key={release.id}` so a switch-release-without-closing-dialog scenario
-// remounts with fresh state. The inner component initializes local state from
+// Per the PSY-930 decision the Edit Sheet opens immediately on click: while the
+// release detail loads this wrapper renders an AdminFormLayout (open) with a
+// spinner body — `open` stays true throughout, so the Sheet stays open — then
+// swaps to EditReleaseFormFields (keyed on release.id, so a
+// switch-release-without-closing-dialog scenario remounts with fresh state)
+// once the detail resolves. The inner component initializes local state from
 // props inline (React's preferred "calculate during render" path — see
 // https://react.dev/learn/you-might-not-need-an-effect). No useEffect, no
 // `initialized` ratchet.


### PR DESCRIPTION
## Summary
- **Radio Edit Station** → AdminFormLayout Sheet. Per the ticket decision the Sheet opens IMMEDIATELY on click and shows a spinner in the body until the async station detail resolves, then the fields populate (`EditStationFormFields` owns the Sheet + field state; `EditStationFormWrapper` gates loading; `open` stays true throughout so the Sheet stays open). Delete Station → `variant="modal"` (first modal-variant consumer).
- **Release** create + edit → Sheet; embedded `ArtistPicker` / `LinkEditor` / `ExistingLinkManager` subcomponents preserved. Delete → modal.
- **Label** create + edit → Sheet. Delete → modal.
- **Festival** create + edit → Sheet. Delete → modal.
- Grids → `AdminFormRow cols={N}`, fields → `AdminFormField`. Create forms carry the reset-on-open guard (adjust-state-during-render, per CreateStationForm); edit forms re-init from the loaded entity via the existing init-from-props-inline + `key`-reset contract.
- Radio *show* create/edit/delete forms intentionally left on Dialog — out of scope (ticket names "Radio Edit Station").

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/releases features/labels features/festivals app/admin/radio components/admin` — 630/630 passing (incl. new reset-on-open tests for the 3 migrated create forms + an Edit Station init/key-reset test; existing EditXFormFields key-reset tests updated to the open/onOpenChange props)
- [x] `/code-review` — 1 cleanup applied (corrected over-claimed "single Sheet / no flicker" comments; Delete Station modal copy moved to a `<p>` child for consistency)
- [x] `/adversarial-review` — CONCERNS → fixed
- [x] Rebased onto latest `origin/main` after PSY-934/942/943 merged; re-verified post-rebase: typecheck clean + `test:run` 634/634 (orchestrator)

## Manual repro
Form-migration render change. Unit-test DOM assertions cover each migrated form + reset-on-open:
- `frontend/app/admin/radio/_components/RadioManagement.editStation.test.tsx` (Edit Station init from detail + key-reset), `RadioManagement.reset.test.tsx` (Create Station reset-on-open, pre-existing template)
- `frontend/features/labels/admin/LabelManagement.test.tsx` (`CreateLabelForm reset-on-open`, `EditLabelFormFields` key-reset)
- `frontend/features/festivals/admin/FestivalManagement.test.tsx` (`CreateFestivalForm reset-on-open`, `EditFestivalFormFields` key-reset)
- `frontend/features/releases/admin/ReleaseManagement.test.tsx` (`CreateReleaseForm reset-on-open`, `EditReleaseFormFields` key-reset)

Edit Station migrated to open-immediately-with-spinner per the ticket decision. Visual screenshots below (captured by the orchestrator against the local dev stack, logged in as admin).

## Code review
`/code-review` — ran the 3 lenses inline (no Agent tool in a worktree); applied 1 quality cleanup (accurate Sheet-lifecycle comments + Delete Station modal copy consistency) in commit `68b2b0cc`.

## Adversarial review
`/adversarial-review` — CONCERNS → 1 MEDIUM addressed in commit `3c58b652`.
- [MEDIUM] Saboteur + Future-Maintainer: migrated Edit/Delete forms were gated `{selectedXId && <Form/>}` while `closeDialog` nulled the id alongside `dialogMode`, unmounting the AdminFormLayout instantly on close (no exit animation; a "not found" flash from the keyed fields falling back to the id<=0 shell) — asymmetric with the always-mounted create forms and Radio. Fixed: `closeDialog` clears `dialogMode` only; the selected id/name persist so the form animates closed and are overwritten on the next open.
Panel run inline (Saboteur · Future-Maintainer · Security · Completeness; no Agent tool in a worktree).

## Screenshots
Captured against the local dev stack (admin login; KEXP station + 31-release seed), worktree rebased onto current `origin/main`.

**Radio Edit Station → AdminFormLayout Sheet** — opens immediately on click as a right-anchored Sheet; the async station detail is loaded into the fields (`AdminFormRow` grids: City/State/Country/Timezone, Broadcast Type/Frequency), with a Cancel / Save Changes footer.

![Edit Station Sheet](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-0360fe8f2ab527b77983/psy930-editstation-loaded.png)

**Create Release → AdminFormLayout Sheet** — embedded `ArtistPicker` ("Search artists…") + External Links editor preserved; reset-on-open guard carried over.

![Create Release Sheet](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-0360fe8f2ab527b77983/psy930-release-create.png)

Closes PSY-930
