### PR TITLE
PSY-661: add release entity to reporting subsystem

### DIFF
--- a/backend/internal/api/handlers/community/entity_report.go
+++ b/backend/internal/api/handlers/community/entity_report.go
@@ -82,6 +82,13 @@ func (h *EntityReportHandler) ReportCollectionHandler(ctx context.Context, req *
 	return h.reportEntity(ctx, "collection", req)
 }
 
+// ReportReleaseHandler handles POST /releases/{entity_id}/report.
+// PSY-661. EntityID is the release's numeric ID; the moderation queue
+// resolves it back to a slug-based public link via resolveEntityNameAndSlug.
+func (h *EntityReportHandler) ReportReleaseHandler(ctx context.Context, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	return h.reportEntity(ctx, "release", req)
+}
+
 // reportEntity is the shared implementation for all report endpoints.
 func (h *EntityReportHandler) reportEntity(ctx context.Context, entityType string, req *ReportEntityRequest) (*ReportEntityResponse, error) {
 	user := middleware.GetUserFromContext(ctx)

--- a/backend/internal/api/handlers/community/entity_report_test.go
+++ b/backend/internal/api/handlers/community/entity_report_test.go
@@ -256,6 +256,48 @@ func TestReportCollection_InvalidReportType(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 422)
 }
 
