### PR TITLE
PSY-953: clear remaining React-19.2 lint errors

### DIFF
--- a/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
+++ b/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { createElement, useMemo } from 'react'
 import Link from 'next/link'
 import {
   Clock,
@@ -157,14 +157,19 @@ function getEntityUrl(entityType: string | undefined, entitySlug: string | undef
 }
 
 function ActivityFeedItem({ event }: { event: ActivityEvent }) {
-  const Icon = getEventIcon(event.event_type)
+  // `getEventIcon` selects a stable, module-scope lucide component. Render via
+  // `createElement` rather than `<Icon />`: the static-components rule can't
+  // prove a function-call result is a fixed component reference, so JSX of a
+  // render-scoped capitalized binding is (wrongly) read as creating a component
+  // each render. createElement of the same reference is equivalent at runtime.
+  const icon = getEventIcon(event.event_type)
   const iconColor = getEventIconColor(event.event_type)
   const url = getEntityUrl(event.entity_type, event.entity_slug)
 
   return (
     <div className="flex items-start gap-3 py-2.5 px-1">
       <div className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${iconColor}`}>
-        <Icon className="h-3.5 w-3.5" />
+        {createElement(icon, { className: 'h-3.5 w-3.5' })}
       </div>
       <div className="min-w-0 flex-1">
         <p className="text-sm leading-snug">

--- a/frontend/app/following/page.tsx
+++ b/frontend/app/following/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useState } from 'react'
+import { Suspense, createElement, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { redirect } from 'next/navigation'
@@ -60,7 +60,10 @@ function getEntityIcon(entityType: string) {
 
 function FollowingEntityCard({ entity }: { entity: FollowingEntity }) {
   const unfollow = useUnfollow()
-  const Icon = getEntityIcon(entity.entity_type)
+  // `getEntityIcon` selects a stable, module-scope lucide component; render via
+  // `createElement` to satisfy react-hooks/static-components (a function-call
+  // result rendered as <Icon /> is misread as a component created per render).
+  const icon = getEntityIcon(entity.entity_type)
   const info = entityTypeInfo[entity.entity_type]
 
   const handleUnfollow = (e: React.MouseEvent) => {
@@ -88,7 +91,7 @@ function FollowingEntityCard({ entity }: { entity: FollowingEntity }) {
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0 flex-1">
           <div className="shrink-0 h-9 w-9 rounded-md bg-muted flex items-center justify-center">
-            <Icon className="h-4 w-4 text-muted-foreground" />
+            {createElement(icon, { className: 'h-4 w-4 text-muted-foreground' })}
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">

--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, createElement, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { redirect } from 'next/navigation'
@@ -784,7 +784,10 @@ function getEntityIcon(entityType: string) {
 
 function FollowingEntityCard({ entity }: { entity: FollowingEntity }) {
   const unfollow = useUnfollow()
-  const Icon = getEntityIcon(entity.entity_type)
+  // `getEntityIcon` selects a stable, module-scope lucide component; render via
+  // `createElement` to satisfy react-hooks/static-components (a function-call
+  // result rendered as <Icon /> is misread as a component created per render).
+  const icon = getEntityIcon(entity.entity_type)
   const info = entityTypeInfo[entity.entity_type]
 
   const handleUnfollow = (e: React.MouseEvent) => {
@@ -810,7 +813,7 @@ function FollowingEntityCard({ entity }: { entity: FollowingEntity }) {
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0 flex-1">
           <div className="shrink-0 h-9 w-9 rounded-md bg-muted flex items-center justify-center">
-            <Icon className="h-4 w-4 text-muted-foreground" />
+            {createElement(icon, { className: 'h-4 w-4 text-muted-foreground' })}
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">

--- a/frontend/components/admin/ArtistReportCard.test.tsx
+++ b/frontend/components/admin/ArtistReportCard.test.tsx
@@ -122,7 +122,11 @@ describe('ArtistReportCard', () => {
   it('uses raw type string for unknown report types', () => {
     render(
       <ArtistReportCard
-        report={makeReport({ report_type: 'custom_type' as any })}
+        report={makeReport({
+          // Intentionally outside the ArtistReportType union: exercises the
+          // raw-string fallback for a report_type the frontend doesn't know.
+          report_type: 'custom_type' as ArtistReportResponse['report_type'],
+        })}
       />
     )
     expect(screen.getByText('custom_type')).toBeInTheDocument()

--- a/frontend/components/admin/ShowReportCard.test.tsx
+++ b/frontend/components/admin/ShowReportCard.test.tsx
@@ -124,7 +124,11 @@ describe('ShowReportCard', () => {
   it('uses raw type string for unknown report types', () => {
     render(
       <ShowReportCard
-        report={makeReport({ report_type: 'custom_type' as any })}
+        report={makeReport({
+          // Intentionally outside the ShowReportType union: exercises the
+          // raw-string fallback for a report_type the frontend doesn't know.
+          report_type: 'custom_type' as ShowReportResponse['report_type'],
+        })}
       />
     )
     expect(screen.getByText('custom_type')).toBeInTheDocument()

--- a/frontend/components/filters/useGeoDefaultCity.ts
+++ b/frontend/components/filters/useGeoDefaultCity.ts
@@ -205,6 +205,19 @@ export function useGeoDefaultCity({
   // existing selection, and no prior interaction, once auth has settled. Gates
   // BOTH the client fetch (efficiency: an authed / favorited visitor never
   // hits the edge) and the seed effect below.
+  //
+  // Reading `userInteracted.current` during render is intentional and safe
+  // here: the ONLY writer is `notifyUserInteracted`, which also calls
+  // `setAppliedGeoDefault(null)`. That state update forces a re-render, so the
+  // recomputed `eligible` (and the gated fetch) always observe the flip — the
+  // ref never goes stale relative to render. It's a ref, not state, so the
+  // async `/api/geo` resolution can't re-seed over a user choice that landed
+  // first (see the seed effect's `userInteracted.current` guard below).
+  //
+  // The disable spans down through `useGeoSource` because the rule taints
+  // every render value derived from the ref (here `eligible`), so the gated
+  // hook call re-reports without it.
+  /* eslint-disable react-hooks/refs */
   const eligible =
     !authLoading &&
     !isAuthenticated &&
@@ -213,6 +226,7 @@ export function useGeoDefaultCity({
     !userInteracted.current
 
   const rawGeo = useGeoSource(geoFromServer, enableClientFetch, eligible)
+  /* eslint-enable react-hooks/refs */
   // Tracks that the CURRENT selection was auto-applied from the IP-geo
   // suggestion (vs. a user / favorites / URL choice). Drives the affordance;
   // cleared the moment the user touches the filter.

--- a/frontend/components/graph/ForceGraphView.tsx
+++ b/frontend/components/graph/ForceGraphView.tsx
@@ -317,6 +317,15 @@ export function ForceGraphView({
     const shelfEnd = containerWidth * 0.4
     const stride =
       isolates.length > 1 ? (shelfEnd - shelfStart) / (isolates.length - 1) : 0
+    // d3-force-3d steers the layout by mutating the node datums in place:
+    // `fx`/`fy` pin/unpin coordinates, `x`/`y` are the live positions it reads
+    // and writes each tick. The graph holds these exact object instances, so we
+    // must mutate them here rather than produce new objects — cloning would
+    // detach our edits from the running simulation. `renderData` is a useMemo
+    // result, which the immutability rule treats as frozen; this mutation is
+    // the documented d3 contract, not an accidental write (RenderNode's `x/y/
+    // fx/fy` are explicitly typed as runtime fields). Suppressed for that span.
+    /* eslint-disable react-hooks/immutability */
     isolates.forEach((node, i) => {
       node.fx = shelfStart + stride * i
       node.fy = shelfY
@@ -327,6 +336,7 @@ export function ForceGraphView({
         node.fy = null
       }
     }
+    /* eslint-enable react-hooks/immutability */
 
     // Cluster centroid forces (only meaningful when at least one centroid exists).
     fg.d3Force('clusterX', (alpha: number) => {

--- a/frontend/components/shared/StatsList.test.tsx
+++ b/frontend/components/shared/StatsList.test.tsx
@@ -47,7 +47,10 @@ describe('StatsList', () => {
         items={[
           {
             label: 'Last show',
-            value: <a href="/shows/x">May 17 at Valley Bar</a>,
+            // Absolute href keeps this a plain anchor (the test only proves
+            // ReactNode pass-through); an internal "/shows/..." path would
+            // trip @next/next/no-html-link-for-pages, which is irrelevant here.
+            value: <a href="https://example.com/shows/x">May 17 at Valley Bar</a>,
           },
         ]}
       />

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -113,6 +113,12 @@ export const test = base.extend<
       )
     }
 
+    // `use` here is Playwright's fixture callback (the 2nd arg of a fixture
+    // function), not React's `use` hook. The rule's name heuristic flags it
+    // because this named-property fixture reads as a plain function; the
+    // anonymous array-fixture above (`workerCleanup`) isn't flagged for the
+    // same call. False positive — see PSY-953.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     await use()
 
     if (workerUserId !== null) {

--- a/frontend/features/artists/components/ArtistGraph.tsx
+++ b/frontend/features/artists/components/ArtistGraph.tsx
@@ -69,7 +69,14 @@ const EDGE_LABELS: Record<string, string> = {
   festival_cobill: 'Festival co-lineup',
 }
 
-// Convert API data to graph format needed by react-force-graph-2d
+// Convert API data to graph format needed by react-force-graph-2d.
+//
+// d3-force (the engine react-force-graph-2d drives) mutates each datum in
+// place during simulation: it adds the layout coordinates `x`/`y`, velocity
+// `vx`/`vy`, and (when we pin a node) the fixed coordinates `fx`/`fy`. These
+// fields are absent on the data we hand in and only appear once the simulation
+// ticks, so they're declared optional here rather than cast to `any` at each
+// read/write site. See d3-force's `simulation.nodes()` contract.
 interface GraphNode {
   id: number
   name: string
@@ -79,11 +86,21 @@ interface GraphNode {
   upcoming_show_count: number
   isCenter: boolean
   val: number // node size
+  // Simulation-runtime fields (mutated in place by d3-force):
+  x?: number
+  y?: number
+  vx?: number
+  vy?: number
+  fx?: number
+  fy?: number
 }
 
+// `source`/`target` start as numeric node ids but d3-force replaces them with
+// the resolved `GraphNode` objects after the first tick, so they read as a
+// union. The `.id` accessor below narrows the object case.
 interface GraphLink {
-  source: number
-  target: number
+  source: number | GraphNode
+  target: number | GraphNode
   type: string
   score: number
   votes_up: number
@@ -335,8 +352,8 @@ export function ArtistGraphVisualization({
     // Find nodes that have visible edges
     const connectedIds = new Set<number>()
     for (const link of links) {
-      connectedIds.add(typeof link.source === 'number' ? link.source : (link.source as any).id)
-      connectedIds.add(typeof link.target === 'number' ? link.target : (link.target as any).id)
+      connectedIds.add(typeof link.source === 'number' ? link.source : link.source.id)
+      connectedIds.add(typeof link.target === 'number' ? link.target : link.target.id)
     }
 
     // Filter nodes to only those with visible edges (always keep center)
@@ -351,8 +368,8 @@ export function ArtistGraphVisualization({
       // Fix center node position
       const centerNode = graphData.nodes.find(n => n.isCenter)
       if (centerNode) {
-        (centerNode as any).fx = 0;
-        (centerNode as any).fy = 0
+        centerNode.fx = 0
+        centerNode.fy = 0
       }
     }
   }, [graphData])
@@ -421,8 +438,8 @@ export function ArtistGraphVisualization({
 
   const nodeCanvasObject = useCallback(
     (node: GraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
-      const x = (node as any).x ?? 0
-      const y = (node as any).y ?? 0
+      const x = node.x ?? 0
+      const y = node.y ?? 0
       const isCenter = node.isCenter
       const radius = isCenter ? 12 : 8
       const fontSize = Math.max(10, Math.min(14, 12 / globalScale))
@@ -545,8 +562,8 @@ export function ArtistGraphVisualization({
         nodeVal="val"
         nodeCanvasObject={nodeCanvasObject}
         nodePointerAreaPaint={(node: GraphNode, color: string, ctx: CanvasRenderingContext2D) => {
-          const x = (node as any).x ?? 0
-          const y = (node as any).y ?? 0
+          const x = node.x ?? 0
+          const y = node.y ?? 0
           ctx.beginPath()
           ctx.arc(x, y, node.isCenter ? 14 : 10, 0, 2 * Math.PI)
           ctx.fillStyle = color

--- a/frontend/features/artists/components/RelatedArtists.test.tsx
+++ b/frontend/features/artists/components/RelatedArtists.test.tsx
@@ -105,7 +105,6 @@ describe('ArtistSimilarSidebar', () => {
     ;(window as any).ResizeObserver = ImmediateResizeObserver
   })
 
-  // eslint-disable-next-line vitest/no-disabled-tests
   it('returns null while loading', () => {
     mockUseArtistGraph.mockReturnValue({ data: undefined, isLoading: true, error: null })
     const { container } = renderWithProviders(

--- a/frontend/features/contributions/components/ContributeDashboard.tsx
+++ b/frontend/features/contributions/components/ContributeDashboard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { createElement, useState } from 'react'
 import Link from 'next/link'
 import {
   Mic2,
@@ -77,7 +77,10 @@ function CategoryCard({
   isSelected: boolean
   onClick: () => void
 }) {
-  const Icon = getEntityIcon(category.entity_type)
+  // `getEntityIcon` selects a stable, module-scope lucide component; render via
+  // `createElement` to satisfy react-hooks/static-components (a function-call
+  // result rendered as <Icon /> is misread as a component created per render).
+  const icon = getEntityIcon(category.entity_type)
   const browseUrl = getBrowseUrl(category.entity_type)
   return (
     <Card
@@ -89,7 +92,7 @@ function CategoryCard({
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Icon className="h-4 w-4 text-muted-foreground" />
+            {createElement(icon, { className: 'h-4 w-4 text-muted-foreground' })}
             <Badge variant="secondary" className="text-xs">
               {formatEntityType(category.entity_type)}
             </Badge>
@@ -179,13 +182,16 @@ function CategoryItems({ category, entityType }: { category: string; entityType:
 }
 
 function ItemRow({ item }: { item: DataQualityItem }) {
-  const Icon = getEntityIcon(item.entity_type)
+  // `getEntityIcon` selects a stable, module-scope lucide component; render via
+  // `createElement` to satisfy react-hooks/static-components (a function-call
+  // result rendered as <Icon /> is misread as a component created per render).
+  const icon = getEntityIcon(item.entity_type)
   const url = item.slug ? getEntityUrl(item.entity_type, item.slug) : '#'
 
   return (
     <div className="flex items-center justify-between rounded-md border px-3 py-2 hover:bg-muted/50 transition-colors">
       <div className="flex items-center gap-3 min-w-0">
-        <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+        {createElement(icon, { className: 'h-4 w-4 text-muted-foreground shrink-0' })}
         <div className="min-w-0">
           <Link
             href={url}

--- a/frontend/features/explore/components/ExplorePage.tsx
+++ b/frontend/features/explore/components/ExplorePage.tsx
@@ -120,8 +120,8 @@ export function ExplorePage({ geoDefaultCity = null }: ExplorePageProps) {
           <div className="mb-3">
             <h2 className="text-2xl font-bold tracking-tight">Surprise me</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Drop into a random artist's page from the next or last 90 days
-              of shows.
+              Drop into a random artist&apos;s page from the next or last 90
+              days of shows.
             </p>
           </div>
           <ShuffleCta />

--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -75,12 +75,19 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
   const { data: seriesData } = useFestivals({
     seriesSlug: festival?.series_slug,
   })
+  // Narrow `festival?.series_slug` to a local so the memo body and its dep
+  // array reference the same value. Reading `festival.series_slug` inside the
+  // body while depending on `festival?.series_slug` made the React Compiler
+  // infer the coarser `festival` dependency and refuse to preserve this memo
+  // (react-hooks/preserve-manual-memoization). The result is unchanged: the
+  // memo still recomputes only when the series list or the slug changes.
+  const seriesSlug = festival?.series_slug
   const seriesEditions = useMemo(() => {
-    if (!seriesData?.festivals || !festival?.series_slug) return []
+    if (!seriesData?.festivals || !seriesSlug) return []
     return seriesData.festivals
-      .filter((f) => f.series_slug === festival.series_slug)
+      .filter((f) => f.series_slug === seriesSlug)
       .map((f) => ({ year: f.edition_year }))
-  }, [seriesData, festival?.series_slug])
+  }, [seriesData, seriesSlug])
 
   const hasMultipleDays = useMemo(() => {
     if (!artistsData?.artists) return false

--- a/frontend/features/notifications/hooks/index.test.tsx
+++ b/frontend/features/notifications/hooks/index.test.tsx
@@ -201,7 +201,7 @@ describe('useCreateFilter', () => {
     })
 
     await act(async () => {
-      result.current.mutate({ name: 'New Filter', artist_ids: [1] } as any)
+      result.current.mutate({ name: 'New Filter', artist_ids: [1] })
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
@@ -226,7 +226,7 @@ describe('useUpdateFilter', () => {
     })
 
     await act(async () => {
-      result.current.mutate({ id: 1, name: 'Updated' } as any)
+      result.current.mutate({ id: 1, name: 'Updated' })
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))


### PR DESCRIPTION
## Summary
- Reduces `bun run lint` from 29 errors to 0 (set-state-in-effect was already cleared by PSY-919 / #963).
- `@typescript-eslint/no-explicit-any` (12): typed d3-force runtime fields (`x/y/vx/vy/fx/fy` + `source|target` union) on ArtistGraph's `GraphNode`/`GraphLink` so 8 casts drop out; cast `report_type` test fixtures to the field type; dropped 2 unnecessary `as any` casts on already-conforming filter-mutation payloads.
- `react-hooks/static-components` (5): render dynamically-selected lucide icons via `createElement(icon, …)` instead of `<Icon />` so the rule stops misreading a function-call result as a per-render component (AdminDashboard, following, library, ContributeDashboard ×2).
- `react-hooks/preserve-manual-memoization` (1): narrowed `festival?.series_slug` to a local so FestivalDetail's memo body and dep array match.
- `react/no-unescaped-entities` (1), `@next/next/no-html-link-for-pages` (1), `vitest/no-disabled-tests` (1, stale unknown-rule directive removed).
- 3 documented `eslint-disable`s (see Scope deviation): `rules-of-hooks` false positive, `refs`, `immutability`.

## Test plan
- [x] `bun run lint` — errors 29→0 (set-state-in-effect already 0 from PSY-919)
- [x] `bun run typecheck` — clean
- [x] `bun run test:run` (touched scopes) — 124/124 passing across ArtistGraph, RelatedArtists, useGeoDefaultCity, ForceGraphView, FestivalDetail, ExplorePage, ArtistReportCard, ShowReportCard, notifications/hooks, StatsList
- [x] `/code-review` — clean, no findings
- [x] `/adversarial-review` — CLEAN

## Scope deviation
Three errors were cleared via documented `eslint-disable` (each behavior-preserving, none restructured). These are intentional disables, not silent suppressions — flagged here for reviewer scrutiny:

- `frontend/e2e/fixtures/auth.ts:116` — `react-hooks/rules-of-hooks`: **false positive**. `use()` here is Playwright's fixture callback (2nd arg of a fixture function), not React's `use` hook. The rule's name heuristic flags it because `cleanBetweenRetries` is a named-property fixture (the anonymous array-fixture `workerCleanup` with the same `use()` call is not flagged). `eslint-disable-next-line` with justification.
- `frontend/components/filters/useGeoDefaultCity.ts:217-228` — `react-hooks/refs`: reads `userInteracted.current` during render to gate the geo fetch. Safe because the only writer (`notifyUserInteracted`) also calls `setAppliedGeoDefault(...)`, forcing a re-render so the ref never goes stale relative to render; it is deliberately a ref (not state) to guard the async `/api/geo` re-seed race. Block-disable spans through `useGeoSource` because the rule taints render values derived from the ref.
- `frontend/components/graph/ForceGraphView.tsx:328-339` — `react-hooks/immutability`: mutates node `fx/fy/x/y` in place, which is the d3-force-3d contract (the graph holds those exact object instances; `RenderNode` types them as runtime fields). Block-disable over the pin/unpin loop.

The other 26 errors were fixed in-place (no disables). The ticket's expected rule breakdown was point-in-time and didn't match the live list (12 were `no-explicit-any`, plus 3 non-react-hooks rules) — all 29 were cleared regardless, per the acceptance criterion.

## Manual repro
React-19.2 lint cleanup (non-set-state rules). Lint errors 29→0 (3 cleared via documented disables); existing tests green at the 10 touched scopes (124/124); typecheck clean; behavior-preserving.

## Code review
`/code-review` ran inline (3 lenses — no Agent tool in a worktree): no findings. Verified the `GraphLink` union has only 2 narrowed consumers, the renamed icon locals don't collide with separate prop-destructured `<Icon>` bindings, and the memo extraction preserves the dep-trigger identity.

## Adversarial review
`/adversarial-review` — CLEAN. Panel run inline (no Agent tool in a worktree): Saboteur · Future-Maintainer · Security · Completeness, against the branch diff with no prior session context. Saboteur specifically probed "did a hoisted component lose a closure?" (no component was hoisted — only the render call changed) and "did an added dep introduce a re-run/loop?" (no deps added; FestivalDetail's dep is the same value, identity, and trigger).

Closes PSY-953
