### PR TITLE
PSY-905: Collections browse filter refine (PSY-895 Option 1)

### DIFF
--- a/frontend/features/collections/components/CollectionAnchorNav.tsx
+++ b/frontend/features/collections/components/CollectionAnchorNav.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+/**
+ * CollectionAnchorNav — sticky jump nav for the collection detail page
+ * (PSY-892 D1, implemented in PSY-898).
+ *
+ * Collections are uniquely long-form curation surfaces — items + tags +
+ * discussion stack vertically and can exceed 3+ viewport heights. The nav
+ * pins below the site TopBar and tracks the section currently in view via
+ * IntersectionObserver. No other entity detail page carries this chrome;
+ * collections earn it (see the PSY-892 decisions comment).
+ *
+ * Section order matches D6: Items → Tags → Discussion. Styling follows the
+ * DS TabTrigger underline-active pattern (border-b accent, muted inactive).
+ *
+ * Not exported from the feature barrel on purpose — only
+ * `CollectionDetail.tsx` consumes it (see PSY-951 de-barrel note in
+ * components/index.ts).
+ */
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Total height (px) of the sticky chrome that sits above anchored content:
+ * the site TopBar (`--topbar-height` = 3.5rem = 56px) + this nav (h-10 =
+ * 40px + 1px border) + breathing room. Single source of truth for both the
+ * IntersectionObserver's top offset and the section scroll-margins below —
+ * change them together.
+ */
+const STICKY_CHROME_OFFSET_PX = 104
+
+/**
+ * Tailwind class for sections the nav jumps to. Pairs `id="<section>"` with a
+ * scroll margin that keeps the jumped-to heading clear of the sticky chrome.
+ * Kept as a full literal (not interpolated) so Tailwind's scanner picks it up;
+ * the value mirrors {@link STICKY_CHROME_OFFSET_PX}.
+ */
+export const ANCHOR_SECTION_SCROLL_MT = 'scroll-mt-[104px]'
+
+export interface AnchorSection {
+  /** DOM id of the section element this nav entry jumps to. */
+  id: string
+  label: string
+}
+
+export function CollectionAnchorNav({
+  sections,
+}: {
+  /**
+   * Stable array of sections (define it as a module-level constant in the
+   * parent) — the IntersectionObserver effect keys on this reference.
+   */
+  sections: AnchorSection[]
+}) {
+  const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? '')
+
+  useEffect(() => {
+    // Track which section currently occupies the reading band. The top
+    // rootMargin offsets the sticky chrome (TopBar + this nav); the -60%
+    // bottom margin keeps the band in the upper part of the viewport so the
+    // section the reader is actually looking at wins when two intersect.
+    const observer = new IntersectionObserver(
+      entries => {
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id)
+        }
+      },
+      { rootMargin: `-${STICKY_CHROME_OFFSET_PX}px 0px -60% 0px` }
+    )
+
+    // The Items section lives inside a dynamic()-imported chunk
+    // (CollectionItemsList) that may not have rendered yet when this effect
+    // runs on a client-side navigation. Retry until every section element
+    // exists before observing, so all three nav entries track correctly.
+    let cancelled = false
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+    let attempts = 0
+    const MAX_ATTEMPTS = 50 // ~5s at 100ms — sections always render well before this
+
+    const tryObserve = () => {
+      if (cancelled) return
+      const els = sections.map(s => document.getElementById(s.id))
+      if (els.every((el): el is HTMLElement => el !== null)) {
+        for (const el of els) observer.observe(el)
+      } else if (attempts < MAX_ATTEMPTS) {
+        attempts += 1
+        retryTimer = setTimeout(tryObserve, 100)
+      }
+    }
+    tryObserve()
+
+    return () => {
+      cancelled = true
+      if (retryTimer) clearTimeout(retryTimer)
+      observer.disconnect()
+    }
+  }, [sections])
+
+  const handleClick = (id: string) => {
+    setActiveId(id)
+    // Optional-call guard: jsdom doesn't implement scrollIntoView.
+    document.getElementById(id)?.scrollIntoView?.({
+      behavior: 'smooth',
+      block: 'start',
+    })
+  }
+
+  return (
+    <nav
+      className="sticky top-[var(--topbar-height)] z-40 -mx-4 mb-6 border-b border-border/50 bg-background/95 px-4 backdrop-blur-sm supports-[backdrop-filter]:bg-background/60"
+      aria-label="Page sections"
+      data-testid="collection-anchor-nav"
+    >
+      <div className="flex items-center gap-1">
+        {sections.map(section => (
+          <button
+            key={section.id}
+            type="button"
+            onClick={() => handleClick(section.id)}
+            aria-current={activeId === section.id ? 'true' : undefined}
+            data-testid={`anchor-nav-${section.id}`}
+            className={cn(
+              'inline-flex h-10 items-center border-b-2 px-3 text-sm font-medium transition-colors',
+              activeId === section.id
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {section.label}
+          </button>
+        ))}
+      </div>
+    </nav>
+  )
+}

--- a/frontend/features/collections/components/CollectionAnchorNav.tsx
+++ b/frontend/features/collections/components/CollectionAnchorNav.tsx
@@ -18,7 +18,7 @@
  * components/index.ts).
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 
 /**
@@ -72,6 +72,14 @@ export function CollectionAnchorNav({
   sections: AnchorSection[]
 }) {
   const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? '')
+  // Set on click; suppresses observer updates while the smooth scroll the
+  // click triggered is still settling. Without it, sections passing through
+  // the reading band mid-scroll (or a short page where the target section
+  // can never reach the band) immediately override the clicked state —
+  // caught in live verification: clicking "Discussion" highlighted "Items".
+  // Timer-based (not a clock comparison) so no impure clock reads are needed.
+  const clickLockRef = useRef(false)
+  const clickLockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     // Track which section currently occupies the reading band. The top
@@ -80,6 +88,7 @@ export function CollectionAnchorNav({
     // section the reader is actually looking at wins when two intersect.
     const observer = new IntersectionObserver(
       entries => {
+        if (clickLockRef.current) return
         const visible = entries
           .filter(e => e.isIntersecting)
           .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
@@ -114,12 +123,21 @@ export function CollectionAnchorNav({
     return () => {
       cancelled = true
       if (retryTimer) clearTimeout(retryTimer)
+      if (clickLockTimerRef.current) clearTimeout(clickLockTimerRef.current)
       observer.disconnect()
     }
   }, [sections])
 
   const handleClick = (id: string) => {
     setActiveId(id)
+    // Hold the clicked state while the smooth scroll settles (~1s covers the
+    // longest scroll on this page); after that the observer resumes tracking
+    // what the user actually scrolls to.
+    clickLockRef.current = true
+    if (clickLockTimerRef.current) clearTimeout(clickLockTimerRef.current)
+    clickLockTimerRef.current = setTimeout(() => {
+      clickLockRef.current = false
+    }, 1000)
     // Optional-call guard: jsdom doesn't implement scrollIntoView.
     document.getElementById(id)?.scrollIntoView?.({
       behavior: 'smooth',

--- a/frontend/features/collections/components/CollectionAnchorNav.tsx
+++ b/frontend/features/collections/components/CollectionAnchorNav.tsx
@@ -22,21 +22,39 @@ import { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
 
 /**
- * Total height (px) of the sticky chrome that sits above anchored content:
- * the site TopBar (`--topbar-height` = 3.5rem = 56px) + this nav (h-10 =
- * 40px + 1px border) + breathing room. Single source of truth for both the
- * IntersectionObserver's top offset and the section scroll-margins below —
- * change them together.
+ * Height (px) this nav adds below the TopBar: h-10 (40px) + 1px border +
+ * breathing room. The TopBar's own height is read from the `--topbar-height`
+ * CSS var at runtime (see the observer setup), so the only hand-maintained
+ * number is this nav-local one. Mirrors the `3rem` addend in
+ * {@link ANCHOR_SECTION_SCROLL_MT} — change them together.
  */
-const STICKY_CHROME_OFFSET_PX = 104
+const NAV_CHROME_PX = 48
 
 /**
  * Tailwind class for sections the nav jumps to. Pairs `id="<section>"` with a
  * scroll margin that keeps the jumped-to heading clear of the sticky chrome.
- * Kept as a full literal (not interpolated) so Tailwind's scanner picks it up;
- * the value mirrors {@link STICKY_CHROME_OFFSET_PX}.
+ * The calc() tracks `--topbar-height` automatically; the `3rem` addend
+ * mirrors {@link NAV_CHROME_PX}. Kept as a full literal (not interpolated) so
+ * Tailwind's scanner picks it up.
  */
