### PR TITLE
PSY-954: make festival co-lineup opt-in (not a default similar signal)

### DIFF
--- a/backend/internal/services/catalog/artist_relationship_service.go
+++ b/backend/internal/services/catalog/artist_relationship_service.go
@@ -381,8 +381,9 @@ func (s *ArtistRelationshipService) GetArtistGraph(artistID uint, types []string
 	var rels []catalogm.ArtistRelationship
 	// If types was non-empty AND every requested type was a query-time
 	// derived type, storedTypes will be empty here — skip the stored-rels
-	// query entirely. Otherwise (empty input = "all types", or any stored
-	// type requested) run the normal query.
+	// query entirely. Otherwise (empty input = "all STORED types", or any
+	// stored type requested) run the normal query. Empty input never pulls
+	// in query-time types (festival_cobill) — those are opt-in (PSY-954).
 	if len(types) == 0 || len(storedTypes) > 0 {
 		query := s.db.Model(&catalogm.ArtistRelationship{}).
 			Where("source_artist_id = ? OR target_artist_id = ?", artistID, artistID)
@@ -1143,15 +1144,20 @@ func filterOutQueryTimeTypes(types []string) []string {
 	return out
 }
 
-// isQueryTimeTypeRequested returns true when `target` is a query-time
-// edge type AND either (a) the filter is empty (=all types) or (b) the
-// filter explicitly contains `target`.
+// isQueryTimeTypeRequested returns true ONLY when `target` is a query-time
+// edge type AND the filter explicitly contains `target`.
+//
+// Query-time types are strictly OPT-IN (PSY-954). An empty filter means
+// "all STORED types only" — it must NOT auto-include query-time signals.
+// Two reasons: (1) performance — query-time types (festival_cobill) run an
+// expensive festival_artists JOIN on every request, so we never pay that cost
+// on a default load; (2) product — festival co-lineup is not a default
+// similarity signal (sharing one festival lineup says nothing about musical
+// similarity), so it must never seed the "Similar artists" sidebar or the
+// default graph view. Callers that want it pass it explicitly in `types`.
 func isQueryTimeTypeRequested(types []string, target string) bool {
 	if _, ok := queryTimeRelationshipTypes[target]; !ok {
 		return false
-	}
-	if len(types) == 0 {
-		return true
 	}
 	for _, t := range types {
 		if t == target {

--- a/backend/internal/services/catalog/artist_relationship_service_test.go
+++ b/backend/internal/services/catalog/artist_relationship_service_test.go
@@ -653,7 +653,11 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_F
 	}
 }
 
-func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_FestivalCobill_IncludedInAllTypes() {
+// TestGetArtistGraph_FestivalCobill_ExcludedFromDefault asserts the PSY-954
+// opt-in semantics: an empty types filter returns STORED types only and must
+// NOT auto-include the query-time festival_cobill signal. Requesting it
+// explicitly (alone or alongside stored types) still returns it.
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_FestivalCobill_ExcludedFromDefault() {
 	a1 := suite.createArtist("Center")
 	a2 := suite.createArtist("Festival peer")
 
@@ -669,13 +673,14 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_F
 	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
 	suite.Require().NoError(err)
 
-	// Empty types = include all (stored + query-time).
-	graph, err := suite.svc.GetArtistGraph(a1, nil, 0)
+	// Empty types = STORED types only (PSY-954). festival_cobill is opt-in
+	// and must be absent; the stored 'similar' edge must still be present.
+	defaultGraph, err := suite.svc.GetArtistGraph(a1, nil, 0)
 	suite.Require().NoError(err)
 
 	hasFestivalCobill := false
 	hasSimilar := false
-	for _, l := range graph.Links {
+	for _, l := range defaultGraph.Links {
 		if l.Type == "festival_cobill" {
 			hasFestivalCobill = true
 		}
@@ -683,8 +688,25 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_F
 			hasSimilar = true
 		}
 	}
-	suite.Assert().True(hasFestivalCobill, "festival_cobill edge should be present when types is empty")
-	suite.Assert().True(hasSimilar, "similar edge should be present when types is empty")
+	suite.Assert().False(hasFestivalCobill, "festival_cobill must be absent on a default (empty-types) graph — it is opt-in (PSY-954)")
+	suite.Assert().True(hasSimilar, "stored 'similar' edge must still be present on a default graph")
+
+	// Explicit opt-in: festival_cobill alongside the stored type returns both.
+	optInGraph, err := suite.svc.GetArtistGraph(a1, []string{"similar", "festival_cobill"}, 0)
+	suite.Require().NoError(err)
+
+	hasFestivalCobill = false
+	hasSimilar = false
+	for _, l := range optInGraph.Links {
+		if l.Type == "festival_cobill" {
+			hasFestivalCobill = true
+		}
+		if l.Type == "similar" {
+			hasSimilar = true
+		}
+	}
+	suite.Assert().True(hasFestivalCobill, "festival_cobill must be present when explicitly requested")
+	suite.Assert().True(hasSimilar, "stored 'similar' edge must be present alongside an explicit festival_cobill request")
 }
 
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_FestivalCobill_NoSharedFestivals() {
@@ -728,7 +750,9 @@ func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetArtistGraph_F
 	_, err = suite.svc.CreateRelationship(a1, a3, "similar", false)
 	suite.Require().NoError(err)
 
-	graph, err := suite.svc.GetArtistGraph(a1, nil, 0)
+	// festival_cobill is opt-in (PSY-954), so request it explicitly to get
+	// the cross-edge between the two related peers.
+	graph, err := suite.svc.GetArtistGraph(a1, []string{"similar", "festival_cobill"}, 0)
 	suite.Require().NoError(err)
 
 	// Find the festival_cobill cross edge between a2 and a3.

--- a/frontend/features/artists/components/RelatedArtists.test.tsx
+++ b/frontend/features/artists/components/RelatedArtists.test.tsx
@@ -185,6 +185,18 @@ describe('ArtistSimilarSidebar', () => {
     )
     expect(screen.queryByRole('button', { name: 'Suggest similar' })).not.toBeInTheDocument()
   })
+
+  // PSY-954: the sidebar fetches the backend default (no `types`), which now
+  // returns STORED types only — festival_cobill is excluded, so the sidebar
+  // can never surface a bogus "similar via 1 shared festival" entry.
+  it('fetches the default graph with no types filter (stored types only)', () => {
+    mockUseArtistGraph.mockClear()
+    renderWithProviders(
+      <ArtistSimilarSidebar artistId={1} artistSlug="gatecreeper" onOpenGraph={() => {}} />
+    )
+    const opts = mockUseArtistGraph.mock.calls[0]?.[0] as { types?: unknown } | undefined
+    expect(opts?.types).toBeUndefined()
+  })
 })
 
 describe('ArtistGraphDialog', () => {
@@ -236,5 +248,93 @@ describe('ArtistGraphDialog', () => {
       />
     )
     expect(screen.getByTestId('artist-graph')).toBeInTheDocument()
+  })
+})
+
+// PSY-954: festival co-lineup is opt-in. The default graph fetch must NOT
+// request festival_cobill; the festival toggle always renders and turning it
+// on lazy-fetches with festival_cobill in `types`.
+describe('ArtistGraphDialog — festival_cobill opt-in (PSY-954)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalResizeObserver = (window as any).ResizeObserver
+
+  beforeEach(() => {
+    mockUseArtistGraph.mockClear()
+    mockUseArtistGraph.mockReturnValue({ data: mockGraphData, isLoading: false, error: null })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).ResizeObserver = ImmediateResizeObserver
+  })
+
+  // Helper: pull the `types` arg out of the most recent useArtistGraph call
+  // that came from the RecenteringGraph fetch (the one with a positive id).
+  const lastFetchTypes = (): unknown => {
+    const calls = mockUseArtistGraph.mock.calls
+    const last = calls[calls.length - 1]?.[0] as { types?: unknown } | undefined
+    return last?.types
+  }
+
+  it('fetches the default graph (no festival_cobill in types) on open', () => {
+    renderWithProviders(
+      <ArtistGraphDialog
+        artistId={1}
+        artistSlug="gatecreeper"
+        artistName="Gatecreeper"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+    // Default: festival toggle OFF → fetch types is undefined (stored types only).
+    expect(lastFetchTypes()).toBeUndefined()
+  })
+
+  it('always renders the Festival co-lineup toggle even when absent from the payload', () => {
+    // mockGraphData has only `similar` + `shared_bills` links — no festival.
+    renderWithProviders(
+      <ArtistGraphDialog
+        artistId={1}
+        artistSlug="gatecreeper"
+        artistName="Gatecreeper"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+    expect(
+      screen.getByRole('button', { name: /Festival co-lineup/ })
+    ).toBeInTheDocument()
+  })
+
+  it('does not show the Festival co-lineup toggle as active by default', () => {
+    renderWithProviders(
+      <ArtistGraphDialog
+        artistId={1}
+        artistSlug="gatecreeper"
+        artistName="Gatecreeper"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+    // Inactive toggles render at opacity-40; active at opacity-100.
+    const toggle = screen.getByRole('button', { name: /Festival co-lineup/ })
+    expect(toggle.className).toContain('opacity-40')
+    expect(toggle.className).not.toContain('opacity-100')
+  })
+
+  it('lazy-fetches with festival_cobill in types when the toggle is turned on', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <ArtistGraphDialog
+        artistId={1}
+        artistSlug="gatecreeper"
+        artistName="Gatecreeper"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /Festival co-lineup/ }))
+    // After opt-in the fetch carries festival_cobill (alongside stored types so
+    // the backend keeps returning stored relationships).
+    const types = lastFetchTypes()
+    expect(Array.isArray(types)).toBe(true)
+    expect(types as string[]).toContain('festival_cobill')
   })
 })

