### PR TITLE
PSY-957: consolidate collections auto-dismiss banner timers

### DIFF
--- a/frontend/features/collections/components/CollectionCard.tsx
+++ b/frontend/features/collections/components/CollectionCard.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useRef, useState } from 'react'
 import {
   Library,
   Users,
@@ -24,6 +23,8 @@ import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { getEntityTypeLabel, type Collection } from '../types'
 import { MarkdownContent } from './MarkdownContent'
 import { CollectionCoverImage } from './CollectionCoverImage'
+import { describeCollectionMutationError } from './collectionDetailShared'
+import { useAutoDismissBanner } from '@/lib/hooks/common/useAutoDismissBanner'
 import { useLikeCollection, useUnlikeCollection } from '../hooks'
 import { useAuthContext } from '@/lib/context/AuthContext'
 
@@ -47,15 +48,14 @@ export function CollectionCard({ collection }: CollectionCardProps) {
   // PSY-609: like/unlike are optimistic-rollback hooks; on a 4xx the heart
   // snaps back but the user got no explanation. Keep an auto-dismiss
   // banner in the card so the *reason* is visible for ~3s. 403 (private
-  // target) gets dedicated copy.
-  const [likeError, setLikeError] = useState<string | null>(null)
-  const errorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current)
-    }
-  }, [])
+  // target) gets dedicated copy. PSY-957: timer lifecycle + error copy come
+  // from the feature's shared banner primitives instead of a hand-rolled
+  // setTimeout + inline 403 formatting.
+  const {
+    value: likeError,
+    show: showLikeError,
+    clear: clearLikeError,
+  } = useAutoDismissBanner<string>(3000)
 
   const handleToggleLike = async (e: React.MouseEvent) => {
     // Card body is wrapped in a link; stop propagation so clicking the
@@ -65,8 +65,7 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 
     const wasLiked = Boolean(collection.user_likes_this)
 
-    setLikeError(null)
-    if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current)
+    clearLikeError()
 
     try {
       if (wasLiked) {
@@ -75,26 +74,17 @@ export function CollectionCard({ collection }: CollectionCardProps) {
         await likeMutation.mutateAsync({ slug: collection.slug })
       }
     } catch (err) {
-      // Status comes from ApiError.status / AuthError.status (403 wraps
-      // as AuthError for the privacy-blocked path).
-      const status =
-        err && typeof err === 'object' && 'status' in err
-          ? Number((err as { status?: number }).status)
-          : undefined
-      let message: string
-      if (status === 403) {
-        message = wasLiked
-          ? "This collection is private — your like was removed."
-          : 'This collection is private.'
-      } else if (err instanceof Error && err.message) {
-        message = err.message
-      } else {
-        message = wasLiked
-          ? 'Failed to unlike collection.'
-          : 'Failed to like collection.'
-      }
-      setLikeError(message)
-      errorTimeoutRef.current = setTimeout(() => setLikeError(null), 3000)
+      // 403 (private target) + message/generic fallbacks share copy with
+      // the detail page via describeCollectionMutationError.
+      showLikeError(
+        describeCollectionMutationError(
+          err,
+          wasLiked
+            ? 'Failed to unlike collection.'
+            : 'Failed to like collection.',
+          { unlikePrivate: wasLiked }
+        )
+      )
     }
   }
 
