### PR TITLE
PSY-668: open venue bio inline editing to trusted tiers

### DIFF
--- a/frontend/features/venues/components/VenueDetail.test.tsx
+++ b/frontend/features/venues/components/VenueDetail.test.tsx
@@ -8,7 +8,7 @@ import type { Venue } from '../types'
 // Return type widened so individual tests can override `user`/`isAuthenticated`
 // without TS narrowing from the default-null literal.
 type MockAuthContextValue = {
-  user: { id: string; is_admin: boolean } | null
+  user: { id: string; is_admin: boolean; user_tier?: string } | null
   isAuthenticated: boolean
   isLoading: boolean
   logout: () => void
@@ -77,9 +77,17 @@ vi.mock('../hooks/useVenues', () => ({
   useVenueShows: (opts: unknown) => mockUseVenueShows(opts),
 }))
 
+// Shared mutate spies so tests can assert which path an inline description save
+// takes: admins -> venueUpdate.mutate; trusted/submitter -> suggestVenueEdit.mutate.
+// Hoisted so they can be referenced inside the vi.mock factories below.
+const { mockVenueUpdateMutate, mockSuggestEditMutate } = vi.hoisted(() => ({
+  mockVenueUpdateMutate: vi.fn(),
+  mockSuggestEditMutate: vi.fn(),
+}))
+
 // Mock useVenueEdit hook
 vi.mock('../hooks/useVenueEdit', () => ({
-  useVenueUpdate: () => ({ mutate: vi.fn(), isPending: false }),
+  useVenueUpdate: () => ({ mutate: mockVenueUpdateMutate, isPending: false }),
   useVenueDelete: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
@@ -96,8 +104,26 @@ vi.mock('@/components/shared', () => ({
   TagPill: ({ label, href }: { label: string; href: string }) => (
     <a href={href} data-testid="tag-pill">{label}</a>
   ),
-  EntityDescription: ({ description, canEdit }: { description: string | null | undefined; canEdit: boolean }) => (
-    <div data-testid="entity-description">{description || (canEdit ? 'Add description' : '')}</div>
+  EntityDescription: ({
+    description,
+    canEdit,
+    onSave,
+  }: {
+    description: string | null | undefined
+    canEdit: boolean
+    onSave?: (description: string) => Promise<void>
+  }) => (
+    <div data-testid="entity-description">
+      {description || (canEdit ? 'Add description' : '')}
+      {canEdit && (
+        <button
+          data-testid="entity-description-save"
+          onClick={() => onSave?.('New venue bio')}
+        >
+          Save description
+        </button>
+      )}
+    </div>
   ),
   AddToCollectionButton: () => <button data-testid="add-to-collection">Collect</button>,
   EntityHeader: ({ title, subtitle, actions }: { title: string; subtitle?: React.ReactNode; actions?: React.ReactNode }) => (
@@ -155,6 +181,7 @@ vi.mock('@/features/contributions', () => ({
   ReportEntityDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="report-dialog">Report Dialog</div> : null,
   ContributionPrompt: (): null => null,
+  useSuggestEdit: () => ({ mutate: mockSuggestEditMutate, isPending: false }),
 }))
 
 vi.mock('./DeleteVenueDialog', () => ({
@@ -506,6 +533,118 @@ describe('VenueDetail', () => {
       expect(screen.getByRole('button', { name: /Edit/ })).toBeInTheDocument()
       // Only admins see delete
       expect(screen.queryByRole('button', { name: /Delete/ })).not.toBeInTheDocument()
+    })
+  })
+
+  // PSY-668: inline bio editing opens to trusted_contributor + local_ambassador
+  // + the venue's original submitter via the canEditDirectly gate. Admins write
+  // through the admin PATCH (useVenueUpdate); everyone else routes through
+  // suggest-edit (useSuggestEdit), which the backend auto-applies for trusted
+  // tiers and queues for review otherwise.
+  describe('inline description editing (PSY-668)', () => {
+    beforeEach(() => {
+      mockUseVenue.mockReturnValue({
+        data: makeVenue({ description: 'Old bio' }),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('routes admin saves through useVenueUpdate, not suggest-edit', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: { id: '1', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<VenueDetail venueId="1" />)
+
+      await user.click(screen.getByTestId('entity-description-save'))
+
+      expect(mockVenueUpdateMutate).toHaveBeenCalledTimes(1)
+      expect(mockVenueUpdateMutate).toHaveBeenCalledWith(
+        { venueId: 1, data: { description: 'New venue bio' } },
+        expect.anything()
+      )
+      expect(mockSuggestEditMutate).not.toHaveBeenCalled()
+    })
+
+    it('routes trusted-tier (non-admin) saves through useSuggestEdit, not useVenueUpdate', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: { id: '7', is_admin: false, user_tier: 'trusted_contributor' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<VenueDetail venueId="1" />)
+
+      await user.click(screen.getByTestId('entity-description-save'))
+
+      expect(mockSuggestEditMutate).toHaveBeenCalledTimes(1)
+      expect(mockSuggestEditMutate).toHaveBeenCalledWith(
+        {
+          entityType: 'venue',
+          entityId: 1,
+          changes: [
+            { field: 'description', old_value: 'Old bio', new_value: 'New venue bio' },
+          ],
+          summary: 'Updated description via inline editor',
+        },
+        expect.anything()
+      )
+      expect(mockVenueUpdateMutate).not.toHaveBeenCalled()
+    })
+
+    it('routes original-submitter (non-admin, non-trusted) saves through useSuggestEdit', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: { id: '42', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockUseVenue.mockReturnValue({
+        data: makeVenue({ description: 'Old bio', submitted_by: 42 }),
+        isLoading: false,
+        error: null,
+      })
+      render(<VenueDetail venueId="1" />)
+
+      await user.click(screen.getByTestId('entity-description-save'))
+
+      expect(mockSuggestEditMutate).toHaveBeenCalledTimes(1)
+      expect(mockVenueUpdateMutate).not.toHaveBeenCalled()
+    })
+
+    it('does NOT show the inline editor for a plain authenticated, non-trusted, non-submitter user', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockUseVenue.mockReturnValue({
+        data: makeVenue({ description: 'Old bio', submitted_by: 42 }),
+        isLoading: false,
+        error: null,
+      })
+      render(<VenueDetail venueId="1" />)
+
+      expect(screen.queryByTestId('entity-description-save')).not.toBeInTheDocument()
+    })
+
+    it('does NOT show the inline editor for anonymous visitors', () => {
+      mockAuthContext.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<VenueDetail venueId="1" />)
+
+      expect(screen.queryByTestId('entity-description-save')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -18,7 +18,7 @@ import { NotifyMeButton } from '@/features/notifications'
 import { VenueLocationCard } from './VenueLocationCard'
 import { VenueShowsList } from './VenueShowsList'
 import { VenueBillNetwork } from './VenueBillNetwork'
-import { EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner, AttributionLine, ReportEntityDialog, ContributionPrompt, type EntityEditSuccess } from '@/features/contributions'
+import { EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner, AttributionLine, ReportEntityDialog, ContributionPrompt, useSuggestEdit, type EntityEditSuccess } from '@/features/contributions'
 import { DeleteVenueDialog } from './DeleteVenueDialog'
 import { FavoriteVenueButton } from './FavoriteVenueButton'
 import { Button } from '@/components/ui/button'
@@ -82,6 +82,7 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
   const queryClient = useQueryClient()
   const router = useRouter()
   const venueUpdate = useVenueUpdate()
+  const suggestVenueEdit = useSuggestEdit()
   const saveBanner = useEntitySaveSuccessBanner()
 
   const { data: venue, isLoading, error } = useVenue({ venueId })
@@ -284,18 +285,45 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
           <div className="mb-6">
             <EntityDescription
               description={venue.description}
-              canEdit={!!user?.is_admin}
+              canEdit={!!canEditDirectly}
               onSave={async (description) => {
                 await new Promise<void>((resolve, reject) => {
-                  venueUpdate.mutate(
-                    { venueId: venue.id, data: { description } },
+                  if (user?.is_admin) {
+                    venueUpdate.mutate(
+                      { venueId: venue.id, data: { description } },
+                      {
+                        onSuccess: () => {
+                          queryClient.invalidateQueries({
+                            queryKey: queryKeys.venues.detail(String(venueId)),
+                          })
+                          resolve()
+                        },
+                        onError: (err) => reject(err),
+                      }
+                    )
+                    return
+                  }
+                  // PSY-668: trusted_contributor + local_ambassador + the venue's
+                  // original submitter route through suggest-edit, which the
+                  // backend auto-applies for trusted tiers via canEditDirectly
+                  // (pending_edit.go) or queues for review otherwise.
+                  // useSuggestEdit's own onSuccess invalidates ['venues'], which
+                  // prefix-matches the detail key — no caller-side invalidate.
+                  suggestVenueEdit.mutate(
                     {
-                      onSuccess: () => {
-                        queryClient.invalidateQueries({
-                          queryKey: queryKeys.venues.detail(String(venueId)),
-                        })
-                        resolve()
-                      },
+                      entityType: 'venue',
+                      entityId: venue.id,
+                      changes: [
+                        {
+                          field: 'description',
+                          old_value: venue.description ?? '',
+                          new_value: description,
+                        },
+                      ],
+                      summary: 'Updated description via inline editor',
+                    },
+                    {
+                      onSuccess: () => resolve(),
                       onError: (err) => reject(err),
                     }
                   )


### PR DESCRIPTION
## Summary

Opens venue bio inline editing to `trusted_contributor` + `local_ambassador` (+ the venue's original submitter), mirroring the canonical PSY-642 artist pattern on `VenueDetail.tsx`. Previously the inline `EntityDescription` editor was admin-only (`canEdit={!!user?.is_admin}` + admin-only PATCH).

**Decision (per the ticket):** the inline editor now gates on the **existing** `canEditDirectly` variable rather than computing a second, narrower one. That variable is broader than the original ticket described — it also includes the venue's original submitter (`venue.submitted_by === Number(user?.id)`). Reusing it keeps the inline bio editor consistent with the `EntityEditDrawer` on the same page (which already gates on `canEditDirectly`). Submitters who aren't trusted still route through suggest-edit; the **backend** decides auto-apply vs pending review — the server-side `canEditDirectly` (pending_edit.go) is `is_admin || trusted_contributor || local_ambassador` and does **not** include submitter, so a non-trusted submitter's edit is queued, not auto-applied. No client-side privilege escalation.

`onSave` branches by role:
- **admins** keep the admin PATCH path (`useVenueUpdate`) unchanged, with its explicit detail-key invalidate;
- **everyone else** routes through `useSuggestEdit` with a `changes` array carrying the description delta and the synthesized summary `'Updated description via inline editor'`. `useSuggestEdit`'s own `onSuccess` invalidates `['venues']`, which prefix-matches `['venues','detail',…]`, so the suggest branch adds no redundant caller-side invalidate (per the PSY-642 `/simplify` finding).

No backend work — `SuggestVenueEditHandler` (`PUT /venues/:entity_id/suggest-edit`) and `description` in `VenueAllowedEditFields` already exist.

### Files changed
- `frontend/features/venues/components/VenueDetail.tsx` — import `useSuggestEdit`; add `suggestVenueEdit` hook; flip gate to `canEditDirectly`; branch `onSave`.
- `frontend/features/venues/components/VenueDetail.test.tsx` — add `useSuggestEdit` + `onSave`-triggering `EntityDescription` mocks; 5 new tests for the routing + gate.

## Test plan
- [x] `bun run typecheck` — passes clean (`tsc --noEmit`, no output).
- [x] `bun run test:run features/venues` — 148 passed (12 files); `VenueDetail.test.tsx` 33 passed (was 28).
- [x] `bun run lint` — 0 errors (154 pre-existing warnings, none introduced by this change; the two warnings touching `VenueDetail.*` are pre-existing: an unused `_opts` mock param and the pre-existing dead `const canEdit` on line 91).

New tests assert:
- admin save → `useVenueUpdate` called with `{venueId, data:{description}}`, `useSuggestEdit` NOT called;
- trusted-tier (non-admin) save → `useSuggestEdit` called with the exact `{entityType, entityId, changes:[{field,old_value,new_value}], summary}`, `useVenueUpdate` NOT called;
- original-submitter (non-admin, non-trusted) save → `useSuggestEdit` called, `useVenueUpdate` NOT called;
- plain authenticated non-trusted non-submitter → inline editor hidden;
- anonymous visitor → inline editor hidden.

## Manual repro

Isolated dispatch stack (`--mode=isolated`), promoted `e2e-user@test.local` to `trusted_contributor`, set a baseline venue description, then exercised the trusted path end-to-end via agent-browser on `the-rebel-lounge-phoenix-az`:

1. Signed in as the trusted user → the inline **"Edit description"** affordance is now visible (was admin-only).
2. Opened the editor, typed a new description, clicked Save.
3. UI updated to show the new description (`document.body.innerText` check returned `FOUND_NEW_TEXT`).

Backend verification (psql):
- `venues.description` for id 1 now = `Updated by trusted contributor via inline editor (PSY-668 repro).`
- `pending_entity_edits`: one row, `status=approved`, `submitted_by=1`, `reviewed_by=1` (trusted self-auto-approve), `summary='Updated description via inline editor'`, correct `field_changes` delta.
- `revisions`: one row for `venue/1`, `user_id=1`, same summary + field_changes — the auto-apply path wrote a revision.

Regression control: signed in as a plain `contributor` (non-trusted, non-submitter) → the inline "Edit description" affordance is **absent** (`editDescription: false`); the header "Edit" button (suggest-edit drawer) remains. Anonymous gate also holds.

## Screenshots
| Trusted user sees inline editor | Editor open with new text |
| --- | --- |
| ![trusted sees edit affordance](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-756e11691ca0b8fa56ec/01-trusted-sees-edit-description-affordance.png) | ![inline editor open](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-756e11691ca0b8fa56ec/02-inline-editor-open-with-new-text.png) |

| UI shows updated description (trusted) | Non-trusted user: no inline editor |
| --- | --- |
| ![ui updated](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-756e11691ca0b8fa56ec/03-ui-shows-updated-description.png) | ![non-trusted no editor](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-756e11691ca0b8fa56ec/04-nontrusted-no-inline-editor.png) |

## Code review
`/code-review` (inline, sub-agent): no correctness bugs. One LOW efficiency note — the admin branch's caller-side `queryKeys.venues.detail` invalidate is redundant because `useVenueUpdate.onSuccess` already broad-invalidates `['venues']` (unlike ArtistDetail, where the caller-side invalidate is NOT redundant because `useArtistUpdate` keys its detail invalidate by numeric id vs the page's slug key). Pre-existing in the original admin path; preserved per the ticket's "keep current admin behavior" instruction; not fixed to keep this PR scoped.

## Adversarial review
`/adversarial-review` — CLEAN (inline, four lenses, no prior session context). Panel: Saboteur · Future-Maintainer · Security · Completeness.
- Saboteur: CLEAN — no null-deref (editor only renders when `canEditDirectly`), no double-submit (`isSaving` guard), promise settles once, errors propagate via `reject`.
- Security: CLEAN — frontend gate is UX-only; backend independently enforces auto-apply (server `canEditDirectly` excludes submitter), so no client-forced privilege escalation; no new injection surface (description sanitized server-side on render).
- Future-Maintainer: CONCERNS (1 LOW) — same redundant-admin-invalidate comprehension note as `/code-review`; pre-existing, out of scope.
- Completeness: CLEAN — all acceptance criteria met; did NOT refactor `canEditDirectly` into a shared helper (ticket said not to).

Closes PSY-668