--- a/frontend/features/artists/components/RelatedArtists.tsx
+++ b/frontend/features/artists/components/RelatedArtists.tsx
@@ -48,6 +48,26 @@ const RELATIONSHIP_BADGES: Record<string, { label: string; className: string }> 
 
 const ALL_TYPES = ['similar', 'shared_bills', 'shared_label', 'side_project', 'member_of', 'radio_cooccurrence', 'festival_cobill']
 
+// PSY-954: festival_cobill is a query-time signal the backend now treats as
+// strictly opt-in — an empty `types` filter returns STORED types only. Sharing
+// one festival lineup says nothing about musical similarity, so it must never
+// seed the default graph view (it floods the graph into an unreadable hairball).
+// It stays toggleable in the graph dialog, but starts OFF.
+const FESTIVAL_COBILL_TYPE = 'festival_cobill'
+
+// The STORED relationship types — everything except the query-time
+// festival_cobill signal. Two uses, hence two aliases below:
+//   - as DEFAULT_ACTIVE_TYPES: the toggles active on open (festival starts off)
+//   - as the fetch payload when opting into festival_cobill: we fetch these
+//     PLUS festival_cobill so the stored relationships keep loading alongside
+//     the festival edges (passing festival_cobill alone would make the backend
+//     skip the stored-rels query entirely).
+const STORED_TYPES = ALL_TYPES.filter(t => t !== FESTIVAL_COBILL_TYPE)
+
+// Toggles active by default = the stored types only. festival_cobill is opt-in
+// (toggle starts off; turning it on lazy-fetches the festival edges).
+const DEFAULT_ACTIVE_TYPES = STORED_TYPES
+
 // PSY-361: URL query param that encodes the currently re-centered artist's
 // slug. Absent means the route's original artist is the center. Stored as a
 // slug (not an ID) so links are human-readable and shareable.
