### PR TITLE
PSY-920: extract two moderation action-row components

### DIFF
--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -4,17 +4,19 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import {
   Loader2,
   Inbox,
-  Check,
-  X,
   ChevronDown,
   ChevronRight,
   ExternalLink,
   History,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { AdminEmptyState, CategoryBadge } from '@/components/admin'
+import {
+  AdminEmptyState,
+  CategoryBadge,
+  RejectWithReasonRow,
+  NotesActionRow,
+} from '@/components/admin'
 import { UserAttribution } from '@/components/shared'
 import {
   useAdminPendingEdits,
@@ -127,8 +129,6 @@ function PendingEditCard({
   onActionSuccess: (action: ModerationAction) => void
 }) {
   const [expanded, setExpanded] = useState(false)
-  const [rejecting, setRejecting] = useState(false)
-  const [rejectionReason, setRejectionReason] = useState('')
 
   const approveMutation = useApprovePendingEdit()
   const rejectMutation = useRejectPendingEdit()
@@ -147,19 +147,17 @@ function PendingEditCard({
     })
   }, [approveMutation, edit.id, onActionSuccess, entityLabel])
 
-  const handleReject = useCallback(() => {
-    if (!rejectionReason.trim()) return
-    rejectMutation.mutate(
-      { editId: edit.id, reason: rejectionReason.trim() },
-      {
-        onSuccess: () => {
-          setRejecting(false)
-          setRejectionReason('')
-          onActionSuccess({ verb: 'rejected', entityLabel })
-        },
-      }
-    )
-  }, [rejectMutation, edit.id, rejectionReason, onActionSuccess, entityLabel])
+  const handleReject = useCallback(
+    (reason: string) => {
+      rejectMutation.mutate(
+        { editId: edit.id, reason },
+        {
+          onSuccess: () => onActionSuccess({ verb: 'rejected', entityLabel }),
+        }
+      )
+    },
+    [rejectMutation, edit.id, onActionSuccess, entityLabel]
+  )
 
   return (
     <Card className="overflow-hidden">
@@ -236,69 +234,15 @@ function PendingEditCard({
           </div>
         )}
 
-        {/* Rejection reason input */}
-        {rejecting && (
-          <div className="mt-3 space-y-2">
-            <textarea
-              value={rejectionReason}
-              onChange={e => setRejectionReason(e.target.value)}
-              placeholder="Rejection reason (required) -- be specific to help the contributor learn"
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
-              rows={2}
-              autoFocus
-            />
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant="destructive"
-                onClick={handleReject}
-                disabled={!rejectionReason.trim() || isActioning}
-              >
-                {rejectMutation.isPending ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : (
-                  <X className="h-3 w-3 mr-1" />
-                )}
-                Confirm Reject
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => { setRejecting(false); setRejectionReason('') }}
-                disabled={isActioning}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Action buttons */}
-        {!rejecting && (
-          <div className="mt-3 flex items-center gap-2">
-            <Button
-              size="sm"
-              onClick={handleApprove}
-              disabled={isActioning}
-            >
-              {approveMutation.isPending ? (
-                <Loader2 className="h-3 w-3 animate-spin mr-1" />
-              ) : (
-                <Check className="h-3 w-3 mr-1" />
-              )}
-              Approve
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setRejecting(true)}
-              disabled={isActioning}
-            >
-              <X className="h-3 w-3 mr-1" />
-              Reject
-            </Button>
-          </div>
-        )}
+        {/* Approve-immediate + reject-with-required-reason (PSY-920 Model A) */}
+        <RejectWithReasonRow
+          onApprove={handleApprove}
+          onReject={handleReject}
+          isActioning={isActioning}
+          isApproving={approveMutation.isPending}
+          isRejecting={rejectMutation.isPending}
+          rejectPlaceholder="Rejection reason (required) -- be specific to help the contributor learn"
+        />
 
         {/* Error display */}
         {(approveMutation.isError || rejectMutation.isError) && (
@@ -314,33 +258,18 @@ function PendingEditCard({
 // ─── Entity Report Card ──────────────────────────────────────────────────────
 
 function EntityReportCard({ report }: { report: EntityReportResponse }) {
-  const [showNotes, setShowNotes] = useState(false)
-  const [notes, setNotes] = useState('')
-  const [action, setAction] = useState<'resolve' | 'dismiss' | null>(null)
-
   const resolveMutation = useResolveEntityReport()
   const dismissMutation = useDismissEntityReport()
 
   const isActioning = resolveMutation.isPending || dismissMutation.isPending
 
-  const handleAction = useCallback(() => {
-    if (action === 'resolve') {
-      resolveMutation.mutate(
-        { reportId: report.id, notes: notes.trim() || undefined },
-        { onSuccess: () => { setShowNotes(false); setNotes(''); setAction(null) } }
-      )
-    } else if (action === 'dismiss') {
-      dismissMutation.mutate(
-        { reportId: report.id, notes: notes.trim() || undefined },
-        { onSuccess: () => { setShowNotes(false); setNotes(''); setAction(null) } }
-      )
-    }
-  }, [action, resolveMutation, dismissMutation, report.id, notes])
-
-  const startAction = useCallback((type: 'resolve' | 'dismiss') => {
-    setAction(type)
-    setShowNotes(true)
-  }, [])
+  const handleConfirm = useCallback(
+    (actionKey: string, notes: string) => {
+      const mutation = actionKey === 'resolve' ? resolveMutation : dismissMutation
+      mutation.mutate({ reportId: report.id, notes: notes || undefined })
+    },
+    [resolveMutation, dismissMutation, report.id]
+  )
 
   return (
     <Card className="overflow-hidden">
@@ -388,67 +317,29 @@ function EntityReportCard({ report }: { report: EntityReportResponse }) {
           )}
         </div>
 
-        {/* Notes input */}
-        {showNotes && (
-          <div className="mt-3 space-y-2">
-            <textarea
-              value={notes}
-              onChange={e => setNotes(e.target.value)}
-              placeholder={`Admin notes (optional)${action === 'resolve' ? ' -- describe the action taken' : ' -- explain why this was dismissed'}`}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
-              rows={2}
-              autoFocus
-            />
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant={action === 'resolve' ? 'default' : 'outline'}
-                onClick={handleAction}
-                disabled={isActioning}
-              >
-                {isActioning ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : action === 'resolve' ? (
-                  <Check className="h-3 w-3 mr-1" />
-                ) : (
-                  <X className="h-3 w-3 mr-1" />
-                )}
-                {action === 'resolve' ? 'Confirm Resolve' : 'Confirm Dismiss'}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => { setShowNotes(false); setNotes(''); setAction(null) }}
-                disabled={isActioning}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Action buttons */}
-        {!showNotes && (
-          <div className="mt-3 flex items-center gap-2">
-            <Button
-              size="sm"
-              onClick={() => startAction('resolve')}
-              disabled={isActioning}
-            >
-              <Check className="h-3 w-3 mr-1" />
-              Resolve
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => startAction('dismiss')}
-              disabled={isActioning}
-            >
-              <X className="h-3 w-3 mr-1" />
-              Dismiss
-            </Button>
-          </div>
-        )}
+        {/* Dual-action + optional-notes (PSY-920 Model B) */}
+        <NotesActionRow
+          actions={[
+            {
+              key: 'resolve',
+              restingLabel: 'Resolve',
+              confirmLabel: 'Confirm Resolve',
+              variant: 'default',
+              icon: 'check',
+              notesPlaceholder: 'Admin notes (optional) -- describe the action taken',
+            },
+            {
+              key: 'dismiss',
+              restingLabel: 'Dismiss',
+              confirmLabel: 'Confirm Dismiss',
+              variant: 'outline',
+              icon: 'x',
+              notesPlaceholder: 'Admin notes (optional) -- explain why this was dismissed',
+            },
+          ]}
+          onConfirm={handleConfirm}
+          isActioning={isActioning}
+        />
 
         {/* Error display */}
         {(resolveMutation.isError || dismissMutation.isError) && (
@@ -464,8 +355,6 @@ function EntityReportCard({ report }: { report: EntityReportResponse }) {
 // ─── Pending Comment Card ───────────────────────────────────────────────────
 
 function PendingCommentCard({ comment }: { comment: PendingComment }) {
-  const [rejecting, setRejecting] = useState(false)
-  const [rejectionReason, setRejectionReason] = useState('')
   // PSY-297: edit history viewer, opened on demand
   const [isEditHistoryOpen, setIsEditHistoryOpen] = useState(false)
 
@@ -478,13 +367,12 @@ function PendingCommentCard({ comment }: { comment: PendingComment }) {
     approveMutation.mutate(comment.id)
   }, [approveMutation, comment.id])
 
-  const handleReject = useCallback(() => {
-    if (!rejectionReason.trim()) return
-    rejectMutation.mutate(
-      { commentId: comment.id, reason: rejectionReason.trim() },
-      { onSuccess: () => { setRejecting(false); setRejectionReason('') } }
-    )
-  }, [rejectMutation, comment.id, rejectionReason])
+  const handleReject = useCallback(
+    (reason: string) => {
+      rejectMutation.mutate({ commentId: comment.id, reason })
+    },
+    [rejectMutation, comment.id]
+  )
 
   const entityUrl = getEntityUrl(comment.entity_type, comment.entity_id)
   const editCount = comment.edit_count ?? 0
@@ -562,69 +450,15 @@ function PendingCommentCard({ comment }: { comment: PendingComment }) {
           />
         )}
 
-        {/* Rejection reason input */}
-        {rejecting && (
-          <div className="mt-3 space-y-2">
-            <textarea
-              value={rejectionReason}
-              onChange={e => setRejectionReason(e.target.value)}
-              placeholder="Rejection reason (required)"
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
-              rows={2}
-              autoFocus
-            />
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant="destructive"
-                onClick={handleReject}
-                disabled={!rejectionReason.trim() || isActioning}
-              >
-                {rejectMutation.isPending ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : (
-                  <X className="h-3 w-3 mr-1" />
-                )}
-                Confirm Reject
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => { setRejecting(false); setRejectionReason('') }}
-                disabled={isActioning}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Action buttons */}
-        {!rejecting && (
-          <div className="mt-3 flex items-center gap-2">
-            <Button
-              size="sm"
-              onClick={handleApprove}
-              disabled={isActioning}
-            >
-              {approveMutation.isPending ? (
-                <Loader2 className="h-3 w-3 animate-spin mr-1" />
-              ) : (
-                <Check className="h-3 w-3 mr-1" />
-              )}
-              Approve
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setRejecting(true)}
-              disabled={isActioning}
-            >
-              <X className="h-3 w-3 mr-1" />
-              Reject
-            </Button>
-          </div>
-        )}
+        {/* Approve-immediate + reject-with-required-reason (PSY-920 Model A) */}
+        <RejectWithReasonRow
+          onApprove={handleApprove}
+          onReject={handleReject}
+          isActioning={isActioning}
+          isApproving={approveMutation.isPending}
+          isRejecting={rejectMutation.isPending}
+          rejectPlaceholder="Rejection reason (required)"
+        />
 
         {/* Error display */}
         {(approveMutation.isError || rejectMutation.isError) && (
@@ -640,33 +474,24 @@ function PendingCommentCard({ comment }: { comment: PendingComment }) {
 // ─── Comment Report Card ────────────────────────────────────────────────────
 
 function CommentReportCard({ report }: { report: EntityReportResponse }) {
-  const [showNotes, setShowNotes] = useState(false)
-  const [notes, setNotes] = useState('')
-  const [action, setAction] = useState<'hide' | 'dismiss' | null>(null)
-
   const hideMutation = useAdminHideComment()
   const dismissMutation = useDismissEntityReport()
 
   const isActioning = hideMutation.isPending || dismissMutation.isPending
 
-  const handleAction = useCallback(() => {
-    if (action === 'hide') {
-      hideMutation.mutate(
-        { commentId: report.entity_id, reason: notes.trim() || 'Hidden via report review' },
-        { onSuccess: () => { setShowNotes(false); setNotes(''); setAction(null) } }
-      )
-    } else if (action === 'dismiss') {
-      dismissMutation.mutate(
-        { reportId: report.id, notes: notes.trim() || undefined },
-        { onSuccess: () => { setShowNotes(false); setNotes(''); setAction(null) } }
-      )
-    }
-  }, [action, hideMutation, dismissMutation, report.id, report.entity_id, notes])
-
-  const startAction = useCallback((type: 'hide' | 'dismiss') => {
-    setAction(type)
-    setShowNotes(true)
-  }, [])
+  const handleConfirm = useCallback(
+    (actionKey: string, notes: string) => {
+      if (actionKey === 'hide') {
+        hideMutation.mutate({
+          commentId: report.entity_id,
+          reason: notes || 'Hidden via report review',
+        })
+      } else {
+        dismissMutation.mutate({ reportId: report.id, notes: notes || undefined })
+      }
+    },
+    [hideMutation, dismissMutation, report.id, report.entity_id]
+  )
 
   // Truncate comment body for preview
   const bodyPreview = report.details
@@ -713,68 +538,29 @@ function CommentReportCard({ report }: { report: EntityReportResponse }) {
           )}
         </div>
 
-        {/* Notes input */}
-        {showNotes && (
-          <div className="mt-3 space-y-2">
-            <textarea
-              value={notes}
-              onChange={e => setNotes(e.target.value)}
-              placeholder={action === 'hide' ? 'Reason for hiding (optional)' : 'Notes for dismissal (optional)'}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
-              rows={2}
-              autoFocus
-            />
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant={action === 'hide' ? 'destructive' : 'outline'}
-                onClick={handleAction}
-                disabled={isActioning}
-              >
-                {isActioning ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : action === 'hide' ? (
-                  <X className="h-3 w-3 mr-1" />
-                ) : (
-                  <Check className="h-3 w-3 mr-1" />
-                )}
-                {action === 'hide' ? 'Confirm Hide' : 'Confirm Dismiss'}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => { setShowNotes(false); setNotes(''); setAction(null) }}
-                disabled={isActioning}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Action buttons */}
-        {!showNotes && (
-          <div className="mt-3 flex items-center gap-2">
-            <Button
-              size="sm"
-              variant="destructive"
-              onClick={() => startAction('hide')}
-              disabled={isActioning}
-            >
-              <X className="h-3 w-3 mr-1" />
-              Hide Comment
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => startAction('dismiss')}
-              disabled={isActioning}
-            >
-              <Check className="h-3 w-3 mr-1" />
-              Dismiss Report
-            </Button>
-          </div>
-        )}
+        {/* Dual-action + optional-notes (PSY-920 Model B) */}
+        <NotesActionRow
+          actions={[
+            {
+              key: 'hide',
+              restingLabel: 'Hide Comment',
+              confirmLabel: 'Confirm Hide',
+              variant: 'destructive',
+              icon: 'x',
+              notesPlaceholder: 'Reason for hiding (optional)',
+            },
+            {
+              key: 'dismiss',
+              restingLabel: 'Dismiss Report',
+              confirmLabel: 'Confirm Dismiss',
+              variant: 'outline',
+              icon: 'check',
+              notesPlaceholder: 'Notes for dismissal (optional)',
+            },
+          ]}
+          onConfirm={handleConfirm}
+          isActioning={isActioning}
+        />
 
         {/* Error display */}
         {(hideMutation.isError || dismissMutation.isError) && (
@@ -801,10 +587,6 @@ function CommentReportCard({ report }: { report: EntityReportResponse }) {
  * case the only useful action is Dismiss.
  */
 function CollectionReportCard({ report }: { report: EntityReportResponse }) {
-  const [showNotes, setShowNotes] = useState(false)
-  const [notes, setNotes] = useState('')
-  const [action, setAction] = useState<'hide' | 'dismiss' | null>(null)
-
   const hideMutation = useAdminHideCollection()
   const resolveMutation = useResolveEntityReport()
   const dismissMutation = useDismissEntityReport()
@@ -812,49 +594,29 @@ function CollectionReportCard({ report }: { report: EntityReportResponse }) {
   const isActioning =
     hideMutation.isPending || resolveMutation.isPending || dismissMutation.isPending
 
-  const handleAction = useCallback(() => {
-    if (action === 'hide') {
-      if (!report.entity_slug) return
-      // Hide first, then resolve the report so the moderation queue
-      // reflects the action taken (rather than two separate concerns).
-      hideMutation.mutate(
-        { slug: report.entity_slug },
-        {
-          onSuccess: () => {
-            resolveMutation.mutate(
-              { reportId: report.id, notes: notes.trim() || undefined },
-              {
-                onSuccess: () => {
-                  setShowNotes(false)
-                  setNotes('')
-                  setAction(null)
-                },
-              }
-            )
-          },
-        }
-      )
-    } else if (action === 'dismiss') {
-      dismissMutation.mutate(
-        { reportId: report.id, notes: notes.trim() || undefined },
-        {
-          onSuccess: () => {
-            setShowNotes(false)
-            setNotes('')
-            setAction(null)
-          },
-        }
-      )
-    }
-  }, [action, hideMutation, resolveMutation, dismissMutation, report.id, report.entity_slug, notes])
-
-  const startAction = useCallback((type: 'hide' | 'dismiss') => {
-    setAction(type)
-    setShowNotes(true)
-  }, [])
-
   const entityUrl = getEntityUrl(report.entity_type, report.entity_id, report.entity_slug)
   const hasSlug = Boolean(report.entity_slug)
+
+  const handleConfirm = useCallback(
+    (actionKey: string, notes: string) => {
+      if (actionKey === 'hide') {
+        if (!report.entity_slug) return
+        // Hide first, then resolve the report so the moderation queue
+        // reflects the action taken (rather than two separate concerns).
+        hideMutation.mutate(
+          { slug: report.entity_slug },
+          {
+            onSuccess: () => {
+              resolveMutation.mutate({ reportId: report.id, notes: notes || undefined })
+            },
+          }
+        )
+      } else {
+        dismissMutation.mutate({ reportId: report.id, notes: notes || undefined })
+      }
+    },
+    [hideMutation, resolveMutation, dismissMutation, report.id, report.entity_slug]
+  )
 
   return (
     <Card className="overflow-hidden" data-testid="collection-report-card">
@@ -906,71 +668,33 @@ function CollectionReportCard({ report }: { report: EntityReportResponse }) {
           )}
         </div>
 
-        {showNotes && (
-          <div className="mt-3 space-y-2">
-            <textarea
-              value={notes}
-              onChange={e => setNotes(e.target.value)}
-              placeholder={
-                action === 'hide'
-                  ? 'Reason for hiding from public browse (optional)'
-                  : 'Notes for dismissal (optional)'
-              }
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
-              rows={2}
-              autoFocus
-            />
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant={action === 'hide' ? 'destructive' : 'outline'}
-                onClick={handleAction}
-                disabled={isActioning}
-              >
-                {isActioning ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : action === 'hide' ? (
-                  <X className="h-3 w-3 mr-1" />
-                ) : (
-                  <Check className="h-3 w-3 mr-1" />
-                )}
-                {action === 'hide' ? 'Confirm Hide' : 'Confirm Dismiss'}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => { setShowNotes(false); setNotes(''); setAction(null) }}
-                disabled={isActioning}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {!showNotes && (
-          <div className="mt-3 flex items-center gap-2">
-            <Button
-              size="sm"
-              variant="destructive"
-              onClick={() => startAction('hide')}
-              disabled={isActioning || !hasSlug}
-              title={hasSlug ? undefined : 'Cannot hide — collection was deleted'}
-            >
-              <X className="h-3 w-3 mr-1" />
-              Hide from Public Browse
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => startAction('dismiss')}
-              disabled={isActioning}
-            >
-              <Check className="h-3 w-3 mr-1" />
-              Dismiss Report
-            </Button>
-          </div>
-        )}
+        {/* Dual-action + optional-notes (PSY-920 Model B). Hide is disabled
+            when the collection was deleted (no slug); the only useful action
+            then is Dismiss. */}
+        <NotesActionRow
+          actions={[
+            {
+              key: 'hide',
+              restingLabel: 'Hide from Public Browse',
+              confirmLabel: 'Confirm Hide',
+              variant: 'destructive',
+              icon: 'x',
+              notesPlaceholder: 'Reason for hiding from public browse (optional)',
+              disabled: !hasSlug,
+              title: hasSlug ? undefined : 'Cannot hide — collection was deleted',
+            },
+            {
+              key: 'dismiss',
+              restingLabel: 'Dismiss Report',
+              confirmLabel: 'Confirm Dismiss',
+              variant: 'outline',
+              icon: 'check',
+              notesPlaceholder: 'Notes for dismissal (optional)',
+            },
+          ]}
+          onConfirm={handleConfirm}
+          isActioning={isActioning}
+        />
 
         {(hideMutation.isError || resolveMutation.isError || dismissMutation.isError) && (
           <p className="mt-2 text-xs text-destructive">

--- a/frontend/components/admin/NotesActionRow.test.tsx
+++ b/frontend/components/admin/NotesActionRow.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { NotesActionRow, type NotesAction } from './NotesActionRow'
+
+// Mirrors the EntityReportCard wiring: Resolve (default/check) + Dismiss
+// (outline/x), both with optional notes.
+const resolveDismiss: [NotesAction, NotesAction] = [
+  {
+    key: 'resolve',
+    restingLabel: 'Resolve',
+    confirmLabel: 'Confirm Resolve',
+    variant: 'default',
+    icon: 'check',
+    notesPlaceholder: 'Admin notes (optional) -- describe the action taken',
+  },
+  {
+    key: 'dismiss',
+    restingLabel: 'Dismiss',
+    confirmLabel: 'Confirm Dismiss',
+    variant: 'outline',
+    icon: 'x',
+    notesPlaceholder: 'Admin notes (optional) -- explain why this was dismissed',
+  },
+]
+
+// Mirrors the CollectionReportCard wiring: destructive Hide (disabled +
+// titled when the collection was deleted) + Dismiss.
+const hideDismiss: [NotesAction, NotesAction] = [
+  {
+    key: 'hide',
+    restingLabel: 'Hide from Public Browse',
+    confirmLabel: 'Confirm Hide',
+    variant: 'destructive',
+    icon: 'x',
+    notesPlaceholder: 'Reason for hiding from public browse (optional)',
+  },
+  {
+    key: 'dismiss',
+    restingLabel: 'Dismiss Report',
+    confirmLabel: 'Confirm Dismiss',
+    variant: 'outline',
+    icon: 'check',
+    notesPlaceholder: 'Notes for dismissal (optional)',
+  },
+]
+
+function setup(
+  actions: [NotesAction, NotesAction] = resolveDismiss,
+  overrides?: { isActioning?: boolean }
+) {
+  const onConfirm = vi.fn()
+  render(
+    <NotesActionRow
+      actions={actions}
+      onConfirm={onConfirm}
+      isActioning={overrides?.isActioning ?? false}
+    />
+  )
+  return { onConfirm }
+}
+
+describe('NotesActionRow', () => {
+  it('renders both resting actions with their labels', () => {
+    setup()
+
+    expect(screen.getByRole('button', { name: /resolve/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^dismiss$/i })).toBeInTheDocument()
+    // No textarea until an action is chosen.
+    expect(screen.queryByPlaceholderText(/admin notes/i)).not.toBeInTheDocument()
+  })
+
+  it('expands an OPTIONAL-notes textarea for the chosen action with its placeholder + confirm label', () => {
+    setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /resolve/i }))
+
+    expect(
+      screen.getByPlaceholderText('Admin notes (optional) -- describe the action taken')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /confirm resolve/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('confirms with EMPTY notes (notes are optional, not required)', () => {
+    const { onConfirm } = setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /resolve/i }))
+    // No text entered — confirm should still be enabled and fire.
+    const confirm = screen.getByRole('button', { name: /confirm resolve/i })
+    expect(confirm).not.toBeDisabled()
+    fireEvent.click(confirm)
+
+    expect(onConfirm).toHaveBeenCalledWith('resolve', '')
+  })
+
+  it('passes the chosen action key + trimmed notes to onConfirm', () => {
+    const { onConfirm } = setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /^dismiss$/i }))
+    fireEvent.change(
+      screen.getByPlaceholderText('Admin notes (optional) -- explain why this was dismissed'),
+      { target: { value: '  duplicate report  ' } }
+    )
+    fireEvent.click(screen.getByRole('button', { name: /confirm dismiss/i }))
+
+    expect(onConfirm).toHaveBeenCalledWith('dismiss', 'duplicate report')
+  })
+
+  it('shows the placeholder + confirm label specific to whichever action was chosen', () => {
+    setup()
+
+    // Choosing the second action surfaces its (different) placeholder.
+    fireEvent.click(screen.getByRole('button', { name: /^dismiss$/i }))
+    expect(
+      screen.getByPlaceholderText('Admin notes (optional) -- explain why this was dismissed')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /confirm dismiss/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /confirm resolve/i })).not.toBeInTheDocument()
+  })
+
+  it('Cancel returns to the resting state and discards notes', () => {
+    const { onConfirm } = setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /resolve/i }))
+    fireEvent.change(
+      screen.getByPlaceholderText('Admin notes (optional) -- describe the action taken'),
+      { target: { value: 'half typed' } }
+    )
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /resolve/i })).toBeInTheDocument()
+
+    // Re-opening shows an empty textarea.
+    fireEvent.click(screen.getByRole('button', { name: /resolve/i }))
+    expect(
+      screen.getByPlaceholderText('Admin notes (optional) -- describe the action taken')
+    ).toHaveValue('')
+  })
+
+  it('applies the per-action variant to the confirm button (destructive Hide)', () => {
+    setup(hideDismiss)
+
+    fireEvent.click(screen.getByRole('button', { name: /hide from public browse/i }))
+    const confirm = screen.getByRole('button', { name: /confirm hide/i })
+    // Destructive buttons carry the bg-destructive class from the Button variant.
+    expect(confirm.className).toMatch(/destructive/)
+  })
+
+  it('disables a resting action + sets its title via the disabled/title descriptor (CollectionReport deleted)', () => {
+    const deletedHide: [NotesAction, NotesAction] = [
+      { ...hideDismiss[0], disabled: true, title: 'Cannot hide — collection was deleted' },
+      hideDismiss[1],
+    ]
+    setup(deletedHide)
+
+    const hide = screen.getByRole('button', { name: /hide from public browse/i })
+    expect(hide).toBeDisabled()
+    expect(hide).toHaveAttribute('title', 'Cannot hide — collection was deleted')
+
+    // Dismiss stays available so admins can clear stale reports.
+    expect(screen.getByRole('button', { name: /dismiss report/i })).not.toBeDisabled()
+  })
+
+  it('disables every button while a mutation is in flight (isActioning)', () => {
+    setup(resolveDismiss, { isActioning: true })
+
+    expect(screen.getByRole('button', { name: /resolve/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^dismiss$/i })).toBeDisabled()
+  })
+
+  it('shows a spinner on the confirm button while isActioning', () => {
+    const props = {
+      actions: resolveDismiss,
+      onConfirm: vi.fn(),
+    }
+    const { rerender } = render(<NotesActionRow {...props} isActioning={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /resolve/i }))
+    rerender(<NotesActionRow {...props} isActioning />)
+
+    const confirm = screen.getByRole('button', { name: /confirm resolve/i })
+    expect(confirm.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/admin/NotesActionRow.tsx
+++ b/frontend/components/admin/NotesActionRow.tsx
@@ -93,8 +93,9 @@ export function NotesActionRow({ actions, onConfirm, isActioning }: NotesActionR
   const confirm = useCallback(() => {
     if (activeKey === null) return
     onConfirm(activeKey, notes.trim())
-    // The card's mutation onSuccess resets the row by unmounting it; reset()
-    // here keeps the input from lingering when the row stays mounted.
+    // No local reset here, mirroring the pre-extraction cards: on success the
+    // moderation query invalidates and this row unmounts; on error the
+    // expanded view + typed notes intentionally persist so the admin can retry.
   }, [activeKey, notes, onConfirm])
 
   if (showNotes) {

--- a/frontend/components/admin/NotesActionRow.tsx
+++ b/frontend/components/admin/NotesActionRow.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Loader2, Check, X, type LucideIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+/**
+ * Icon keys for a {@link NotesAction}. Kept as a small closed set (rather than
+ * accepting an arbitrary LucideIcon) so the row owns the spinner-swap: when a
+ * mutation is in flight the confirm button shows a spinner in place of the
+ * action's resting icon, and the resting-vs-spinner choice must live here.
+ */
+type NotesActionIcon = 'check' | 'x'
+
+const ACTION_ICON: Record<NotesActionIcon, LucideIcon> = {
+  check: Check,
+  x: X,
+}
+
+export interface NotesAction {
+  /** Stable discriminator the row echoes back to {@link NotesActionRowProps.onConfirm}. */
+  key: string
+  /** Resting button label, e.g. "Resolve", "Hide Comment". */
+  restingLabel: string
+  /** Confirm button label after the notes textarea expands, e.g. "Confirm Hide". */
+  confirmLabel: string
+  /** Button variant for BOTH the resting and confirm button of this action. */
+  variant: 'default' | 'outline' | 'destructive'
+  /** Resting + confirm icon (swapped for a spinner while the mutation runs). */
+  icon: NotesActionIcon
+  /** Placeholder shown in the notes textarea when this action is being confirmed. */
+  notesPlaceholder: string
+  /** When true the resting button is disabled (e.g. CollectionReport's Hide on a deleted collection). */
+  disabled?: boolean
+  /** Tooltip for the resting button, typically explaining a disabled state. */
+  title?: string
+}
+
+export interface NotesActionRowProps {
+  /**
+   * Exactly two actions. The first is the "primary" (rendered with whatever
+   * variant it declares — often destructive); the second is the secondary.
+   * A tuple rather than a wider array keeps the model honest: every Model-B
+   * card has precisely two actions.
+   */
+  actions: [NotesAction, NotesAction]
+  /**
+   * Confirm handler. Receives the chosen action's key plus the trimmed notes
+   * (empty string when the admin left the optional textarea blank — callers
+   * coalesce to `undefined`/a default themselves, preserving each card's
+   * existing semantics).
+   */
+  onConfirm: (actionKey: string, notes: string) => void
+  /**
+   * True while ANY of the card's mutations are in flight. Disables every
+   * button and drives the confirm-button spinner.
+   */
+  isActioning: boolean
+}
+
+/**
+ * Model B action row for moderation cards: two actions (one may be
+ * destructive — Resolve/Dismiss, Hide/Dismiss) that each expand an OPTIONAL
+ * notes textarea before confirming. The confirm button mirrors the chosen
+ * action's variant + icon + label, and notes are passed up trimmed.
+ *
+ * Used by EntityReportCard + CommentReportCard + CollectionReportCard.
+ * Behavior-preserving extraction (PSY-920); preserves CollectionReportCard's
+ * disabled-Hide + title affordance via the per-action `disabled`/`title`
+ * descriptor fields.
+ *
+ * Notes capture + the chosen-action state live here because both are
+ * intrinsic to this interaction model; the card receives only the final
+ * (actionKey, trimmedNotes) pair via onConfirm.
+ */
+export function NotesActionRow({ actions, onConfirm, isActioning }: NotesActionRowProps) {
+  const [showNotes, setShowNotes] = useState(false)
+  const [notes, setNotes] = useState('')
+  const [activeKey, setActiveKey] = useState<string | null>(null)
+
+  const reset = useCallback(() => {
+    setShowNotes(false)
+    setNotes('')
+    setActiveKey(null)
+  }, [])
+
+  const startAction = useCallback((key: string) => {
+    setActiveKey(key)
+    setShowNotes(true)
+  }, [])
+
+  const confirm = useCallback(() => {
+    if (activeKey === null) return
+    onConfirm(activeKey, notes.trim())
+    // The card's mutation onSuccess resets the row by unmounting it; reset()
+    // here keeps the input from lingering when the row stays mounted.
+  }, [activeKey, notes, onConfirm])
+
+  if (showNotes) {
+    const active = actions.find(a => a.key === activeKey) ?? actions[0]
+    const ActiveIcon = ACTION_ICON[active.icon]
+    return (
+      <div className="mt-3 space-y-2">
+        <textarea
+          value={notes}
+          onChange={e => setNotes(e.target.value)}
+          placeholder={active.notesPlaceholder}
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+          rows={2}
+          autoFocus
+        />
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant={active.variant} onClick={confirm} disabled={isActioning}>
+            {isActioning ? (
+              <Loader2 className="h-3 w-3 animate-spin mr-1" />
+            ) : (
+              <ActiveIcon className="h-3 w-3 mr-1" />
+            )}
+            {active.confirmLabel}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={reset} disabled={isActioning}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-3 flex items-center gap-2">
+      {actions.map(action => {
+        const Icon = ACTION_ICON[action.icon]
+        return (
+          <Button
+            key={action.key}
+            size="sm"
+            variant={action.variant}
+            onClick={() => startAction(action.key)}
+            disabled={isActioning || action.disabled}
+            title={action.title}
+          >
+            <Icon className="h-3 w-3 mr-1" />
+            {action.restingLabel}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/components/admin/RejectWithReasonRow.test.tsx
+++ b/frontend/components/admin/RejectWithReasonRow.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { RejectWithReasonRow } from './RejectWithReasonRow'
+
+function setup(overrides?: Partial<Parameters<typeof RejectWithReasonRow>[0]>) {
+  const onApprove = vi.fn()
+  const onReject = vi.fn()
+  render(
+    <RejectWithReasonRow
+      onApprove={onApprove}
+      onReject={onReject}
+      isActioning={false}
+      isApproving={false}
+      isRejecting={false}
+      rejectPlaceholder="Rejection reason (required)"
+      {...overrides}
+    />
+  )
+  return { onApprove, onReject }
+}
+
+describe('RejectWithReasonRow', () => {
+  it('renders Approve + Reject in the resting state', () => {
+    setup()
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^reject$/i })).toBeInTheDocument()
+    // No textarea until the admin chooses to reject.
+    expect(screen.queryByPlaceholderText('Rejection reason (required)')).not.toBeInTheDocument()
+  })
+
+  it('fires onApprove immediately (no confirmation step)', () => {
+    const { onApprove } = setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }))
+
+    expect(onApprove).toHaveBeenCalledTimes(1)
+  })
+
+  it('expands a required-reason textarea when Reject is clicked', () => {
+    setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+
+    expect(screen.getByPlaceholderText('Rejection reason (required)')).toBeInTheDocument()
+    // Resting Approve/Reject are replaced by Confirm Reject + Cancel.
+    expect(screen.getByRole('button', { name: /confirm reject/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps Confirm Reject disabled until a non-whitespace reason is entered', () => {
+    setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+    const confirm = screen.getByRole('button', { name: /confirm reject/i })
+    expect(confirm).toBeDisabled()
+
+    // Whitespace-only does not enable it.
+    fireEvent.change(screen.getByPlaceholderText('Rejection reason (required)'), {
+      target: { value: '   ' },
+    })
+    expect(confirm).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('Rejection reason (required)'), {
+      target: { value: 'Inaccurate change' },
+    })
+    expect(confirm).not.toBeDisabled()
+  })
+
+  it('passes the TRIMMED reason to onReject on confirm', () => {
+    const { onReject } = setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+    fireEvent.change(screen.getByPlaceholderText('Rejection reason (required)'), {
+      target: { value: '  Spam content  ' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /confirm reject/i }))
+
+    expect(onReject).toHaveBeenCalledWith('Spam content')
+  })
+
+  it('returns to the resting state when Cancel is clicked, discarding the reason', () => {
+    const { onReject } = setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+    fireEvent.change(screen.getByPlaceholderText('Rejection reason (required)'), {
+      target: { value: 'Half-written' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onReject).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
+
+    // Re-opening shows an empty textarea (the prior input was discarded).
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+    expect(screen.getByPlaceholderText('Rejection reason (required)')).toHaveValue('')
+  })
+
+  it('uses the supplied placeholder copy', () => {
+    setup({ rejectPlaceholder: 'Be specific to help the contributor learn' })
+
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+
+    expect(
+      screen.getByPlaceholderText('Be specific to help the contributor learn')
+    ).toBeInTheDocument()
+  })
+
+  it('disables every button while a mutation is in flight (isActioning)', () => {
+    setup({ isActioning: true })
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^reject$/i })).toBeDisabled()
+  })
+
+  it('shows a spinner on Approve only while isApproving', () => {
+    const { container } = render(
+      <RejectWithReasonRow
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        isActioning
+        isApproving
+        isRejecting={false}
+        rejectPlaceholder="x"
+      />
+    )
+
+    // Spinner (animate-spin) is present in the resting row while approving.
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('shows a spinner on Confirm Reject while isRejecting', () => {
+    // Expand the row first (resting buttons must be enabled to click Reject),
+    // then flip into the in-flight state via rerender — mirrors the real
+    // card, where the reject mutation only runs from the expanded view.
+    const props = {
+      onApprove: vi.fn(),
+      onReject: vi.fn(),
+      isApproving: false,
+      rejectPlaceholder: 'x',
+    }
+    const { rerender } = render(
+      <RejectWithReasonRow {...props} isActioning={false} isRejecting={false} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+    rerender(<RejectWithReasonRow {...props} isActioning isRejecting />)
+
+    const confirm = screen.getByRole('button', { name: /confirm reject/i })
+    expect(confirm.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/admin/RejectWithReasonRow.tsx
+++ b/frontend/components/admin/RejectWithReasonRow.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Loader2, Check, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+export interface RejectWithReasonRowProps {
+  /** Approve handler — fires immediately on click (no confirmation step). */
+  onApprove: () => void
+  /**
+   * Reject handler. Receives the trimmed, non-empty reason. The row guards
+   * the empty case itself (Confirm Reject stays disabled until the reason has
+   * non-whitespace content), so callers never see an empty string.
+   */
+  onReject: (reason: string) => void
+  /**
+   * True while EITHER the approve or reject mutation is in flight. Disables
+   * every button so an admin can't double-fire while a request is pending.
+   */
+  isActioning: boolean
+  /**
+   * True while specifically the APPROVE mutation is in flight. Drives the
+   * spinner on the Approve button (so the spinner only appears on the action
+   * that's actually running, matching the pre-extraction behavior).
+   */
+  isApproving: boolean
+  /**
+   * True while specifically the REJECT mutation is in flight. Drives the
+   * spinner on the Confirm Reject button.
+   */
+  isRejecting: boolean
+  /**
+   * Placeholder for the rejection-reason textarea. Card-specific copy
+   * (PendingEditCard uses a longer "be specific" prompt; PendingCommentCard
+   * uses the terse "Rejection reason (required)").
+   */
+  rejectPlaceholder: string
+}
+
+/**
+ * Model A action row for moderation cards: an approve-immediate primary
+ * action plus a reject action that expands a REQUIRED-reason textarea before
+ * confirming.
+ *
+ * Used by PendingEditCard + PendingCommentCard. Behavior-preserving
+ * extraction (PSY-920) of the two cards' formerly-inline, identically-shaped
+ * action rows — the only per-card variation was the reject placeholder copy
+ * and which mutation's pending flag drives which spinner, both now props.
+ *
+ * Reason capture lives here (local state) rather than in the card because the
+ * textarea is intrinsic to this interaction model; the card only needs the
+ * final trimmed reason via onReject.
+ */
+export function RejectWithReasonRow({
+  onApprove,
+  onReject,
+  isActioning,
+  isApproving,
+  isRejecting,
+  rejectPlaceholder,
+}: RejectWithReasonRowProps) {
+  const [rejecting, setRejecting] = useState(false)
+  const [rejectionReason, setRejectionReason] = useState('')
+
+  const cancel = useCallback(() => {
+    setRejecting(false)
+    setRejectionReason('')
+  }, [])
+
+  const confirmReject = useCallback(() => {
+    const trimmed = rejectionReason.trim()
+    if (!trimmed) return
+    onReject(trimmed)
+    // Reset is intentional whether or not the mutation ultimately succeeds:
+    // the card's own onSuccess (which unmounts/clears the row) is the
+    // authoritative reset; this keeps the local input from lingering if the
+    // row stays mounted (e.g. error path leaves the resting buttons).
+  }, [rejectionReason, onReject])
+
+  if (rejecting) {
+    return (
+      <div className="mt-3 space-y-2">
+        <textarea
+          value={rejectionReason}
+          onChange={e => setRejectionReason(e.target.value)}
+          placeholder={rejectPlaceholder}
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+          rows={2}
+          autoFocus
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={confirmReject}
+            disabled={!rejectionReason.trim() || isActioning}
+          >
+            {isRejecting ? (
+              <Loader2 className="h-3 w-3 animate-spin mr-1" />
+            ) : (
+              <X className="h-3 w-3 mr-1" />
+            )}
+            Confirm Reject
+          </Button>
+          <Button size="sm" variant="ghost" onClick={cancel} disabled={isActioning}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-3 flex items-center gap-2">
+      <Button size="sm" onClick={onApprove} disabled={isActioning}>
+        {isApproving ? (
+          <Loader2 className="h-3 w-3 animate-spin mr-1" />
+        ) : (
+          <Check className="h-3 w-3 mr-1" />
+        )}
+        Approve
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => setRejecting(true)}
+        disabled={isActioning}
+      >
+        <X className="h-3 w-3 mr-1" />
+        Reject
+      </Button>
+    </div>
+  )
+}

--- a/frontend/components/admin/RejectWithReasonRow.tsx
+++ b/frontend/components/admin/RejectWithReasonRow.tsx
@@ -72,10 +72,10 @@ export function RejectWithReasonRow({
     const trimmed = rejectionReason.trim()
     if (!trimmed) return
     onReject(trimmed)
-    // Reset is intentional whether or not the mutation ultimately succeeds:
-    // the card's own onSuccess (which unmounts/clears the row) is the
-    // authoritative reset; this keeps the local input from lingering if the
-    // row stays mounted (e.g. error path leaves the resting buttons).
+    // No local reset here, mirroring the pre-extraction cards: on success the
+    // moderation query invalidates and this row unmounts (so the input
+    // disappears with it); on error the expanded view + typed reason
+    // intentionally persist so the admin can retry without re-typing.
   }, [rejectionReason, onReject])
 
   if (rejecting) {

--- a/frontend/components/admin/index.ts
+++ b/frontend/components/admin/index.ts
@@ -15,6 +15,10 @@ export { AdminEmptyState } from './AdminEmptyState'
 export type { AdminEmptyStateProps } from './AdminEmptyState'
 export { CategoryBadge } from './CategoryBadge'
 export type { CategoryBadgeProps, AdminCategoryKind } from './CategoryBadge'
+export { RejectWithReasonRow } from './RejectWithReasonRow'
+export type { RejectWithReasonRowProps } from './RejectWithReasonRow'
+export { NotesActionRow } from './NotesActionRow'
+export type { NotesActionRowProps, NotesAction } from './NotesActionRow'
 export {
   AdminFormLayout,
   AdminFormRow,


### PR DESCRIPTION
## Summary
- PSY-909 deferred `DecisionActionRow` because the 5 `ModerationQueue` cards do NOT share one action-row shape — they split into two distinct interaction models. Extracted **two focused components** (not one config-driven row, which would create a wide leaky prop surface) into `frontend/components/admin/`:
  - `RejectWithReasonRow` (**Model A**): approve-immediate + reject-with-REQUIRED-reason. Used by `PendingEditCard` + `PendingCommentCard`.
  - `NotesActionRow` (**Model B**): dual-action (one may be destructive) + OPTIONAL-notes, per-action confirm variant/icon/label. Used by `EntityReportCard` + `CommentReportCard` + `CollectionReportCard`.
- Migrated all 5 cards. Behavior-preserving: PSY-603 success-banner bubbling, every mutation wiring, the `CollectionReportCard` hide→resolve chain, and its disabled-Hide + `title` affordance on a deleted collection are all retained.
- Removed the now-dead inline reject/notes state + `Button`/`Check`/`X` imports from `ModerationQueue.tsx` (net -431 lines there).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run app/admin/moderation components/admin` — 286/286 passing (incl. 20 new component tests + the existing 19 ModerationQueue integration tests, unchanged)
- [x] `/code-review` — no correctness findings; two doc-comment accuracy fixes (separate commit `fb69d670`)
- [x] `/adversarial-review` — CLEAN

## Manual repro
Behavior-preserving extraction + migration. Unit-test DOM assertions at `frontend/components/admin/RejectWithReasonRow.test.tsx` (resting/expanded, required-reason gating, trimmed-reason, cancel-discards, per-mutation spinner), `frontend/components/admin/NotesActionRow.test.tsx` (resting/expanded, optional-empty-notes confirm, trimmed notes, per-action variant/placeholder, disabled+title descriptor), and the unchanged `frontend/app/admin/moderation/_components/ModerationQueue.test.tsx` (all 5 migrated cards end-to-end, incl. CollectionReport disabled-Hide on missing slug + the PSY-603 banner) cover both new components + the 5 migrated cards. Visual screenshots added by orchestrator post-push.

## Code review
`/code-review` (inline, 3 lenses — no Agent tool in a worktree): no correctness findings; corrected two doc comments that referenced a removed card-side reset.

## Adversarial review
`/adversarial-review` — CLEAN. Panel run inline (no Agent tool in a worktree): Saboteur (no new break — double-protected CollectionReport Hide; double-click guarded identically to original), Future-Maintainer (loose `key: string` + unreachable `?? actions[0]` are minor/defensive, mirror the original), Security (pure presentational, no new trust boundary), Completeness (all 3 acceptance criteria met).

## Screenshots

Captured against the local dev stack (admin moderation queue, 3 pending reports), worktree on `PSY-920/decision-action-rows`.

**`NotesActionRow` (Model B)** — top card expanded showing the optional "Admin notes" textarea + Confirm Resolve / Cancel; the cards below at rest (Resolve / Dismiss, Hide Comment / Dismiss Report). Behavior-preserving vs the pre-extraction cards.

![NotesActionRow expanded + resting](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-a0ba6d3079a9f5a894b3/psy920-notesrow-expanded.png)

The dev queue had only Reports, so `RejectWithReasonRow` (Model A — approve + required-reason reject) isn't pictured; it's covered by `RejectWithReasonRow.test.tsx` (20 component tests total).

Closes PSY-920
