### PR TITLE
PSY-925: DS DateInput primitive + admin date-input migration

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -29,6 +29,7 @@ import { AdminEmptyState } from '@/components/admin'
 import { AdminTable, type AdminTableColumn } from '@/components/admin/AdminTable'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { DateInput } from '@/components/ui/date-input'
 import {
   Select,
   SelectContent,
@@ -786,8 +787,7 @@ function ShowImportControls({ show }: { show: RadioShowListItem }) {
       <div className="flex items-end gap-2">
         <div>
           <Label className="text-xs text-muted-foreground">Since</Label>
-          <Input
-            type="date"
+          <DateInput
             value={since}
             onChange={(e) => setSince(e.target.value)}
             className="h-8 text-xs w-36"
@@ -795,8 +795,7 @@ function ShowImportControls({ show }: { show: RadioShowListItem }) {
         </div>
         <div>
           <Label className="text-xs text-muted-foreground">Until</Label>
-          <Input
-            type="date"
+          <DateInput
             value={until}
             onChange={(e) => setUntil(e.target.value)}
             className="h-8 text-xs w-36"
@@ -1013,18 +1012,16 @@ function ShowImportSection({
           <div className="grid grid-cols-2 gap-3">
             <div>
               <Label htmlFor={`since-${show.id}`}>From</Label>
-              <Input
+              <DateInput
                 id={`since-${show.id}`}
-                type="date"
                 value={since}
                 onChange={(e) => setSince(e.target.value)}
               />
             </div>
             <div>
               <Label htmlFor={`until-${show.id}`}>To</Label>
-              <Input
+              <DateInput
                 id={`until-${show.id}`}
-                type="date"
                 value={until}
                 onChange={(e) => setUntil(e.target.value)}
               />

--- a/frontend/components/forms/FormField.test.tsx
+++ b/frontend/components/forms/FormField.test.tsx
@@ -120,6 +120,14 @@ describe('FormField', () => {
     expect(screen.getByPlaceholderText('Enter value').tagName).toBe('TEXTAREA')
   })
 
+  it('routes type="date" through the DateInput primitive', () => {
+    renderWithProviders(<TestFormField type="date" />)
+    const input = screen.getByLabelText('Test Label')
+    expect(input.tagName).toBe('INPUT')
+    expect(input).toHaveAttribute('type', 'date')
+    expect(input).toHaveAttribute('data-slot', 'date-input')
+  })
+
   it('renders disabled input when disabled prop is true', () => {
     renderWithProviders(<TestFormField disabled />)
     expect(screen.getByPlaceholderText('Enter value')).toBeDisabled()

--- a/frontend/components/forms/FormField.tsx
+++ b/frontend/components/forms/FormField.tsx
@@ -2,6 +2,7 @@
 
 import { type AnyFieldApi } from '@tanstack/react-form'
 import { Input } from '@/components/ui/input'
+import { DateInput } from '@/components/ui/date-input'
 import { Label } from '@/components/ui/label'
 import { getUniqueErrors } from '@/lib/utils/formErrors'
 
@@ -71,6 +72,18 @@ export function FormField({
       {type === 'textarea' ? (
         <textarea
           className="flex min-h-[100px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+          id={field.name}
+          name={field.name}
+          value={field.state.value}
+          onBlur={field.handleBlur}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          aria-invalid={field.state.meta.errors.length > 0}
+          disabled={disabled}
+        />
+      ) : type === 'date' ? (
+        <DateInput
           id={field.name}
           name={field.name}
           value={field.state.value}

--- a/frontend/components/ui/date-input.test.tsx
+++ b/frontend/components/ui/date-input.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createRef } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DateInput } from './date-input'
+
+describe('DateInput', () => {
+  it('renders a native date input', () => {
+    render(<DateInput aria-label="release date" />)
+    const input = screen.getByLabelText('release date')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveAttribute('type', 'date')
+  })
+
+  it('merges a custom className alongside the DS token classes', () => {
+    render(<DateInput aria-label="release date" className="custom-class" />)
+    const input = screen.getByLabelText('release date')
+    expect(input).toHaveClass('custom-class')
+    // DS state-treatment token still present (mirrors Input).
+    expect(input).toHaveClass('border-input')
+  })
+
+  it('forwards a ref to the underlying input element', () => {
+    const ref = createRef<HTMLInputElement>()
+    render(<DateInput aria-label="release date" ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLInputElement)
+  })
+
+  it('round-trips a controlled value', () => {
+    render(<DateInput aria-label="release date" value="2026-06-01" readOnly />)
+    expect(screen.getByLabelText('release date')).toHaveValue('2026-06-01')
+  })
+
+  it('fires onChange with the edited value', () => {
+    const onChange = vi.fn()
+    render(<DateInput aria-label="release date" onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText('release date'), {
+      target: { value: '2026-07-04' },
+    })
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0].target.value).toBe('2026-07-04')
+  })
+
+  it('honors the disabled prop', () => {
+    render(<DateInput aria-label="release date" disabled />)
+    expect(screen.getByLabelText('release date')).toBeDisabled()
+  })
+
+  it('reflects aria-invalid for the destructive state', () => {
+    render(<DateInput aria-label="release date" aria-invalid />)
+    expect(screen.getByLabelText('release date')).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    )
+  })
+})

--- a/frontend/components/ui/date-input.tsx
+++ b/frontend/components/ui/date-input.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * DateInput — a styled wrapper over the native `<input type="date">`.
+ *
+ * Deliberately wraps the native control (no calendar library) so the OS-native
+ * date picker, keyboard handling, and screen-reader semantics are preserved.
+ * The visual treatment mirrors the DS `Input` primitive exactly (hairline
+ * border, transparent bg, orange focus ring, aria-invalid destructive state,
+ * disabled opacity) so date fields sit flush with the rest of a form.
+ *
+ * `type` is fixed to "date" and intentionally not overridable — for free-text
+ * or other input types, use `Input`.
+ */
+function DateInput({
+  className,
+  ...props
+}: Omit<React.ComponentProps<"input">, "type">) {
+  return (
+    <input
+      type="date"
+      data-slot="date-input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { DateInput }

--- a/frontend/features/festivals/admin/FestivalManagement.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { DateInput } from '@/components/ui/date-input'
 import {
   Select,
   SelectContent,
@@ -267,17 +268,15 @@ export function CreateFestivalForm({
 
       <AdminFormRow cols={2}>
         <AdminFormField label="Start Date *" htmlFor="create-start-date">
-          <Input
+          <DateInput
             id="create-start-date"
-            type="date"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
           />
         </AdminFormField>
         <AdminFormField label="End Date *" htmlFor="create-end-date">
-          <Input
+          <DateInput
             id="create-end-date"
-            type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
           />
@@ -614,17 +613,15 @@ export function EditFestivalFormFields({
 
       <AdminFormRow cols={2}>
         <AdminFormField label="Start Date" htmlFor="edit-start-date">
-          <Input
+          <DateInput
             id="edit-start-date"
-            type="date"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
           />
         </AdminFormField>
         <AdminFormField label="End Date" htmlFor="edit-end-date">
-          <Input
+          <DateInput
             id="edit-end-date"
-            type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
           />
@@ -1000,8 +997,7 @@ function LineupManagement({ festivalId }: { festivalId: number }) {
         <div className="grid grid-cols-3 gap-3">
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">Day Date</Label>
-            <Input
-              type="date"
+            <DateInput
               value={addDayDate}
               onChange={(e) => setAddDayDate(e.target.value)}
               className="h-8 text-xs"
@@ -1195,8 +1191,7 @@ function LineupManagement({ festivalId }: { festivalId: number }) {
             <div className="grid grid-cols-3 gap-4">
               <div className="space-y-2">
                 <Label>Day Date</Label>
-                <Input
-                  type="date"
+                <DateInput
                   value={editDayDate}
                   onChange={(e) => setEditDayDate(e.target.value)}
                 />

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { DateInput } from '@/components/ui/date-input'
 import {
   Select,
   SelectContent,
@@ -635,9 +636,8 @@ export function CreateReleaseForm({
       </AdminFormRow>
 
       <AdminFormField label="Release Date" htmlFor="create-date">
-        <Input
+        <DateInput
           id="create-date"
-          type="date"
           value={releaseDate}
           onChange={(e) => setReleaseDate(e.target.value)}
         />
@@ -906,9 +906,8 @@ export function EditReleaseFormFields({
       </AdminFormRow>
 
       <AdminFormField label="Release Date" htmlFor="edit-date">
-        <Input
+        <DateInput
           id="edit-date"
-          type="date"
           value={releaseDate}
           onChange={(e) => setReleaseDate(e.target.value)}
         />


### PR DESCRIPTION
## Summary
- New `DateInput` DS primitive (`frontend/components/ui/date-input.tsx`) — a styled wrapper over the native `<input type="date">`. Mirrors the `Input` primitive's class composition and state treatment byte-for-byte (hairline border, transparent bg, orange focus ring, `aria-invalid` destructive state, disabled opacity). Keeps the OS-native calendar picker plus native keyboard + screen-reader semantics. No new dependency. `type` is fixed to `"date"` and not overridable.
- Migrated all 13 native `<Input type="date">` sites across 4 admin form files:
  - `features/releases/admin/ReleaseManagement.tsx` — Release Date (create + edit)
  - `features/festivals/admin/FestivalManagement.tsx` — Start/End Date (create + edit) + Day Date (add + edit lineup)
  - `app/admin/radio/_components/RadioManagement.tsx` — broadcast Since/Until filters (×2 contexts) → two single DateInputs each (not a range)
  - `components/forms/ShowForm.tsx` — via routing the `FormField` `type="date"` path through `DateInput`

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/ui features/releases features/festivals app/admin/radio components/forms` — 529/529 passing (62 files), incl. 7 new `DateInput` cases + 1 new FormField date-routing case
- [x] `/code-review` — clean (no findings; mechanical 1:1 swap, invariant preserved, no selectors keyed on old structure)
- [x] `/adversarial-review` — CLEAN

## Deferred
- Formal Figma DatePicker component deferred to a follow-up (decision: ship code primitive now). Filed **PSY-952**. Orchestrator will link the ticket.

## Manual repro
Control-swap + new primitive. Unit-test DOM assertions cover DateInput and the migrated date fields:
- `frontend/components/ui/date-input.test.tsx` — renders native date input, type=date, className merge, ref forwarding, controlled-value round-trip, onChange, disabled, aria-invalid
- `frontend/components/forms/FormField.test.tsx` — `routes type="date" through the DateInput primitive` (asserts `data-slot="date-input"` + `type="date"`)
- Existing label-based admin tests (releases/festivals/radio) continue to pass, confirming the swap preserves `htmlFor`/`id`/label wiring.

Visual screenshots added by orchestrator post-push.

## Code review
`/code-review` (3 lenses inline, no Agent tool in worktree) — clean: no correctness/reuse/efficiency findings; DateInput reuses Input's exact class string; `Input` still used in all touched files (no unused imports); no test or selector keys on the old `<Input>`/`data-slot="input"` date structure.

## Adversarial review
`/adversarial-review` — CLEAN. Panel run inline (no Agent tool in a worktree): Saboteur · Future-Maintainer · Security · Completeness. Reviewers found no CRITICAL/HIGH/MEDIUM findings — value flows are React-controlled, no new trust/security surface, full coverage of the new primitive and routing branch, all acceptance criteria met.

Closes PSY-925
