### PR TITLE
PSY-950: evict ArtistDetail from shared chunk (canonical artists phase)

### DIFF
--- a/frontend/app/artists/[slug]/page.tsx
+++ b/frontend/app/artists/[slug]/page.tsx
@@ -1,16 +1,33 @@
 import { Suspense, cache } from 'react'
 import { Metadata } from 'next'
+import dynamic from 'next/dynamic'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
 import { HydrationBoundary } from '@tanstack/react-query'
-import { ArtistDetail } from '@/features/artists'
 import type { Artist } from '@/features/artists/types'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateMusicGroupSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
 import { API_BASE_URL } from '@/lib/api-base'
 import { queryKeys } from '@/lib/queryClient'
 import { prefetchEntity } from '@/lib/query-hydration'
+
+// Dynamic-imported from the component FILE (never the `@/features/artists` barrel)
+// to evict ArtistDetail.tsx (~40 KB raw) from Turbopack's global shared client
+// chunk that loads on every route incl. /explore. PSY-950 (rollout) / PSY-944
+// (spike): `dynamic()` alone is a no-op — a barrel re-export keeps the module
+// reachable from 2+ routes so Turbopack re-hoists it. The eviction only holds
+// when this is paired with REMOVING ArtistDetail from features/artists/index.ts
+// + features/artists/components/index.ts. Do NOT re-add the barrel export or this
+// silently un-does the chunk split. ssr:true preserves the PSY-796/841
+// prefetchEntity + HydrationBoundary SSR (verified byte-equivalent in the spike).
+const ArtistDetail = dynamic(
+  () =>
+    import('@/features/artists/components/ArtistDetail').then((m) => ({
+      default: m.ArtistDetail,
+    })),
+  { ssr: true },
+)
 
 interface ArtistPageProps {
   params: Promise<{ slug: string }>

--- a/frontend/features/artists/components/index.ts
+++ b/frontend/features/artists/components/index.ts
@@ -1,6 +1,10 @@
 export { ArtistCard } from './ArtistCard'
 export { ArtistSearch } from './ArtistSearch'
-export { ArtistDetail } from './ArtistDetail'
+// ArtistDetail is intentionally NOT re-exported here (PSY-950). The route page
+// `app/artists/[slug]/page.tsx` imports it directly via `dynamic()` from the
+// component file so Turbopack can evict it from the global shared client chunk.
+// Re-adding a barrel export makes it multi-route-reachable again and silently
+// re-hoists ArtistDetail.tsx (~40 KB) back into the chunk that loads on /explore.
 export { ArtistList } from './ArtistList'
 export { ArtistListSkeleton } from './ArtistListSkeleton'
 export { ArtistShowsList } from './ArtistShowsList'

--- a/frontend/features/artists/index.ts
+++ b/frontend/features/artists/index.ts
@@ -59,10 +59,13 @@ export {
 export { useReducedMotion } from './hooks'
 
 // Components
+// NOTE: ArtistDetail is intentionally omitted (PSY-950). The route page imports it
+// directly via `dynamic()` from '@/features/artists/components/ArtistDetail' so
+// Turbopack evicts it from the global shared client chunk (loaded on every route).
+// Re-adding it here re-hoists ArtistDetail.tsx (~40 KB) into the shared chunk.
 export {
   ArtistCard,
   ArtistSearch,
-  ArtistDetail,
   ArtistList,
   ArtistListSkeleton,
   ArtistShowsList,


### PR DESCRIPTION
Part of **PSY-950** (canonical first phase — **artists only**). Does NOT close PSY-950; the fan-out to the remaining 10 detail components follows in a separate PR once this clears the CI + Vercel-preview Lighthouse gate.

## Summary
- Dynamic-import `ArtistDetail` (`ssr:true`, from the component file `@/features/artists/components/ArtistDetail`) at `app/artists/[slug]/page.tsx` + remove it from BOTH artists feature barrels (`features/artists/index.ts` and `features/artists/components/index.ts`), evicting `ArtistDetail.tsx` (~40 KB raw) from Turbopack's global shared client chunk (the chunk loaded on every route's initial paint, incl. `/explore`, which renders none of it).

## Why both dynamic() AND de-barrel (PSY-944 spike finding)
`dynamic()` alone is a no-op — the route-page dynamic import removes only ONE static-import path, but the `@/features/artists` barrel re-export keeps `ArtistDetail` reachable from 2+ route entries (other routes import `ArtistList`/`ArtistCard`/hooks from the same barrel, and `'use client'` barrels aren't reliably per-export tree-shaken under Turbopack), so Turbopack re-hoists it into the shared chunk. Eviction only holds when the dynamic import is paired with removing the barrel export. WHY-comments in all three files warn against re-adding the export.

## Analyzer (Turbopack `next experimental-analyze --no-mangling -o`, before → after)
Parsed each route's `data/<route>/analyze.data` (4-byte big-endian length prefix + JSON; `chunk_parts[].source_index → sources[].path`; `output_file_index → output_files[].filename`; `[client-fs]` = browser chunk). The global shared chunk is the one that appears identically (same hash, same total) on BOTH `/explore` and `/artists/[slug]`.

| metric (raw bytes) | before | after |
| --- | --- | --- |
| `ArtistDetail.tsx` in `/explore` global shared chunk | **yes — 40,196 B** (chunk `f20a1289fce16c52.js`) | **GONE from `/explore`** |
| global shared chunk total | **1,283,817 B** | **1,242,914 B** (chunk `e0e34ef91fcf135c.js`) |
| shared-chunk delta | — | **−40,903 B** |
| `ArtistDetail.tsx` on `/artists/[slug]` | in the shared chunk | in a dedicated **per-route async client chunk** `7096700bb563d548.js` (40,405 B) **+** a server SSR chunk (40,291 B) |

Matches the PSY-944 spike's experiment build (−40,901 B / shared chunk 1,243,487 B) within sub-KB build noise. The same shared chunk hash appears on both routes before and after, confirming it is the global shared chunk.

## SSR preserved
- **Build-level proof:** the AFTER analyzer shows `ArtistDetail.tsx` present in a **server SSR chunk** (`.next/server/chunks/ssr/...`, 40,291 B) on `/artists/[slug]`. With `ssr:false`, the component would be absent from ALL server chunks — its presence there proves the server still renders it. The route builds as `◐ (Partial Prerender)`, same render mode as before and as sibling entity routes.
- The existing `<Suspense fallback={<ArtistLoadingFallback />}>` + `<HydrationBoundary>` (PSY-796/841) wrapping is unchanged, so no redundant `loading:` was added to the `dynamic()` call.
- The PSY-944 spike already curl-verified this exact change keeps `/artists/chloe-tang` server HTML byte-equivalent (20 entity-name occurrences + rendered `<h1>` + `ArtistDetailResponse` hydration payload).

## Barrel-straggler audit
`grep -rn "ArtistDetail" app features components` (excluding tests/stories). The ONLY importers of the `ArtistDetail` *component* were:
- `app/artists/[slug]/page.tsx` (the route page) — repointed to the direct component-file path via `dynamic()`. Now the sole consumer.
- `features/artists/components/ArtistDetail.test.tsx` — imports via the relative path `./ArtistDetail`, unaffected by barrel removal.

All other grep matches are `revalidateArtistDetail` (an unrelated ISR-revalidation helper in `@/lib/revalidate-entity`) or comments/string literals. Confirmed no file imports `ArtistDetail` from the `@/features/artists` barrel. Other barrel symbols (`ArtistList`, `ArtistCard`, hooks, types) remain exported and untouched.

## Adversarial review
`/adversarial-review` (inline lenses, dispatched sub-agent has no Agent tool) — **PASS, no fixes required**. Lenses: Saboteur (SSR confirmed preserved via server-chunk presence + PSY-944 curl; no non-route importer breaks; Suspense prevents flash/CLS) · Future-Maintainer (WHY-comments in all 3 files warn against re-adding the barrel export) · Security (n/a — build-chunking/module-export change only) · Completeness (analyzer before/after captured, both barrels de-exported, sole straggler repointed). The one `/code-review` cleanup (grouping imports above the `dynamic()` declaration) was folded into the single implementation commit before commit, so there is no separate adversarial fix commit.

## Test plan
- [x] `bun run typecheck` — clean (`tsc --noEmit`, no output)
- [x] `bun run test:run features/artists` — **266/266 passed** (22 files)
- [x] `bunx eslint` on the 3 changed files — clean (exit 0)
- [x] `bun run build` — clean; `/artists/[slug]` builds as `◐ (Partial Prerender)`; analyzer before/after above
- [x] SSR check — build-level proof (ArtistDetail in server SSR chunk) + PSY-944 prior curl byte-equivalence; local curl gap disclosed below
- [ ] CI Lighthouse-explore gate on the Vercel preview — runs automatically (the real gate; local can't validate per PSY-944)

## Coverage gaps
- **Local curl SSR check not run.** The per-worktree dispatch stack couldn't come up cleanly: the shared backend at :8080 wasn't responding, and the isolated-mode fallback failed docker-compose project-name validation (the worktree name `PSY-950-...` contains uppercase letters → "invalid project name … must consist only of lowercase"). Per the ticket's guidance I did NOT grab raw :8080/:3000 (a sibling PSY-951 agent runs in parallel). SSR is instead proven by the build-level server-chunk evidence + PSY-944's prior curl verification of this identical change. The Vercel preview is the authoritative SSR + perf gate.
- **Local Lighthouse can't validate the perf win** — loopback RTT under `simulate` throttling inflates LCP/TTI (~7 s local vs ~2.1 s CI per PSY-944). The analyzer is the proof of the chunk reduction; the Vercel-preview `lighthouse-explore.yml` gate is authoritative for the runtime win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