+// PSY-661: releases accept the same shape as the other entity types.
+// The taxonomy is release-tailored (inaccurate/duplicate/wrong_cover_art/
+// wrong_release_date/wrong_artist_attribution/missing_info) — see
+// entity_report.go for the rationale.
+func TestReportRelease_Success(t *testing.T) {
+	expected := makeEntityReportResponse(7, "release", "wrong_cover_art")
+	h := NewEntityReportHandler(
+		&testhelpers.MockEntityReportService{
+			CreateEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				if req.EntityType != "release" {
+					t.Errorf("expected entity_type=release, got %s", req.EntityType)
+				}
+				if req.ReportType != "wrong_cover_art" {
+					t.Errorf("expected report_type=wrong_cover_art, got %s", req.ReportType)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "wrong_cover_art"
+
+	resp, err := h.ReportReleaseHandler(entityReportUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.EntityType != "release" {
+		t.Errorf("expected entity_type=release, got %s", resp.Body.EntityType)
+	}
+}
+
+func TestReportRelease_InvalidReportType(t *testing.T) {
+	// e.g. "wrong_venue" is valid for shows but not for releases.
+	h := testEntityReportHandler()
+	req := &ReportEntityRequest{EntityID: "1"}
+	req.Body.ReportType = "wrong_venue"
+	_, err := h.ReportReleaseHandler(entityReportUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
 // ============================================================================
 // Tests: Report Entity — Error Cases
 // ============================================================================

--- a/backend/internal/api/routes/reports.go
+++ b/backend/internal/api/routes/reports.go
@@ -98,6 +98,9 @@ func setupEntityReportRoutes(rc RouteContext) {
 		// stays on the generic /{type}/{id}/report shape so the moderation
 		// queue can ingest collection reports through the same pipeline.)
 		huma.Post(reportAPI, "/collections/{entity_id}/report", entityReportHandler.ReportCollectionHandler)
+		// PSY-661: report a release. EntityID is the numeric release ID; the
+		// moderation queue deep-links via the resolved slug.
+		huma.Post(reportAPI, "/releases/{entity_id}/report", entityReportHandler.ReportReleaseHandler)
 	})
 
 	// Admin: entity report management (PSY-423: rc.Admin enforces auth + IsAdmin)

--- a/backend/internal/models/community/entity_report.go
+++ b/backend/internal/models/community/entity_report.go
@@ -23,6 +23,7 @@ const (
 	EntityReportEntityShow       = "show"
 	EntityReportEntityComment    = "comment"
 	EntityReportEntityCollection = "collection"
+	EntityReportEntityRelease    = "release"
 )
 
 // Valid report types per entity type.
@@ -77,6 +78,23 @@ var validReportTypes = map[string]map[string]bool{
 		"misleading":    true,
 		"other":         true,
 	},
+	// PSY-661: release-tailored taxonomy. Like the PSY-578 collection set,
+	// these diverge from the generic artist/venue vocabulary to name the
+	// abuse/error vectors specific to a release record:
+	//   - wrong_cover_art / wrong_release_date / wrong_artist_attribution:
+	//     field-specific corrections that "inaccurate" would bury (the most
+	//     common report on a release is "this one field is wrong").
+	//   - duplicate: the same release entered twice (e.g. a reissue logged as
+	//     a new entry).
+	//   - inaccurate / missing_info: catch-alls for everything else.
+	EntityReportEntityRelease: {
+		"inaccurate":               true,
+		"duplicate":                true,
+		"wrong_cover_art":          true,
+		"wrong_release_date":       true,
+		"wrong_artist_attribution": true,
+		"missing_info":             true,
+	},
 }
 
 // EntityReport represents a user report about an entity issue.
@@ -110,6 +128,7 @@ func ValidEntityReportEntityTypes() []string {
 		EntityReportEntityShow,
 		EntityReportEntityComment,
 		EntityReportEntityCollection,
+		EntityReportEntityRelease,
 	}
 }
 

--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -28,8 +28,10 @@ func TestEntityReportModel_Validation(t *testing.T) {
 	assert.True(t, communitym.IsValidEntityReportEntityType("show"))
 	assert.True(t, communitym.IsValidEntityReportEntityType("comment"))
 	assert.True(t, communitym.IsValidEntityReportEntityType("collection"))
+	// PSY-661: releases are now reportable.
+	assert.True(t, communitym.IsValidEntityReportEntityType("release"))
 	assert.False(t, communitym.IsValidEntityReportEntityType(""))
-	assert.False(t, communitym.IsValidEntityReportEntityType("release"))
+	// label is still not a reportable entity type (see PSY-666).
 	assert.False(t, communitym.IsValidEntityReportEntityType("label"))
 
 	// Valid report types per entity
@@ -67,8 +69,19 @@ func TestEntityReportModel_Validation(t *testing.T) {
 	assert.False(t, communitym.IsValidReportType("collection", "cancelled"))
 	assert.False(t, communitym.IsValidReportType("collection", "wrong_image"))
 
-	// Invalid entity type
-	assert.False(t, communitym.IsValidReportType("release", "inaccurate"))
+	// PSY-661: release-tailored taxonomy.
+	assert.True(t, communitym.IsValidReportType("release", "inaccurate"))
+	assert.True(t, communitym.IsValidReportType("release", "duplicate"))
+	assert.True(t, communitym.IsValidReportType("release", "wrong_cover_art"))
+	assert.True(t, communitym.IsValidReportType("release", "wrong_release_date"))
+	assert.True(t, communitym.IsValidReportType("release", "wrong_artist_attribution"))
+	assert.True(t, communitym.IsValidReportType("release", "missing_info"))
+	// Types from other taxonomies are not valid for releases.
+	assert.False(t, communitym.IsValidReportType("release", "wrong_image"))
+	assert.False(t, communitym.IsValidReportType("release", "cancelled"))
+
+	// Still-invalid entity type (label is not reportable — see PSY-666).
+	assert.False(t, communitym.IsValidReportType("label", "inaccurate"))
 }
 
 func TestValidReportTypesForEntity(t *testing.T) {
@@ -88,19 +101,26 @@ func TestValidReportTypesForEntity(t *testing.T) {
 	collectionTypes := communitym.ValidReportTypesForEntity("collection")
 	assert.Len(t, collectionTypes, 4)
 
-	unknownTypes := communitym.ValidReportTypesForEntity("release")
+	// PSY-661: release-tailored taxonomy has 6 types.
+	releaseTypes := communitym.ValidReportTypesForEntity("release")
+	assert.Len(t, releaseTypes, 6)
+
+	// label remains unsupported (see PSY-666).
+	unknownTypes := communitym.ValidReportTypesForEntity("label")
 	assert.Nil(t, unknownTypes)
 }
 
 func TestValidEntityReportEntityTypes(t *testing.T) {
 	types := communitym.ValidEntityReportEntityTypes()
-	assert.Len(t, types, 6)
+	assert.Len(t, types, 7)
 	assert.Contains(t, types, "artist")
 	assert.Contains(t, types, "venue")
 	assert.Contains(t, types, "festival")
 	assert.Contains(t, types, "show")
 	assert.Contains(t, types, "comment")
 	assert.Contains(t, types, "collection")
+	// PSY-661
+	assert.Contains(t, types, "release")
 }
 
 // =============================================================================
@@ -205,6 +225,18 @@ func (s *EntityReportServiceIntegrationTestSuite) createTestShow() *catalogm.Sho
 	err := s.db.Create(show).Error
 	s.Require().NoError(err)
 	return show
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) createTestRelease(title string) *catalogm.Release {
+	slug := fmt.Sprintf("test-release-%d", time.Now().UnixNano())
+	release := &catalogm.Release{
+		Title:       title,
+		Slug:        &slug,
+		ReleaseType: catalogm.ReleaseTypeLP,
+	}
+	err := s.db.Create(release).Error
+	s.Require().NoError(err)
+	return release
 }
 
 func (s *EntityReportServiceIntegrationTestSuite) createReport(entityType string, entityID, userID uint, reportType string) *contracts.EntityReportResponse {
@@ -367,11 +399,35 @@ func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_ShowSuc
 	s.Equal("wrong_venue", resp.ReportType)
 }
 
+// PSY-661: end-to-end create + entity-name/slug resolution for releases.
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_ReleaseSuccess() {
+	user := s.createTestUser()
+	release := s.createTestRelease("Test Release")
+
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "release",
+		EntityID:   release.ID,
+		UserID:     user.ID,
+		ReportType: "wrong_cover_art",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("release", resp.EntityType)
+	s.Equal("wrong_cover_art", resp.ReportType)
+	// The moderation queue deep-links via the resolved name + slug.
+	s.Equal("Test Release", resp.EntityName)
+	s.Require().NotNil(resp.EntitySlug)
+	s.NotEmpty(*resp.EntitySlug)
+}
+
 func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_InvalidEntityType() {
 	user := s.createTestUser()
 
+	// `label` is not a reportable entity type (PSY-661 added `release`;
+	// labels are tracked separately under PSY-666).
 	_, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
-		EntityType: "release",
+		EntityType: "label",
 		EntityID:   1,
 		UserID:     user.ID,
 		ReportType: "inaccurate",

--- a/backend/internal/services/contracts/entity_report.go
+++ b/backend/internal/services/contracts/entity_report.go
@@ -56,9 +56,11 @@ type EntityReportResponse struct {
 	EntityType string `json:"entity_type"`
 	EntityID   uint   `json:"entity_id"`
 	EntityName string `json:"entity_name,omitempty"`
-	// EntitySlug is populated only for entity types addressed by slug in the
-	// public app (currently `collection`). Other entity types use ID-based
-	// URLs and leave this nil so the JSON omits the field. PSY-357.
+	// EntitySlug is populated for entity types addressed by slug in the
+	// public app (collection, artist, venue, festival, release, label) so the
+	// moderation queue can deep-link to the affected entity. Types with
+	// ID-based URLs (show, comment) leave this nil so the JSON omits the
+	// field. PSY-357 (collection); PSY-600 (extended); PSY-661 (release).
 	EntitySlug   *string `json:"entity_slug,omitempty"`
 	ReportedBy   uint    `json:"reported_by"`
 	ReporterName string  `json:"reporter_name,omitempty"`

--- a/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
@@ -87,6 +87,23 @@ const mockCollectionReport: EntityReportResponse = {
   created_at: '2026-04-05T00:00:00Z',
 }
 
+// PSY-661: release-typed report payload. Includes entity_slug so the
+// generic EntityReportCard can deep-link to the public /releases/{slug} page.
+const mockReleaseReport: EntityReportResponse = {
+  id: 7,
+  entity_type: 'release',
+  entity_id: 70,
+  entity_name: 'In Rainbows',
+  entity_slug: 'in-rainbows',
+  reported_by: 7,
+  reporter_name: 'reporter4',
+  reporter_username: null,
+  report_type: 'wrong_cover_art',
+  details: 'Cover art shows the wrong album',
+  status: 'pending',
+  created_at: '2026-04-06T00:00:00Z',
+}
+
 // --- Mocks ---
 
 const mockUseAdminPendingEdits = vi.fn()
@@ -247,6 +264,20 @@ describe('ModerationQueue', () => {
     // Dismiss is still available so admins can clear stale reports.
     const dismissButton = screen.getByText('Dismiss Report').closest('button')
     expect(dismissButton).not.toBeDisabled()
+  })
+
+  // PSY-661: release reports flow through the generic EntityReportCard (no
+  // bespoke moderation action). The card must show the entity-type badge,
+  // the release-tailored report-type label, and a slug-based deep-link.
+  it('renders release report via the generic entity report card', () => {
+    setDefaultMocks({ reports: [mockReleaseReport] })
+
+    render(<ModerationQueue />)
+
+    expect(screen.getByText('Release')).toBeInTheDocument()
+    expect(screen.getByText('Wrong Cover Art')).toBeInTheDocument()
+    const link = screen.getByText('In Rainbows').closest('a')
+    expect(link).toHaveAttribute('href', '/releases/in-rainbows')
   })
 
   it('shows correct counts in filter buttons', () => {

--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -59,6 +59,10 @@ function getEntityUrl(entityType: string, entityId: number, entitySlug?: string)
     // to '#' if the slug couldn't be resolved (deleted collection, etc.).
     case 'collection':
       return entitySlug ? `/collections/${entitySlug}` : '#'
+    // PSY-661: releases are addressed by slug. The backend resolves the slug
+    // onto report.entity_slug; fall back to '#' if it couldn't be resolved.
+    case 'release':
+      return entitySlug ? `/releases/${entitySlug}` : '#'
     default:
       return '#'
   }
@@ -99,7 +103,7 @@ function renderValue(value: unknown): string {
 // ─── Filter Types ────────────────────────────────────────────────────────────
 
 type ItemTypeFilter = 'all' | 'edits' | 'reports' | 'comments'
-type EntityTypeFilter = '' | 'artist' | 'venue' | 'festival' | 'show' | 'collection'
+type EntityTypeFilter = '' | 'artist' | 'venue' | 'festival' | 'show' | 'collection' | 'release'
 
 // ─── Unified Item Type ───────────────────────────────────────────────────────
 
@@ -888,6 +892,7 @@ export function ModerationQueue() {
           <option value="festival">Festivals</option>
           <option value="show">Shows</option>
           <option value="collection">Collections</option>
+          <option value="release">Releases</option>
         </select>
 
         {/* Summary count */}

--- a/frontend/features/contributions/hooks/useReportEntity.test.tsx
+++ b/frontend/features/contributions/hooks/useReportEntity.test.tsx
@@ -43,6 +43,8 @@ describe('useReportEntity', () => {
     { entityType: 'venue', expectedPath: 'venues/42/report' },
     { entityType: 'festival', expectedPath: 'festivals/42/report' },
     { entityType: 'collection', expectedPath: 'collections/42/report' },
+    // PSY-661: releases use the regular /{plural}/{id}/report shape.
+    { entityType: 'release', expectedPath: 'releases/42/report' },
     // comment uses the same /{plural}/{id}/report shape as artist/venue;
     // the dedicated /comments handler family is a backend implementation
     // detail. URL identity is what this test pins.

--- a/frontend/features/contributions/hooks/useReportEntity.ts
+++ b/frontend/features/contributions/hooks/useReportEntity.ts
@@ -36,6 +36,7 @@ const REPORT_PLURAL: Record<ReportableEntityType, string> = {
   show: 'shows',
   comment: 'comments',
   collection: 'collections',
+  release: 'releases',
 }
 
 /**
@@ -52,6 +53,7 @@ const REPORT_SUFFIX: Record<ReportableEntityType, string> = {
   show: 'entity-report',
   comment: 'report',
   collection: 'report',
+  release: 'report',
 }
 
 export const useReportEntity = () => {

--- a/frontend/features/contributions/types.ts
+++ b/frontend/features/contributions/types.ts
@@ -163,7 +163,7 @@ export function validateUrlField(value: string): string | null {
   return null
 }
 
-export type ReportableEntityType = 'artist' | 'venue' | 'festival' | 'show' | 'comment' | 'collection'
+export type ReportableEntityType = 'artist' | 'venue' | 'festival' | 'show' | 'comment' | 'collection' | 'release'
 
 export interface ReportTypeOption {
   value: string
@@ -217,6 +217,19 @@ export const REPORT_TYPES: Record<ReportableEntityType, ReportTypeOption[]> = {
     { value: 'inappropriate', label: 'Inappropriate', description: 'NSFW cover, hateful theme, or abusive content' },
     { value: 'misleading', label: 'Misleading', description: 'False claims in the description or item notes' },
     { value: 'other', label: 'Other', description: 'Another issue not listed above' },
+  ],
+  // PSY-661: release-tailored taxonomy (diverges from the generic
+  // artist/venue vocab to name field-specific corrections common on a
+  // release record). Aligned with the backend allow list in
+  // backend/internal/models/community/entity_report.go — `value` strings
+  // must match byte-for-byte.
+  release: [
+    { value: 'inaccurate', label: 'Inaccurate Information', description: 'Title, year, tracklist, or other info is wrong' },
+    { value: 'duplicate', label: 'Duplicate Release', description: 'This release already exists under a different entry' },
+    { value: 'wrong_cover_art', label: 'Wrong Cover Art', description: 'The cover image is incorrect' },
+    { value: 'wrong_release_date', label: 'Wrong Release Date', description: 'The release date or year is incorrect' },
+    { value: 'wrong_artist_attribution', label: 'Wrong Artist', description: 'This release is attributed to the wrong artist' },
+    { value: 'missing_info', label: 'Missing Information', description: 'Important information is missing' },
   ],
 }
 

--- a/frontend/features/releases/components/ReleaseDetail.test.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { ReleaseDetail } from './ReleaseDetail'
 import type { ReleaseDetail as ReleaseDetailType } from '../types'
 
@@ -86,8 +86,18 @@ vi.mock('@/components/shared', () => ({
   AddToCollectionButton: () => (
     <button data-testid="add-to-collection">Collect</button>
   ),
-  BracketLink: ({ label, onClick }: { label: string; onClick: () => void }) => (
-    <button onClick={onClick}>{label}</button>
+  BracketLink: ({
+    label,
+    onClick,
+    title,
+  }: {
+    label: string
+    onClick: () => void
+    title?: string
+  }) => (
+    <button onClick={onClick} title={title}>
+      {label}
+    </button>
   ),
 }))
 
@@ -98,6 +108,22 @@ vi.mock('@/features/contributions', () => ({
     open ? <div data-testid="edit-drawer">Edit Drawer</div> : null,
   EntitySaveSuccessBanner: ({ visible }: { visible: boolean }) =>
     visible ? <div data-testid="save-banner">Saved</div> : null,
+  // PSY-661: report dialog renders only when opened; the test toggles it via
+  // the [Report] bracket link.
+  ReportEntityDialog: ({
+    open,
+    entityType,
+    entityName,
+  }: {
+    open: boolean
+    entityType: string
+    entityName: string
+  }) =>
+    open ? (
+      <div data-testid="report-dialog">
+        Report {entityType} {entityName}
+      </div>
+    ) : null,
   useEntitySaveSuccessBanner: () => ({
     isVisible: false,
     handleSaveSuccess: vi.fn(),
@@ -336,6 +362,12 @@ describe('ReleaseDetail', () => {
       expect(screen.queryByText('Edit')).not.toBeInTheDocument()
       expect(screen.queryByText('Suggest edit')).not.toBeInTheDocument()
     })
+
+    // PSY-661: the report affordance is auth-gated.
+    it('does not render the Report bracket link for anonymous users', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.queryByTitle('Report an issue')).not.toBeInTheDocument()
+    })
   })
 
   describe('contributor affordances', () => {
@@ -379,6 +411,31 @@ describe('ReleaseDetail', () => {
       })
       render(<ReleaseDetail idOrSlug="in-rainbows" />)
       expect(screen.getByText('Suggest description')).toBeInTheDocument()
+    })
+
+    // PSY-661: signed-in users get a [Report] affordance that opens the
+    // report dialog bound to the release.
+    it('shows the Report bracket link and opens the report dialog', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'contributor' },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+
+      const reportLink = screen.getByTitle('Report an issue')
+      expect(reportLink).toBeInTheDocument()
+      // Dialog is closed until the link is clicked.
+      expect(screen.queryByTestId('report-dialog')).not.toBeInTheDocument()
+
+      fireEvent.click(reportLink)
+      expect(
+        screen.getByText('Report release In Rainbows')
+      ).toBeInTheDocument()
     })
   })
 

--- a/frontend/features/releases/components/ReleaseDetail.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.tsx
@@ -21,7 +21,7 @@ import {
   AddToCollectionButton,
   BracketLink,
 } from '@/components/shared'
-import { AttributionLine, ContributionPrompt, EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner } from '@/features/contributions'
+import { AttributionLine, ContributionPrompt, EntityEditDrawer, EntitySaveSuccessBanner, ReportEntityDialog, useEntitySaveSuccessBanner } from '@/features/contributions'
 import { EntityTagList, AddTagDialog } from '@/features/tags'
 import { AsHeardOn } from '@/features/radio'
 import { EntityCollections } from '@/features/collections'
@@ -74,6 +74,7 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [addTagDialogOpen, setAddTagDialogOpen] = useState(false)
+  const [isReportOpen, setIsReportOpen] = useState(false)
   const saveBanner = useEntitySaveSuccessBanner()
 
   if (isLoading) {
@@ -273,6 +274,13 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
                       onClick={() => setAddTagDialogOpen(true)}
                     />
                   )}
+                  {isAuthenticated && (
+                    <BracketLink
+                      label="Report"
+                      title="Report an issue"
+                      onClick={() => setIsReportOpen(true)}
+                    />
+                  )}
                 </div>
               }
             />
@@ -404,6 +412,17 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
           entityId={release.id}
           open={addTagDialogOpen}
           onOpenChange={setAddTagDialogOpen}
+        />
+      )}
+
+      {/* Report Dialog (authenticated users) — PSY-661 */}
+      {isAuthenticated && (
+        <ReportEntityDialog
+          open={isReportOpen}
+          onOpenChange={setIsReportOpen}
+          entityType="release"
+          entityId={release.id}
+          entityName={release.title}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Extends the polymorphic entity-reports subsystem to support **releases** (backend + frontend). PSY-658 deliberately deferred the `[Report]` affordance on ReleaseDetail to this ticket.

Follows the **PSY-578 collection precedent**: a release-tailored report taxonomy (six entity-specific types) with a documented rationale, rather than reusing the generic artist/venue vocabulary. The release set names field-specific corrections that are the most common report on a release record:

| value | label |
| --- | --- |
| `inaccurate` | Inaccurate Information |
| `duplicate` | Duplicate Release |
| `wrong_cover_art` | Wrong Cover Art |
| `wrong_release_date` | Wrong Release Date |
| `wrong_artist_attribution` | Wrong Artist |
| `missing_info` | Missing Information |

`value` strings are byte-identical across `validReportTypes["release"]` (backend) and `REPORT_TYPES.release` (frontend). Both sides carry a PSY-661 comment documenting the release-tailored taxonomy, mirroring PSY-578's collection comment.

**Backend** (model + handler + route + contract + tests): `EntityReportEntityRelease` constant, `validReportTypes["release"]`, `release` in `ValidEntityReportEntityTypes()`, `ReportReleaseHandler` + `POST /releases/{entity_id}/report` on the rate-limited report group. `resolveEntityNameAndSlug` already resolves releases (PSY-600), so the admin queue gets slug deep-links with no service change — refreshed the stale `EntityReportResponse.EntitySlug` doc comment to match reality.

**Frontend** (types + hook + ReleaseDetail + moderation queue + tests): `release` added to `ReportableEntityType`, `REPORT_TYPES`, the exhaustive `REPORT_PLURAL`/`REPORT_SUFFIX` maps, an auth-only `[Report]` BracketLink + `ReportEntityDialog` on ReleaseDetail (mirrors ArtistDetail), and a `release` case in `getEntityUrl` (slug-based `/releases/{slug}`) + a Releases entity-type filter option.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/models/community/... ./internal/api/handlers/community/... ./internal/services/admin/...` — all pass (model/taxonomy assertions updated for the new 7-type set; release handler unit + integration tests added)
- [x] `cd backend && go test ./internal/api/routes/...` — pass (route registration)
- [x] `cd frontend && bun run typecheck` — clean (exhaustive `Record<ReportableEntityType,…>` maps forced + satisfied)
- [x] `cd frontend && bun run test:run features/releases features/contributions` — 224 pass
- [x] `cd frontend && bun run test:run app/admin/moderation` — 20 pass
- [x] `cd frontend && bun run lint` — 0 errors

## Manual repro

Isolated dispatch stack (`stack-up.sh --mode=isolated`), seeded users + the `futures` release exemplar:

1. Signed in as a non-admin contributor (`e2e-user-1`) → release page shows `[Report]` in the header linkbox → opened the dialog → all six release report types render.
2. Selected "Wrong Cover Art" + a detail note → submitted → "Report submitted" success state. Verified the `entity_reports` row: `release / id=1 / wrong_cover_art / pending`.
3. Signed in as the seeded admin → `/admin/moderation` → the release report renders via the generic card: "Report"+"Release" badges, entity name "Futures" deep-linking to `/releases/futures` (slug-based), "Wrong Cover Art" type, reporter byline, detail quote, Resolve/Dismiss actions.

## Screenshots

**Release header with `[Report]` link (contributor)**
![header](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-d755faee0afcc944a325/01-release-header-report-link.png)

**Report dialog — six release-tailored types**
![dialog](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-d755faee0afcc944a325/02-report-dialog-six-types.png)

**Submission success**
![success](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-d755faee0afcc944a325/03-report-success.png)

**Admin moderation queue — release report with slug deep-link**
![moderation](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-d755faee0afcc944a325/04-admin-moderation-release-report.png)

## Code review

`/code-review` (extra-high, inline 9-angle pass) — **no findings**. Clean mechanical extension following three established precedents (PSY-578 taxonomy, PSY-357 routing, ArtistDetail wiring) at the correct altitude (releases ride the generic `EntityReportCard` — no `is_public`/`visibility` field means no bespoke hide action).

## Adversarial review

`/adversarial-review` — **CLEAN** (no findings). Panel: Saboteur · Future-Maintainer · Security · Completeness, run inline with no prior session context against the branch diff.
- Saboteur: table-name derivation (`"release"+"s"`=`releases`) confirmed correct + verified live (report created, not 404'd); slug-missing fallback graceful.
- Security: auth-gating + rate-limiting inherited correctly from the shared report group; `entity_id` parsed via `ParseUint`, `report_type` allow-listed, parameterized queries — no new surface.
- Future-Maintainer: stale `EntitySlug` doc-comment actively corrected; every new branch covered.
- Completeness: all 8 acceptance criteria + every Decision item implemented; taxonomy values byte-identical across both sides.

Closes PSY-661