@@ -340,9 +330,9 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 
           {/*
             PSY-609: like/unlike error banner. Auto-dismisses after ~3s
-            (set by handleToggleLike's setTimeout). role="status" because
-            this is informational — the optimistic state already snapped
-            back; this banner just explains why.
+            (via the shared useAutoDismissBanner primitive, PSY-957).
+            role="status" because this is informational — the optimistic
+            state already snapped back; this banner just explains why.
           */}
           {likeError && (
             <div

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import {
@@ -76,6 +76,7 @@ import {
   MutationFeedback,
   useAutoDismissError,
 } from './collectionDetailShared'
+import { useAutoDismissFlag } from '@/lib/hooks/common/useAutoDismissBanner'
 import { CollectionGraph } from './CollectionGraph'
 import { CollectionCoverImage } from './CollectionCoverImage'
 import {
@@ -127,17 +128,15 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
 
   const [isEditing, setIsEditing] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
-  const [showCopied, setShowCopied] = useState(false)
+  // PSY-892 D4: "Link copied" blip after Share (the overflow menu closes on
+  // click, so feedback can't live on the trigger). PSY-957: auto-dismiss
+  // timer lifecycle lives in the shared primitive.
+  const [showCopied, triggerCopied] = useAutoDismissFlag(2000)
   // PSY-894 D4: green "Collection updated" banner after a successful edit
   // save. The form closing + header re-render is the inherent confirmation;
   // the banner makes it explicit and auto-dismisses after ~3s. No toast —
   // the project has no toast library (PSY-608/609 convention).
-  const [showUpdateSuccess, setShowUpdateSuccess] = useState(false)
-  useEffect(() => {
-    if (!showUpdateSuccess) return
-    const timer = setTimeout(() => setShowUpdateSuccess(false), 3000)
-    return () => clearTimeout(timer)
-  }, [showUpdateSuccess])
+  const [showUpdateSuccess, triggerUpdateSuccess] = useAutoDismissFlag(3000)
   // PSY-357: report dialog open state. The trigger is only rendered for
   // authenticated, non-creator viewers (private collections aren't visible
   // to non-creators, so no extra public-state gate is needed).
@@ -176,10 +175,9 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
 
   const handleShare = useCallback(() => {
     navigator.clipboard.writeText(window.location.href).then(() => {
-      setShowCopied(true)
-      setTimeout(() => setShowCopied(false), 2000)
+      triggerCopied()
     })
-  }, [])
+  }, [triggerCopied])
 
   const items = collection?.items ?? []
   // PSY-555 (was PSY-366): surface the graph toggle whenever the collection
@@ -328,7 +326,7 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
             onSaved={() => {
               setIsEditing(false)
               // PSY-894 D4: only a successful save shows the green banner.
-              setShowUpdateSuccess(true)
+              triggerUpdateSuccess()
             }}
             onCancel={() => setIsEditing(false)}
           />

--- a/frontend/features/collections/components/CollectionItemsList.test.tsx
+++ b/frontend/features/collections/components/CollectionItemsList.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { CollectionItemsList } from './CollectionItemsList'
+import type { StagedCollectionItem } from './AddItemsPicker'
+
+// PSY-957: integration coverage for AddItemsPanel's sticky-vs-auto-dismiss
+// feedback — the headline behavior the banner-timer consolidation had to
+// preserve/fix. The shared primitive is unit-tested in
+// lib/hooks/common/useAutoDismissBanner.test.ts; THIS file pins that
+// AddItemsPanel actually routes a thrown (network/5xx) error to the sticky
+// path and a resolved response to the auto-dismiss path. Without it, a future
+// edit that swaps showStickyFeedback↔showFeedback ships green (both render the
+// same red banner; only dismiss timing differs).
+
+const mockBulkAddMutateAsync = vi.fn()
+let mockBulkAddIsPending = false
+
+vi.mock('../hooks', () => ({
+  useReorderCollectionItems: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useRemoveCollectionItem: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useUpdateCollectionItem: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useBulkAddCollectionItems: () => ({
+    mutateAsync: mockBulkAddMutateAsync,
+    isPending: mockBulkAddIsPending,
+    isError: false,
+    error: null,
+  }),
+}))
+
+// Stub the picker: real entity-search behavior is covered in
+// AddItemsPicker.test.tsx. Here we only need a way to stage one item so the
+// submit button enables and handleSubmit runs.
+const STAGED_ITEM: StagedCollectionItem = {
+  entityType: 'artist',
+  entityId: 1,
+  name: 'Test Artist',
+  subtitle: null,
+}
+vi.mock('./AddItemsPicker', () => ({
+  AddItemsPicker: ({
+    onStagedItemsChange,
+  }: {
+    onStagedItemsChange: (items: StagedCollectionItem[]) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="stub-stage-item"
+      onClick={() => onStagedItemsChange([STAGED_ITEM])}
+    >
+      stage one item
+    </button>
+  ),
+}))
+
+// DensityToggle pulls in shared-bundle deps we don't exercise here.
+vi.mock('@/components/shared', () => ({
+  DensityToggle: () => <div data-testid="density-toggle-stub" />,
+}))
+
+function renderEmptyCreatorList() {
+  // items=[] ⇒ AddItemsPanel auto-opens (isAddItemsOpen defaults to true);
+  // isCreator ⇒ the panel is gated visible; unranked ⇒ no dnd-kit reorder mount
+  // (canReorder is isCreator && isRanked).
+  return render(
+    <CollectionItemsList
+      items={[]}
+      slug="test-collection"
+      isCreator
+      displayMode="unranked"
+    />
+  )
+}
+
+async function stageAndSubmit() {
+  fireEvent.click(screen.getByTestId('stub-stage-item'))
+  // handleSubmit awaits mutateAsync; flush its microtasks inside act so the
+  // post-await setState (showFeedback / showStickyFeedback) is applied.
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('add-items-picker-submit'))
+  })
+}
+
+describe('AddItemsPanel feedback (PSY-957 sticky-vs-auto-dismiss)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockBulkAddMutateAsync.mockReset()
+    mockBulkAddIsPending = false
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('auto-dismisses the success banner ~4s after a fully-successful add', async () => {
+    mockBulkAddMutateAsync.mockResolvedValue({ added: [{ id: 1 }], errors: [] })
+    renderEmptyCreatorList()
+
+    await stageAndSubmit()
+
+    expect(screen.getByTestId('add-item-success')).toBeInTheDocument()
+
+    // Still up just before the window closes…
+    act(() => {
+      vi.advanceTimersByTime(3999)
+    })
+    expect(screen.queryByTestId('add-item-success')).toBeInTheDocument()
+
+    // …gone at 4s.
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(screen.queryByTestId('add-item-success')).not.toBeInTheDocument()
+  })
+
+  it('auto-dismisses the resolved-rejection error banner ~4s (all rows rejected)', async () => {
+    // A resolved response where every row failed is a per-row rejection, not a
+    // thrown error — it stays on the auto-dismiss path (the user can retry).
+    mockBulkAddMutateAsync.mockResolvedValue({
+      added: [],
+      errors: [{ reason: 'dupe' }],
+    })
+    renderEmptyCreatorList()
+
+    await stageAndSubmit()
+
+    expect(screen.getByTestId('add-item-error')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+    expect(screen.queryByTestId('add-item-error')).not.toBeInTheDocument()
+  })
+
+  it('keeps the thrown-error banner STICKY past the auto-dismiss window', async () => {
+    // A rejected promise (network / 5xx) is a hard failure the user must read;
+    // it must NOT auto-dismiss. This is the regression the swap-back would break.
+    mockBulkAddMutateAsync.mockRejectedValue(new Error('network blew up'))
+    renderEmptyCreatorList()
+
+    await stageAndSubmit()
+
+    expect(screen.getByTestId('add-item-error')).toHaveTextContent(
+      'network blew up'
+    )
+
+    // Well past the 4s auto-dismiss window — still on screen.
+    act(() => {
+      vi.advanceTimersByTime(20_000)
+    })
+    expect(screen.getByTestId('add-item-error')).toHaveTextContent(
+      'network blew up'
+    )
+  })
+})

