### PR TITLE
PSY-959: stack VenueDetail header name+location above actions

### DIFF
--- a/frontend/components/shared/EntityHeader.test.tsx
+++ b/frontend/components/shared/EntityHeader.test.tsx
@@ -87,4 +87,79 @@ describe('EntityHeader', () => {
     )
     expect(container.firstChild).toHaveClass('mt-8')
   })
+
+  describe('actionsPlacement', () => {
+    it('defaults to inline: title keeps flex-1 min-w-0 and sits in a flex-row with actions', () => {
+      // Default placement must reproduce the historical side-by-side layout
+      // exactly so artist/release/label/festival headers are visually unchanged.
+      const { container } = render(
+        <EntityHeader title="Test Album" actions={<button>Follow</button>} />
+      )
+      // The sm:flex-row justify-between row is the inline-layout signature.
+      const row = container.querySelector(
+        '.flex.flex-col.sm\\:flex-row.sm\\:justify-between'
+      )
+      expect(row).toBeInTheDocument()
+      // Title block constrains itself with flex-1 min-w-0 so the narrow action
+      // cluster never squeezes it in inline mode.
+      const titleBlock = container.querySelector('.flex-1.min-w-0')
+      expect(titleBlock).toBeInTheDocument()
+      expect(titleBlock).toContainElement(
+        screen.getByRole('heading', { level: 1 })
+      )
+    })
+
+    it('inline placement matches the explicit default (no flex-row regression)', () => {
+      const { container } = render(
+        <EntityHeader
+          title="Test Album"
+          actionsPlacement="inline"
+          actions={<button>Follow</button>}
+        />
+      )
+      const row = container.querySelector(
+        '.flex.flex-col.sm\\:flex-row.sm\\:justify-between'
+      )
+      expect(row).toBeInTheDocument()
+    })
+
+    it('below placement: title renders full width (no flex-1 min-w-0) with no side-by-side row', () => {
+      // PSY-959: VenueDetail's wide button cluster squeezed the title in the
+      // inline layout. In 'below' mode the title block must NOT be constrained
+      // by flex-1 min-w-0, and the side-by-side justify-between row must be gone.
+      const { container } = render(
+        <EntityHeader
+          title="The Rebel Lounge"
+          actionsPlacement="below"
+          actions={<button>Follow</button>}
+        />
+      )
+      expect(
+        container.querySelector('.sm\\:justify-between')
+      ).not.toBeInTheDocument()
+      expect(container.querySelector('.flex-1.min-w-0')).not.toBeInTheDocument()
+      // Both the title and the actions still render.
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'The Rebel Lounge'
+      )
+      expect(
+        screen.getByRole('button', { name: 'Follow' })
+      ).toBeInTheDocument()
+    })
+
+    it('below placement keeps the actions wrapper (flex-wrap, sm:shrink-0) for its own row', () => {
+      const { container } = render(
+        <EntityHeader
+          title="The Rebel Lounge"
+          actionsPlacement="below"
+          actions={<button>Follow</button>}
+        />
+      )
+      const actionsDiv = container.querySelector('.flex-wrap.sm\\:shrink-0')
+      expect(actionsDiv).toBeInTheDocument()
+      expect(actionsDiv).toContainElement(
+        screen.getByRole('button', { name: 'Follow' })
+      )
+    })
+  })
 })

