### PR TITLE
PSY-664: clear #graph hash when graph dialog/toggle closes

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
@@ -133,9 +133,29 @@ vi.mock('@/features/collections', () => ({
   EntityCollections: (): null => null,
 }))
 
+// PSY-664: the graph dialog mock surfaces `open` + a close affordance wired
+// to `onOpenChange(false)` so the close-path hash cleanup is testable without
+// rendering the real ForceGraph2D-backed dialog. The real Dialog routes every
+// close path (X, Escape, backdrop) through this same `onOpenChange`.
 vi.mock('./RelatedArtists', () => ({
   ArtistSimilarSidebar: (): null => null,
-  ArtistGraphDialog: (): null => null,
+  ArtistGraphDialog: ({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+  }) =>
+    open ? (
+      <div data-testid="graph-dialog">
+        <button
+          data-testid="graph-dialog-close"
+          onClick={() => onOpenChange(false)}
+        >
+          Close graph
+        </button>
+      </div>
+    ) : null,
 }))
 
 // PSY-641: ArtistDetail is now a flat two-column layout — no page-level tabs.
@@ -378,6 +398,71 @@ describe('ArtistDetail', () => {
       // useUrlHash → graphDialogOpen plumbing, but the link itself no
       // longer renders as an anchor.
       expect(screen.getByTestId('bracket-Graph').tagName).toBe('BUTTON')
+    })
+
+    // PSY-664: the graph dialog drives the `#graph` URL hash so the open
+    // state is shareable/deep-linkable. Opening pushes `#graph`; every close
+    // path (X, Escape, backdrop — all route through onOpenChange) must strip
+    // it again, otherwise a refresh or shared link re-opens the dialog.
+    describe('graph dialog #graph hash (PSY-664)', () => {
+      // window.location.hash is real jsdom state and not reset by the global
+      // afterEach — restore it per test so a stray `#graph` cannot leak into
+      // an unrelated suite (and re-trip the auto-open path here).
+      let originalHref: string
+
+      beforeEach(() => {
+        originalHref = window.location.href
+      })
+
+      afterEach(() => {
+        window.history.replaceState(null, '', originalHref)
+      })
+
+      it('auto-opens the dialog when the URL already carries #graph', () => {
+        window.history.replaceState(null, '', '/artists/test-artist#graph')
+        renderWithProviders(<ArtistDetail artistId="test-artist" />)
+        expect(screen.getByTestId('graph-dialog')).toBeInTheDocument()
+      })
+
+      it('pushes #graph to the URL when [Graph] opens the dialog', async () => {
+        const user = userEvent.setup()
+        renderWithProviders(<ArtistDetail artistId="test-artist" />)
+        expect(window.location.hash).toBe('')
+
+        await user.click(screen.getByTestId('bracket-Graph'))
+
+        expect(screen.getByTestId('graph-dialog')).toBeInTheDocument()
+        expect(window.location.hash).toBe('#graph')
+      })
+
+      it('clears #graph from the URL when the dialog closes', async () => {
+        const user = userEvent.setup()
+        window.history.replaceState(null, '', '/artists/test-artist#graph')
+        renderWithProviders(<ArtistDetail artistId="test-artist" />)
+        // Auto-opened from the hash.
+        expect(screen.getByTestId('graph-dialog')).toBeInTheDocument()
+        expect(window.location.hash).toBe('#graph')
+
+        await user.click(screen.getByTestId('graph-dialog-close'))
+
+        expect(screen.queryByTestId('graph-dialog')).not.toBeInTheDocument()
+        expect(window.location.hash).toBe('')
+        // Path + search are preserved (only the hash is stripped).
+        expect(window.location.pathname).toBe('/artists/test-artist')
+      })
+
+      it('leaves an unrelated hash untouched when the dialog closes', async () => {
+        const user = userEvent.setup()
+        window.history.replaceState(null, '', '/artists/test-artist#discussion')
+        renderWithProviders(<ArtistDetail artistId="test-artist" />)
+        // #discussion does not auto-open — open via the [Graph] button, which
+        // replaces the hash with #graph.
+        await user.click(screen.getByTestId('bracket-Graph'))
+        expect(window.location.hash).toBe('#graph')
+
+        await user.click(screen.getByTestId('graph-dialog-close'))
+        expect(window.location.hash).toBe('')
+      })
     })
 
     it('shows the report bracket link for authenticated users', () => {

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -1001,10 +1001,31 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   // (matches pre-PSY-645 behavior of the inline graph). `replaceState` to
   // avoid creating an extra history entry per open.
   const openGraphDialog = () => {
-    if (typeof window !== 'undefined' && window.location.hash !== '#graph') {
-      window.history.replaceState(null, '', '#graph')
+    if (typeof window !== 'undefined' && window.location.hash !== GRAPH_HASH) {
+      window.history.replaceState(null, '', GRAPH_HASH)
     }
     setGraphDialogUserToggle(true)
+  }
+
+  // PSY-664: mirror openGraphDialog on the close side. The Dialog's
+  // onOpenChange fires for every close path (X button, Escape, backdrop
+  // click), so strip `#graph` here to keep the shareable-URL contract
+  // symmetric — without this, closing left `#graph` in the URL and a
+  // refresh or shared link re-opened the dialog. `replaceState` only when
+  // the hash is actually `#graph` so we never clobber an unrelated hash.
+  const handleGraphDialogOpenChange = (open: boolean) => {
+    setGraphDialogUserToggle(open)
+    if (
+      !open &&
+      typeof window !== 'undefined' &&
+      window.location.hash === GRAPH_HASH
+    ) {
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search
+      )
+    }
   }
   const saveBanner = useEntitySaveSuccessBanner()
 
@@ -1232,7 +1253,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
         artistSlug={artist.slug}
         artistName={artist.name}
         open={graphDialogOpen}
-        onOpenChange={setGraphDialogUserToggle}
+        onOpenChange={handleGraphDialogOpenChange}
       />
 
       {/* Edit Drawer (all authenticated users) */}

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CollectionDetail } from './CollectionDetail'
@@ -269,6 +269,14 @@ vi.mock('@/features/comments', () => ({
 // isolates them from useEntitySearch + useResolveCollectionItems wiring.
 vi.mock('./AddItemsPicker', () => ({
   AddItemsPicker: () => <div data-testid="add-items-picker-stub" />,
+}))
+
+// PSY-664: stub the graph — its real implementation fires a fetch (the
+// multi-type graph data) and renders ForceGraph2D. The hash-cleanup tests
+// only need to observe that the graph mounts/unmounts on toggle, so a marker
+// keeps them hermetic under the onUnhandledRequest:'error' MSW policy.
+vi.mock('./CollectionGraph', () => ({
+  CollectionGraph: () => <div data-testid="collection-graph-stub" />,
 }))
 
 // PSY-354: stub EntityTagList — its real implementation pulls in tag
@@ -2325,6 +2333,96 @@ describe('CollectionDetail', () => {
         expect(
           screen.queryByTestId('overflow-explore-graph')
         ).not.toBeInTheDocument()
+      })
+
+      // PSY-664: `#graph` deep-links auto-open the inline graph (parallel to
+      // the artist graph dialog). Hiding the graph must strip `#graph` again,
+      // otherwise a refresh or shared link re-opens it.
+      describe('graph #graph hash (PSY-664)', () => {
+        // window.location.hash is real jsdom state, not reset by the global
+        // afterEach — restore per test so a stray `#graph` cannot leak.
+        let originalHref: string
+
+        beforeEach(() => {
+          originalHref = window.location.href
+        })
+
+        afterEach(() => {
+          window.history.replaceState(null, '', originalHref)
+        })
+
+        it('auto-opens the graph when the URL carries #graph and the collection has items', () => {
+          window.history.replaceState(
+            null,
+            '',
+            '/collections/test-collection#graph'
+          )
+          mockCollection.mockReturnValue({
+            data: makeCollection({ items: sampleItems }),
+            isLoading: false,
+            error: null,
+          })
+          render(<CollectionDetail slug="test-collection" />)
+          expect(
+            screen.getByTestId('collection-graph-stub')
+          ).toBeInTheDocument()
+        })
+
+        it('clears #graph from the URL when "Hide graph" closes the graph', async () => {
+          const user = userEvent.setup()
+          window.history.replaceState(
+            null,
+            '',
+            '/collections/test-collection#graph'
+          )
+          mockCollection.mockReturnValue({
+            data: makeCollection({ items: sampleItems }),
+            isLoading: false,
+            error: null,
+          })
+          render(<CollectionDetail slug="test-collection" />)
+          // Auto-opened from the hash.
+          expect(
+            screen.getByTestId('collection-graph-stub')
+          ).toBeInTheDocument()
+          expect(window.location.hash).toBe('#graph')
+
+          // Overflow now reads "Hide graph" — clicking it hides the graph.
+          await user.click(screen.getByTestId('collection-overflow-trigger'))
+          await user.click(screen.getByTestId('overflow-explore-graph'))
+
+          expect(
+            screen.queryByTestId('collection-graph-stub')
+          ).not.toBeInTheDocument()
+          expect(window.location.hash).toBe('')
+          expect(window.location.pathname).toBe('/collections/test-collection')
+        })
+
+        it('leaves an unrelated hash untouched when hiding the graph', async () => {
+          const user = userEvent.setup()
+          window.history.replaceState(
+            null,
+            '',
+            '/collections/test-collection#discussion'
+          )
+          mockCollection.mockReturnValue({
+            data: makeCollection({ items: sampleItems }),
+            isLoading: false,
+            error: null,
+          })
+          render(<CollectionDetail slug="test-collection" />)
+          // #discussion does not auto-open the graph — open it via the menu.
+          await user.click(screen.getByTestId('collection-overflow-trigger'))
+          await user.click(screen.getByTestId('overflow-explore-graph'))
+          expect(
+            screen.getByTestId('collection-graph-stub')
+          ).toBeInTheDocument()
+
+          // Now hide it — the unrelated hash must be preserved.
+          await user.click(screen.getByTestId('collection-overflow-trigger'))
+          await user.click(screen.getByTestId('overflow-explore-graph'))
+          expect(window.location.hash).toBe('#discussion')
+        })
       })
 
       it('shows the inline "Forking collection…" row while a clone is pending', () => {

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -193,6 +193,28 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
   const autoOpenFromHash = hash === GRAPH_HASH && hasItems
   const showGraph = showGraphOverride ?? autoOpenFromHash
 
+  // PSY-664: hiding the graph also strips `#graph` from the URL so the
+  // shareable-deep-link contract stays symmetric — without this, a visitor
+  // who arrived via `/collections/{slug}#graph` (graph auto-open) and then
+  // clicked "Hide graph" still had `#graph` in the URL, so a refresh or a
+  // shared link re-opened the graph. `replaceState` only when the hash is
+  // actually `#graph`, so an unrelated hash is never clobbered.
+  const toggleGraph = () => {
+    const next = !showGraph
+    setShowGraphOverride(next)
+    if (
+      !next &&
+      typeof window !== 'undefined' &&
+      window.location.hash === GRAPH_HASH
+    ) {
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search
+      )
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
@@ -609,7 +631,7 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                         graph. */}
                     {hasItems && (
                       <DropdownMenuItem
-                        onClick={() => setShowGraphOverride(!showGraph)}
+                        onClick={toggleGraph}
                         data-testid="overflow-explore-graph"
                       >
                         <Network className="h-4 w-4" />


### PR DESCRIPTION
## Summary

The artist graph dialog pushed `#graph` to the URL on open (PSY-361's shareable deep-link contract) but its close path (`onOpenChange={setGraphDialogUserToggle}`) only flipped React state — it never stripped the hash. Closing left `#graph` in the URL, so a refresh or a shared link re-opened the dialog for the recipient.

The fix replaces the inline setter with `handleGraphDialogOpenChange`, which mirrors the existing `openGraphDialog` on the close side: on close, when the hash is `#graph`, it `replaceState`s to `pathname + search`, guarded so an unrelated hash is never clobbered. Radix routes every close path (X button, Escape, backdrop click) through the single `onOpenChange`, so one handler covers all three.

Files changed:
- `frontend/features/artists/components/ArtistDetail.tsx` — `handleGraphDialogOpenChange` close handler; tidied the open path's `'#graph'` literals to the exported `GRAPH_HASH`.
- `frontend/features/collections/components/CollectionDetail.tsx` — `toggleGraph` handler (parallel fix, see below).
- `+` test additions in both component test files.

## Parallel-site check

The ticket asked whether other graph surfaces share the close-doesn't-clear-hash bug. Swept every `GRAPH_HASH` consumer:

- **CollectionDetail** (`CollectionDetail.tsx:193`) — **same bug shape, fixed here.** Its inline graph auto-opens from `#graph` (`autoOpenFromHash`), but "Hide graph" only flipped `showGraphOverride` and left `#graph` in the URL, so a refresh re-opened it. New `toggleGraph` handler strips `#graph` on hide with the same `=== GRAPH_HASH` guard.
- **SceneGraph** (`SceneGraph.tsx`) and **VenueBillNetwork** (`VenueBillNetwork.tsx`) — **not affected.** These are always-rendered inline graphs where `id="graph"` is a Cmd+K *scroll-to anchor*, not an auto-open trigger. Their fullscreen overlay is an internal toggle independent of the URL hash; there is no close-doesn't-clear-hash bug. `SceneDetail`/`VenueDetail` don't consume `useUrlHash`/`GRAPH_HASH` at all.
- **CommandPalette** (`CommandPalette.tsx`) — only *generates* `#graph` deep-links; no dialog close behavior. Not affected.

## Test plan

- [x] `cd frontend && bun run typecheck` — clean.
- [x] `cd frontend && bun run test:run features/artists` — 275 passed (incl. 4 new graph-dialog tests).
- [x] `cd frontend && bun run test:run features/collections` — 328 passed (incl. 3 new graph-hash tests in CollectionDetail).
- [x] `cd frontend && bun run lint` — 0 errors (154 pre-existing warnings, none in changed files).

New tests (both component suites): auto-open from `#graph`, push-`#graph`-on-open, clear-`#graph`-on-close, and unrelated-hash-preservation (`#discussion` left untouched).

## Manual repro

Exercised against an isolated dispatch stack (`stack-up.sh --mode=isolated`), seeded artist `calexico` and a public collection (`e2e-worker-collection-1`, 2 artist items added for the graph). URL values captured via `evaluate_script` (`window.location.href` / `.hash`):

Artist graph dialog (`/artists/calexico`):
1. Click `[Graph]` → dialog opens, URL `…/artists/calexico#graph` (hash `#graph`, dialog present). Screenshot 01.
2. Click **X** close → dialog gone, URL `…/artists/calexico` (hash `""`). Screenshot 02.
3. Fresh-session direct-nav `…/artists/calexico#graph` → dialog auto-opens (no regression). Screenshot 03.
4. **Escape** close on the auto-opened dialog → URL `…/artists/calexico` (hash `""`). Screenshot 04. (Backdrop-click routes through the same `onOpenChange` handler as X + Escape, both verified; unit test additionally drives `onOpenChange(false)` directly.)

Collection graph (`/collections/e2e-worker-collection-1`):
5. Direct-nav `…#graph` → inline graph auto-opens (canvas + "Collection graph · 2 artists"). Screenshot 05.
6. Overflow menu → **Hide graph** → graph gone, URL `…/collections/e2e-worker-collection-1` (hash `""`). Screenshot 06.

Each PNG was read back to confirm it shows what its filename claims. Stack torn down after.

## Screenshots

| Step | Image |
| --- | --- |
| 01 — artist `[Graph]` open, URL has `#graph` | ![](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9da08cecfbbb244d14de/01-artist-graph-open-hash.png) |
| 02 — artist X-close, `#graph` cleared | ![](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9da08cecfbbb244d14de/02-artist-graph-closed-hash-cleared.png) |
| 03 — artist direct-nav `#graph` auto-opens (no regression) | ![](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9da08cecfbbb244d14de/03-artist-direct-nav-graph-autoopen.png) |
| 04 — artist Escape-close, `#graph` cleared | ![](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9da08cecfbbb244d14de/04-artist-escape-close-hash-cleared.png) |
| 05 — collection graph open from `#graph` | ![](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9da08cecfbbb244d14de/05-collection-graph-open-hash.png) |
| 06 — collection "Hide graph", `#graph` cleared | ![](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9da08cecfbbb244d14de/06-collection-graph-hidden-hash-cleared.png) |

## Code review

`/code-review` (three lenses inline — dispatched sub-agent, no Agent tool): CLEAN, no findings. Reuse (both handlers use the `GRAPH_HASH` constant; no new duplication), correctness (the `replaceState`-doesn't-fire-`hashchange` quirk is benign — the user-toggle state masks the stale `useUrlHash` value after close), efficiency (plain functions, consistent with the existing `openGraphDialog`).

## Adversarial review

`/adversarial-review` (four lenses inline — Saboteur / Future-Maintainer / Security / Completeness): **CLEAN**, no CRITICAL/HIGH/MEDIUM. No separate fix commit needed.
- **Saboteur** — no injection surface (`replaceState` target is browser-owned `pathname + search`); stale `useUrlHash` after `replaceState` cannot re-open the dialog (toggle state overrides); SSR-guarded.
- **Future-Maintainer** — one LOW (a shared `clearGraphHash` helper) declined with counter-argument: a 4-line guarded `replaceState` across two features with different state models (Radix `onOpenChange(open)` vs click-computed toggle) would add cross-feature coupling for marginal DRY gain.
- **Security** — pure client-side URL-hash manipulation; no authz/secrets/PII/network surface.
- **Completeness** — all acceptance criteria met; confirmed via `components/ui/dialog.tsx` that the Radix Root routes X + Escape + backdrop through the one `onOpenChange`.

Panel ran with no prior session context against the branch diff.

Closes PSY-664