--- a/frontend/features/collections/components/CollectionItemsList.tsx
+++ b/frontend/features/collections/components/CollectionItemsList.tsx
@@ -502,11 +502,13 @@ function AddItemsPanel({
   const bulkAddMutation = useBulkAddCollectionItems()
 
   // The panel unmounts when closed (unlike the old always-mounted
-  // AddItemsSection), so async work must not land after unmount: the
-  // post-await feedback / staged-items writes bail when the panel has
-  // already closed. The flag is set in the effect SETUP (not just
-  // initialized at declaration) so StrictMode's dev-only
-  // mount→cleanup→remount cycle restores it to true.
+  // AddItemsSection), so async work must not land after unmount. The shared
+  // banner primitive already clears its own timer on unmount, but this ref is
+  // still load-bearing: it guards the post-await `setStagedItems([])` write
+  // (and the showFeedback/showStickyFeedback calls) when the user closes the
+  // panel mid-request — do NOT delete it as redundant. The flag is set in the
+  // effect SETUP (not just initialized at declaration) so StrictMode's
+  // dev-only mount→cleanup→remount cycle restores it to true.
   const isMountedRef = useRef(true)
   useEffect(() => {
     isMountedRef.current = true

--- a/frontend/features/collections/components/CollectionItemsList.tsx
+++ b/frontend/features/collections/components/CollectionItemsList.tsx
@@ -88,6 +88,7 @@ import {
   MutationFeedback,
   useAutoDismissError,
 } from './collectionDetailShared'
+import { useAutoDismissBanner } from '@/lib/hooks/common/useAutoDismissBanner'
 
 // ──────────────────────────────────────────────
 // Items List (with reorder support + grid/list view toggle, PSY-360)
@@ -485,26 +486,32 @@ function AddItemsPanel({
 }) {
   // PSY-823: items staged in the picker, submitted in one bulk-add request.
   const [stagedItems, setStagedItems] = useState<StagedCollectionItem[]>([])
-  const [feedback, setFeedback] = useState<
-    | { variant: 'success'; message: string }
-    | { variant: 'error'; message: string }
-    | null
-  >(null)
+  // PSY-957: bulk-add result feedback via the shared banner primitive.
+  // Submission results auto-dismiss after ~4s; thrown (network / 5xx)
+  // errors stay sticky until the next submit so the user has time to read
+  // what failed (PSY-608/609 policy). Timer lifecycle — including
+  // clear-on-unmount — lives in the primitive.
+  const {
+    value: feedback,
+    show: showFeedback,
+    showSticky: showStickyFeedback,
+  } = useAutoDismissBanner<{
+    variant: 'success' | 'error'
+    message: string
+  }>(4000)
   const bulkAddMutation = useBulkAddCollectionItems()
 
   // The panel unmounts when closed (unlike the old always-mounted
-  // AddItemsSection), so async work must not setState after unmount: the
-  // feedback timer is cleared on unmount, and the post-await feedback
-  // writes bail when the panel has already closed. The flag is set in the
-  // effect SETUP (not just initialized at declaration) so StrictMode's
-  // dev-only mount→cleanup→remount cycle restores it to true.
-  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // AddItemsSection), so async work must not land after unmount: the
+  // post-await feedback / staged-items writes bail when the panel has
+  // already closed. The flag is set in the effect SETUP (not just
+  // initialized at declaration) so StrictMode's dev-only
+  // mount→cleanup→remount cycle restores it to true.
   const isMountedRef = useRef(true)
   useEffect(() => {
     isMountedRef.current = true
     return () => {
       isMountedRef.current = false
-      if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
     }
   }, [])
 
@@ -523,17 +530,17 @@ function AddItemsPanel({
       const addedCount = resp.added.length
       const rejectedCount = resp.errors.length
       if (rejectedCount === 0) {
-        setFeedback({
+        showFeedback({
           variant: 'success',
           message: `Added ${addedCount} ${addedCount === 1 ? 'item' : 'items'} to collection`,
         })
       } else if (addedCount === 0) {
-        setFeedback({
+        showFeedback({
           variant: 'error',
           message: `Couldn't add any items (${rejectedCount} ${rejectedCount === 1 ? 'error' : 'errors'}). Adjust the picker and try again.`,
         })
       } else {
-        setFeedback({
+        showFeedback({
           variant: 'success',
           message: `Added ${addedCount} ${addedCount === 1 ? 'item' : 'items'}; ${rejectedCount} couldn't be added.`,
         })
@@ -544,11 +551,9 @@ function AddItemsPanel({
       if (addedCount > 0) {
         setStagedItems([])
       }
-      if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
-      feedbackTimerRef.current = setTimeout(() => setFeedback(null), 4000)
     } catch (err) {
       if (!isMountedRef.current) return
-      setFeedback({
+      showStickyFeedback({
         variant: 'error',
         message: describeCollectionMutationError(err, 'Failed to add items.'),
       })

--- a/frontend/features/collections/components/collectionDetailShared.test.tsx
+++ b/frontend/features/collections/components/collectionDetailShared.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import {
+  describeCollectionMutationError,
+  useAutoDismissError,
+} from './collectionDetailShared'
+
+// PSY-957: the reactive wrapper consumed by the like/unlike/reorder call
+// sites. Its signature and observable behavior predate PSY-957 (PSY-609);
+// these tests pin that rebuilding it on the shared useAutoDismissBanner
+// (now at @/lib/hooks/common) didn't change the contract.
+describe('useAutoDismissError (PSY-609 contract)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  const formatter = (e: unknown) =>
+    e instanceof Error ? e.message : 'something failed'
+
+  it('returns null while there is no error', () => {
+    const { result } = renderHook(() =>
+      useAutoDismissError(null, false, formatter)
+    )
+    expect(result.current).toBeNull()
+  })
+
+  it('shows the formatted message when the mutation errors, then auto-dismisses', () => {
+    const { result, rerender } = renderHook(
+      ({ e, isErr }: { e: unknown; isErr: boolean }) =>
+        useAutoDismissError(e, isErr, formatter),
+      { initialProps: { e: null as unknown, isErr: false } }
+    )
+
+    rerender({ e: new Error('boom'), isErr: true })
+    expect(result.current).toBe('boom')
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('shows immediately when the first render already has an error', () => {
+    // NOTE: `err` must be referentially stable across renders (it is in real
+    // usage — TanStack keeps mutation.error stable between state changes).
+    // Constructing it inside the renderHook callback would re-trigger the
+    // error-signal guard every render.
+    const err = new Error('immediate')
+    const { result } = renderHook(() =>
+      useAutoDismissError(err, true, formatter)
+    )
+    expect(result.current).toBe('immediate')
+  })
+
+  it('does NOT re-show after auto-dismiss while the mutation stays in its error state', () => {
+    // The subtle half of the previous-value-guard contract: once a banner
+    // auto-dismisses, an unrelated re-render (parent state change) while
+    // isError/err are unchanged must NOT revive the dismissed banner. A
+    // guard keyed on render count instead of err identity would regress this.
+    const err = new Error('persistent 4xx')
+    const { result, rerender } = renderHook(() =>
+      useAutoDismissError(err, true, formatter)
+    )
+    expect(result.current).toBe('persistent 4xx')
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(result.current).toBeNull()
+
+    // Same err + isError; just a re-render. Banner stays dismissed.
+    rerender()
+    expect(result.current).toBeNull()
+  })
+
+  it('re-shows when a new error fires after the previous one dismissed', () => {
+    const { result, rerender } = renderHook(
+      ({ e, isErr }: { e: unknown; isErr: boolean }) =>
+        useAutoDismissError(e, isErr, formatter),
+      { initialProps: { e: null as unknown, isErr: false } }
+    )
+
+    rerender({ e: new Error('first'), isErr: true })
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(result.current).toBeNull()
+
+    // The mutation resets, then errors again with a new error object.
+    rerender({ e: null, isErr: false })
+    rerender({ e: new Error('second'), isErr: true })
+    expect(result.current).toBe('second')
+  })
+
+  it('respects a custom delay', () => {
+    const err = new Error('slow burn')
+    const { result } = renderHook(() =>
+      useAutoDismissError(err, true, formatter, 5000)
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(result.current).toBe('slow burn')
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current).toBeNull()
+  })
+})
+
+// Direct coverage for the copy helper now that this module has its own test
+// file (previously only exercised through component tests). CollectionCard
+// delegates to it as of PSY-957, so its copy is load-bearing on three
+// surfaces (detail like/unlike, reorder, card like/unlike).
+describe('describeCollectionMutationError (PSY-609)', () => {
+  it('renders dedicated copy for 403 (private target)', () => {
+    const err = Object.assign(new Error('forbidden'), { status: 403 })
+    expect(describeCollectionMutationError(err, 'fallback')).toBe(
+      'This collection is private.'
+    )
+  })
+
+  it('renders unlike-specific copy for 403 with unlikePrivate', () => {
+    const err = Object.assign(new Error('forbidden'), { status: 403 })
+    expect(
+      describeCollectionMutationError(err, 'fallback', { unlikePrivate: true })
+    ).toBe('This collection is private — your like was removed.')
+  })
+
+  it('falls back to the error message for non-403 errors', () => {
+    expect(
+      describeCollectionMutationError(new Error('network blew up'), 'fallback')
+    ).toBe('network blew up')
+  })
+
+  it('falls back to the provided copy when the error has no message', () => {
+    expect(
+      describeCollectionMutationError({}, 'Failed to like collection.')
+    ).toBe('Failed to like collection.')
+  })
+})

--- a/frontend/features/collections/components/collectionDetailShared.test.tsx
+++ b/frontend/features/collections/components/collectionDetailShared.test.tsx
@@ -78,6 +78,37 @@ describe('useAutoDismissError (PSY-609 contract)', () => {
     expect(result.current).toBeNull()
   })
 
+  it('re-arms the dismiss window when a fresh error object carries identical copy', () => {
+    // PSY-957 semantics: two consecutive failures whose formatted copy is the
+    // same (e.g. two 403s → "This collection is private.") still re-arm the
+    // window off the LATEST failure. The pre-PSY-957 `[message]`-keyed effect
+    // did not re-arm on an identical string; the entry-identity keying does.
+    const formatSame = () => 'This collection is private.'
+    const { result, rerender } = renderHook(
+      ({ e }: { e: unknown }) => useAutoDismissError(e, true, formatSame),
+      { initialProps: { e: new Error('a') as unknown } }
+    )
+    expect(result.current).toBe('This collection is private.')
+
+    // Part-way through the first window, a new error object (same copy) fires.
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    rerender({ e: new Error('b') })
+
+    // The original window would have closed by now (2000 + 2000 > 3000), but
+    // the re-arm keeps the banner up for a full window after the second error.
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current).toBe('This collection is private.')
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current).toBeNull()
+  })
+
   it('re-shows when a new error fires after the previous one dismissed', () => {
     const { result, rerender } = renderHook(
       ({ e, isErr }: { e: unknown; isErr: boolean }) =>

--- a/frontend/features/collections/components/collectionDetailShared.tsx
+++ b/frontend/features/collections/components/collectionDetailShared.tsx
@@ -1,28 +1,28 @@
 'use client'
 
 /**
- * Small helpers shared between `CollectionDetail` and its lazily-loaded items
- * list (`CollectionItemsList`). Extracted in PSY-951 so the items list — which
+ * Small helpers shared across the collections feature's banner surfaces
+ * (`CollectionDetail`, its lazily-loaded items list `CollectionItemsList`,
+ * and `CollectionCard`). Extracted in PSY-951 so the items list — which
  * carries the `@dnd-kit/*` drag-reorder machinery — can live in its own module
  * and be `dynamic()`-imported (evicting `@dnd-kit` from the global shared
  * client chunk) without a circular import back into `CollectionDetail.tsx`.
  *
- * These were previously module-private in `CollectionDetail.tsx`; behavior is
- * unchanged, this is purely a move so both modules can share them.
+ * PSY-957: the generic auto-dismiss timer primitives now live in
+ * `@/lib/hooks/common/useAutoDismissBanner` (the cross-feature consolidation
+ * home). What stays here is collections-specific: the `MutationFeedback`
+ * render primitive, the 403-aware error copy, and `useAutoDismissError` (the
+ * reactive wrapper that adapts a TanStack mutation's error state onto the
+ * shared banner timer). This module stays dependency-light (react + lucide
+ * icons + cn only) — keep it that way so importing it from browse-surface
+ * components (CollectionCard) never drags detail-page-only libs into the
+ * shared chunk.
  */
 
-import { useState, useRef, useEffect } from 'react'
-import {
-  Mic2,
-  MapPin,
-  Calendar,
-  Disc3,
-  Tag,
-  Tent,
-  Check,
-  AlertCircle,
-} from 'lucide-react'
+import { useState } from 'react'
+import { Mic2, MapPin, Calendar, Disc3, Tag, Tent, Check, AlertCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useAutoDismissBanner } from '@/lib/hooks/common/useAutoDismissBanner'
 
 export const ENTITY_ICONS: Record<string, React.ElementType> = {
   artist: Mic2,
@@ -104,9 +104,12 @@ const ERROR_SIGNAL_UNSET = Symbol('error-signal-unset')
  * snap-back of the optimistic state is the primary signal; this banner
  * just makes the *reason* visible.
  *
- * `formatter` MUST be stable across renders (wrap in useCallback) — it
- * sits in the timer effect's dependency array indirectly via `message`, so
- * an unstable reference would otherwise reset the auto-dismiss timer.
+ * `formatter` MUST be stable across renders (wrap in useCallback) — it runs
+ * during render when the error signal changes, so an unstable reference
+ * that closes over changing values would produce inconsistent copy.
+ *
+ * PSY-957: timer mechanics live in `useAutoDismissBanner`; this wrapper
+ * owns only the "react to a mutation error-state change" part.
  */
 export function useAutoDismissError(
   err: unknown,
@@ -114,19 +117,16 @@ export function useAutoDismissError(
   formatter: (e: unknown) => string,
   delayMs = 3000
 ): string | null {
-  const [message, setMessage] = useState<string | null>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { value, show } = useAutoDismissBanner<string>(delayMs)
 
-  // Surface the formatted error the moment the mutation errors (or when the
+  // Show the formatted error the moment the mutation errors (or when the
   // error signal changes while still erroring). React 19.2: adjust state
   // during render via the previous-value-guard idiom instead of a synchronous
   // setState in an effect (cascading render). The tracker starts at a sentinel
   // so the guard also fires on the FIRST render when `isError` is already true
-  // (matching the prior effect, which always ran on mount). The auto-dismiss
-  // timer below re-arms whenever `message` changes, preserving the prior
-  // single-effect behavior. `formatter` is required-stable (see the doc
-  // comment), so keying the guard on `isError`/`err` matches the prior
-  // dependency semantics.
+  // (matching the prior effect, which always ran on mount). `show` is a pure
+  // state setter (see useAutoDismissBanner), so calling it here is the same
+  // documented idiom.
   const [prevErrorSignal, setPrevErrorSignal] = useState<
     { isError: boolean; err: unknown } | typeof ERROR_SIGNAL_UNSET
   >(ERROR_SIGNAL_UNSET)
@@ -140,24 +140,9 @@ export function useAutoDismissError(
     // the tracker in step so the next error re-triggers (even with the same
     // `err` value).
     if (isError) {
-      setMessage(formatter(err))
+      show(formatter(err))
     }
   }
 
-  // Arm / re-arm the auto-dismiss timer whenever a message is shown. The
-  // setMessage(null) here is inside the deferred timer callback, not
-  // synchronous in the effect body.
-  useEffect(() => {
-    if (message === null) return
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => {
-      setMessage(null)
-      timeoutRef.current = null
-    }, delayMs)
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    }
-  }, [message, delayMs])
-
-  return message
+  return value
 }

--- a/frontend/features/collections/components/collectionDetailShared.tsx
+++ b/frontend/features/collections/components/collectionDetailShared.tsx
@@ -104,12 +104,20 @@ const ERROR_SIGNAL_UNSET = Symbol('error-signal-unset')
  * snap-back of the optimistic state is the primary signal; this banner
  * just makes the *reason* visible.
  *
- * `formatter` MUST be stable across renders (wrap in useCallback) — it runs
- * during render when the error signal changes, so an unstable reference
- * that closes over changing values would produce inconsistent copy.
+ * `formatter` is invoked only at the error-signal edge (when `isError`/`err`
+ * change), not inside any dependency array, so its referential stability is
+ * no longer required for timer correctness (PSY-957 moved the timer off a
+ * formatter-derived dep). Keeping the existing call sites' `useCallback`
+ * wrappers is tidy, not mandatory.
  *
- * PSY-957: timer mechanics live in `useAutoDismissBanner`; this wrapper
- * owns only the "react to a mutation error-state change" part.
+ * PSY-957: timer mechanics live in `useAutoDismissBanner`; this wrapper owns
+ * only the "react to a mutation error-state change" part. One edge differs
+ * from the pre-PSY-957 `[message]`-keyed effect: a *fresh* error object whose
+ * formatted copy is identical to the previous one now re-arms the dismiss
+ * window (the banner times its 3s from the latest failure), because the timer
+ * keys on the shown entry's identity rather than the message string. This is
+ * the intended "re-arm on re-show" semantics — see the
+ * `useAutoDismissError` re-arm test.
  */
 export function useAutoDismissError(
   err: unknown,

--- a/frontend/lib/hooks/common/index.ts
+++ b/frontend/lib/hooks/common/index.ts
@@ -12,6 +12,11 @@ export { useFilterNavigation } from './useFilterNavigation'
 export { usePrefetchRoutes } from './usePrefetchRoutes'
 
 export {
+  useAutoDismissBanner,
+  useAutoDismissFlag,
+} from './useAutoDismissBanner'
+
+export {
   useEntityRevisions,
   useRevision,
   useUserRevisions,

--- a/frontend/lib/hooks/common/useAutoDismissBanner.test.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useAutoDismissBanner, useAutoDismissFlag } from './useAutoDismissBanner'
+
+// PSY-957: the one timer implementation behind auto-dismiss banners. These
+// tests pin the lifecycle contract all call sites rely on — arm on show,
+// re-arm on re-show, sticky variant, clear-on-unmount — so a future edit to
+// the primitive can't silently regress one of them.
+describe('useAutoDismissBanner (PSY-957)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('starts with no value', () => {
+    const { result } = renderHook(() => useAutoDismissBanner<string>(3000))
+    expect(result.current.value).toBeNull()
+  })
+
+  it('exposes the value after show() and auto-dismisses after the delay', () => {
+    const { result } = renderHook(() => useAutoDismissBanner<string>(3000))
+
+    act(() => {
+      result.current.show('saved')
+    })
+    expect(result.current.value).toBe('saved')
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(result.current.value).toBeNull()
+  })
+
+  it('re-arms the timer when show() is called again before dismissal', () => {
+    const { result } = renderHook(() => useAutoDismissBanner<string>(3000))
+
+    act(() => {
+      result.current.show('first')
+    })
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    act(() => {
+      result.current.show('second')
+    })
+
+    // The first show()'s window has fully elapsed by now, but the re-shown
+    // banner stays up for its own full window.
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current.value).toBe('second')
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current.value).toBeNull()
+  })
+
+  it('re-arms even when the re-shown value is identical', () => {
+    // Two consecutive failures with the same message must keep the banner
+    // up for a full window after the SECOND failure (entry identity is the
+    // re-arm key, not value equality).
+    const { result } = renderHook(() => useAutoDismissBanner<string>(3000))
+
+    act(() => {
+      result.current.show('same message')
+    })
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    act(() => {
+      result.current.show('same message')
+    })
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current.value).toBe('same message')
+  })
+
+  it('showSticky() keeps the value past the dismiss window', () => {
+    const { result } = renderHook(() => useAutoDismissBanner<string>(3000))
+
+    act(() => {
+      result.current.showSticky('error the user needs to read')
+    })
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    expect(result.current.value).toBe('error the user needs to read')
+  })
+
+  it('showSticky() cancels a pending auto-dismiss from a prior show()', () => {
+    // Regression guard for the pre-PSY-957 AddItemsPanel bug: a sticky
+    // error shown while a prior success's timer was still pending got
+    // dismissed early by that stale timer.
+    const { result } = renderHook(() => useAutoDismissBanner<string>(3000))
+
+    act(() => {
+      result.current.show('auto-dismissing success')
+    })
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    act(() => {
+      result.current.showSticky('sticky error')
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(result.current.value).toBe('sticky error')
+  })
+
+  it('clear() hides immediately and cancels the pending dismissal', () => {
+    const { result } = renderHook(() => useAutoDismissBanner<string>(3000))
+
+    act(() => {
+      result.current.show('visible')
+    })
+    act(() => {
+      result.current.clear()
+    })
+    expect(result.current.value).toBeNull()
+
+    // No stray timer fires later.
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(result.current.value).toBeNull()
+  })
+
+  it('clears the pending timer on unmount (no setState after unmount)', () => {
+    const { result, unmount } = renderHook(() =>
+      useAutoDismissBanner<string>(3000)
+    )
+
+    act(() => {
+      result.current.show('visible')
+    })
+
+    // Unmounting before the timer fires must not throw / leak.
+    expect(() => {
+      unmount()
+      vi.advanceTimersByTime(5000)
+    }).not.toThrow()
+  })
+
+  it('holds non-string values (feedback objects)', () => {
+    const { result } = renderHook(() =>
+      useAutoDismissBanner<{ variant: string; message: string }>(4000)
+    )
+
+    act(() => {
+      result.current.show({ variant: 'success', message: 'Added 3 items' })
+    })
+    expect(result.current.value).toEqual({
+      variant: 'success',
+      message: 'Added 3 items',
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+    expect(result.current.value).toBeNull()
+  })
+
+  it('returns referentially stable show/showSticky/clear across renders', () => {
+    // Call sites put these in dependency arrays / useCallback deps; unstable
+    // identities would defeat their memoization.
+    const { result, rerender } = renderHook(() =>
+      useAutoDismissBanner<string>(3000)
+    )
+    const { show, showSticky, clear } = result.current
+
+    rerender()
+    expect(result.current.show).toBe(show)
+    expect(result.current.showSticky).toBe(showSticky)
+    expect(result.current.clear).toBe(clear)
+  })
+})
+
+describe('useAutoDismissFlag (PSY-957)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('starts hidden, shows on trigger, hides after the delay', () => {
+    const { result } = renderHook(() => useAutoDismissFlag(2000))
+    expect(result.current[0]).toBe(false)
+
+    act(() => {
+      result.current[1]()
+    })
+    expect(result.current[0]).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current[0]).toBe(false)
+  })
+
+  it('re-arms on rapid double trigger (e.g. Share clicked twice)', () => {
+    const { result } = renderHook(() => useAutoDismissFlag(2000))
+
+    act(() => {
+      result.current[1]()
+    })
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    act(() => {
+      result.current[1]()
+    })
+
+    // First trigger's window has elapsed; flag stays up for the full window
+    // after the second trigger.
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(result.current[0]).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(result.current[0]).toBe(false)
+  })
+
+  it('returns a referentially stable trigger across renders', () => {
+    // Call sites put trigger in dependency arrays (e.g. handleShare's
+    // useCallback) — an unstable identity would defeat their memoization.
+    const { result, rerender } = renderHook(() => useAutoDismissFlag(2000))
+    const firstTrigger = result.current[1]
+
+    rerender()
+    expect(result.current[1]).toBe(firstTrigger)
+  })
+})

--- a/frontend/lib/hooks/common/useAutoDismissBanner.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.ts
@@ -1,0 +1,83 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+/**
+ * PSY-957: the one timer implementation behind auto-dismiss banners. Holds a
+ * banner value (message string or feedback object), shows it for `delayMs`,
+ * then clears it. Centralizes the lifecycle every banner call site used to
+ * hand-roll — arm, re-arm on re-show, clear on unmount — so new banners can't
+ * get those wrong (one pre-PSY-957 collections banner, for example, never
+ * cleared its timer on unmount).
+ *
+ * - `show(value)` — display + auto-dismiss after `delayMs`. Re-showing before
+ *   dismissal re-arms the timer, so the banner stays up for a full window
+ *   after the latest trigger (even when the value is identical).
+ * - `showSticky(value)` — display until explicitly cleared or replaced. For
+ *   non-optimistic failures the user needs time to read (the PSY-608/609
+ *   sticky-vs-auto-dismiss policy).
+ * - `clear()` — hide immediately, canceling any pending dismissal.
+ *
+ * The timer is armed in an effect keyed on the shown entry (not imperatively
+ * inside `show`), so `show` is a pure state setter — safe to call from event
+ * handlers, async continuations, AND during render via the
+ * adjust-state-during-render idiom (collections' `useAutoDismissError` relies
+ * on this).
+ *
+ * Scope note: this is the shared consolidation target named in PSY-957.
+ * Collections adopts it now (its 5 banner call sites). The pre-existing
+ * per-feature auto-dismiss timers — comments' `useAutoDismissError`
+ * (`features/comments/hooks`), contributions' `useEntitySaveSuccessBanner`,
+ * and `StatusBanner`'s embedded `dismissAfterMs` — are tracked for migration
+ * onto this primitive separately so the refactor stays reviewable.
+ */
+export function useAutoDismissBanner<T>(delayMs: number): {
+  value: T | null
+  show: (value: T) => void
+  showSticky: (value: T) => void
+  clear: () => void
+} {
+  // Entry object identity doubles as the re-arm key: every show() creates a
+  // new entry, so the timer effect re-runs even when the value is identical
+  // (e.g. the same error message twice in a row).
+  const [entry, setEntry] = useState<{
+    value: T
+    autoDismiss: boolean
+  } | null>(null)
+
+  useEffect(() => {
+    if (entry === null || !entry.autoDismiss) return
+    const timer = setTimeout(() => setEntry(null), delayMs)
+    // Cleanup covers every cancellation path: re-show (effect re-runs),
+    // sticky replacement, manual clear, and unmount.
+    return () => clearTimeout(timer)
+  }, [entry, delayMs])
+
+  const show = useCallback(
+    (value: T) => setEntry({ value, autoDismiss: true }),
+    []
+  )
+  const showSticky = useCallback(
+    (value: T) => setEntry({ value, autoDismiss: false }),
+    []
+  )
+  const clear = useCallback(() => setEntry(null), [])
+
+  return {
+    value: entry === null ? null : entry.value,
+    show,
+    showSticky,
+    clear,
+  }
+}
+
+/**
+ * PSY-957: boolean variant of `useAutoDismissBanner` for "it worked" blips
+ * (edit-save success, link-copied). Returns `[visible, trigger]`; `trigger`
+ * is referentially stable, so it's safe in dependency arrays.
+ */
+export function useAutoDismissFlag(delayMs: number): [boolean, () => void] {
+  const { value, show } = useAutoDismissBanner<true>(delayMs)
+  const trigger = useCallback(() => show(true), [show])
+  return [value === true, trigger]
+}

--- a/frontend/lib/hooks/common/useAutoDismissBanner.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.ts
@@ -73,8 +73,12 @@ export function useAutoDismissBanner<T>(delayMs: number): {
 
 /**
  * PSY-957: boolean variant of `useAutoDismissBanner` for "it worked" blips
- * (edit-save success, link-copied). Returns `[visible, trigger]`; `trigger`
- * is referentially stable, so it's safe in dependency arrays.
+ * (edit-save success, link-copied). Returns a `[visible, trigger]` tuple
+ * deliberately — it mirrors `useState`'s `[value, setter]` shape so call
+ * sites read as `const [shown, show] = ...`. (The base hook returns an object
+ * because it exposes three methods; the tuple here is the intentional
+ * exception, not drift.) `trigger` is referentially stable, so it's safe in
+ * dependency arrays.
  */
 export function useAutoDismissFlag(delayMs: number): [boolean, () => void] {
   const { value, show } = useAutoDismissBanner<true>(delayMs)

--- a/frontend/lib/hooks/common/useAutoDismissBanner.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.ts
@@ -18,6 +18,11 @@ import { useState, useEffect, useCallback } from 'react'
  *   sticky-vs-auto-dismiss policy).
  * - `clear()` — hide immediately, canceling any pending dismissal.
  *
+ * `value` is `null` only when nothing is shown; consumers typically gate
+ * rendering on it (`{value && <Banner .../>}`). Don't `show()` a falsy-but-valid
+ * value (empty string, `0`) — the truthiness gate would suppress the banner
+ * while the dismiss timer still runs. Wrap such payloads in an object instead.
+ *
  * The timer is armed in an effect keyed on the shown entry (not imperatively
  * inside `show`), so `show` is a pure state setter — safe to call from event
  * handlers, async continuations, AND during render via the


### PR DESCRIPTION
Closes PSY-957.

## Summary

Consolidates the collections feature's four hand-rolled "show a banner, then auto-dismiss after N ms" timer idioms into one primitive:

- **`useAutoDismissBanner<T>(delayMs)`** — `{ value, show, showSticky, clear }`. Timer is armed in an effect keyed on the shown entry's identity, so it re-arms on every re-show (even with an identical value) and clears on unmount, sticky replacement, and manual clear.
- **`useAutoDismissFlag(delayMs)`** — `[visible, trigger]` boolean variant for "it worked" blips.

Both live at `@/lib/hooks/common/useAutoDismissBanner` — the cross-feature consolidation home. (The codebase already had **four** separate auto-dismiss timers across collections / comments / contributions / StatusBanner; this lands the shared primitive at the target location and migrates collections. The other three are deferred — see below.) The collections-specific reactive wrapper `useAutoDismissError` and the 403-aware copy helper `describeCollectionMutationError` stay in `collectionDetailShared.tsx`, rebuilt on the shared primitive.

Call sites routed through it (the four previously-distinct idioms):
- `CollectionDetail` — edit-save success + link-copied flags (`useAutoDismissFlag`)
- `CollectionItemsList` `AddItemsPanel` — bulk-add result feedback (`useAutoDismissBanner`)
- `CollectionCard` — like/unlike error banner (`useAutoDismissBanner`)
- `useAutoDismissError` — like/unlike/reorder errors on the detail page (rebuilt on the primitive)

**Pure refactor** with the two fixes the ticket allows:
1. The link-copied (`handleShare`) timer now cleans up on unmount (it previously had no cleanup).
2. `AddItemsPanel`'s thrown (network/5xx) errors now stay **sticky** instead of being wiped early by a stale success timer; resolved responses still auto-dismiss at 4s.

`CollectionCard`'s like/unlike copy now delegates to `describeCollectionMutationError`, so all three error surfaces (detail like/unlike, reorder, card like/unlike) share one copy source.

## Behavior note (disclosed)

One edge differs from the pre-refactor `[message]`-keyed effect: a *fresh* error object whose formatted copy is **identical** to the previous one now re-arms the 3s dismiss window (it times from the latest failure), because the timer keys on the shown entry's identity rather than the message string. This is the intended "re-arm on re-show" semantics and is more correct (the banner stays visible a full window after the latest error). Pinned by a `useAutoDismissError` re-arm test.

## Deferred (filed as follow-up)

- **Routing the other three auto-dismiss timers** (comments `useAutoDismissError`, contributions `useEntitySaveSuccessBanner`, `StatusBanner`'s `dismissAfterMs`) onto the new shared primitive — filed **PSY-958**. Scoped out of this PR to keep it reviewable; the primitive intentionally landed at `lib/hooks/common` so that rollout is a move-free migration.

## Heads up from `/code-review`

- `CollectionCard` keeps its own module-level `ENTITY_ICONS` map that duplicates the one exported from `collectionDetailShared` (and a third copy lives in `CollectionItemCard`). It's now trivially de-dupable since `CollectionCard` imports from that module — but it's a different concern (icon-map dedup, not timer consolidation), so it's left out of this PR. Noted for a future cleanup; not filed (low value, pre-existing).

## Adversarial review

`/adversarial-review` — CONCERNS; all findings addressed in commit `9795bbae`. Panel: Saboteur · Future-Maintainer · Security. Reviewers ran with no prior session context against the branch diff.

- [MEDIUM, raised by 2 lenses] `AddItemsPanel` sticky-vs-auto-dismiss (the PR's headline behavior) had no integration coverage → added `CollectionItemsList.test.tsx` (thrown error stays sticky past 4s; resolved success/rejection auto-dismiss at 4s).
- [MEDIUM, raised by 2 lenses] identical-message re-arm was an undisclosed behavior change → documented in the doc comment + PR body, pinned by a re-arm test.
- [MEDIUM] stale "`formatter` MUST be stable (useCallback)" comment described a constraint that no longer holds → corrected.
- [LOW] `isMountedRef` survivor comment could invite wrong deletion → clarified it still guards the post-await `setStagedItems` write.
- [LOW] `useAutoDismissFlag` tuple-vs-object return → documented as a deliberate `useState`-mirroring choice.
- Security lens: CLEAN (pure client-side timer refactor; error-copy paths are unchanged consolidations of pre-existing logic; banner text is JSX-escaped; no new info reaches the client).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean for all changed/new files (PSY-955 gate)
- [x] `bun run test:run features/collections lib/hooks/common/useAutoDismissBanner.test.ts` — 352/352 passing
  - New: `lib/hooks/common/useAutoDismissBanner.test.ts` (13) — primitive lifecycle: arm, re-arm on re-show (incl. identical value), sticky, sticky-cancels-pending-auto-dismiss, clear, clear-on-unmount, stable callbacks
  - New: `features/collections/components/collectionDetailShared.test.tsx` (11) — `useAutoDismissError` reactive contract (incl. identical-message re-arm + does-NOT-revive-after-dismiss) + `describeCollectionMutationError` copy
  - New: `features/collections/components/CollectionItemsList.test.tsx` (3) — `AddItemsPanel` sticky-vs-auto-dismiss integration
  - Existing collections suites (CollectionDetail 98, CollectionCard 41, etc.) unchanged and green
- [x] `/code-review` (xhigh) — addressed: primitive moved to the shared consolidation home (`lib/hooks/common`); findings on render-loop / nullable-T / delayMs / module placement reviewed (current callers unaffected; documented). ENTITY_ICONS dedup noted above, scoped out.
- [x] `/adversarial-review` — CONCERNS addressed; fixes in separate commit `9795bbae`
- [x] `/psy-self-review` — see below
- [x] No UI surface change — banner chrome + copy are byte-identical to main; only timer lifecycle changed (not capturable in a static screenshot). Behavior verified via unit + integration tests instead of screenshots.

## Coverage gaps

Honest disclosure of what the tests do NOT cover:

- **Real browser timing** — the auto-dismiss/sticky behavior is verified with fake timers in jsdom, not against a real browser clock. The delays (2000/3000/4000ms) are asserted as constants, not visually timed.
- **StrictMode dev double-mount** — the `isMountedRef` set-in-effect-setup pattern (preserved from the original) is relied upon for StrictMode but not asserted by a dedicated test; the primitive's clear-on-unmount test covers the production unmount path.
- **Migrated call sites are covered transitively by the hook tests, not re-asserted in their component suites:**
  - `CollectionDetail`'s two `useAutoDismissFlag` sites (link-copied + edit-save success) — covered by `useAutoDismissFlag` tests; the existing CollectionDetail suite (98 tests) still asserts the banners *appear* (`share-copied`, `collection-update-success`), just not their new timer mechanics.
  - `CollectionCard` like/unlike copy now flows through `describeCollectionMutationError` — the helper's copy is unit-tested (403 / unlikePrivate / fallback), and the existing CollectionCard suite asserts the banner renders for 403 + generic failures; the `unlikePrivate: wasLiked` wiring itself isn't re-asserted at the component level.
  - The reorder error path (`useAutoDismissError` consumer) is covered by the `useAutoDismissError` contract tests, not a reorder-specific component test.
- **The three deferred timers** (comments / contributions / StatusBanner) are untouched and out of scope (PSY-958).