@@ -192,7 +212,9 @@ export function ArtistGraphDialog({
   // Filter + traversal state lives per-viewing-session in the Dialog.
   // Trail / slug→id cache are reset each time the parent unmounts the
   // Dialog (Radix lazy-mounts DialogContent under `open`).
-  const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set(ALL_TYPES))
+  // PSY-954: default-active set excludes festival_cobill (opt-in). Turning the
+  // festival toggle on lazy-fetches the festival edges (see RecenteringGraph).
+  const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set(DEFAULT_ACTIVE_TYPES))
   const [trail, setTrail] = useState<TraversalEntry[]>([])
   const [slugToIdCache, setSlugToIdCache] = useState<Record<string, number>>({})
   const [announcement, setAnnouncement] = useState('')
@@ -340,6 +362,26 @@ function RecenteringGraph({
     ? originalArtistId
     : (cachedId ?? resolvedArtist?.id ?? 0)
 
+  // PSY-954: festival_cobill is a LAZY opt-in fetch. The backend returns it
+  // only when explicitly requested in `types`; an empty filter = stored types
+  // only. So the fetch `types` depends solely on whether the festival toggle
+  // is on:
+  //   - off → fetch default (no `types`) = all stored types. The non-festival
+  //     toggles stay purely client-side display filters over this payload
+  //     (ArtistGraphVisualization filters links by activeTypes), so toggling
+  //     them never refetches.
+  //   - on  → fetch STORED_TYPES + festival_cobill, so the stored relationships
+  //     keep loading alongside the festival edges (festival_cobill alone would
+  //     make the backend skip the stored-rels query entirely).
+  // useArtistGraph keys its query on `types`, so flipping the festival toggle
+  // changes the queryKey → triggers the refetch with no setState-in-effect
+  // (React 19.2 react-hooks/set-state-in-effect, PSY-919).
+  const wantFestival = activeTypes.has(FESTIVAL_COBILL_TYPE)
+  const fetchTypes = useMemo(
+    () => (wantFestival ? [...STORED_TYPES, FESTIVAL_COBILL_TYPE] : undefined),
+    [wantFestival]
+  )
+
   // Fetch the graph for the current center. Same hook, just dynamic ID.
   // The 5-min staleTime in the hook + TanStack Query's keyed cache means
   // we don't refetch when the user clicks back to a previously-visited
@@ -347,6 +389,7 @@ function RecenteringGraph({
   // instant.
   const { data: graph, isFetching: fetchingGraph } = useArtistGraph({
     artistId: centerId,
+    types: fetchTypes,
     enabled: centerId > 0,
   })
 
@@ -546,8 +589,12 @@ function RecenteringGraph({
         {ALL_TYPES.map(type => {
           const badge = RELATIONSHIP_BADGES[type]
           const isActive = activeTypes.has(type)
-          // Only show toggle if this type exists in the current graph.
-          if (!linkTypesPresent.has(type)) return null
+          // PSY-954: festival_cobill always renders — it's the opt-in entry
+          // point and won't be present in the default (stored-only) payload, so
+          // present-gating it would hide the only way to turn it on. The other
+          // (stored) toggles stay present-gated: only show a toggle for a type
+          // that actually appears in the current graph.
+          if (type !== FESTIVAL_COBILL_TYPE && !linkTypesPresent.has(type)) return null
           return (
             <button
               key={type}


### PR DESCRIPTION
Closes PSY-954.

## Summary
- `festival_cobill` is now strictly opt-in: excluded from the default `/artists/{id}/graph` response (skips the expensive festival_artists JOIN on every load), so the "Similar artists" sidebar shows only truly-similar types and the graph defaults to a readable view. Festivals remain explorable via the graph's "Festival co-lineup" toggle (lazy-loaded on opt-in). Sharing one festival lineup says nothing about musical similarity — it should never seed similarity, and it floods the graph into an unreadable ~30-node / ~465-edge hairball.

## Backend
- `isQueryTimeTypeRequested` (`internal/services/catalog/artist_relationship_service.go`): dropped the `if len(types) == 0 { return true }` branch. Query-time types (festival_cobill is the only one today) are now returned **only when explicitly named** in `types`. An empty filter = STORED types only, never the query-time festival computation.
- Why empty types still returns stored relationships: `GetArtistGraph` gates the stored-rels query on `len(types) == 0 || len(storedTypes) > 0` (unchanged), so an empty filter still runs the normal stored query — it just no longer sets `wantFestivalCobill`, so the festival_artists JOIN (`computeFestivalCobillCenterEdges` / `computeFestivalCobillCrossEdges`) is skipped on the default load.
- Verified the only caller of `isQueryTimeTypeRequested` is `GetArtistGraph`. The collection graph uses a separate allowlist (`allowedCollectionEdgeTypes`) that already excludes festival_cobill, and `InlineGraph` (explore show-bill teaser) calls the same default endpoint, so it also benefits (no festival hairball) with no code change.
- Comment added explaining the opt-in special-case (perf + product).

## Frontend (`features/artists/components/RelatedArtists.tsx`)
- **Default-active set excludes festival_cobill**: `DEFAULT_ACTIVE_TYPES = STORED_TYPES` (all types except festival_cobill); `activeTypes` initializes from it. festival_cobill stays in `ALL_TYPES` so it remains a toggle.
- **Festival toggle = lazy opt-in**: `RecenteringGraph` derives `fetchTypes` via `useMemo(() => wantFestival ? [...STORED_TYPES, 'festival_cobill'] : undefined, [wantFestival])` and passes it to `useArtistGraph`. Off → default fetch (stored types only); on → fetch stored types + festival_cobill (so stored relationships keep loading alongside the festival edges — passing festival_cobill alone would make the backend skip the stored-rels query). Toggling festival changes the queryKey → triggers the refetch; no setState-in-effect (respects React 19.2 `react-hooks/set-state-in-effect`, PSY-919). The non-festival toggles stay purely client-side display filters over the fetched stored payload — only festival_cobill changes what's fetched.
- **Always-show festival toggle**: the toggle list stays present-gated by `linkTypesPresent` for stored types, but festival_cobill always renders (it's the opt-in entry point and won't appear in the default payload, so present-gating would hide it).
- **Sidebar auto-clean**: `ArtistSimilarSidebar` calls `useArtistGraph` with no `types` → now returns stored types only → no bogus festival "similar" entries. No sidebar code change needed.

## Verification

Backend curl (artist 373 = Chloe Tang, festival-only — mirrors the Bright Eyes repro):

| | default (no types) | opt-in (?types=festival_cobill) |
| --- | --- | --- |
| artist 373 graph | 0 nodes, 0 links, types `[]` (no festival_cobill) | 30 nodes, 465 links, types `['festival_cobill']` |
| artist 16 (Baller, 5 stored shared_bills) | 5 nodes, 15 links, types `['shared_bills']` | 5 nodes, 15 links, `['shared_bills']` (no festivals to add) |

Artist 16 confirms artists with legitimate STORED relationships still render them on the default load — the flip only removes the query-time festival signal.

- Sidebar (chloe-tang): STATISTICS shows "Similar artists: 0", "Festival appearances: 1" — no festival flood. [screenshot]
- Graph default: single center node, festival toggle present but inactive (opacity-40) — sparse/readable. [screenshot]
- Toggle ON: festival cluster (~30 nodes) lazy-loads, "Festival co-lineup" appears in the legend. [screenshot]
- Toggle OFF: returns to the sparse single-node view, festival legend row removed. [screenshot]

## Adversarial review
`/adversarial-review` (inline lenses) — **pass, no blocking findings**. Lenses: Saboteur · Future-Maintainer · Security · Completeness.
- Saboteur: stored-relationship artists unaffected (verified live, artist 16); toggle refetch doesn't race or drop the other toggles' state (`fetchTypes` keys only on `wantFestival`, `activeTypes` preserved); toggle ON→OFF round-trip verified (cluster loads then clears); empty-state correct.
- Future-Maintainer: `isQueryTimeTypeRequested` doc + FE comments explain why festival_cobill is opt-in. Noted limitation: the FE `STORED_TYPES` filter excludes festival_cobill by name (single query-time type today); a future second query-time type would need a parallel FE update — flagged, not over-engineered into a shared registry (out of scope).
- Security: n/a (no auth/validation/exposure surface touched; `types` already parameterized server-side).
- Completeness: backend flip + sidebar + graph default + lazy toggle + always-show toggle + both-direction tests all done.

## Test plan
- [x] `go build ./...` + `go test -count=1 ./internal/services/catalog/...` — pass (incl. new `TestGetArtistGraph_FestivalCobill_ExcludedFromDefault` asserting empty-types excludes + explicit-types includes, and `CrossEdges` updated to request festival_cobill explicitly)
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/artists` — 271/271 (RelatedArtists.test.tsx 17 tests, +5 new PSY-954 cases)
- [x] Backend curl: default excludes festival_cobill (0 nodes), `?types=festival_cobill` includes it (30 nodes); stored-rel artist 16 still returns stored edges on default
- [x] Browser: sidebar truly-similar-only, graph default sparse, toggle opt-in lazy-loads + toggle-off clears

OpenAPI spec unchanged — only default behavior changed; no route/request/response shape change.

## Screenshots
- Sidebar (chloe-tang): https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-83e263be522887cc22e2/psy-954-sidebar-chloe-tang.png
- Graph default (sparse): https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-83e263be522887cc22e2/psy-954-graph-default.png
- Graph festival toggle ON (lazy-loaded cluster): https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-83e263be522887cc22e2/psy-954-graph-festival-on.png
- Graph festival toggle OFF (back to sparse): https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-83e263be522887cc22e2/psy-954-graph-off.png

## Out of scope
Label/node overlap on genuinely-dense graphs (an artist with many real similar artists) is a separate ForceGraphView rendering concern — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
