### PR TITLE
PSY-924: adopt DS Select across remaining admin selects

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -1480,20 +1480,30 @@ function RadioMatchingTab() {
             <Label htmlFor="station-filter" className="text-sm text-muted-foreground">
               Station:
             </Label>
-            {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-            <select
-              id="station-filter"
-              value={stationFilter}
-              onChange={(e) => handleStationFilterChange(e.target.value)}
-              className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm"
+            <Select
+              value={String(stationFilter)}
+              onValueChange={handleStationFilterChange}
             >
-              <option value={0}>All Stations</option>
-              {stations.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger
+                id="station-filter"
+                className="w-44"
+                aria-label="Filter by station"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {/* Station ids are positive integers, so "0" is a safe
+                    non-empty Radix value for the "All Stations" option;
+                    handleStationFilterChange maps it back to the numeric
+                    0 the unmatched-plays query treats as "no filter". */}
+                <SelectItem value="0">All Stations</SelectItem>
+                {stations.map((s) => (
+                  <SelectItem key={s.id} value={String(s.id)}>
+                    {s.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             {unmatchedFetching && (
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             )}

--- a/frontend/features/festivals/admin/FestivalManagement.test.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.test.tsx
@@ -130,6 +130,54 @@ describe('FestivalManagement', () => {
     expect(screen.getByText('load failed')).toBeInTheDocument()
   })
 
+  it('renders the status filter as the DS Select with the All sentinel', () => {
+    // PSY-924: native <select> filter is now a Radix combobox; "All Statuses"
+    // is the FILTER_SELECT_ALL sentinel round-tripped to '' for the query.
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [], count: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+    const statusSelect = screen.getByRole('combobox', { name: 'Filter by status' })
+    expect(statusSelect).toHaveTextContent('All Statuses')
+  })
+
+  it('passes the selected status filter through to useFestivals', async () => {
+    const user = userEvent.setup()
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [], count: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by status' }))
+    await user.click(await screen.findByRole('option', { name: 'Cancelled' }))
+
+    expect(mockUseFestivals).toHaveBeenLastCalledWith({ status: 'cancelled' })
+  })
+
+  it('round-trips the All sentinel back to no status filter', async () => {
+    // Guards the sentinel: "All Statuses" must clear status ('' → undefined),
+    // not pass the literal 'all' to the backend query.
+    const user = userEvent.setup()
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [], count: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by status' }))
+    await user.click(await screen.findByRole('option', { name: 'Cancelled' }))
+    expect(mockUseFestivals).toHaveBeenLastCalledWith({ status: 'cancelled' })
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by status' }))
+    await user.click(await screen.findByRole('option', { name: 'All Statuses' }))
+    expect(mockUseFestivals).toHaveBeenLastCalledWith({ status: undefined })
+  })
+
   it('renders the empty state when there are no festivals', () => {
     mockUseFestivals.mockReturnValue({
       data: { festivals: [], count: 0 },

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -41,6 +41,11 @@ import {
   AdminFormField,
 } from '@/components/admin/AdminFormLayout'
 import { InlineErrorBanner } from '@/components/shared'
+import {
+  FILTER_SELECT_ALL,
+  toFilterSelectValue,
+  fromFilterSelectValue,
+} from '@/lib/filterSelectValue'
 import { useFestivals, useFestival, useFestivalLineup, useFestivalVenues } from '../hooks/useFestivals'
 import { useArtistSearch } from '@/features/artists'
 import { useVenueSearch } from '@/features/venues'
@@ -963,18 +968,22 @@ function LineupManagement({ festivalId }: { festivalId: number }) {
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">Billing Tier</Label>
-            {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-            <select
-              value={addBillingTier}
-              onChange={(e) => setAddBillingTier(e.target.value)}
-              className="h-8 w-full rounded-md border bg-background px-2 text-xs"
-            >
-              {BILLING_TIERS.map((t) => (
-                <option key={t} value={t}>
-                  {BILLING_TIER_LABELS[t]}
-                </option>
-              ))}
-            </select>
+            <Select value={addBillingTier} onValueChange={setAddBillingTier}>
+              <SelectTrigger
+                size="sm"
+                className="w-full text-xs"
+                aria-label="Billing tier for new artist"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {BILLING_TIERS.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {BILLING_TIER_LABELS[t]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">Position</Label>
@@ -1154,18 +1163,24 @@ function LineupManagement({ festivalId }: { festivalId: number }) {
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label>Billing Tier</Label>
-                {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-                <select
+                <Select
                   value={editBillingTier}
-                  onChange={(e) => setEditBillingTier(e.target.value)}
-                  className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+                  onValueChange={setEditBillingTier}
                 >
-                  {BILLING_TIERS.map((t) => (
-                    <option key={t} value={t}>
-                      {BILLING_TIER_LABELS[t]}
-                    </option>
-                  ))}
-                </select>
+                  <SelectTrigger
+                    className="w-full"
+                    aria-label="Billing tier"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {BILLING_TIERS.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        {BILLING_TIER_LABELS[t]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div className="space-y-2">
                 <Label>Position</Label>
@@ -1586,19 +1601,22 @@ export function FestivalManagement() {
             className="pl-9"
           />
         </div>
-        {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className="h-9 rounded-md border bg-background px-3 text-sm"
+        <Select
+          value={toFilterSelectValue(statusFilter)}
+          onValueChange={(value) => setStatusFilter(fromFilterSelectValue(value))}
         >
-          <option value="">All Statuses</option>
-          {FESTIVAL_STATUSES.map((s) => (
-            <option key={s} value={s}>
-              {FESTIVAL_STATUS_LABELS[s]}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger className="w-44" aria-label="Filter by status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={FILTER_SELECT_ALL}>All Statuses</SelectItem>
+            {FESTIVAL_STATUSES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {FESTIVAL_STATUS_LABELS[s]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Loading */}

--- a/frontend/features/labels/admin/LabelManagement.test.tsx
+++ b/frontend/features/labels/admin/LabelManagement.test.tsx
@@ -165,14 +165,38 @@ describe('LabelManagement', () => {
     expect(screen.queryByText('Sub Pop')).not.toBeInTheDocument()
   })
 
+  it('renders the status filter as the DS Select with the All sentinel', () => {
+    // PSY-924: native <select> filter is now a Radix combobox; "All Statuses"
+    // is the FILTER_SELECT_ALL sentinel round-tripped to '' for the query.
+    renderWithProviders(<LabelManagement />)
+    const statusSelect = screen.getByRole('combobox', { name: 'Filter by status' })
+    expect(statusSelect).toHaveTextContent('All Statuses')
+  })
+
   it('passes the selected status filter through to useLabels', async () => {
     const user = userEvent.setup()
     renderWithProviders(<LabelManagement />)
 
-    const statusSelect = screen.getByRole('combobox')
-    await user.selectOptions(statusSelect, 'defunct')
+    // DS Select (Radix) interaction: open the combobox, pick an option.
+    await user.click(screen.getByRole('combobox', { name: 'Filter by status' }))
+    await user.click(await screen.findByRole('option', { name: 'Defunct' }))
 
     expect(mockUseLabels).toHaveBeenLastCalledWith({ status: 'defunct' })
+  })
+
+  it('round-trips the All sentinel back to no status filter', async () => {
+    // Guards the sentinel: selecting "All Statuses" must clear status ('' →
+    // undefined), not pass the literal 'all' to the backend query.
+    const user = userEvent.setup()
+    renderWithProviders(<LabelManagement />)
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by status' }))
+    await user.click(await screen.findByRole('option', { name: 'Defunct' }))
+    expect(mockUseLabels).toHaveBeenLastCalledWith({ status: 'defunct' })
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by status' }))
+    await user.click(await screen.findByRole('option', { name: 'All Statuses' }))
+    expect(mockUseLabels).toHaveBeenLastCalledWith({ status: undefined })
   })
 
   it('opens the create dialog form when New Label is clicked', async () => {

--- a/frontend/features/labels/admin/LabelManagement.tsx
+++ b/frontend/features/labels/admin/LabelManagement.tsx
@@ -28,6 +28,11 @@ import {
   AdminFormField,
 } from '@/components/admin/AdminFormLayout'
 import { InlineErrorBanner } from '@/components/shared'
+import {
+  FILTER_SELECT_ALL,
+  toFilterSelectValue,
+  fromFilterSelectValue,
+} from '@/lib/filterSelectValue'
 import { useLabels, useLabel } from '../hooks/useLabels'
 import {
   useCreateLabel,
@@ -952,19 +957,22 @@ export function LabelManagement() {
             className="pl-9"
           />
         </div>
-        {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className="h-9 rounded-md border bg-background px-3 text-sm"
+        <Select
+          value={toFilterSelectValue(statusFilter)}
+          onValueChange={(value) => setStatusFilter(fromFilterSelectValue(value))}
         >
-          <option value="">All Statuses</option>
-          {LABEL_STATUSES.map((s) => (
-            <option key={s} value={s}>
-              {LABEL_STATUS_LABELS[s]}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger className="w-44" aria-label="Filter by status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={FILTER_SELECT_ALL}>All Statuses</SelectItem>
+            {LABEL_STATUSES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {LABEL_STATUS_LABELS[s]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Loading */}

--- a/frontend/features/releases/admin/ReleaseManagement.test.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.test.tsx
@@ -173,15 +173,44 @@ describe('ReleaseManagement', () => {
     expect(screen.getByText('Kid A')).toBeInTheDocument()
   })
 
+  it('renders the type filter as the DS Select with the All sentinel', () => {
+    // PSY-924: the native <select> filter became a Radix combobox. The "All
+    // Types" option is the FILTER_SELECT_ALL sentinel ('') round-tripped to ''
+    // for the query — assert the trigger defaults to "All Types".
+    renderWithProviders(<ReleaseManagement />)
+    const typeSelect = screen.getByRole('combobox', { name: 'Filter by type' })
+    expect(typeSelect).toHaveTextContent('All Types')
+  })
+
   it('passes the type filter through to useReleases', async () => {
     const user = userEvent.setup()
     renderWithProviders(<ReleaseManagement />)
 
-    const typeSelect = screen.getByRole('combobox')
-    await user.selectOptions(typeSelect, 'ep')
+    // DS Select (Radix) interaction: open the combobox, pick an option.
+    await user.click(screen.getByRole('combobox', { name: 'Filter by type' }))
+    await user.click(await screen.findByRole('option', { name: 'EP' }))
 
     expect(mockUseReleases).toHaveBeenLastCalledWith(
       expect.objectContaining({ releaseType: 'ep' })
+    )
+  })
+
+  it('round-trips the All sentinel back to no type filter', async () => {
+    // Guards the sentinel: selecting "All Types" must clear releaseType (''
+    // → undefined), not pass the literal 'all' to the backend query.
+    const user = userEvent.setup()
+    renderWithProviders(<ReleaseManagement />)
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by type' }))
+    await user.click(await screen.findByRole('option', { name: 'EP' }))
+    expect(mockUseReleases).toHaveBeenLastCalledWith(
+      expect.objectContaining({ releaseType: 'ep' })
+    )
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by type' }))
+    await user.click(await screen.findByRole('option', { name: 'All Types' }))
+    expect(mockUseReleases).toHaveBeenLastCalledWith(
+      expect.objectContaining({ releaseType: undefined })
     )
   })
 

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -31,6 +31,11 @@ import {
   AdminFormField,
 } from '@/components/admin/AdminFormLayout'
 import { InlineErrorBanner } from '@/components/shared'
+import {
+  FILTER_SELECT_ALL,
+  toFilterSelectValue,
+  fromFilterSelectValue,
+} from '@/lib/filterSelectValue'
 import { useReleases, useRelease } from '../hooks/useReleases'
 import { useArtistSearch } from '@/features/artists'
 import {
@@ -188,18 +193,25 @@ function ArtistPicker({
               <span className="text-sm font-medium flex-1">
                 {artist.artist_name}
               </span>
-              {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-              <select
+              <Select
                 value={artist.role}
-                onChange={(e) => onRoleChange(index, e.target.value)}
-                className="h-8 rounded-md border bg-background px-2 text-xs"
+                onValueChange={(value) => onRoleChange(index, value)}
               >
-                {ARTIST_ROLES.map((r) => (
-                  <option key={r.value} value={r.value}>
-                    {r.label}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger
+                  size="sm"
+                  className="w-32 text-xs"
+                  aria-label={`Role for ${artist.artist_name}`}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ARTIST_ROLES.map((r) => (
+                    <SelectItem key={r.value} value={r.value}>
+                      {r.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <Button
                 type="button"
                 variant="ghost"
@@ -1134,19 +1146,22 @@ export function ReleaseManagement() {
             className="pl-9"
           />
         </div>
-        {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-        <select
-          value={typeFilter}
-          onChange={(e) => setTypeFilter(e.target.value)}
-          className="h-9 rounded-md border bg-background px-3 text-sm"
+        <Select
+          value={toFilterSelectValue(typeFilter)}
+          onValueChange={(value) => setTypeFilter(fromFilterSelectValue(value))}
         >
-          <option value="">All Types</option>
-          {RELEASE_TYPES.map((type) => (
-            <option key={type} value={type}>
-              {RELEASE_TYPE_LABELS[type]}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger className="w-44" aria-label="Filter by type">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={FILTER_SELECT_ALL}>All Types</SelectItem>
+            {RELEASE_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {RELEASE_TYPE_LABELS[type]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Loading */}

--- a/frontend/features/tags/admin/TagManagement.test.tsx
+++ b/frontend/features/tags/admin/TagManagement.test.tsx
@@ -113,6 +113,65 @@ describe('TagManagement — official indicator', () => {
   })
 })
 
+describe('TagManagement — category filter (PSY-924)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseTags.mockReturnValue({
+      data: { tags: [], total: 0 },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('renders the category filter as the DS Select with the All sentinel', () => {
+    // PSY-924: native <select> filter is now a Radix combobox; "All
+    // Categories" is the FILTER_SELECT_ALL sentinel round-tripped to '' for
+    // the query.
+    renderWithProviders(<TagManagement />)
+    const categorySelect = screen.getByRole('combobox', {
+      name: 'Filter by category',
+    })
+    expect(categorySelect).toHaveTextContent('All Categories')
+  })
+
+  it('passes the selected category filter through to useTags', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TagManagement />)
+
+    await user.click(
+      screen.getByRole('combobox', { name: 'Filter by category' })
+    )
+    await user.click(await screen.findByRole('option', { name: 'Genre' }))
+
+    expect(mockUseTags).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: 'genre' })
+    )
+  })
+
+  it('round-trips the All sentinel back to no category filter', async () => {
+    // Guards the sentinel: "All Categories" must clear category ('' →
+    // undefined), not pass the literal 'all' to the backend query.
+    const user = userEvent.setup()
+    renderWithProviders(<TagManagement />)
+
+    await user.click(
+      screen.getByRole('combobox', { name: 'Filter by category' })
+    )
+    await user.click(await screen.findByRole('option', { name: 'Genre' }))
+    expect(mockUseTags).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: 'genre' })
+    )
+
+    await user.click(
+      screen.getByRole('combobox', { name: 'Filter by category' })
+    )
+    await user.click(await screen.findByRole('option', { name: 'All Categories' }))
+    expect(mockUseTags).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: undefined })
+    )
+  })
+})
+
 describe('EditTagFormFields: tag switch resets fields via key prop', () => {
   // Pins PSY-768: the inner form initializes local state from the tag prop
   // on mount, with no useEffect and no `initialized` ratchet. Callers pass

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -34,6 +34,11 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
+import {
+  FILTER_SELECT_ALL,
+  toFilterSelectValue,
+  fromFilterSelectValue,
+} from '@/lib/filterSelectValue'
 import { useTags, useTag } from '../hooks'
 import { AliasListing } from './AliasListing'
 import { LowQualityTagQueue } from './LowQualityTagQueue'
@@ -686,19 +691,22 @@ export function TagManagement() {
             className="pl-9"
           />
         </div>
-        {/* Deferred to PSY-924; outside PSY-907's entity create/edit form-field scope. */}
-        <select
-          value={categoryFilter}
-          onChange={(e) => setCategoryFilter(e.target.value)}
-          className="h-9 rounded-md border bg-background px-3 text-sm"
+        <Select
+          value={toFilterSelectValue(categoryFilter)}
+          onValueChange={(value) => setCategoryFilter(fromFilterSelectValue(value))}
         >
-          <option value="">All Categories</option>
-          {TAG_CATEGORIES.map((cat) => (
-            <option key={cat} value={cat}>
-              {getCategoryLabel(cat)}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger className="w-44" aria-label="Filter by category">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={FILTER_SELECT_ALL}>All Categories</SelectItem>
+            {TAG_CATEGORIES.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {getCategoryLabel(cat)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Loading */}

--- a/frontend/lib/filterSelectValue.test.ts
+++ b/frontend/lib/filterSelectValue.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FILTER_SELECT_ALL,
+  toFilterSelectValue,
+  fromFilterSelectValue,
+} from './filterSelectValue'
+import { RELEASE_TYPES } from '@/features/releases/types'
+import { LABEL_STATUSES } from '@/features/labels/types'
+import { FESTIVAL_STATUSES } from '@/features/festivals/types'
+import { TAG_CATEGORIES } from '@/features/tags/types'
+
+describe('filter Select "All" sentinel mapping (PSY-924)', () => {
+  it('maps the empty (no filter) state to the Radix sentinel', () => {
+    expect(toFilterSelectValue('')).toBe(FILTER_SELECT_ALL)
+  })
+
+  it('passes a real filter value through to the Select unchanged', () => {
+    expect(toFilterSelectValue('lp')).toBe('lp')
+  })
+
+  it('maps the sentinel back to the empty (no filter) state', () => {
+    // Guards the regression where state would persist the literal 'all' and
+    // send an invalid filter value to the backend instead of clearing it.
+    expect(fromFilterSelectValue(FILTER_SELECT_ALL)).toBe('')
+  })
+
+  it('passes a real selected value back to state unchanged', () => {
+    expect(fromFilterSelectValue('active')).toBe('active')
+  })
+
+  it('round-trips the empty state and every entity filter value', () => {
+    const values = [
+      '',
+      ...RELEASE_TYPES,
+      ...LABEL_STATUSES,
+      ...FESTIVAL_STATUSES,
+      ...TAG_CATEGORIES,
+    ]
+    for (const value of values) {
+      expect(fromFilterSelectValue(toFilterSelectValue(value))).toBe(value)
+    }
+  })
+
+  it('uses a sentinel that cannot collide with any real filter value', () => {
+    // Asserts against the live filter-value lists so a future enum addition
+    // named 'all' fails here instead of silently shipping a filter that can
+    // never be selected (its SelectItem value would equal the "All" item).
+    const realValues = [
+      ...RELEASE_TYPES,
+      ...LABEL_STATUSES,
+      ...FESTIVAL_STATUSES,
+      ...TAG_CATEGORIES,
+    ] as string[]
+    expect(realValues).not.toContain(FILTER_SELECT_ALL)
+  })
+})

--- a/frontend/lib/filterSelectValue.ts
+++ b/frontend/lib/filterSelectValue.ts
@@ -1,0 +1,16 @@
+// Radix Select reserves the empty string for "no value", so admin list
+// filters whose "All …" option means "no filter" (state held as '') cannot
+// use value="" on a SelectItem. This sentinel represents the "All" option in
+// the Select and maps back to '' in the filter state.
+//
+// Mirrors the PSY-907 precedent in
+// app/admin/radio/_components/playlistSourceSelect.ts, generalized for the
+// PSY-924 filter migration where four entity managers (releases, labels,
+// festivals, tags) share the same ''-means-no-filter contract.
+export const FILTER_SELECT_ALL = 'all'
+
+export const toFilterSelectValue = (value: string) =>
+  value || FILTER_SELECT_ALL
+
+export const fromFilterSelectValue = (value: string) =>
+  value === FILTER_SELECT_ALL ? '' : value


### PR DESCRIPTION
## Summary
- Migrate the native `<select>` elements deferred by PSY-907 to the DS `Select` primitive across the 5 admin entity managers.
- List/toolbar filters: release Type, label Status, festival Status, tag Category, radio Station.
- Inline artist-role selector in the release lineup editor (`size="sm"`).
- Festival lineup Billing Tier selects — add (`size="sm"`, compact h-8) and edit (default, matches its dialog sibling Input).
- New shared sentinel helper `lib/filterSelectValue.ts` round-trips `'all'` ⇄ `''` for the four `''`-means-no-filter "All …" filters (Radix forbids `value=""`), generalizing the PSY-907 `playlistSourceSelect` precedent.
- The radio Station filter is numeric (`0` = all), so `"0"` is already a valid non-empty Radix value and needs no sentinel; `handleStationFilterChange` maps it back via the existing `Number(value)`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/releases features/labels features/festivals features/tags app/admin/radio lib/filterSelectValue` — 666/666 passing (56 files)
- [x] `bunx eslint <changed files>` — 0 errors (only pre-existing unused-import warnings; net warnings decreased)
- [x] `/code-review` — clean, no findings
- [x] `/adversarial-review` — CLEAN

## Out of scope
- `ReplyPermissionSelect` (PSY-296) left native by decision — comments component, outside this admin ticket.
- Native `<input type="date">` controls left untouched so the PSY-925 date-input migration doesn't conflict.

## Manual repro
Control-swap render change. Unit-test DOM assertions cover the migrated filters + the "All" sentinel round-trip:
- `frontend/lib/filterSelectValue.test.ts` — sentinel `'all'` ⇄ `''` round-trips every entity filter value; asserts no collision against the live RELEASE_TYPES / LABEL_STATUSES / FESTIVAL_STATUSES / TAG_CATEGORIES lists.
- `frontend/features/releases/admin/ReleaseManagement.test.tsx` — Type filter renders the DS Select w/ "All Types" default; passes `releaseType` through; "All Types" clears to `undefined`.
- `frontend/features/labels/admin/LabelManagement.test.tsx` — Status filter DS Select + sentinel round-trip.
- `frontend/features/festivals/admin/FestivalManagement.test.tsx` — Status filter DS Select + sentinel round-trip.
- `frontend/features/tags/admin/TagManagement.test.tsx` — Category filter DS Select + sentinel round-trip.

Inline-role and billing-tier selects are pure control-swaps (no sentinel logic; the latter's components aren't exported for isolated mount) — covered by typecheck and the shared Radix interaction pattern. Visual screenshots added by orchestrator post-push.

## Code review
`/code-review` (xhigh, inline 9-angle): no correctness, reuse, simplification, efficiency, or altitude findings. Verdict `[]`.

## Adversarial review
`/adversarial-review` — CLEAN. Panel: Saboteur · Future-Maintainer · Security · Completeness, run inline (no Agent tool in a worktree) against the branch diff. No CRITICAL/HIGH/MEDIUM findings, so no fixes commit. One LOW note (empty `editBillingTier` renders a blank Radix trigger) is a pre-existing data dependency matching the prior native-select behaviour, not a regression introduced here.

## Screenshots

Captured against the local dev stack (admin), worktree on `PSY-924/ds-select-adoption-tail`.

**Release Type filter → DS `Select`** — the migrated filter dropdown open, showing the editorial DS styling (All Types ✓ / LP / EP / Single / Compilation / Live / Remix / Demo) instead of native browser chrome. "All Types" is the `'all'` → `''` sentinel. The other filters / inline-role / billing-tier are the same control-swap (covered by the unit tests above).

![Release Type filter DS Select](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-bd3c35905f841b779e3b/psy924-release-filter.png)

Closes PSY-924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