--- a/frontend/components/shared/EntityHeader.tsx
+++ b/frontend/components/shared/EntityHeader.tsx
@@ -60,6 +60,9 @@ export function EntityHeader({
   )
 
   if (actionsPlacement === 'below') {
+    // space-y-4 (vs the inline layout's space-y-2): the action row is now a
+    // full-width sibling of the title block, so it wants more vertical
+    // separation than the tightly-coupled title/subtitle pair does.
     return (
       <div className={cn('space-y-4', className)}>
         {titleBlock}

--- a/frontend/components/shared/EntityHeader.tsx
+++ b/frontend/components/shared/EntityHeader.tsx
@@ -9,6 +9,17 @@ interface EntityHeaderProps {
   subtitle?: React.ReactNode
   /** Optional action buttons (Save, Follow, etc.) */
   actions?: React.ReactNode
+  /**
+   * Where the action cluster sits relative to the title/subtitle block.
+   * - `'inline'` (default): actions sit beside the title at the sm breakpoint
+   *   (`sm:justify-between`). Narrow actions (e.g. a single BracketLink linkbox)
+   *   leave the title its full width.
+   * - `'below'`: title + subtitle render at full width and the action row drops
+   *   onto its own line underneath. Use when the actions are a WIDE cluster
+   *   (e.g. VenueDetail's full Favorite/Follow/Collect/Notify/Edit/Report/Delete
+   *   row) that would otherwise squeeze the title (PSY-959).
+   */
+  actionsPlacement?: 'inline' | 'below'
   className?: string
 }
 
@@ -28,24 +39,40 @@ export function EntityHeader({
   title,
   subtitle,
   actions,
+  actionsPlacement = 'inline',
   className,
 }: EntityHeaderProps) {
+  const titleBlock = (
+    <div className={cn(actionsPlacement === 'inline' && 'flex-1 min-w-0')}>
+      <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">
+        {title}
+      </h1>
+      {subtitle && (
+        <div className="flex items-center gap-2 mt-2 text-muted-foreground">
+          {subtitle}
+        </div>
+      )}
+    </div>
+  )
+
+  const actionsRow = actions && (
+    <div className="flex flex-wrap items-center gap-2 sm:shrink-0">{actions}</div>
+  )
+
+  if (actionsPlacement === 'below') {
+    return (
+      <div className={cn('space-y-4', className)}>
+        {titleBlock}
+        {actionsRow}
+      </div>
+    )
+  }
+
   return (
     <div className={cn('space-y-2', className)}>
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-        <div className="flex-1 min-w-0">
-          <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">
-            {title}
-          </h1>
-          {subtitle && (
-            <div className="flex items-center gap-2 mt-2 text-muted-foreground">
-              {subtitle}
-            </div>
-          )}
-        </div>
-        {actions && (
-          <div className="flex flex-wrap items-center gap-2 sm:shrink-0">{actions}</div>
-        )}
+        {titleBlock}
+        {actionsRow}
       </div>
     </div>
   )

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -182,6 +182,7 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
           <header className="mb-8">
             <EntityHeader
               title={venue.name}
+              actionsPlacement="below"
               subtitle={
                 <>
                   {venue.verified && (


### PR DESCRIPTION
## Summary

On `/venues/<slug>`, the venue name ("The Rebel Lounge") wrapped to three lines and the location ("Phoenix, AZ") was squeezed. Root cause: the shared `EntityHeader` lays the title block and `actions` side-by-side at the `sm` breakpoint (`sm:justify-between`). The other four entity pages (artist / release / label / festival) pass a **narrow** BracketLink linkbox into `actions`, so their titles keep full width — but **VenueDetail is the only page passing a WIDE full Button cluster** (Favorite / Follow / Collect / Notify me / Edit / Report / Delete). That wide row consumed the horizontal space and squeezed the title.

**Option A (locked by the user):** stack the name + location at full width on top, move the existing button row below them — implemented as a **backward-compatible prop on the shared `EntityHeader`** so the other four pages are untouched.

- `frontend/components/shared/EntityHeader.tsx` — adds optional `actionsPlacement?: 'inline' | 'below'` (default `'inline'`). `'inline'` reproduces today's exact side-by-side layout (byte-identical rendered classes); `'below'` renders title + subtitle full width with the action row on its own line beneath.
- `frontend/features/venues/components/VenueDetail.tsx` — opts in with `actionsPlacement="below"` (one line).
- `frontend/components/shared/EntityHeader.test.tsx` — extends coverage to both placements.

## Test plan

- [x] `bun run typecheck` — clean (`tsc --noEmit`).
- [x] `bun run test:run components/shared features/venues` — 36 files, 508 tests pass (incl. 14 EntityHeader tests, up from 10).
- [x] `bun run test:run components/shared/EntityHeader` — 14/14 pass (re-run after adversarial-review comment).
- [x] `bun run lint` — 0 errors (only pre-existing warnings; none in the three changed files). PSY-955 ESLint CI gate.

## Manual repro

Dev stack (`stack-up.sh --mode=shared` → auto-escalated to `isolated`), seeded `the-rebel-lounge-phoenix-az`, via agent-browser at 1280×720 (desktop width — two-column layout active):

- **Anonymous view** — "The Rebel Lounge" renders on **one line** at full width, "Phoenix, AZ" below it, the [Follow] / [Notify me] buttons on their own row beneath. DOM check: `h1` height 36px == line-height 36px → exactly 1 line (width 576px, not squeezed).
- **Admin view (the actual problem case)** — the **full WIDE button row** (Favorite / Follow / Collect / Notify me / Edit / Report on row 1, Delete wrapping to row 2 via `flex-wrap`) renders entirely BELOW the title block; the title stays on one line. This is the cluster that previously forced the 3-line wrap.
- **Unchanged-peer spot-check** — `/artists/ajj` (default `inline` placement): title on the left, narrow bracket-link actions on the right, side-by-side, exactly as before. Confirmed the four peer pages are visually unchanged (grep confirms all 7 other `EntityHeader` callers don't pass the prop).

## Screenshots

**Venue fix — admin, full wide button row below the title (the problem case):**
![venue admin full buttons](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-4e991e523dad9407eac0/venue-header-fix-admin-full-buttons.png)

**Venue fix — anonymous view:**
![venue anon](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-4e991e523dad9407eac0/venue-header-fix.png)

**Unchanged peer — artist page (default inline placement):**
![artist unchanged](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-4e991e523dad9407eac0/artist-header-unchanged.png)

## Code review

`/code-review` (inline, sub-agent fallback — no Agent tool in worktree; ran reuse / quality / efficiency + correctness lenses). No findings. Change is additive (optional prop + default); inline branch is byte-identical to the original rendered output; 7 peer callers verified to get the default; uses existing `cn` util; no language pitfalls; symmetric test coverage.

## Adversarial review

`/adversarial-review` — CLEAN. 1 LOW finding addressed in commit `e6c25f53`.
- [LOW] Future-Maintainer: undocumented `space-y-4` (vs inline's `space-y-2`) in the `below` branch → added an explanatory comment.
Panel: Saboteur · Future-Maintainer · Security · Completeness (ran inline against the branch diff). No CRITICAL/HIGH/MEDIUM.

Closes PSY-959
