### PR TITLE
PSY-663: render [Add to collection] bracket for unauth viewers

### DIFF
--- a/frontend/components/shared/AddToCollectionButton.test.tsx
+++ b/frontend/components/shared/AddToCollectionButton.test.tsx
@@ -21,6 +21,13 @@ vi.mock('@/lib/context/AuthContext', () => ({
   useAuthContext: () => mockAuthContext(),
 }))
 
+// Mock next/navigation — the unauth bracket variant pushes to /auth.
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/releases/test-release',
+}))
+
 // Mock collection hooks
 const mockMutateAsync = vi.fn()
 const mockMyCollections = vi.fn(() => ({
@@ -457,4 +464,76 @@ describe('AddToCollectionButton — bracket variant (PSY-641)', () => {
     await user.click(screen.getByRole('button', { name: /add to collection/i }))
     expect(await screen.findByText('My Favorites')).toBeInTheDocument()
   })
+
+  // ── PSY-663: unauthenticated bracket variant renders a public affordance ──
+  // Releases and labels aren't follow/notify-able, so the bracket
+  // [Add to collection] is their only public header bracket. For unauth
+  // viewers it must still render (not return an empty linkbox) and redirect
+  // to /auth on click, mirroring FollowButton / NotifyMeButton.
+  it('renders [Add to collection] for an unauthenticated viewer in bracket variant', () => {
+    mockAuthContext.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    render(
+      <AddToCollectionButton
+        entityType="release"
+        entityId={7}
+        entityName="Test Release"
+        variant="bracket"
+      />
+    )
+    const trigger = screen.getByRole('button', { name: /add to collection/i })
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveTextContent('[Add to collection]')
+  })
+
+  it('redirects an unauthenticated viewer to /auth with returnTo on click', async () => {
+    mockAuthContext.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton
+        entityType="release"
+        entityId={7}
+        entityName="Test Release"
+        variant="bracket"
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /add to collection/i }))
+    expect(mockPush).toHaveBeenCalledWith(
+      '/auth?returnTo=%2Freleases%2Ftest-release'
+    )
+    // No popover should open for unauth viewers.
+    expect(screen.queryByText('My Favorites')).not.toBeInTheDocument()
+  })
+
+  // Non-bracket variants have no public surface — they still return null for
+  // unauth viewers (the fix is scoped to the bracket variant only).
+  it.each(['default', 'ghost', 'outline'] as const)(
+    'renders nothing for an unauthenticated viewer in %s variant',
+    (variant) => {
+      mockAuthContext.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      const { container } = render(
+        <AddToCollectionButton
+          entityType="release"
+          entityId={7}
+          entityName="Test Release"
+          variant={variant}
+        />
+      )
+      expect(container.innerHTML).toBe('')
+    }
+  )
 })

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import Link from 'next/link'
+import { useRouter, usePathname } from 'next/navigation'
 import { Library, Check, Plus, Loader2, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { BracketLink } from './BracketLink'
@@ -57,6 +58,8 @@ export function AddToCollectionButton({
   // early return triggered a Rules-of-Hooks violation once the auth
   // profile resolved (PSY-466).
   const { isAuthenticated } = useAuthContext()
+  const router = useRouter()
+  const pathname = usePathname()
   const [open, setOpen] = useState(false)
 
   // The contains query is gated on `open` so we don't fetch on every
@@ -120,6 +123,23 @@ export function AddToCollectionButton({
     return result
   }, [selected, savedIds])
 
+  // Unauthenticated bracket variant — render the public [Add to collection]
+  // affordance and redirect to /auth on click, mirroring FollowButton /
+  // NotifyMeButton. Releases and labels aren't in FOLLOW_ENTITY_TYPES /
+  // NOTIFY_ENTITY_TYPES, so this is their only public header bracket (PSY-663).
+  // Non-bracket variants still return null below — they have no public surface.
+  if (!isAuthenticated && variant === 'bracket') {
+    return (
+      <BracketLink
+        label="Add to collection"
+        title={`Add "${entityName}" to a collection`}
+        ariaLabel="Add to Collection"
+        onClick={() =>
+          router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)
+        }
+      />
+    )
+  }
   if (!isAuthenticated) return null
 
   const errorByCollection = new Map(

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -125,8 +125,10 @@ export function AddToCollectionButton({
 
   // Unauthenticated bracket variant — render the public [Add to collection]
   // affordance and redirect to /auth on click, mirroring FollowButton /
-  // NotifyMeButton. Releases and labels aren't in FOLLOW_ENTITY_TYPES /
-  // NOTIFY_ENTITY_TYPES, so this is their only public header bracket (PSY-663).
+  // NotifyMeButton (which both render their bracket for unauth viewers).
+  // ReleaseDetail renders neither a [Follow] nor a [Notify me] bracket, so
+  // [Add to collection] is the ONLY public header bracket on a release —
+  // returning null here left an empty linkbox for anonymous visitors (PSY-663).
   // Non-bracket variants still return null below — they have no public surface.
   if (!isAuthenticated && variant === 'bracket') {
     return (


### PR DESCRIPTION
## Summary

`AddToCollectionButton` returned `null` for ALL variants when unauthenticated — including `variant="bracket"`. This created an asymmetry with `FollowButton` and `NotifyMeButton`, both of which render their bracket for unauthenticated viewers and redirect to `/auth` on click.

`ReleaseDetail` renders neither a `[Follow]` nor a `[Notify me]` bracket (release isn't a follow- or notify-able entity type), so `[Add to collection]` is the *only* public header bracket on a release — returning `null` left an **empty linkbox** for anonymous visitors of `/releases/<slug>`.

This PR special-cases the bracket variant before the existing early return, mirroring the Follow/Notify convention: render `[Add to collection]` and `router.push('/auth?returnTo=<pathname>')` on click. `useRouter` / `usePathname` are called above the early return to preserve the Rules-of-Hooks ordering documented at the top of the component (PSY-466). Non-bracket variants (`default` / `ghost` / `outline`) still return `null` — they have no public surface.

## Test plan

- [x] `cd frontend && bun run typecheck` — clean (`tsc --noEmit`, no errors)
- [x] `cd frontend && bun run test:run components/shared` — 24 files / 361 tests pass (`AddToCollectionButton.test.tsx`: 16 → 20 tests)
- [x] `cd frontend && bun run lint` — 0 errors (154 pre-existing warnings, none in the changed files)

## Manual repro

Brought up an isolated dispatch stack (`stack-up.sh --mode=isolated`) and navigated to `/releases/sundressed-ep` **without logging in** (header showed `login / sign-up`), using agent-browser:

1. Header linkbox renders `[Add to collection]` for the unauthenticated viewer (was empty before the fix). Snapshot exposed a `button "Add to Collection"` with visible text `[Add to collection]`.
2. Clicking it redirected to `/auth?returnTo=%2Freleases%2Fsundressed-ep` and rendered the sign-in page.

## Screenshots

![Unauthenticated release header shows the [Add to collection] bracket](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-256d4e8f7f75d1b5e01b/01-unauth-release-header-linkbox.png)
*`[Add to collection]` rendered in the top-right header linkbox while unauthenticated (`login / sign-up` in nav confirms anon state).*

![After clicking, the /auth sign-in page with returnTo in the URL](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-256d4e8f7f75d1b5e01b/02-auth-redirect-with-returnTo.png)
*After clicking `[Add to collection]`: `/auth?returnTo=%2Freleases%2Fsundressed-ep` sign-in page.*

## Code review

`/code-review` (inline, sub-agent) — 1 finding: the original code comment claimed "labels aren't in FOLLOW_ENTITY_TYPES / NOTIFY_ENTITY_TYPES," but `LabelDetail` renders both `FollowButton` and `NotifyMeButton` and `NOTIFY_ENTITY_TYPES` includes `'label'`. Only `ReleaseDetail` renders neither. Comment corrected to cite the real call-site state (commit `af8538c8`, comment-only, no behavior change).

## Adversarial review

`/adversarial-review` — **CLEAN** (inline, 4 lenses, no prior session context). No CRITICAL/HIGH/MEDIUM findings.
- **Saboteur**: `usePathname()`-null and double-click probed — both match the unguarded Follow/Notify convention; `router.push` is idempotent; no partial-state risk (unauth path never mounts the popover/hooks-gated queries).
- **Future-Maintainer**: two `BracketLink` renders for the bracket variant use identical literals (`label="Add to collection"`, accessible name `"Add to Collection"`) — no drift; mirrors the Follow/Notify multi-render pattern; comment now accurate.
- **Security**: `returnTo` encodes the in-app `usePathname()` (not user-controlled URL params), so no open-redirect injection; no new attack surface; public affordance by design.
- **Completeness**: all acceptance criteria met (unauth render, redirect, auth-unchanged, non-bracket-null, unit tests, manual repro + screenshots).

Panel: Saboteur · Future-Maintainer · Security · Completeness.

Closes PSY-663
