### PR TITLE
docs(skills): Figma desktop-crashes-on-MCP-bursts gotcha

### DIFF
--- a/.claude/skills/figma-reference/SKILL.md
+++ b/.claude/skills/figma-reference/SKILL.md
@@ -133,6 +133,11 @@ Download via `curl -o /tmp/<name>.png "<url>"` then `Read` the PNG to verify vis
 
 ## Recovery patterns
 
+**Figma DESKTOP APP CRASHES during MCP interaction (HIGH — caught PSY-891, 2026-05-29).** The Figma MCP routes through the desktop app's plugin host. A **burst of MCP calls — reads (`get_screenshot`, inventory `use_figma`) AND writes (`use_figma`) — can crash the desktop app**, which silently drops the MCP write path while `whoami` keeps succeeding (misleading partial-up state). Observed signatures: `use_figma` → `MCP error -32602: Tool use_figma not found` (recurs while `whoami` works), `ReadMcpResourceTool` → `-32601: Method not found`, `get_screenshot` asset URLs 404 on download, stale-`nodeId` "invalid node" after reconnect.
+- **Primary cause is agent-side and preventable:** firing multiple `use_figma` mutations and/or `get_screenshot` calls **in one parallel message** violates the `figma-use` "never parallelize `use_figma`" rule and overwhelms the plugin host. **Mitigation: strictly ONE mutating `use_figma` per message, sequential; minimize `get_screenshot` (batch verification — don't screenshot after every micro-edit); never fan out Figma calls in a single message.**
+- **Recovery when it crashes:** STOP hammering retries (3 consecutive `-32602`s = the path is down, not a transient). Ask the user to **reconnect the plugin / re-open the Figma desktop app on the target file** (`/mcp` to reconnect the server). Confirm with a cheap `whoami`, then re-verify the last write landed (re-read the node — don't assume) before continuing, because the crash may have dropped an in-flight mutation.
+- Work is NOT lost on crash: `use_figma` is atomic, and committed nodes persist in the file. After reconnect, re-read state (don't trust your last in-memory node-ids — re-fetch) and resume.
+
 **MCP server disconnected mid-session** (e.g. system-reminder says "deferred tools are no longer available"):
 - Read-only inspection is blocked until the MCP reconnects.
 - Workaround: ask the user to paste a screenshot of the relevant Figma frame into the chat, then `Read` the screenshot image directly.

--- a/.claude/skills/psy-design-system/SKILL.md
+++ b/.claude/skills/psy-design-system/SKILL.md
@@ -236,6 +236,12 @@ Then update the brief inline as part of each impl PR — don't ship a docs-only 
 
 ## Gotchas (read all before building)
 
+### G0. Figma DESKTOP crashes on MCP-call bursts (HIGH — caught PSY-891, 2026-05-29)
+
+The Figma MCP routes through the desktop app's plugin host. Firing **many MCP calls in quick succession — especially multiple `use_figma` mutations and/or `get_screenshot` calls in a single parallel message — crashes the desktop app**, dropping the MCP write path while `whoami` keeps working (misleading "still up" signal). Signatures: `use_figma` → `MCP error -32602: Tool use_figma not found` (recurs), `get_screenshot` URLs 404, `-32601` on resource reads.
+
+**Prevention (this is the fix):** ONE mutating `use_figma` per message, strictly sequential (already the figma-use rule — but easy to violate when building fast). Minimize `get_screenshot` — verify in batches, not after every micro-edit. Never fan out Figma tool calls in one assistant message. **On 3 consecutive `-32602`s, STOP** — the path is down; ask the user to reconnect (`/mcp` + re-open desktop on the file), confirm with `whoami`, re-read the last node to confirm the write landed (atomic — may have been dropped), then resume. Full recovery decision tree: `figma-reference` SKILL → "Recovery patterns".
+
 ### G1. Bound-paint cache mismatch (HIGH — has bitten this project twice)
 
 `figma.variables.setBoundVariableForPaint(placeholder, 'color', variable)` does **NOT** refresh the paint's cached `color` field when the paint was already bound to the same variable (common after `clone()`-then-rebind). Figma renders the cached `color`, NOT the bound variable's resolved value.


### PR DESCRIPTION
## Summary

Documents the Figma-desktop-crashes-on-MCP-bursts gotcha in `figma-reference` + `psy-design-system` SKILL.md files. This commit was authored 2026-05-30 on a local branch that never got pushed/PR'd; recovered during the 2026-05-31 session's worktree/branch cleanup sweep.

## Test plan

- Docs-only (SKILL.md files), no tests applicable.

## Manual repro

Docs-only, no manual repro applicable.