-export const ANCHOR_SECTION_SCROLL_MT = 'scroll-mt-[104px]'
+export const ANCHOR_SECTION_SCROLL_MT =
+  'scroll-mt-[calc(var(--topbar-height)+3rem)]'
+
+/**
+ * Resolve the total sticky-chrome height (TopBar + this nav) in px from the
+ * live `--topbar-height` var, so the IntersectionObserver's reading band
+ * tracks TopBar changes without manual sync. Falls back to the current
+ * documented values (3.5rem topbar / 16px rem) outside a browser (jsdom).
+ */
+function resolveStickyChromeOffsetPx(): number {
+  const rootStyle = getComputedStyle(document.documentElement)
+  const topbarRaw = rootStyle.getPropertyValue('--topbar-height').trim()
+  const remPx = parseFloat(rootStyle.fontSize) || 16
+  const topbarPx = topbarRaw.endsWith('rem')
+    ? parseFloat(topbarRaw) * remPx
+    : parseFloat(topbarRaw) || 3.5 * remPx
+  return Math.round(topbarPx) + NAV_CHROME_PX
+}
 
 export interface AnchorSection {
   /** DOM id of the section element this nav entry jumps to. */
@@ -69,7 +87,7 @@ export function CollectionAnchorNav({
           setActiveId(visible[0].target.id)
         }
       },
-      { rootMargin: `-${STICKY_CHROME_OFFSET_PX}px 0px -60% 0px` }
+      { rootMargin: `-${resolveStickyChromeOffsetPx()}px 0px -60% 0px` }
     )
 
     // The Items section lives inside a dynamic()-imported chunk

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CollectionDetail } from './CollectionDetail'
 import type {
@@ -699,15 +699,17 @@ describe('CollectionDetail', () => {
       expect(screen.getByTestId('forks-count').textContent).toContain('5 forks')
     })
 
-    it('hides Fork button on the user\'s own collection', () => {
+    it('hides Fork on the user\'s own collection (not in overflow either)', async () => {
       // current user (id=1) is the creator (creator_id=1) by default.
+      // PSY-892 D4: Fork lives in the ⋯ overflow — open it to assert absence.
+      const user = userEvent.setup()
       render(<CollectionDetail slug="test-collection" />)
-      expect(
-        screen.queryByRole('button', { name: 'Fork collection' })
-      ).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.queryByTestId('overflow-fork')).not.toBeInTheDocument()
     })
 
-    it('hides Fork button on private collections', () => {
+    it('hides Fork on private collections (not in overflow either)', async () => {
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: { id: '999' },
         isAuthenticated: true,
@@ -720,12 +722,12 @@ describe('CollectionDetail', () => {
         error: null,
       })
       render(<CollectionDetail slug="test-collection" />)
-      expect(
-        screen.queryByRole('button', { name: 'Fork collection' })
-      ).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.queryByTestId('overflow-fork')).not.toBeInTheDocument()
     })
 
-    it('hides Fork button when not authenticated', () => {
+    it('hides Fork when not authenticated (not in overflow either)', async () => {
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: null,
         isAuthenticated: false,
@@ -738,12 +740,13 @@ describe('CollectionDetail', () => {
         error: null,
       })
       render(<CollectionDetail slug="test-collection" />)
-      expect(
-        screen.queryByRole('button', { name: 'Fork collection' })
-      ).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.queryByTestId('overflow-fork')).not.toBeInTheDocument()
     })
 
-    it('shows Fork button to authenticated non-owners on public collections', () => {
+    it('shows Fork in the ⋯ overflow menu for authenticated non-owners on public collections', async () => {
+      // PSY-892 D4: Fork moved from the primary action row into the overflow.
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: { id: '999' },
         isAuthenticated: true,
@@ -756,9 +759,9 @@ describe('CollectionDetail', () => {
         error: null,
       })
       render(<CollectionDetail slug="test-collection" />)
-      expect(
-        screen.getByRole('button', { name: 'Fork collection' })
-      ).toBeInTheDocument()
+      expect(screen.queryByTestId('overflow-fork')).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.getByTestId('overflow-fork')).toBeInTheDocument()
     })
 
     it('navigates to the new collection slug after a successful clone', async () => {
@@ -790,9 +793,9 @@ describe('CollectionDetail', () => {
       )
 
       render(<CollectionDetail slug="test-collection" />)
-      await user.click(
-        screen.getByRole('button', { name: 'Fork collection' })
-      )
+      // PSY-892 D4: Fork lives in the ⋯ overflow menu.
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      await user.click(screen.getByTestId('overflow-fork'))
 
       expect(mockCloneMutate).toHaveBeenCalledWith(
         { slug: 'test-collection' },
@@ -836,7 +839,11 @@ describe('CollectionDetail', () => {
       expect(btn).toHaveAttribute('aria-label', 'Unlike collection')
     })
 
-    it('renders read-only count for anonymous viewers', () => {
+    it('renders a Like button that prompts sign-in for anonymous viewers (PSY-892 D4)', async () => {
+      // Pre-D4 anonymous viewers saw a read-only count; the redesign makes
+      // Like a primary action in every viewer state — anonymous clicks route
+      // to sign-in (matches FollowButton's unauth pattern).
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: null,
         isAuthenticated: false,
@@ -850,8 +857,20 @@ describe('CollectionDetail', () => {
       })
       render(<CollectionDetail slug="test-collection" />)
 
-      expect(screen.getByTestId('collection-like-count')).toHaveTextContent('9')
-      expect(screen.queryByTestId('collection-like-button')).not.toBeInTheDocument()
+      const btn = screen.getByTestId('collection-like-button')
+      expect(btn).toHaveTextContent('9')
+      expect(btn).toHaveAttribute('aria-label', 'Sign in to like collection')
+      // Not pressed/pressable state for anonymous viewers.
+      expect(btn).not.toHaveAttribute('aria-pressed')
+
+      await user.click(btn)
+      // Same returnTo redirect as FollowButton / AttendanceButton so the
+      // viewer lands back on this collection after signing in.
+      expect(mockPush).toHaveBeenCalledWith(
+        '/auth?returnTo=%2Fcollections%2Ftest-collection'
+      )
+      expect(mockLikeMutate).not.toHaveBeenCalled()
+      expect(mockUnlikeMutate).not.toHaveBeenCalled()
     })
 
     it('calls likeCollection when an unliked heart is clicked', async () => {
@@ -888,7 +907,10 @@ describe('CollectionDetail', () => {
   // ──────────────────────────────────────────────
 
   describe('PSY-578 report button visibility', () => {
-    it('renders Report for an authenticated non-creator non-admin', () => {
+    // PSY-892 D4: Report lives in the ⋯ overflow menu — every test opens the
+    // overflow first so presence/absence is asserted against the real menu.
+    it('renders Report in the overflow for an authenticated non-creator non-admin', async () => {
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: { id: '999', is_admin: false },
         isAuthenticated: true,
@@ -902,13 +924,13 @@ describe('CollectionDetail', () => {
       })
       render(<CollectionDetail slug="test-collection" />)
 
-      expect(
-        screen.getByTestId('collection-report-button')
-      ).toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.getByTestId('overflow-report')).toBeInTheDocument()
     })
 
-    it('hides Report for the collection creator', () => {
+    it('hides Report for the collection creator', async () => {
       // Creator uses Edit / Delete instead of Report.
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: { id: '1', is_admin: false },
         isAuthenticated: true,
@@ -922,12 +944,12 @@ describe('CollectionDetail', () => {
       })
       render(<CollectionDetail slug="test-collection" />)
 
-      expect(
-        screen.queryByTestId('collection-report-button')
-      ).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.queryByTestId('overflow-report')).not.toBeInTheDocument()
     })
 
-    it('hides Report for admins (they use the moderation queue)', () => {
+    it('hides Report for admins (they use the moderation queue)', async () => {
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: { id: '999', is_admin: true },
         isAuthenticated: true,
@@ -941,12 +963,12 @@ describe('CollectionDetail', () => {
       })
       render(<CollectionDetail slug="test-collection" />)
 
-      expect(
-        screen.queryByTestId('collection-report-button')
-      ).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.queryByTestId('overflow-report')).not.toBeInTheDocument()
     })
 
-    it('hides Report for unauthenticated viewers', () => {
+    it('hides Report for unauthenticated viewers', async () => {
+      const user = userEvent.setup()
       mockAuthContext.mockReturnValue({
         user: null,
         isAuthenticated: false,
@@ -960,9 +982,8 @@ describe('CollectionDetail', () => {
       })
       render(<CollectionDetail slug="test-collection" />)
 
-      expect(
-        screen.queryByTestId('collection-report-button')
-      ).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('collection-overflow-trigger'))
+      expect(screen.queryByTestId('overflow-report')).not.toBeInTheDocument()
     })
   })
 
@@ -1045,10 +1066,13 @@ describe('CollectionDetail', () => {
       })
       render(<CollectionDetail slug="test-collection" />)
 
-      // Numbered positions visible
-      expect(screen.getByText('1')).toBeInTheDocument()
-      expect(screen.getByText('2')).toBeInTheDocument()
-      expect(screen.getByText('3')).toBeInTheDocument()
+      // Numbered positions visible. Scope to the items container — the items
+      // header now also renders the item count ("3"), which would make a
+      // page-wide getByText('3') ambiguous (PSY-892 D7).
+      const itemsContainer = within(screen.getByTestId('collection-items'))
+      expect(itemsContainer.getByText('1')).toBeInTheDocument()
+      expect(itemsContainer.getByText('2')).toBeInTheDocument()
+      expect(itemsContainer.getByText('3')).toBeInTheDocument()
       // Drag handles visible (one per item) — only when ranked + creator
       expect(screen.getAllByTestId('drag-handle')).toHaveLength(3)
     })
@@ -1780,17 +1804,17 @@ describe('CollectionDetail', () => {
       render(<CollectionDetail slug="test-collection" />)
 
       const container = screen.getByTestId('collection-items')
-      // Default density is comfortable (ph-density default).
-      expect(container.className).toContain('grid-cols-2')
-      expect(container.className).toContain('sm:grid-cols-3')
+      // Default density is Compact (PSY-892 D3 — collections default dense).
+      expect(container.className).toContain('grid-cols-3')
+      expect(container.className).toContain('sm:grid-cols-4')
 
-      // Compact density → tighter grid.
-      await user.click(screen.getByText('compact'))
-      const compactContainer = screen.getByTestId('collection-items')
-      expect(compactContainer.className).toContain('grid-cols-3')
-      expect(compactContainer.className).toContain('sm:grid-cols-4')
+      // Comfortable density → wider tiles, fewer columns.
+      await user.click(screen.getByText('comfortable'))
+      const comfortableContainer = screen.getByTestId('collection-items')
+      expect(comfortableContainer.className).toContain('grid-cols-2')
+      expect(comfortableContainer.className).toContain('sm:grid-cols-3')
 
-      // Expanded density → wider tiles, fewer columns.
+      // Expanded density → widest tiles, fewest columns.
       await user.click(screen.getByText('expanded'))
       const expandedContainer = screen.getByTestId('collection-items')
       expect(expandedContainer.className).toContain('grid-cols-1')
@@ -2135,6 +2159,417 @@ describe('CollectionDetail', () => {
       expect(screen.getByTestId('reorder-error')).toHaveTextContent(
         'Failed to save order'
       )
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // PSY-898: detail page redesign (PSY-892 D1–D7 + PSY-894 edit form)
+  // ──────────────────────────────────────────────
+
+  describe('PSY-898 detail page redesign', () => {
+    const sampleItems: CollectionItem[] = [
+      {
+        id: 41,
+        entity_type: 'artist',
+        entity_id: 401,
+        entity_name: 'Redesign Artist',
+        entity_slug: 'redesign-artist',
+        image_url: null,
+        position: 0,
+        added_by_user_id: 1,
+        added_by_name: 'testuser',
+        notes: null,
+        created_at: '2025-01-01T00:00:00Z',
+      },
+      {
+        id: 42,
+        entity_type: 'venue',
+        entity_id: 402,
+        entity_name: 'Redesign Venue',
+        entity_slug: 'redesign-venue',
+        image_url: null,
+        position: 1,
+        added_by_user_id: 1,
+        added_by_name: 'testuser',
+        notes: null,
+        created_at: '2025-01-01T00:00:00Z',
+      },
+    ]
+
+    describe('D4: header action consolidation + ⋯ overflow menu', () => {
+      it('owner: Like + Edit + Delete primary; Share + Explore graph in overflow; no Fork/Report/Subscribe', async () => {
+        const user = userEvent.setup()
+        mockCollection.mockReturnValue({
+          data: makeCollection({ items: sampleItems }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        // Primary row: Like + Edit + Delete (the curator's daily actions).
+        expect(
+          screen.getByTestId('collection-like-button')
+        ).toBeInTheDocument()
+        expect(
+          screen.getByRole('button', { name: 'Edit' })
+        ).toBeInTheDocument()
+        expect(
+          screen.getByRole('button', { name: 'Delete collection' })
+        ).toBeInTheDocument()
+        // Subscribe never shows for the owner.
+        expect(
+          screen.queryByRole('button', { name: /Subscribe/i })
+        ).not.toBeInTheDocument()
+
+        // Overflow: Share + Explore graph; Fork/Report are non-owner actions.
+        await user.click(screen.getByTestId('collection-overflow-trigger'))
+        expect(screen.getByTestId('overflow-share')).toBeInTheDocument()
+        expect(
+          screen.getByTestId('overflow-explore-graph')
+        ).toBeInTheDocument()
+        expect(screen.queryByTestId('overflow-fork')).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId('overflow-report')
+        ).not.toBeInTheDocument()
+      })
+
+      it('non-owner (auth): Like + Subscribe primary; Share/graph/Fork/Report in overflow; no Edit/Delete', async () => {
+        const user = userEvent.setup()
+        mockAuthContext.mockReturnValue({
+          user: { id: '999', is_admin: false },
+          isAuthenticated: true,
+          isLoading: false,
+          logout: vi.fn(),
+        })
+        mockCollection.mockReturnValue({
+          data: makeCollection({
+            creator_id: 1,
+            is_public: true,
+            items: sampleItems,
+          }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        // Primary row: Like + Subscribe (the social actions).
+        expect(
+          screen.getByTestId('collection-like-button')
+        ).toBeInTheDocument()
+        expect(
+          screen.getByRole('button', { name: /Subscribe/i })
+        ).toBeInTheDocument()
+        // Owner-only actions absent.
+        expect(
+          screen.queryByRole('button', { name: 'Edit' })
+        ).not.toBeInTheDocument()
+        expect(
+          screen.queryByRole('button', { name: 'Delete collection' })
+        ).not.toBeInTheDocument()
+
+        // Overflow: all four secondary actions.
+        await user.click(screen.getByTestId('collection-overflow-trigger'))
+        expect(screen.getByTestId('overflow-share')).toBeInTheDocument()
+        expect(
+          screen.getByTestId('overflow-explore-graph')
+        ).toBeInTheDocument()
+        expect(screen.getByTestId('overflow-fork')).toBeInTheDocument()
+        expect(screen.getByTestId('overflow-report')).toBeInTheDocument()
+      })
+
+      it('logged out: Like primary (sign-in prompt); Share + Explore graph in overflow only', async () => {
+        const user = userEvent.setup()
+        mockAuthContext.mockReturnValue({
+          user: null,
+          isAuthenticated: false,
+          isLoading: false,
+          logout: vi.fn(),
+        })
+        mockCollection.mockReturnValue({
+          data: makeCollection({ creator_id: 1, items: sampleItems }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        // Primary row: just the Like button (prompts sign-in).
+        expect(
+          screen.getByTestId('collection-like-button')
+        ).toHaveAttribute('aria-label', 'Sign in to like collection')
+        expect(
+          screen.queryByRole('button', { name: /Subscribe/i })
+        ).not.toBeInTheDocument()
+        expect(
+          screen.queryByRole('button', { name: 'Edit' })
+        ).not.toBeInTheDocument()
+
+        // Overflow: Share + Explore graph only.
+        await user.click(screen.getByTestId('collection-overflow-trigger'))
+        expect(screen.getByTestId('overflow-share')).toBeInTheDocument()
+        expect(
+          screen.getByTestId('overflow-explore-graph')
+        ).toBeInTheDocument()
+        expect(screen.queryByTestId('overflow-fork')).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId('overflow-report')
+        ).not.toBeInTheDocument()
+      })
+
+      it('hides Explore graph from the overflow when the collection has no items', async () => {
+        // Default fixture: creator viewing an empty collection.
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByTestId('collection-overflow-trigger'))
+        expect(screen.getByTestId('overflow-share')).toBeInTheDocument()
+        expect(
+          screen.queryByTestId('overflow-explore-graph')
+        ).not.toBeInTheDocument()
+      })
+
+      it('Share copies the page link and shows the copied banner', async () => {
+        const user = userEvent.setup()
+        // userEvent.setup() installs a navigator.clipboard stub; spy on it so
+        // the component's writeText().then(...) chain still resolves.
+        const writeSpy = vi.spyOn(navigator.clipboard, 'writeText')
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByTestId('collection-overflow-trigger'))
+        await user.click(screen.getByTestId('overflow-share'))
+
+        expect(writeSpy).toHaveBeenCalledWith(window.location.href)
+        // Banner appears once the clipboard promise resolves; it lives in the
+        // header banner block since the menu closes on click.
+        expect(await screen.findByTestId('share-copied')).toHaveTextContent(
+          'Link copied to clipboard'
+        )
+      })
+    })
+
+    describe('D1: sticky anchor nav', () => {
+      it('renders Items / Tags / Discussion jump links with Items active by default', () => {
+        render(<CollectionDetail slug="test-collection" />)
+
+        const nav = screen.getByTestId('collection-anchor-nav')
+        expect(within(nav).getByTestId('anchor-nav-items')).toHaveAttribute(
+          'aria-current',
+          'true'
+        )
+        expect(
+          within(nav).getByTestId('anchor-nav-tags')
+        ).not.toHaveAttribute('aria-current')
+        expect(
+          within(nav).getByTestId('anchor-nav-discussion')
+        ).not.toHaveAttribute('aria-current')
+      })
+
+      it('clicking a jump link marks it active', async () => {
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByTestId('anchor-nav-discussion'))
+
+        expect(screen.getByTestId('anchor-nav-discussion')).toHaveAttribute(
+          'aria-current',
+          'true'
+        )
+        expect(
+          screen.getByTestId('anchor-nav-items')
+        ).not.toHaveAttribute('aria-current')
+      })
+    })
+
+    describe('D6: section order (Items → Tags → Discussion)', () => {
+      it('renders the three sections in the locked order', () => {
+        mockCollection.mockReturnValue({
+          data: makeCollection({ items: sampleItems }),
+          isLoading: false,
+          error: null,
+        })
+        const { container } = render(
+          <CollectionDetail slug="test-collection" />
+        )
+
+        const items = container.querySelector('#items')
+        const tags = container.querySelector('#tags')
+        const discussion = container.querySelector('#discussion')
+        expect(items).not.toBeNull()
+        expect(tags).not.toBeNull()
+        expect(discussion).not.toBeNull()
+
+        // DOCUMENT_POSITION_FOLLOWING — tags follows items, discussion
+        // follows tags in document order.
+        expect(
+          items!.compareDocumentPosition(tags!) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy()
+        expect(
+          tags!.compareDocumentPosition(discussion!) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy()
+      })
+    })
+
+    describe('D7: + Add Items in the items header', () => {
+      it('shows the items count and the Add Items toggle for the creator', () => {
+        mockCollection.mockReturnValue({
+          data: makeCollection({ items: sampleItems }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        expect(screen.getByTestId('items-count')).toHaveTextContent('2')
+        expect(screen.getByTestId('add-items-toggle')).toBeInTheDocument()
+        // Panel collapsed by default for a non-empty collection (PSY-581
+        // default-open only applies to empty collections).
+        expect(
+          screen.queryByTestId('add-items-picker-stub')
+        ).not.toBeInTheDocument()
+      })
+
+      it('hides the Add Items toggle for non-creators', () => {
+        mockAuthContext.mockReturnValue({
+          user: { id: '999' },
+          isAuthenticated: true,
+          isLoading: false,
+          logout: vi.fn(),
+        })
+        mockCollection.mockReturnValue({
+          data: makeCollection({ creator_id: 1, items: sampleItems }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        expect(
+          screen.queryByTestId('add-items-toggle')
+        ).not.toBeInTheDocument()
+        // Count still shows for everyone.
+        expect(screen.getByTestId('items-count')).toHaveTextContent('2')
+      })
+
+      it('toggles the picker panel open and closed from the header button', async () => {
+        const user = userEvent.setup()
+        mockCollection.mockReturnValue({
+          data: makeCollection({ items: sampleItems }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByTestId('add-items-toggle'))
+        expect(
+          screen.getByTestId('add-items-picker-stub')
+        ).toBeInTheDocument()
+
+        await user.click(screen.getByTestId('add-items-toggle'))
+        expect(
+          screen.queryByTestId('add-items-picker-stub')
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    describe('PSY-894: edit form polish', () => {
+      it('Esc closes the edit form without saving', async () => {
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByRole('button', { name: 'Edit' }))
+        expect(screen.getByLabelText('Title')).toBeInTheDocument()
+
+        // Title input has autoFocus, so the keypress originates inside the
+        // form and bubbles to its onKeyDown handler.
+        await user.keyboard('{Escape}')
+
+        expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+        expect(mockUpdateMutate).not.toHaveBeenCalled()
+        expect(
+          screen.queryByTestId('collection-update-success')
+        ).not.toBeInTheDocument()
+      })
+
+      it('⌘S saves the form', async () => {
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByRole('button', { name: 'Edit' }))
+        await user.keyboard('{Meta>}s{/Meta}')
+
+        expect(mockUpdateMutate).toHaveBeenCalledWith(
+          expect.objectContaining({ slug: 'test-collection' }),
+          expect.any(Object)
+        )
+      })
+
+      it('shows the green "Collection updated" banner after a successful save', async () => {
+        // Mutation invokes onSuccess synchronously so the parent closes the
+        // form and shows the banner.
+        mockUpdateMutate.mockImplementation((_args, opts) =>
+          opts?.onSuccess?.()
+        )
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByRole('button', { name: 'Edit' }))
+        await user.click(screen.getByRole('button', { name: /Save/i }))
+
+        expect(
+          screen.getByTestId('collection-update-success')
+        ).toHaveTextContent('Collection updated')
+        // Form closed (header re-rendered).
+        expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+      })
+
+      it('does NOT show the success banner after Cancel', async () => {
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByRole('button', { name: 'Edit' }))
+        await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+        expect(
+          screen.queryByTestId('collection-update-success')
+        ).not.toBeInTheDocument()
+        // Form closed without saving.
+        expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+        expect(mockUpdateMutate).not.toHaveBeenCalled()
+      })
+
+      it('Public + Collaborative DS checkboxes toggle and land in the save payload', async () => {
+        const user = userEvent.setup()
+        mockCollection.mockReturnValue({
+          data: makeCollection({ is_public: true, collaborative: false }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+        const publicCheckbox = screen.getByRole('checkbox', {
+          name: 'Public',
+        })
+        const collabCheckbox = screen.getByRole('checkbox', {
+          name: 'Collaborative',
+        })
+        expect(publicCheckbox).toBeChecked()
+        expect(collabCheckbox).not.toBeChecked()
+
+        await user.click(publicCheckbox)
+        await user.click(collabCheckbox)
+        expect(publicCheckbox).not.toBeChecked()
+        expect(collabCheckbox).toBeChecked()
+
+        await user.click(screen.getByRole('button', { name: /Save/i }))
+        expect(mockUpdateMutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            is_public: false,
+            collaborative: true,
+          }),
+          expect.any(Object)
+        )
+      })
     })
   })
 })

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -2327,6 +2327,33 @@ describe('CollectionDetail', () => {
         ).not.toBeInTheDocument()
       })
 
+      it('shows the inline "Forking collection…" row while a clone is pending', () => {
+        // The overflow menu closes on click, taking its pending label with
+        // it — the inline status row is the only in-flight feedback.
+        mockAuthContext.mockReturnValue({
+          user: { id: '999' },
+          isAuthenticated: true,
+          isLoading: false,
+          logout: vi.fn(),
+        })
+        mockCloneMutation.mockReturnValue({
+          mutate: mockCloneMutate,
+          isPending: true,
+          isError: false,
+          error: null,
+        })
+        mockCollection.mockReturnValue({
+          data: makeCollection({ creator_id: 1, is_public: true }),
+          isLoading: false,
+          error: null,
+        })
+        render(<CollectionDetail slug="test-collection" />)
+
+        expect(screen.getByTestId('fork-pending')).toHaveTextContent(
+          'Forking collection'
+        )
+      })
+
       it('Share copies the page link and shows the copied banner', async () => {
         const user = userEvent.setup()
         // userEvent.setup() installs a navigator.clipboard stub; spy on it so

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CollectionDetail } from './CollectionDetail'
 import type {
@@ -2377,6 +2377,76 @@ describe('CollectionDetail', () => {
           screen.getByTestId('anchor-nav-items')
         ).not.toHaveAttribute('aria-current')
       })
+
+      it('updates the active link when the observer reports a section in view (scroll tracking)', () => {
+        // The global IntersectionObserver mock (test/setup.ts) is a no-op
+        // stub and is not `configurable`, so it can't be replaced via
+        // vi.stubGlobal — but it IS `writable`, so plain assignment works.
+        // Swap in a capturing stub for this test so we can drive the
+        // callback with synthetic entries (the only way to exercise the
+        // scroll-tracking path in jsdom).
+        let capturedCallback: IntersectionObserverCallback | null = null
+        const observeSpy = vi.fn()
+        const makeEntry = (target: Element, top: number) =>
+          ({
+            isIntersecting: true,
+            target,
+            boundingClientRect: { top },
+          }) as unknown as IntersectionObserverEntry
+
+        const OriginalIO = window.IntersectionObserver
+        window.IntersectionObserver = class {
+          constructor(cb: IntersectionObserverCallback) {
+            capturedCallback = cb
+          }
+          observe = observeSpy
+          unobserve = vi.fn()
+          disconnect = vi.fn()
+          takeRecords = () => []
+        } as unknown as typeof IntersectionObserver
+
+        try {
+          render(<CollectionDetail slug="test-collection" />)
+
+          // The nav observed all three sections (they render synchronously
+          // in jsdom, so the retry loop succeeds on its first pass).
+          expect(observeSpy).toHaveBeenCalledTimes(3)
+          expect(capturedCallback).not.toBeNull()
+
+          // Simulate the discussion section scrolling into the reading band.
+          const discussionEl = document.getElementById('discussion')!
+          act(() => {
+            capturedCallback!(
+              [makeEntry(discussionEl, 120)],
+              {} as IntersectionObserver
+            )
+          })
+
+          expect(
+            screen.getByTestId('anchor-nav-discussion')
+          ).toHaveAttribute('aria-current', 'true')
+          expect(
+            screen.getByTestId('anchor-nav-items')
+          ).not.toHaveAttribute('aria-current')
+
+          // When two sections intersect, the one nearest the top of the
+          // viewport wins.
+          const itemsEl = document.getElementById('items')!
+          act(() => {
+            capturedCallback!(
+              [makeEntry(discussionEl, 400), makeEntry(itemsEl, 150)],
+              {} as IntersectionObserver
+            )
+          })
+
+          expect(screen.getByTestId('anchor-nav-items')).toHaveAttribute(
+            'aria-current',
+            'true'
+          )
+        } finally {
+          window.IntersectionObserver = OriginalIO
+        }
+      })
     })
 
     describe('D6: section order (Items → Tags → Discussion)', () => {
@@ -2471,7 +2541,7 @@ describe('CollectionDetail', () => {
     })
 
     describe('PSY-894: edit form polish', () => {
-      it('Esc closes the edit form without saving', async () => {
+      it('Esc closes a pristine edit form without saving', async () => {
         const user = userEvent.setup()
         render(<CollectionDetail slug="test-collection" />)
 
@@ -2489,6 +2559,32 @@ describe('CollectionDetail', () => {
         ).not.toBeInTheDocument()
       })
 
+      it('Esc does NOT discard a dirty form (unsaved-work protection)', async () => {
+        // Adversarial-review finding: a reflexive Esc press while typing a
+        // long description must not silently destroy the user's work. A
+        // dirty form ignores Esc; closing it requires the deliberate Cancel
+        // click.
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByRole('button', { name: 'Edit' }))
+        // Dirty the form.
+        await user.type(screen.getByLabelText('Title'), ' updated')
+
+        await user.keyboard('{Escape}')
+
+        // Form stays open — unsaved work is protected.
+        expect(screen.getByLabelText('Title')).toBeInTheDocument()
+        expect(mockUpdateMutate).not.toHaveBeenCalled()
+
+        // The hint stops promising Esc once the form is dirty.
+        expect(screen.queryByText(/Esc to cancel/)).not.toBeInTheDocument()
+
+        // Cancel still works as the deliberate exit.
+        await user.click(screen.getByRole('button', { name: 'Cancel' }))
+        expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+      })
+
       it('⌘S saves the form', async () => {
         const user = userEvent.setup()
         render(<CollectionDetail slug="test-collection" />)
@@ -2500,6 +2596,19 @@ describe('CollectionDetail', () => {
           expect.objectContaining({ slug: 'test-collection' }),
           expect.any(Object)
         )
+      })
+
+      it('⌘S respects the same validation as the Save button (empty title)', async () => {
+        // Code-review finding: the shortcut must not bypass the empty-title
+        // guard that disables the Save button.
+        const user = userEvent.setup()
+        render(<CollectionDetail slug="test-collection" />)
+
+        await user.click(screen.getByRole('button', { name: 'Edit' }))
+        await user.clear(screen.getByLabelText('Title'))
+        await user.keyboard('{Meta>}s{/Meta}')
+
+        expect(mockUpdateMutate).not.toHaveBeenCalled()
       })
 
       it('shows the green "Collection updated" banner after a successful save', async () => {

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import {
@@ -14,12 +14,12 @@ import {
   Check,
   X,
   Trash2,
-  Plus,
   Share2,
   GitFork,
   Heart,
   ListOrdered,
   LayoutGrid,
+  MoreHorizontal,
   Network,
   Flag,
 } from 'lucide-react'
@@ -32,9 +32,14 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
   useCollection,
   useUpdateCollection,
-  useBulkAddCollectionItems,
   useSubscribeCollection,
   useUnsubscribeCollection,
   useDeleteCollection,
@@ -42,10 +47,6 @@ import {
   useLikeCollection,
   useUnlikeCollection,
 } from '../hooks'
-import {
-  AddItemsPicker,
-  type StagedCollectionItem,
-} from './AddItemsPicker'
 import { cn } from '@/lib/utils'
 import {
   getEntityTypeLabel,
@@ -53,7 +54,7 @@ import {
   MAX_COVER_IMAGE_URL_LENGTH,
   validateCoverImageUrl,
 } from '../types'
-import type { CollectionDisplayMode, CollectionItem } from '../types'
+import type { CollectionDisplayMode } from '../types'
 import { MarkdownContent } from './MarkdownContent'
 // Lazily-loaded write-mode editor (keeps marked/dompurify out of the shared
 // chunk). See MarkdownEditorLazy / PSY-951.
@@ -77,13 +78,19 @@ import {
 } from './collectionDetailShared'
 import { CollectionGraph } from './CollectionGraph'
 import { CollectionCoverImage } from './CollectionCoverImage'
+import {
+  CollectionAnchorNav,
+  ANCHOR_SECTION_SCROLL_MT,
+  type AnchorSection,
+} from './CollectionAnchorNav'
 import { GRAPH_HASH, useUrlHash } from '@/lib/hooks/common/useUrlHash'
 import { Breadcrumb, UserAttribution } from '@/components/shared'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import type { ApiError } from '@/lib/api'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { CommentThread } from '@/features/comments'
@@ -94,8 +101,18 @@ interface CollectionDetailProps {
   slug: string
 }
 
+// PSY-892 D1/D6: sticky anchor nav sections, in locked page order
+// (Items → Tags → Discussion). Module-level constant so the nav's
+// IntersectionObserver effect keys on a stable reference.
+const ANCHOR_SECTIONS: AnchorSection[] = [
+  { id: 'items', label: 'Items' },
+  { id: 'tags', label: 'Tags' },
+  { id: 'discussion', label: 'Discussion' },
+]
+
 export function CollectionDetail({ slug }: CollectionDetailProps) {
   const router = useRouter()
+  const pathname = usePathname()
   const { user, isAuthenticated } = useAuthContext()
   const { data: collection, isLoading, error } = useCollection(slug)
   const subscribeMutation = useSubscribeCollection()
@@ -111,6 +128,16 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [showCopied, setShowCopied] = useState(false)
+  // PSY-894 D4: green "Collection updated" banner after a successful edit
+  // save. The form closing + header re-render is the inherent confirmation;
+  // the banner makes it explicit and auto-dismisses after ~3s. No toast —
+  // the project has no toast library (PSY-608/609 convention).
+  const [showUpdateSuccess, setShowUpdateSuccess] = useState(false)
+  useEffect(() => {
+    if (!showUpdateSuccess) return
+    const timer = setTimeout(() => setShowUpdateSuccess(false), 3000)
+    return () => clearTimeout(timer)
+  }, [showUpdateSuccess])
   // PSY-357: report dialog open state. The trigger is only rendered for
   // authenticated, non-creator viewers (private collections aren't visible
   // to non-creators, so no extra public-state gate is needed).
@@ -274,6 +301,10 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
     }
   }
   const isLikePending = likeMutation.isPending || unlikeMutation.isPending
+  // The "this viewer has liked it" visual state — only meaningful for
+  // authenticated viewers (anonymous viewers see the count but never a
+  // filled heart).
+  const showLiked = isAuthenticated && (collection.user_likes_this ?? false)
 
   return (
     <div className="container max-w-6xl mx-auto px-4 py-6">
@@ -294,7 +325,12 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
             collaborative={collection.collaborative}
             displayMode={collection.display_mode}
             coverImageUrl={collection.cover_image_url ?? ''}
-            onDone={() => setIsEditing(false)}
+            onSaved={() => {
+              setIsEditing(false)
+              // PSY-894 D4: only a successful save shows the green banner.
+              setShowUpdateSuccess(true)
+            }}
+            onCancel={() => setIsEditing(false)}
           />
         ) : (
           <div>
@@ -451,71 +487,50 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                 </div>
               </div>
 
-              {/* Action buttons */}
+              {/* Action buttons — consolidated per PSY-892 D4. Each viewer
+                  state shows 2-3 primary actions; secondary actions live in
+                  the ⋯ overflow menu:
+                  - Owner:            Like · Edit · Delete  |  ⋯ Share · Explore graph
+                  - Non-owner (auth): Like · Subscribe      |  ⋯ Share · Explore graph · Fork · Report
+                  - Logged out:       Like (sign-in prompt) |  ⋯ Share · Explore graph */}
               <div className="flex items-center gap-2 shrink-0">
-                {/* PSY-352: Like toggle. Authenticated viewers can click;
-                    anonymous viewers see a read-only heart + count so they
-                    know the signal exists. Aggregate count only — privacy
+                {/* PSY-352: Like toggle. Primary in every viewer state.
+                    Authenticated viewers toggle; anonymous viewers are routed
+                    to sign-in on click (D4 — same returnTo redirect as
+                    FollowButton / AttendanceButton so they land back here
+                    after signing in). Aggregate count only — privacy
                     decision: no list of likers exposed. */}
-                {isAuthenticated ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleToggleLike}
-                    disabled={isLikePending}
-                    aria-pressed={collection.user_likes_this ?? false}
-                    aria-label={
-                      collection.user_likes_this
-                        ? 'Unlike collection'
-                        : 'Like collection'
-                    }
-                    className={cn(
-                      collection.user_likes_this && 'text-primary'
-                    )}
-                    data-testid="collection-like-button"
-                  >
-                    <Heart
-                      className={cn(
-                        'h-4 w-4 mr-1.5',
-                        collection.user_likes_this && 'fill-current'
-                      )}
-                    />
-                    {collection.like_count}
-                  </Button>
-                ) : (
-                  <span
-                    className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border/60 px-3 text-sm text-muted-foreground"
-                    data-testid="collection-like-count"
-                  >
-                    <Heart className="h-4 w-4" />
-                    {collection.like_count}
-                  </span>
-                )}
-
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={handleShare}
+                  onClick={
+                    isAuthenticated
+                      ? handleToggleLike
+                      : () =>
+                          router.push(
+                            `/auth?returnTo=${encodeURIComponent(pathname)}`
+                          )
+                  }
+                  disabled={isAuthenticated && isLikePending}
+                  aria-pressed={isAuthenticated ? showLiked : undefined}
+                  aria-label={
+                    !isAuthenticated
+                      ? 'Sign in to like collection'
+                      : showLiked
+                        ? 'Unlike collection'
+                        : 'Like collection'
+                  }
+                  className={cn(showLiked && 'text-primary')}
+                  data-testid="collection-like-button"
                 >
-                  <Share2 className="h-4 w-4 mr-1.5" />
-                  {showCopied ? 'Copied!' : 'Share'}
+                  <Heart
+                    className={cn(
+                      'h-4 w-4 mr-1.5',
+                      showLiked && 'fill-current'
+                    )}
+                  />
+                  {collection.like_count}
                 </Button>
-
-                {/* PSY-555 (was PSY-366): Explore graph toggle. Visible
-                    whenever the collection has at least one item — every
-                    entity type renders as a node in the multi-type graph. */}
-                {hasItems && (
-                  <Button
-                    variant={showGraph ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => setShowGraphOverride(!showGraph)}
-                    aria-pressed={showGraph}
-                    aria-label={showGraph ? 'Hide collection graph' : 'Explore collection graph'}
-                  >
-                    <Network className="h-4 w-4 mr-1.5" />
-                    {showGraph ? 'Hide graph' : 'Explore graph'}
-                  </Button>
-                )}
 
                 {canSubscribe && (
                   <Button
@@ -541,41 +556,9 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                   </Button>
                 )}
 
-                {/* PSY-351: Clone/fork. Visible only when caller is
-                    authenticated AND not the owner AND the source is
-                    public. */}
-                {canClone && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleClone}
-                    disabled={cloneMutation.isPending}
-                    aria-label="Fork collection"
-                  >
-                    {cloneMutation.isPending ? (
-                      <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-                    ) : (
-                      <GitFork className="h-4 w-4 mr-1.5" />
-                    )}
-                    {cloneMutation.isPending ? 'Forking...' : 'Fork'}
-                  </Button>
-                )}
-
-                {/* PSY-578: report a collection. Mirrors the Report
-                    button on artist/venue/festival/show detail pages. */}
-                {canReport && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setIsReportOpen(true)}
-                    aria-label="Report collection"
-                    data-testid="collection-report-button"
-                  >
-                    <Flag className="h-4 w-4 mr-1.5" />
-                    Report
-                  </Button>
-                )}
-
+                {/* Edit + Delete: the curator's daily actions stay primary
+                    (D4); Edit's click behavior is the inline form (D5,
+                    locked by PSY-894). */}
                 {isCreator && (
                   <>
                     <Button
@@ -598,6 +581,69 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                     </Button>
                   </>
                 )}
+
+                {/* ⋯ overflow menu (D4): Share + Explore graph for everyone;
+                    Fork + Report join for authenticated non-owners. */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      aria-label="More actions"
+                      data-testid="collection-overflow-trigger"
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      onClick={handleShare}
+                      data-testid="overflow-share"
+                    >
+                      <Share2 className="h-4 w-4" />
+                      Share
+                    </DropdownMenuItem>
+                    {/* PSY-555 (was PSY-366): Explore graph toggle. Visible
+                        whenever the collection has at least one item — every
+                        entity type renders as a node in the multi-type
+                        graph. */}
+                    {hasItems && (
+                      <DropdownMenuItem
+                        onClick={() => setShowGraphOverride(!showGraph)}
+                        data-testid="overflow-explore-graph"
+                      >
+                        <Network className="h-4 w-4" />
+                        {showGraph ? 'Hide graph' : 'Explore graph'}
+                      </DropdownMenuItem>
+                    )}
+                    {/* PSY-351: Clone/fork. Visible only when caller is
+                        authenticated AND not the owner AND the source is
+                        public. */}
+                    {canClone && (
+                      <DropdownMenuItem
+                        onClick={handleClone}
+                        disabled={cloneMutation.isPending}
+                        aria-label="Fork collection"
+                        data-testid="overflow-fork"
+                      >
+                        <GitFork className="h-4 w-4" />
+                        {cloneMutation.isPending ? 'Forking...' : 'Fork'}
+                      </DropdownMenuItem>
+                    )}
+                    {/* PSY-578: report a collection. Mirrors the Report
+                        button on artist/venue/festival/show detail pages. */}
+                    {canReport && (
+                      <DropdownMenuItem
+                        onClick={() => setIsReportOpen(true)}
+                        aria-label="Report collection"
+                        data-testid="overflow-report"
+                      >
+                        <Flag className="h-4 w-4" />
+                        Report
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </div>
             </div>
 
@@ -613,6 +659,26 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                 it doesn't accrue after the user moves on. 403 (private
                 target) renders dedicated copy via describeCollectionMutationError.
             */}
+            {/* PSY-894 D4: edit-save success confirmation — the form has
+                already closed and the header re-rendered with new values;
+                this banner makes the save explicit. Auto-dismisses ~3s. */}
+            {showUpdateSuccess && (
+              <MutationFeedback
+                variant="success"
+                testId="collection-update-success"
+                message="Collection updated"
+              />
+            )}
+            {/* PSY-892 D4: Share lives in the overflow menu now, so its
+                "Copied!" feedback can't render on the trigger — surface it
+                as an inline success banner instead. */}
+            {showCopied && (
+              <MutationFeedback
+                variant="success"
+                testId="share-copied"
+                message="Link copied to clipboard"
+              />
+            )}
             {subscribeMutation.isError && (
               <MutationFeedback
                 variant="error"
@@ -661,41 +727,21 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
         )}
       </header>
 
-      {/* PSY-354: tag chips + picker. Reuses the same EntityTagList that
-          renders on artist/release/etc detail pages — chips link to
-          /tags/{slug} for the deep-dive (the collection-card override
-          links to /collections?tag=<slug> instead because cards prefer
-          the lateral "show me other collections like this" path). The
-          per-collection 10-tag cap is enforced server-side in
-          catalog.TagService.AddTagToEntity, so this picker honors the
-          limit regardless of the picker's UI cap awareness. */}
-      <div className="mb-4">
-        <EntityTagList
-          entityType="collection"
-          entityId={collection.id}
-          isAuthenticated={isAuthenticated}
-        />
-      </div>
+      {/* PSY-892 D1: sticky anchor nav — jump links for the page's three
+          long-form sections (Items · Tags · Discussion). Pins below the site
+          TopBar; the active link tracks scroll position. */}
+      <CollectionAnchorNav sections={ANCHOR_SECTIONS} />
 
       {/* PSY-555 (was PSY-366): collection graph (toggleable). Renders
-          only when the user clicks "Explore graph" in the actions row.
+          only when the user clicks "Explore graph" in the ⋯ overflow menu.
           The wrapper has `id="graph"` so Cmd+K deep-links resolve. */}
       {showGraph && hasItems && (
         <CollectionGraph slug={slug} collectionTitle={collection.title} />
       )}
 
-      {/* Add Items (creator only). PSY-581: empty collections render the
-          search open so the "Add your first item using the search above"
-          copy is honest. */}
-      {isCreator && (
-        <AddItemsSection
-          slug={slug}
-          existingItems={items}
-          defaultOpen={items.length === 0}
-        />
-      )}
-
-      {/* Items list */}
+      {/* Items list — leads the page (PSY-892 D6: visitors come for items).
+          Carries the creator's "+ Add Items" affordance in its header (D7)
+          and the `id="items"` anchor for the nav above. */}
       <CollectionItemsList
         items={items}
         slug={slug}
@@ -703,8 +749,28 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
         displayMode={collection.display_mode}
       />
 
-      {/* Discussion */}
-      <CommentThread entityType="collection" entityId={collection.id} />
+      {/* PSY-354: tag chips + picker — between Items and Discussion per
+          PSY-892 D6 (tags are useful metadata but secondary to items).
+          Reuses the same EntityTagList that renders on artist/release/etc
+          detail pages — chips link to /tags/{slug} for the deep-dive (the
+          collection-card override links to /collections?tag=<slug> instead
+          because cards prefer the lateral "show me other collections like
+          this" path). The per-collection 10-tag cap is enforced server-side
+          in catalog.TagService.AddTagToEntity, so this picker honors the
+          limit regardless of the picker's UI cap awareness. */}
+      <div id="tags" className={cn('mt-8', ANCHOR_SECTION_SCROLL_MT)}>
+        <EntityTagList
+          entityType="collection"
+          entityId={collection.id}
+          isAuthenticated={isAuthenticated}
+        />
+      </div>
+
+      {/* Discussion — stays at the page bottom (PSY-892 D2); the anchor nav
+          provides the jump-to affordance. */}
+      <div id="discussion" className={ANCHOR_SECTION_SCROLL_MT}>
+        <CommentThread entityType="collection" entityId={collection.id} />
+      </div>
 
       {/* Mounted only when `canReport` so we don't ship the dialog tree
           to viewers who can't open it. `entityTypeLabel="collection"`
@@ -774,142 +840,6 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
 }
 
 // ──────────────────────────────────────────────
-// Add Items Search Panel
-// ──────────────────────────────────────────────
-
-function AddItemsSection({
-  slug,
-  existingItems,
-  defaultOpen = false,
-}: {
-  slug: string
-  existingItems: CollectionItem[]
-  /**
-   * PSY-581: when true, the picker renders open on first paint. Parent
-   * passes `items.length === 0` so the empty-state copy stays honest.
-   * Sets only the initial state — the X toggle still collapses/reopens.
-   */
-  defaultOpen?: boolean
-}) {
-  const [isOpen, setIsOpen] = useState(defaultOpen)
-  // PSY-823: items staged in the picker, submitted in one bulk-add request.
-  const [stagedItems, setStagedItems] = useState<StagedCollectionItem[]>([])
-  const [feedback, setFeedback] = useState<
-    | { variant: 'success'; message: string }
-    | { variant: 'error'; message: string }
-    | null
-  >(null)
-  const bulkAddMutation = useBulkAddCollectionItems()
-
-  const handleSubmit = async () => {
-    if (stagedItems.length === 0) return
-    try {
-      const resp = await bulkAddMutation.mutateAsync({
-        slug,
-        items: stagedItems.map((s) => ({
-          entity_type: s.entityType,
-          entity_id: s.entityId,
-        })),
-      })
-      const addedCount = resp.added.length
-      const rejectedCount = resp.errors.length
-      if (rejectedCount === 0) {
-        setFeedback({
-          variant: 'success',
-          message: `Added ${addedCount} ${addedCount === 1 ? 'item' : 'items'} to collection`,
-        })
-      } else if (addedCount === 0) {
-        setFeedback({
-          variant: 'error',
-          message: `Couldn't add any items (${rejectedCount} ${rejectedCount === 1 ? 'error' : 'errors'}). Adjust the picker and try again.`,
-        })
-      } else {
-        setFeedback({
-          variant: 'success',
-          message: `Added ${addedCount} ${addedCount === 1 ? 'item' : 'items'}; ${rejectedCount} couldn't be added.`,
-        })
-      }
-      // Clear staged list only if at least one row committed. When EVERY
-      // row failed, leave the picker as-is so the user can edit/retry
-      // without re-staging from scratch.
-      if (addedCount > 0) {
-        setStagedItems([])
-      }
-      setTimeout(() => setFeedback(null), 4000)
-    } catch (err) {
-      setFeedback({
-        variant: 'error',
-        message: describeCollectionMutationError(err, 'Failed to add items.'),
-      })
-    }
-  }
-
-  return (
-    <div className="mb-6">
-      {!isOpen ? (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setIsOpen(true)}
-        >
-          <Plus className="h-4 w-4 mr-1.5" />
-          Add Items
-        </Button>
-      ) : (
-        <div className="rounded-lg border border-border/50 bg-card p-4">
-          <div className="flex items-center justify-between mb-3">
-            <span className="text-sm font-semibold sr-only">Add items</span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 w-7 p-0 ml-auto"
-              onClick={() => {
-                setIsOpen(false)
-                setStagedItems([])
-                setFeedback(null)
-              }}
-              aria-label="Close add-items picker"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-
-          <AddItemsPicker
-            existingItems={existingItems.map((i) => ({
-              entity_type: i.entity_type,
-              entity_id: i.entity_id,
-            }))}
-            stagedItems={stagedItems}
-            onStagedItemsChange={setStagedItems}
-          />
-
-          {feedback && (
-            <MutationFeedback
-              variant={feedback.variant}
-              message={feedback.message}
-              testId={feedback.variant === 'success' ? 'add-item-success' : 'add-item-error'}
-            />
-          )}
-
-          <div className="flex justify-end mt-4">
-            <Button
-              size="sm"
-              onClick={handleSubmit}
-              disabled={stagedItems.length === 0 || bulkAddMutation.isPending}
-              data-testid="add-items-picker-submit"
-            >
-              {bulkAddMutation.isPending
-                ? 'Adding...'
-                : `Add ${stagedItems.length || ''} item${stagedItems.length === 1 ? '' : 's'}`.trim()}
-            </Button>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ──────────────────────────────────────────────
 // Inline Edit Form
 // ──────────────────────────────────────────────
 
@@ -921,7 +851,8 @@ function InlineEditForm({
   collaborative: initialCollaborative,
   displayMode: initialDisplayMode,
   coverImageUrl: initialCoverImageUrl,
-  onDone,
+  onSaved,
+  onCancel,
 }: {
   slug: string
   title: string
@@ -930,7 +861,10 @@ function InlineEditForm({
   collaborative: boolean
   displayMode: CollectionDisplayMode
   coverImageUrl: string
-  onDone: () => void
+  /** Called after a successful save (PSY-894 D4 — parent shows the banner). */
+  onSaved: () => void
+  /** Called when the form closes without saving (Cancel button or Esc). */
+  onCancel: () => void
 }) {
   const updateMutation = useUpdateCollection()
   const [title, setTitle] = useState(initialTitle)
@@ -955,8 +889,15 @@ function InlineEditForm({
   const showCoverImagePreview =
     trimmedCoverUrl.length > 0 && coverImageUrlError === null
 
+  // Single source of truth for "the form may be submitted" — keeps the Save
+  // button's disabled state and the ⌘S shortcut in lockstep.
+  const canSave =
+    title.trim().length > 0 &&
+    coverImageUrlError === null &&
+    !updateMutation.isPending
+
   const handleSave = () => {
-    if (coverImageUrlError) return
+    if (!canSave) return
     updateMutation.mutate(
       {
         slug,
@@ -969,12 +910,28 @@ function InlineEditForm({
         // distinguishes "set to null" from "no change".
         cover_image_url: trimmedCoverUrl.length === 0 ? null : trimmedCoverUrl,
       },
-      { onSuccess: () => onDone() }
+      { onSuccess: () => onSaved() }
     )
   }
 
+  // PSY-894 D3: keyboard shortcuts — Esc cancels, ⌘/Ctrl+S saves. Attached to
+  // the form's root so they work from any focused field. handleSave's canSave
+  // guard makes the shortcut respect the same validation as the Save button.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onCancel()
+    } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+      e.preventDefault()
+      handleSave()
+    }
+  }
+
   return (
-    <div className="space-y-4 rounded-lg border border-border/50 bg-card p-4">
+    <div
+      className="space-y-4 rounded-lg border border-border/50 bg-card p-4"
+      onKeyDown={handleKeyDown}
+    >
       <div>
         <label htmlFor="edit-title" className="text-sm font-medium mb-1.5 block">
           Title
@@ -984,6 +941,7 @@ function InlineEditForm({
           value={title}
           onChange={e => setTitle(e.target.value)}
           autoFocus
+          disabled={updateMutation.isPending}
         />
       </div>
 
@@ -1002,6 +960,7 @@ function InlineEditForm({
           maxLength={MAX_COLLECTION_MARKDOWN_LENGTH}
           placeholder="Markdown supported: **bold**, *italic*, [link](url), > quote, - list"
           testId="collection-description-editor"
+          disabled={updateMutation.isPending}
         />
       </div>
 
@@ -1030,6 +989,7 @@ function InlineEditForm({
             onBlur={() => setCoverImageUrlTouched(true)}
             placeholder="https://example.com/cover.jpg"
             maxLength={MAX_COVER_IMAGE_URL_LENGTH}
+            disabled={updateMutation.isPending}
             aria-invalid={showCoverImageUrlError ? true : undefined}
             aria-describedby={
               showCoverImageUrlError
@@ -1142,26 +1102,35 @@ function InlineEditForm({
         </div>
       </fieldset>
 
+      {/* PSY-894 D6: DS Checkbox primitives. Public is a plain toggle —
+          NO publish quality gate (PSY-822 removed it; do not re-add). */}
       <div className="flex items-center gap-6">
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <input
-            type="checkbox"
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="edit-is-public"
             checked={isPublic}
-            onChange={e => setIsPublic(e.target.checked)}
-            className="rounded border-border"
+            onCheckedChange={checked => setIsPublic(checked === true)}
+            disabled={updateMutation.isPending}
           />
-          Public
-        </label>
+          <label htmlFor="edit-is-public" className="text-sm cursor-pointer">
+            Public
+          </label>
+        </div>
 
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <input
-            type="checkbox"
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="edit-collaborative"
             checked={collaborative}
-            onChange={e => setCollaborative(e.target.checked)}
-            className="rounded border-border"
+            onCheckedChange={checked => setCollaborative(checked === true)}
+            disabled={updateMutation.isPending}
           />
-          Collaborative
-        </label>
+          <label
+            htmlFor="edit-collaborative"
+            className="text-sm cursor-pointer"
+          >
+            Collaborative
+          </label>
+        </div>
       </div>
 
       {updateMutation.error && (
@@ -1172,22 +1141,18 @@ function InlineEditForm({
         </p>
       )}
 
-      <div className="flex gap-2">
-        <Button
-          size="sm"
-          onClick={handleSave}
-          disabled={
-            !title.trim() ||
-            coverImageUrlError !== null ||
-            updateMutation.isPending
-          }
-        >
+      <div className="flex items-center gap-2">
+        <Button size="sm" onClick={handleSave} disabled={!canSave}>
           <Check className="h-4 w-4 mr-1" />
           {updateMutation.isPending ? 'Saving...' : 'Save'}
         </Button>
-        <Button size="sm" variant="outline" onClick={onDone}>
+        <Button size="sm" variant="outline" onClick={onCancel}>
           Cancel
         </Button>
+        {/* PSY-894 D3: keyboard shortcut hint (V1-optional affordance). */}
+        <p className="ml-auto hidden text-xs text-muted-foreground sm:block">
+          Esc to cancel · ⌘S to save
+        </p>
       </div>
     </div>
   )

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -679,6 +679,22 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                 message="Link copied to clipboard"
               />
             )}
+            {/* Fork-in-flight feedback: the overflow menu closes on click,
+                taking its "Forking..." pending label with it — surface the
+                in-flight state inline so a slow clone isn't dead air. */}
+            {cloneMutation.isPending && (
+              <p
+                className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground"
+                role="status"
+                data-testid="fork-pending"
+              >
+                <Loader2
+                  className="h-3.5 w-3.5 animate-spin"
+                  aria-hidden="true"
+                />
+                Forking collection…
+              </p>
+            )}
             {subscribeMutation.isError && (
               <MutationFeedback
                 variant="error"
@@ -896,6 +912,17 @@ function InlineEditForm({
     coverImageUrlError === null &&
     !updateMutation.isPending
 
+  // Dirty tracking: Esc-to-cancel only fires on a pristine form. Discarding
+  // typed work on a reflexive Esc press is a data-loss foot-gun (adversarial
+  // review finding) — a dirty form requires the deliberate Cancel click.
+  const isDirty =
+    title !== initialTitle ||
+    description !== initialDescription ||
+    isPublic !== initialPublic ||
+    collaborative !== initialCollaborative ||
+    displayMode !== initialDisplayMode ||
+    coverImageUrl !== initialCoverImageUrl
+
   const handleSave = () => {
     if (!canSave) return
     updateMutation.mutate(
@@ -916,11 +943,14 @@ function InlineEditForm({
 
   // PSY-894 D3: keyboard shortcuts — Esc cancels, ⌘/Ctrl+S saves. Attached to
   // the form's root so they work from any focused field. handleSave's canSave
-  // guard makes the shortcut respect the same validation as the Save button.
+  // guard makes the shortcut respect the same validation as the Save button;
+  // the isDirty guard keeps Esc from discarding typed work.
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault()
-      onCancel()
+      if (!isDirty) {
+        onCancel()
+      }
     } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
       e.preventDefault()
       handleSave()
@@ -1149,9 +1179,12 @@ function InlineEditForm({
         <Button size="sm" variant="outline" onClick={onCancel}>
           Cancel
         </Button>
-        {/* PSY-894 D3: keyboard shortcut hint (V1-optional affordance). */}
+        {/* PSY-894 D3: keyboard shortcut hint (V1-optional affordance).
+            Esc only cancels a pristine form, so the hint drops it once the
+            form is dirty — the hint never promises something that won't
+            happen. */}
         <p className="ml-auto hidden text-xs text-muted-foreground sm:block">
-          Esc to cancel · ⌘S to save
+          {isDirty ? '⌘S to save' : 'Esc to cancel · ⌘S to save'}
         </p>
       </div>
     </div>

--- a/frontend/features/collections/components/CollectionItemsList.tsx
+++ b/frontend/features/collections/components/CollectionItemsList.tsx
@@ -20,7 +20,7 @@
  * before this move. Behavior is unchanged; this is purely a module relocation.
  */
 
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import Link from 'next/link'
 import {
   Library,
@@ -29,6 +29,7 @@ import {
   ChevronDown,
   Pencil,
   Check,
+  Plus,
   X,
   Loader2,
   LayoutGrid,
@@ -57,7 +58,12 @@ import {
   useReorderCollectionItems,
   useRemoveCollectionItem,
   useUpdateCollectionItem,
+  useBulkAddCollectionItems,
 } from '../hooks'
+import {
+  AddItemsPicker,
+  type StagedCollectionItem,
+} from './AddItemsPicker'
 import { cn } from '@/lib/utils'
 import {
   getEntityUrl,
@@ -70,6 +76,7 @@ import { MarkdownContent } from './MarkdownContent'
 // chunk). See MarkdownEditorLazy / PSY-951.
 import { MarkdownEditor } from './MarkdownEditorLazy'
 import { CollectionItemCard } from './CollectionItemCard'
+import { ANCHOR_SECTION_SCROLL_MT } from './CollectionAnchorNav'
 import { useDensity, type Density } from '@/lib/hooks/common/useDensity'
 import { useLocalStorageEnum } from '@/lib/hooks/common/useLocalStorageEnum'
 import { DensityToggle } from '@/components/shared'
@@ -101,6 +108,12 @@ const VIEW_MODES = ['grid', 'list'] as const
 type CollectionItemsViewMode = (typeof VIEW_MODES)[number]
 
 const VIEW_MODE_STORAGE_KEY = 'ph-collection-items-view-mode'
+
+/**
+ * DOM id linking the header's "+ Add Items" toggle (aria-controls) to the
+ * picker panel it expands (PSY-892 D7).
+ */
+const ADD_ITEMS_PANEL_ID = 'add-items-panel'
 
 /**
  * Density-driven column counts for the grid view (PSY-360). Mirrors the
@@ -149,8 +162,18 @@ export function CollectionItemsList({
 
   // Density preference for the grid view. List view ignores density (its
   // layout is intentionally fixed). Storage key matches the hook's prefix
-  // convention (ph-density-collections).
-  const { density, setDensity } = useDensity('collections')
+  // convention (ph-density-collections). Default is Compact (PSY-892 D3) —
+  // collection viewers are already-curated audiences scanning a list; the
+  // toggle to Comfortable / Expanded still persists per browser.
+  const { density, setDensity } = useDensity('collections', 'compact')
+
+  // PSY-892 D7: the "+ Add Items" affordance lives next to the items count in
+  // the header (creator-only); the picker panel expands below the header row.
+  // Empty collections open the panel by default so the empty-state copy stays
+  // honest (PSY-581). The creator gate lives at the render sites (header
+  // button + panel), not here — so a late-resolving isCreator still gets the
+  // default-open behavior.
+  const [isAddItemsOpen, setIsAddItemsOpen] = useState(items.length === 0)
 
   // View-mode preference (grid vs list). Default `grid` so first-time viewers
   // see the visual layout. Persists per-browser. `useLocalStorageEnum` returns
@@ -225,22 +248,6 @@ export function CollectionItemsList({
     [items, persistOrder]
   )
 
-  if (items.length === 0) {
-    return (
-      <div>
-        <h2 className="text-lg font-semibold mb-4">Items</h2>
-        <div className="text-center py-12 text-muted-foreground">
-          <Library className="h-12 w-12 mx-auto mb-3 text-muted-foreground/30" />
-          <p>
-            {isCreator
-              ? 'Add your first item using the search above.'
-              : 'This collection is empty.'}
-          </p>
-        </div>
-      </div>
-    )
-  }
-
   // Container layout depends on view + display mode:
   // - grid view  → density-driven responsive grid of CollectionItemCard
   // - list view + ranked → vertical stack (numbering reads top-to-bottom)
@@ -302,15 +309,38 @@ export function CollectionItemsList({
 
   const renderItems = isGridView ? renderGridCards : renderListRows
 
-  // Header row: section title on the left, view + density toggles on the
-  // right. Density toggle stays mounted in list view so the toolbar
-  // doesn't shift between modes (PSY-556); it's disabled there with a
-  // tooltip explaining the constraint. The persisted selection is
-  // preserved so toggling back to grid restores the user's choice.
+  // Header row: section title + item count + creator's "+ Add Items" button
+  // on the left (PSY-892 D7 — "add more" reads in the same glance as "what's
+  // here"); view + density toggles on the right. Density toggle stays mounted
+  // in list view so the toolbar doesn't shift between modes (PSY-556); it's
+  // disabled there with a tooltip explaining the constraint. The persisted
+  // selection is preserved so toggling back to grid restores the user's choice.
   const header = (
     <div className="mb-4 flex items-center justify-between gap-3 flex-wrap">
-      <h2 className="text-lg font-semibold">Items</h2>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2.5">
+        <h2 className="text-lg font-semibold">Items</h2>
+        <span
+          className="text-sm text-muted-foreground tabular-nums"
+          data-testid="items-count"
+        >
+          {items.length}
+        </span>
+        {isCreator && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsAddItemsOpen(open => !open)}
+            aria-expanded={isAddItemsOpen}
+            aria-controls={isAddItemsOpen ? ADD_ITEMS_PANEL_ID : undefined}
+            data-testid="add-items-toggle"
+          >
+            <Plus className="h-4 w-4 mr-1.5" />
+            Add Items
+          </Button>
+        )}
+      </div>
+      {items.length > 0 && (
+        <div className="flex items-center gap-2">
         <DensityToggle
           density={density}
           onDensityChange={setDensity}
@@ -356,51 +386,214 @@ export function CollectionItemsList({
             <List className="h-4 w-4" />
           </button>
         </div>
-      </div>
+        </div>
+      )}
     </div>
   )
 
+  // PSY-892 D7: the add-items picker panel expands directly below the header
+  // row. Closing unmounts the panel, which resets its staged-items state.
+  const addItemsPanel = isCreator && isAddItemsOpen && (
+    <AddItemsPanel
+      slug={slug}
+      existingItems={items}
+      onClose={() => setIsAddItemsOpen(false)}
+    />
+  )
+
+  // The items container is identical with or without reorder support — define
+  // it once so the wrapper's classes/test-ids can't drift between branches.
+  const itemsGrid = (
+    <div
+      className={containerClasses}
+      data-testid="collection-items"
+      data-view-mode={viewMode}
+    >
+      {renderItems()}
+    </div>
+  )
+
+  // `id="items"` + scroll-margin pair with the sticky CollectionAnchorNav
+  // (PSY-892 D1) — the margin keeps jumped-to content clear of the sticky
+  // chrome (TopBar + nav).
   return (
-    <div>
+    <div id="items" className={ANCHOR_SECTION_SCROLL_MT}>
       {header}
-      {/*
-        PSY-609: surface drag-drop / arrow-key reorder failures. The
-        useReorderCollectionItems mutation has no optimistic update, so a
-        rejected request leaves the items in their original order with no
-        feedback. Auto-dismiss the banner after ~3s.
-      */}
-      {reorderError && (
+      {addItemsPanel}
+      {items.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <Library className="h-12 w-12 mx-auto mb-3 text-muted-foreground/30" />
+          <p>
+            {isCreator
+              ? 'Add your first item using the search above.'
+              : 'This collection is empty.'}
+          </p>
+        </div>
+      ) : (
+        <>
+          {/*
+            PSY-609: surface drag-drop / arrow-key reorder failures. The
+            useReorderCollectionItems mutation has no optimistic update, so a
+            rejected request leaves the items in their original order with no
+            feedback. Auto-dismiss the banner after ~3s.
+          */}
+          {reorderError && (
+            <MutationFeedback
+              variant="error"
+              testId="reorder-error"
+              message={reorderError}
+            />
+          )}
+          {canReorder ? (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={itemIds} strategy={sortStrategy}>
+                {itemsGrid}
+              </SortableContext>
+            </DndContext>
+          ) : (
+            itemsGrid
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Add Items Panel (PSY-892 D7)
+// ──────────────────────────────────────────────
+
+/**
+ * The entity-search picker panel that the header's "+ Add Items" button
+ * toggles (PSY-892 D7). Moved here from `CollectionDetail.tsx`'s old
+ * standalone AddItemsSection so the items header, panel, and grid live in one
+ * module. The panel is fully unmounted when closed — staged items and
+ * feedback reset via unmount rather than explicit clearing.
+ */
+function AddItemsPanel({
+  slug,
+  existingItems,
+  onClose,
+}: {
+  slug: string
+  existingItems: CollectionItem[]
+  onClose: () => void
+}) {
+  // PSY-823: items staged in the picker, submitted in one bulk-add request.
+  const [stagedItems, setStagedItems] = useState<StagedCollectionItem[]>([])
+  const [feedback, setFeedback] = useState<
+    | { variant: 'success'; message: string }
+    | { variant: 'error'; message: string }
+    | null
+  >(null)
+  const bulkAddMutation = useBulkAddCollectionItems()
+
+  // The panel unmounts when closed (unlike the old always-mounted
+  // AddItemsSection), so the post-submit feedback timer must be cleared on
+  // unmount or it fires setState against an unmounted component.
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
+    },
+    []
+  )
+
+  const handleSubmit = async () => {
+    if (stagedItems.length === 0) return
+    try {
+      const resp = await bulkAddMutation.mutateAsync({
+        slug,
+        items: stagedItems.map((s) => ({
+          entity_type: s.entityType,
+          entity_id: s.entityId,
+        })),
+      })
+      const addedCount = resp.added.length
+      const rejectedCount = resp.errors.length
+      if (rejectedCount === 0) {
+        setFeedback({
+          variant: 'success',
+          message: `Added ${addedCount} ${addedCount === 1 ? 'item' : 'items'} to collection`,
+        })
+      } else if (addedCount === 0) {
+        setFeedback({
+          variant: 'error',
+          message: `Couldn't add any items (${rejectedCount} ${rejectedCount === 1 ? 'error' : 'errors'}). Adjust the picker and try again.`,
+        })
+      } else {
+        setFeedback({
+          variant: 'success',
+          message: `Added ${addedCount} ${addedCount === 1 ? 'item' : 'items'}; ${rejectedCount} couldn't be added.`,
+        })
+      }
+      // Clear staged list only if at least one row committed. When EVERY
+      // row failed, leave the picker as-is so the user can edit/retry
+      // without re-staging from scratch.
+      if (addedCount > 0) {
+        setStagedItems([])
+      }
+      if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
+      feedbackTimerRef.current = setTimeout(() => setFeedback(null), 4000)
+    } catch (err) {
+      setFeedback({
+        variant: 'error',
+        message: describeCollectionMutationError(err, 'Failed to add items.'),
+      })
+    }
+  }
+
+  return (
+    <div
+      id={ADD_ITEMS_PANEL_ID}
+      className="mb-6 rounded-lg border border-border/50 bg-card p-4"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-semibold sr-only">Add items</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 ml-auto"
+          onClick={onClose}
+          aria-label="Close add-items picker"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <AddItemsPicker
+        existingItems={existingItems.map((i) => ({
+          entity_type: i.entity_type,
+          entity_id: i.entity_id,
+        }))}
+        stagedItems={stagedItems}
+        onStagedItemsChange={setStagedItems}
+      />
+
+      {feedback && (
         <MutationFeedback
-          variant="error"
-          testId="reorder-error"
-          message={reorderError}
+          variant={feedback.variant}
+          message={feedback.message}
+          testId={feedback.variant === 'success' ? 'add-item-success' : 'add-item-error'}
         />
       )}
-      {canReorder ? (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
+
+      <div className="flex justify-end mt-4">
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={stagedItems.length === 0 || bulkAddMutation.isPending}
+          data-testid="add-items-picker-submit"
         >
-          <SortableContext items={itemIds} strategy={sortStrategy}>
-            <div
-              className={containerClasses}
-              data-testid="collection-items"
-              data-view-mode={viewMode}
-            >
-              {renderItems()}
-            </div>
-          </SortableContext>
-        </DndContext>
-      ) : (
-        <div
-          className={containerClasses}
-          data-testid="collection-items"
-          data-view-mode={viewMode}
-        >
-          {renderItems()}
-        </div>
-      )}
+          {bulkAddMutation.isPending
+            ? 'Adding...'
+            : `Add ${stagedItems.length || ''} item${stagedItems.length === 1 ? '' : 's'}`.trim()}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/frontend/features/collections/components/CollectionItemsList.tsx
+++ b/frontend/features/collections/components/CollectionItemsList.tsx
@@ -493,15 +493,20 @@ function AddItemsPanel({
   const bulkAddMutation = useBulkAddCollectionItems()
 
   // The panel unmounts when closed (unlike the old always-mounted
-  // AddItemsSection), so the post-submit feedback timer must be cleared on
-  // unmount or it fires setState against an unmounted component.
+  // AddItemsSection), so async work must not setState after unmount: the
+  // feedback timer is cleared on unmount, and the post-await feedback
+  // writes bail when the panel has already closed. The flag is set in the
+  // effect SETUP (not just initialized at declaration) so StrictMode's
+  // dev-only mount→cleanup→remount cycle restores it to true.
   const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(
-    () => () => {
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
       if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
-    },
-    []
-  )
+    }
+  }, [])
 
   const handleSubmit = async () => {
     if (stagedItems.length === 0) return
@@ -513,6 +518,8 @@ function AddItemsPanel({
           entity_id: s.entityId,
         })),
       })
+      // The user may have closed the panel while the request was in flight.
+      if (!isMountedRef.current) return
       const addedCount = resp.added.length
       const rejectedCount = resp.errors.length
       if (rejectedCount === 0) {
@@ -540,6 +547,7 @@ function AddItemsPanel({
       if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
       feedbackTimerRef.current = setTimeout(() => setFeedback(null), 4000)
     } catch (err) {
+      if (!isMountedRef.current) return
       setFeedback({
         variant: 'error',
         message: describeCollectionMutationError(err, 'Failed to add items.'),

--- a/frontend/features/collections/components/CollectionList.test.tsx
+++ b/frontend/features/collections/components/CollectionList.test.tsx
@@ -981,6 +981,10 @@ describe('CollectionList', () => {
     it('chips use the DS Badge square shape — no rounded-full (PSY-895 D1)', () => {
       // PSY-895 D1 drops rounded-full per the DS editorial direction; chips
       // adopt the Badge primitive's square-ish rounded-md shape.
+      // NOTE: this test (and the active-fill test below) intentionally
+      // asserts class names owned by components/ui/badge.tsx — they are
+      // design-lock guards for the PSY-895 AC. If a DS refactor renames the
+      // Badge variant tokens, update these assertions alongside badge.tsx.
       render(<CollectionList />)
 
       const group = screen.getByRole('group', {

--- a/frontend/features/collections/components/CollectionList.test.tsx
+++ b/frontend/features/collections/components/CollectionList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CollectionList } from './CollectionList'
 import type { Collection } from '../types'
@@ -910,6 +910,100 @@ describe('CollectionList', () => {
       const pushedUrl = mockPush.mock.calls[0]?.[0] as string
       expect(pushedUrl).toContain('tab=recent')
       expect(pushedUrl).toContain('tag=phoenix')
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // PSY-905: entity-type filter chips (PSY-895 D1)
+  // ──────────────────────────────────────────────
+
+  describe('PSY-905 entity-type filter chips', () => {
+    beforeEach(() => {
+      mockUseCollections.mockReturnValue({
+        data: { collections: [makeCollection()] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+    })
+
+    it('renders the All types chip plus one chip per entity type', () => {
+      render(<CollectionList />)
+
+      const group = screen.getByRole('group', {
+        name: 'Filter by entity type',
+      })
+      const chips = within(group).getAllByRole('button')
+      // All types + artist/release/label/show/venue/festival
+      expect(chips).toHaveLength(7)
+      expect(
+        within(group).getByRole('button', { name: 'All types' })
+      ).toBeInTheDocument()
+      expect(
+        within(group).getByRole('button', { name: 'Artists' })
+      ).toBeInTheDocument()
+      expect(
+        within(group).getByRole('button', { name: 'Festivals' })
+      ).toBeInTheDocument()
+    })
+
+    it('marks only the active chip as pressed; defaults to All types', () => {
+      render(<CollectionList />)
+
+      const group = screen.getByRole('group', {
+        name: 'Filter by entity type',
+      })
+      expect(
+        within(group).getByRole('button', { name: 'All types' })
+      ).toHaveAttribute('aria-pressed', 'true')
+      expect(
+        within(group).getByRole('button', { name: 'Artists' })
+      ).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('clicking a chip filters the public query by that entity type', async () => {
+      const user = userEvent.setup()
+      render(<CollectionList />)
+
+      await user.click(screen.getByRole('button', { name: 'Artists' }))
+
+      expect(mockUseCollections).toHaveBeenLastCalledWith(
+        expect.objectContaining({ entityType: 'artist' })
+      )
+      expect(
+        screen.getByRole('button', { name: 'Artists' })
+      ).toHaveAttribute('aria-pressed', 'true')
+      expect(
+        screen.getByRole('button', { name: 'All types' })
+      ).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('chips use the DS Badge square shape — no rounded-full (PSY-895 D1)', () => {
+      // PSY-895 D1 drops rounded-full per the DS editorial direction; chips
+      // adopt the Badge primitive's square-ish rounded-md shape.
+      render(<CollectionList />)
+
+      const group = screen.getByRole('group', {
+        name: 'Filter by entity type',
+      })
+      for (const chip of within(group).getAllByRole('button')) {
+        expect(chip.className).not.toContain('rounded-full')
+        expect(chip.className).toContain('rounded-md')
+      }
+    })
+
+    it('active chip uses the subtle secondary fill, not the solid primary (PSY-895 D1)', () => {
+      render(<CollectionList />)
+
+      const activeChip = screen.getByRole('button', { name: 'All types' })
+      const inactiveChip = screen.getByRole('button', { name: 'Artists' })
+      // Active = DS Badge secondary variant (subtle), never the loud
+      // primary fill that out-shouted the mode tabs pre-redesign.
+      expect(activeChip.className).toContain('bg-secondary')
+      expect(activeChip.className).not.toContain('bg-primary')
+      // Inactive = outline shape with muted text.
+      expect(inactiveChip.className).not.toContain('bg-secondary')
+      expect(inactiveChip.className).toContain('text-muted-foreground')
     })
   })
 })

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -268,7 +268,7 @@ export function CollectionList() {
             <TabsTrigger
               key={tab.value}
               value={tab.value}
-              className="h-10 flex-none gap-1.5 rounded-none border-0 border-b-2 border-transparent px-3 text-muted-foreground hover:text-foreground data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:border-b-primary dark:data-[state=active]:bg-transparent"
+              className="h-10 flex-none gap-1.5 rounded-none border-b-2 border-transparent px-3 text-muted-foreground hover:text-foreground data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:border-b-primary dark:data-[state=active]:bg-transparent"
             >
               {tab.icon}
               {tab.label}

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -25,6 +25,7 @@ import {
   validateCoverImageUrl,
 } from '../types'
 import { LoadingSpinner } from '@/components/shared'
+import { badgeVariants } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -248,15 +249,27 @@ export function CollectionList() {
         )}
       </div>
 
-      {/* Tabs */}
+      {/* Tabs — PSY-895 D1 (implemented in PSY-905): mode tabs read as
+          NAVIGATION, not pills. Underline-active style (DS TabTrigger
+          pattern, matching PSY-898's detail-page anchor nav) replaces the
+          boxed pill row so the tabs sit a clear hierarchy level above the
+          entity-type refinement chips below.
+          NOTE for the future cross-browse cohesion ticket: when this
+          underline pattern propagates to other browse pages, extract these
+          overrides into a `variant="underline"` on ui/tabs.tsx instead of
+          copy-pasting this string — see PSY-895's flagged follow-ups. */}
       <Tabs
         value={activeTab}
         onValueChange={handleTabChange}
         className="w-full"
       >
-        <TabsList className="mb-4">
+        <TabsList className="mb-4 h-auto w-full justify-start gap-1 rounded-none border-b border-border/50 bg-transparent p-0 text-muted-foreground">
           {tabs.map((tab) => (
-            <TabsTrigger key={tab.value} value={tab.value} className="gap-1.5">
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              className="h-10 flex-none gap-1.5 rounded-none border-0 border-b-2 border-transparent px-3 text-muted-foreground hover:text-foreground data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:border-b-primary dark:data-[state=active]:bg-transparent"
+            >
               {tab.icon}
               {tab.label}
             </TabsTrigger>
@@ -280,10 +293,11 @@ export function CollectionList() {
           ))}
         </div>
 
-        {/* PSY-354: active tag-filter pill. Distinct from the entity-type
+        {/* PSY-354: active tag-filter chip. Distinct from the entity-type
             chips above (those are toggleable filters; this is a "you are
             currently filtering" indicator with an X-to-clear). Empty when
-            ?tag=<slug> isn't present in the URL. */}
+            ?tag=<slug> isn't present in the URL. PSY-905: squared to match
+            the entity-type chips (rounded-full is DS-banned). */}
         {tagFilter && (
           <div
             className="mb-6 flex flex-wrap items-center gap-2 text-sm"
@@ -294,7 +308,7 @@ export function CollectionList() {
             <span className="text-muted-foreground">Tagged with</span>
             <span
               className={cn(
-                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5',
+                'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-0.5',
                 'border-primary/40 bg-primary/10 text-primary'
               )}
             >
@@ -303,7 +317,7 @@ export function CollectionList() {
                 type="button"
                 onClick={handleClearTag}
                 aria-label={`Clear tag filter (${tagFilter})`}
-                className="rounded-full p-0.5 hover:bg-primary/20 focus:outline-none focus:ring-2 focus:ring-ring"
+                className="rounded-md p-0.5 hover:bg-primary/20 focus:outline-none focus:ring-2 focus:ring-ring"
                 data-testid="collection-tag-filter-clear"
               >
                 <X className="h-3 w-3" />
@@ -340,6 +354,13 @@ export function CollectionList() {
 // Entity Type Filter Chip
 // ──────────────────────────────────────────────
 
+/**
+ * PSY-895 D1 (implemented in PSY-905): entity-type chips use the DS Badge
+ * shape — square-ish (`rounded-md`), not pills (`rounded-full` is banned by
+ * the DS editorial direction). Active state is a subtle Secondary fill, NOT
+ * the previous solid primary that out-shouted the mode tabs above; the chips
+ * read as a refinement level below the tabs' navigation level.
+ */
 function TypeChip({
   active,
   onClick,
@@ -355,10 +376,13 @@ function TypeChip({
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-        active
-          ? 'border-primary bg-primary text-primary-foreground'
-          : 'border-border/60 bg-background text-muted-foreground hover:text-foreground hover:border-border'
+        badgeVariants({ variant: active ? 'secondary' : 'outline' }),
+        // py-1 restores the pre-redesign tap-target height (≥24px, WCAG
+        // 2.5.8) — the Badge primitive's py-0.5 is sized for non-interactive
+        // chips.
+        'cursor-pointer py-1',
+        !active &&
+          'border-border/60 text-muted-foreground hover:border-border hover:text-foreground'
       )}
     >
       {label}

--- a/frontend/features/collections/types.ts
+++ b/frontend/features/collections/types.ts
@@ -43,15 +43,17 @@ export function validateCoverImageUrl(value: string): string | null {
     return `URL is too long (max ${MAX_COVER_IMAGE_URL_LENGTH} characters).`
   }
 
+  // PSY-894 D6: one tightened message for both parse failures and
+  // non-http(s) protocols — matches the locked edit-form design copy.
   let parsed: URL
   try {
     parsed = new URL(trimmed)
   } catch {
-    return 'Enter a valid URL starting with http:// or https://.'
+    return 'Enter a valid http(s) image URL.'
   }
 
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return 'URL must start with http:// or https://.'
+    return 'Enter a valid http(s) image URL.'
   }
 
   return null

--- a/frontend/lib/hooks/common/useDensity.ts
+++ b/frontend/lib/hooks/common/useDensity.ts
@@ -18,15 +18,22 @@ function getStorageKey(suffix?: string): string {
  * Persists the selection in localStorage under a configurable key.
  *
  * @param storageKeySuffix - Optional suffix appended to the storage key (e.g., 'shows', 'artists')
+ * @param defaultDensity - Density used until the user picks one (default 'comfortable').
+ *   Collections pass 'compact' per PSY-892 D3 — collection viewers are
+ *   already-curated audiences scanning a list, not first-time browsers.
  *
  * Usage:
  *   const { density, setDensity } = useDensity('shows')
+ *   const { density, setDensity } = useDensity('collections', 'compact')
  */
-export function useDensity(storageKeySuffix?: string) {
+export function useDensity(
+  storageKeySuffix?: string,
+  defaultDensity: Density = DEFAULT_DENSITY
+) {
   const key = getStorageKey(storageKeySuffix)
   const [density, setDensity] = useLocalStorageEnum<Density>(
     key,
-    DEFAULT_DENSITY,
+    defaultDensity,
     VALID_DENSITIES
   )
   return { density, setDensity }


### PR DESCRIPTION
Closes PSY-905.

Implements **Option 1 (refine existing)** locked in PSY-895 (Figma node `186:11`, decisions comment `#comment-2bfbf6ad`).

> **Stacked PR:** based on `PSY-898/collections-detail-redesign` (#968) so the Collections cohesion-pass changes review and land in order. Merge #968 first; this PR's diff shows only the browse-filter changes.

## Summary

- **Mode tabs** (All · Popular · Recent · Featured · Yours) → DS TabTrigger **underline-active** style. Tabs read as navigation — same idiom as PSY-898's detail-page anchor nav. Implemented as className overrides on the existing Radix Tabs (URL-driven `?tab=` behavior untouched); a breadcrumb comment points the future cross-browse cohesion ticket at extracting a shared `variant="underline"` instead of copy-pasting.
- **Entity-type filter** (All types · Artists · … · Festivals) → DS Badge **square chips** via `badgeVariants`; active = subtle **Secondary** fill instead of the solid primary that out-shouted the mode tabs. Tap-target kept ≥24px (WCAG 2.5.8).
- **`rounded-full` dropped** from the filter UI — tabs, entity-type chips, and the adjacent PSY-354 tag-filter indicator (squared for cohesion; small scope addition disclosed here, rationale: same DS ban, same filter block, 2-line change).
- **"N new" Yours-tab badge**: verified already shipped by PSY-350 (`CollectionCard.tsx:176-185`, filled primary `{N} new`, gated on `new_since_last_visit > 0`, with 3 existing tests). No change needed — AC met by existing code.

Net effect (per PSY-895 D1): clear two-level hierarchy — tabs = navigation, chips = refinement. No function removed; type filter stays one-click.

## Deferred

- **Cross-browse propagation** (Artists / Releases / Labels browse pages) — explicitly out of scope per PSY-895; flagged there as a future cohesion ticket. The underline-tab override carries a breadcrumb comment for that ticket.
- **Entity-type filter usage metric** — flagged in PSY-895, not actioned here (Option 1 is safe regardless of the metric's outcome).

## Heads up from `/code-review`

Two findings fixed pre-commit: the DS Badge's `py-0.5` shrank the chip tap-target below WCAG 2.5.8's 24px minimum (restored with `py-1`), and the adjacent tag-filter pill would have been the page's only surviving `rounded-full` (squared in-scope).

## Adversarial review

`/adversarial-review` — 2 findings addressed in commit `45974edb`.
- [MEDIUM] `border-0` + `border-b-2` combo relied on Tailwind v4 longhand sort order → dropped `border-0`; now matches the CollectionAnchorNav / NetworkTabBar underline precedents exactly.
- [MEDIUM] New className tests couple to `badge.tsx` tokens with nothing marking them as intentional → comment marks them as PSY-895 design-lock guards.
- [LOW] `data-testid="collection-tag-filter-pill"` now names a square chip → left as-is (renaming churns tests for zero behavior gain).
Panel: Saboteur+Future-Maintainer · Completeness · Security. Completeness verified all 4 spec items including the PSY-350 badge claim; Security verified the `?tag=` param renders only through React text auto-escaping. Reviewers ran with no prior session context.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (no new warnings on changed lines)
- [x] `bun run test:run features/collections` — 325/325 passing (includes 5 new entity-type chip tests: chip inventory, default pressed state, click-to-filter wiring, no-rounded-full guard, secondary-fill guard)
- [x] `/code-review` — 2 findings, both fixed pre-commit
- [x] `/adversarial-review` — CONCERNS addressed; fixes in separate commit `45974edb`
- [x] `/psy-self-review` — run before push
- [x] Manual repro against local dev stack: browse page exercised logged-in (Yours tab visible) at `/collections`; clicked the Artists chip → grid filtered to artist-containing collections + chip pressed state verified; live DOM assertion confirms 0 `rounded-full` elements across both filter rows and a 2px primary underline on the active tab

## Screenshots

**Browse page (logged in)** — underline mode tabs + square entity-type chips; "All types" carries the subtle secondary active fill:

![browse default](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-c1d6c6a859e7295e4a10/psy-905-browse-default.png)

**Artists chip active** — grid filtered to artist-containing collections; clicked chip pressed (orange ring is the click focus indicator):

![artists filter](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-c1d6c6a859e7295e4a10/psy-905-browse-artists-filter.png)

**Final build after adversarial fixes** — underline intact after the `border-0` removal:

![final](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-c1d6c6a859e7295e4a10/psy-905-browse-final.png)

## Coverage gaps

- **Mode-tab underline style has no unit-test coverage** — `CollectionList.test.tsx` mocks `@/components/ui/tabs`, so the TabsList/TabsTrigger className overrides aren't exercised by tests; verified via screenshots + a live DOM assertion (2px primary underline) instead. Tab *behavior* (URL-driven switching, auth gating) keeps its existing 12 tests.
- **"N new" badge not re-verified visually** — the dev DB has no subscribed collection with new items; relied on the existing PSY-350 unit tests (render when >0, omit when 0/undefined).
- **Logged-out browse view not screenshotted** — covered by existing tests (Yours tab hidden for unauthenticated viewers); only the logged-in view was captured.
- **Dark-mode rendering not screenshotted** — the adversarial panel verified the dark-mode class merge resolves correctly (active tab = transparent bg + primary underline), but no dark-mode screenshot was taken.
