### PR TITLE
PSY-955: add frontend ESLint CI gate (bun run lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,28 @@ jobs:
           working-directory: ./frontend
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # PSY-955: frontend ESLint gate. Runs the bare `bun run lint` (= `eslint`),
+  # which exits non-zero on ERRORS only — it does NOT fail on warnings. There
+  # are ~154 pre-existing warnings that are intentionally NOT gated here; do
+  # NOT add `--max-warnings` or it will immediately re-break CI on those.
+  # PSY-953 (#964) cleared lint errors to 0, so this gate starts green.
+  # Branch-protection / required-check config is handled outside this workflow.
+  frontend-lint:
+    name: Frontend Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: bun install --frozen-lockfile
+
+      - name: Lint (eslint)
+        working-directory: ./frontend
+        run: bun run lint
+
   e2e-smoke:
     name: E2E Smoke (PR)
     # PSY-446: fast PR feedback. Runs only `@smoke`-tagged Playwright tests
@@ -384,7 +406,7 @@ jobs:
     name: Notify on main CI failure
     # `always()` so this runs even when upstream `needs:` failed — the
     # whole point. Scoped to main-branch push events (not PRs).
-    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.migration-lint.result == 'failure' || needs.migration-reversibility.result == 'failure' || needs.backend-tests.result == 'failure' || needs.backend-lint.result == 'failure' || needs.mocks-gen-check.result == 'failure' || needs.frontend-unit-tests.result == 'failure' || needs.e2e-tests.result == 'failure' || needs.e2e-report.result == 'failure') }}
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.migration-lint.result == 'failure' || needs.migration-reversibility.result == 'failure' || needs.backend-tests.result == 'failure' || needs.backend-lint.result == 'failure' || needs.mocks-gen-check.result == 'failure' || needs.frontend-unit-tests.result == 'failure' || needs.frontend-lint.result == 'failure' || needs.e2e-tests.result == 'failure' || needs.e2e-report.result == 'failure') }}
     needs:
       - migration-lint
       - migration-reversibility
@@ -392,6 +414,7 @@ jobs:
       - backend-lint
       - mocks-gen-check
       - frontend-unit-tests
+      - frontend-lint
       - e2e-tests
       - e2e-report
     runs-on: ubuntu-latest
@@ -407,6 +430,7 @@ jobs:
           RES_BACKEND_LINT: ${{ needs.backend-lint.result }}
           RES_MOCKS_GEN_CHECK: ${{ needs.mocks-gen-check.result }}
           RES_FRONTEND_UNIT: ${{ needs.frontend-unit-tests.result }}
+          RES_FRONTEND_LINT: ${{ needs.frontend-lint.result }}
           RES_E2E_TESTS: ${{ needs.e2e-tests.result }}
           RES_E2E_REPORT: ${{ needs.e2e-report.result }}
         with:
@@ -436,6 +460,7 @@ jobs:
               'Backend Lint': process.env.RES_BACKEND_LINT,
               'Mocks Generator Drift': process.env.RES_MOCKS_GEN_CHECK,
               'Frontend Unit Tests': process.env.RES_FRONTEND_UNIT,
+              'Frontend Lint': process.env.RES_FRONTEND_LINT,
               'E2E Tests (sharded)': process.env.RES_E2E_TESTS,
               'E2E Merged Report': process.env.RES_E2E_REPORT,
             }


### PR DESCRIPTION
## Summary
- Add a `frontend-lint` CI job running `bun run lint` (eslint) on PRs + main, mirroring the existing `backend-lint` job.
- Wire it into the `notify-on-main-failure` aggregator (needs / if / RES_ env / result-name map).
- Bare `bun run lint` — fails on errors only; the ~154 pre-existing warnings are intentionally NOT gated (no `--max-warnings`).

## Test plan
- [x] `cd frontend && bun run lint` — exits 0 (the exact command the gate runs; 0 errors, 154 warnings)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — ci.yml parses
- [x] diff is `.github/workflows/ci.yml` only

## Manual repro
CI-config change — GitHub Actions can't run locally. Local verification: `bun run lint` exits 0, ci.yml YAML parses, diff is wiring-only. The real validation is the new **Frontend Lint** check appearing + passing on this PR's own CI run (orchestrator confirms post-push).

## Out of scope
- Marking "Frontend Lint" a *required* status check is a repo branch-protection setting (configured outside the workflow file). Follow-on manual step.

## Code review
`/code-review` (xhigh, inline 9-angle + sweep) — clean, no findings. Diff is a consistent application of the existing parallel-job + 4-spot aggregator-wiring pattern.

## Adversarial review
`/adversarial-review` — CLEAN, no findings. Panel run inline (no Agent tool in a worktree): Saboteur · Future-Maintainer · Security · Completeness. Saboteur confirmed (1) the job fails the build on a lint error (`bun run lint` = bare eslint → non-zero exit on errors; bun propagates it; Actions fails the step), (2) the aggregator wiring is complete (all 4 spots → a main-branch frontend-lint failure files an issue), (3) no `--max-warnings` snuck in (the only occurrence is the cautionary comment).

Closes PSY-955
