### PR TITLE
PSY-829: AddToCollectionButton popover redesign (PSY-893 D1/D2/D5)

### DIFF
--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -834,12 +834,14 @@ type GetUserCollectionsContainingHandlerRequest struct {
 	EntityID   uint   `query:"entity_id" required:"true" doc:"Entity ID" example:"42"`
 }
 
-// GetUserCollectionsContainingHandlerResponse returns the collection IDs
-// (within the user's own + subscribed-to set) that already contain the
-// entity. Empty array — not null — when no match.
+// GetUserCollectionsContainingHandlerResponse returns the user's collections
+// (within their own + subscribed-to set) that already contain the entity, each
+// paired with the collection_item id so the popover can both pre-check the row
+// AND remove the entity by item id (PSY-829). Empty array — not null — when no
+// match.
 type GetUserCollectionsContainingHandlerResponse struct {
 	Body struct {
-		CollectionIDs []uint `json:"collection_ids" doc:"IDs of the user's collections that already contain the entity"`
+		Items []contracts.ContainingCollectionItem `json:"items" doc:"The user's collections that already contain the entity, each with the collection_item id"`
 	}
 }
 
@@ -865,13 +867,13 @@ func (h *CollectionHandler) GetUserCollectionsContainingHandler(ctx context.Cont
 		return nil, huma.Error400BadRequest("entity_id must be > 0")
 	}
 
-	ids, err := h.collectionService.GetUserCollectionsContainingEntity(user.ID, req.EntityType, req.EntityID)
+	items, err := h.collectionService.GetUserCollectionsContainingEntity(user.ID, req.EntityType, req.EntityID)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to look up containing collections", err)
 	}
 
 	resp := &GetUserCollectionsContainingHandlerResponse{}
-	resp.Body.CollectionIDs = ids
+	resp.Body.Items = items
 	return resp, nil
 }
 

--- a/backend/internal/api/handlers/community/collection_integration_test.go
+++ b/backend/internal/api/handlers/community/collection_integration_test.go
@@ -1185,13 +1185,17 @@ func (s *CollectionHandlerIntegrationSuite) TestGetUserCollectionsContaining_Onl
 	s.NoError(err)
 	s.NotNil(resp)
 
-	got := make(map[uint]bool, len(resp.Body.CollectionIDs))
-	for _, id := range resp.Body.CollectionIDs {
-		got[id] = true
+	got := make(map[uint]uint, len(resp.Body.Items))
+	for _, item := range resp.Body.Items {
+		got[item.CollectionID] = item.ItemID
 	}
-	s.True(got[collA.ID], "collA should be in containing set")
-	s.True(got[collB.ID], "collB should be in containing set")
-	s.False(got[collC.ID], "collC has no item — must not be returned")
+	s.Contains(got, collA.ID, "collA should be in containing set")
+	s.Contains(got, collB.ID, "collB should be in containing set")
+	s.NotContains(got, collC.ID, "collC has no item — must not be returned")
+	// PSY-829: each pair carries a non-zero collection_item id so the popover
+	// can DELETE the entity by item id on uncheck.
+	s.NotZero(got[collA.ID], "collA pair must carry the collection_item id")
+	s.NotZero(got[collB.ID], "collB pair must carry the collection_item id")
 }
 
 // TestGetUserCollectionsContaining_DoesNotIncludeOtherUsers prevents leaking
@@ -1220,13 +1224,14 @@ func (s *CollectionHandlerIntegrationSuite) TestGetUserCollectionsContaining_Doe
 	}
 	resp, err := s.handler.GetUserCollectionsContainingHandler(ctx, req)
 	s.NoError(err)
-	s.Len(resp.Body.CollectionIDs, 1)
-	s.Equal(user1Coll.ID, resp.Body.CollectionIDs[0])
+	s.Len(resp.Body.Items, 1)
+	s.Equal(user1Coll.ID, resp.Body.Items[0].CollectionID)
+	s.NotZero(resp.Body.Items[0].ItemID)
 }
 
 // TestGetUserCollectionsContaining_NoMatches returns an empty (non-nil)
-// slice. Frontend decodes the JSON into a Set and the empty case must not
-// crash on a missing `collection_ids` key.
+// slice. Frontend decodes the JSON into a Map and the empty case must not
+// crash on a missing `items` key.
 func (s *CollectionHandlerIntegrationSuite) TestGetUserCollectionsContaining_NoMatches() {
 	user := testhelpers.CreateTestUser(s.deps.DB)
 	s.createCollectionViaService(user, "No Match", false)
@@ -1240,8 +1245,8 @@ func (s *CollectionHandlerIntegrationSuite) TestGetUserCollectionsContaining_NoM
 	}
 	resp, err := s.handler.GetUserCollectionsContainingHandler(ctx, req)
 	s.NoError(err)
-	s.NotNil(resp.Body.CollectionIDs, "must be a non-nil slice for stable JSON shape")
-	s.Empty(resp.Body.CollectionIDs)
+	s.NotNil(resp.Body.Items, "must be a non-nil slice for stable JSON shape")
+	s.Empty(resp.Body.Items)
 }
 
 func (s *CollectionHandlerIntegrationSuite) TestGetUserCollectionsContaining_NoAuth() {

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -712,7 +712,7 @@ type MockCollectionService struct {
 	UnlikeFn                             func(string, uint) (*contracts.CollectionLikeResponse, error)
 	GetStatsFn                           func(string) (*contracts.CollectionStatsResponse, error)
 	GetUserCollectionsFn                 func(uint, string, int, int) ([]*contracts.CollectionListResponse, int64, error)
-	GetUserCollectionsContainingEntityFn func(uint, string, uint) ([]uint, error)
+	GetUserCollectionsContainingEntityFn func(uint, string, uint) ([]contracts.ContainingCollectionItem, error)
 	GetEntityCollectionsFn               func(string, uint, uint, int) ([]*contracts.CollectionListResponse, error)
 	GetUserPublicCollectionsFn           func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	GetUserPublicCollectionsByUsernameFn func(string, int, int) ([]*contracts.CollectionListResponse, int64, error)
@@ -842,7 +842,7 @@ func (m *MockCollectionService) GetUserCollections(userID uint, search string, l
 	}
 	return nil, 0, nil
 }
-func (m *MockCollectionService) GetUserCollectionsContainingEntity(userID uint, entityType string, entityID uint) ([]uint, error) {
+func (m *MockCollectionService) GetUserCollectionsContainingEntity(userID uint, entityType string, entityID uint) ([]contracts.ContainingCollectionItem, error) {
 	if m.GetUserCollectionsContainingEntityFn != nil {
 		return m.GetUserCollectionsContainingEntityFn(userID, entityType, entityID)
 	}

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -1960,21 +1960,25 @@ func (s *CollectionService) GetUserCollections(userID uint, search string, limit
 	return responses, total, nil
 }
 
-// GetUserCollectionsContainingEntity returns the IDs of the user's editable
-// collections (creator OR collaborative-and-subscribed) that already contain
-// the supplied entity. PSY-359 — backs the multi-select Add-to-Collection
-// popover so it can pre-check rows the user has already added the entity to.
+// GetUserCollectionsContainingEntity returns the user's editable collections
+// (creator OR collaborative-and-subscribed) that already contain the supplied
+// entity, each paired with the collection_item id. PSY-359 — backs the
+// multi-select Add-to-Collection popover's pre-check; PSY-829 added the item
+// id so the popover's uncheck→remove affordance can DELETE by item id without
+// a second round-trip.
 //
-// Single round-trip; one indexed lookup. Caller scopes the result to the
-// candidate collections shown in the popover by intersecting with the user's
-// own collection list (already cached). Returns an empty slice for an
-// unauthenticated caller (userID == 0) — not an error.
-func (s *CollectionService) GetUserCollectionsContainingEntity(userID uint, entityType string, entityID uint) ([]uint, error) {
+// Single round-trip; one indexed lookup. The UNIQUE(collection_id,
+// entity_type, entity_id) constraint guarantees one row per collection, so no
+// Distinct is needed. Caller scopes the result to the candidate collections
+// shown in the popover by intersecting with the user's own collection list
+// (already cached). Returns an empty slice for an unauthenticated caller
+// (userID == 0) — not an error.
+func (s *CollectionService) GetUserCollectionsContainingEntity(userID uint, entityType string, entityID uint) ([]contracts.ContainingCollectionItem, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 	if userID == 0 {
-		return []uint{}, nil
+		return []contracts.ContainingCollectionItem{}, nil
 	}
 
 	// Mirror GetUserCollections's scope: collections the user CREATED or
@@ -1985,20 +1989,23 @@ func (s *CollectionService) GetUserCollectionsContainingEntity(userID uint, enti
 		Select("collection_id").
 		Where("user_id = ?", userID)
 
-	var ids []uint
+	items := []contracts.ContainingCollectionItem{}
 	err := s.db.Model(&communitym.CollectionItem{}).
-		Distinct("collection_items.collection_id").
+		Select("collection_items.collection_id AS collection_id, collection_items.id AS item_id").
 		Joins("JOIN collections ON collections.id = collection_items.collection_id").
 		Where("collection_items.entity_type = ? AND collection_items.entity_id = ?", entityType, entityID).
 		Where("collections.creator_id = ? OR collections.id IN (?)", userID, subQuery).
-		Pluck("collection_items.collection_id", &ids).Error
+		Scan(&items).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to look up containing collections: %w", err)
 	}
-	if ids == nil {
-		ids = []uint{}
+	// Guarantee a non-nil slice so the handler serializes `[]`, not `null`
+	// (the frontend tolerates both, but the contract is "empty slice"). Kept
+	// explicit rather than relying on GORM's zero-row Scan behavior.
+	if items == nil {
+		items = []contracts.ContainingCollectionItem{}
 	}
-	return ids, nil
+	return items, nil
 }
 
 // GetEntityCollections returns collections that contain the given entity.

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -308,6 +308,18 @@ type CollectionItemResponse struct {
 	CreatedAt     time.Time `json:"created_at"`
 }
 
+// ContainingCollectionItem pairs a collection the user can edit with the
+// collection_item id of the supplied entity inside it. Backs the
+// Add-to-Collection popover's pre-check (collection_id) AND its
+// uncheck→remove affordance (item_id, removed via DELETE
+// /collections/{slug}/items/{item_id}). PSY-829. One row per collection —
+// the UNIQUE(collection_id, entity_type, entity_id) constraint guarantees an
+// entity appears at most once per collection.
+type ContainingCollectionItem struct {
+	CollectionID uint `json:"collection_id"`
+	ItemID       uint `json:"item_id"`
+}
+
 // CollectionStatsResponse represents statistics for a collection
 type CollectionStatsResponse struct {
 	ItemCount        int            `json:"item_count"`
@@ -497,11 +509,13 @@ type CollectionServiceInterface interface {
 	// public browse listing (PSY-355). Tier-ranked relevance ORDER BY is
 	// applied when search is non-empty; otherwise default updated_at DESC.
 	GetUserCollections(userID uint, search string, limit, offset int) ([]*CollectionListResponse, int64, error)
-	// GetUserCollectionsContainingEntity returns the IDs of the user's
-	// editable collections (creator + subscribed) that already contain
-	// the supplied entity. Backs the multi-select Add-to-Collection
-	// popover (PSY-359). Returns empty slice for userID == 0.
-	GetUserCollectionsContainingEntity(userID uint, entityType string, entityID uint) ([]uint, error)
+	// GetUserCollectionsContainingEntity returns the user's editable
+	// collections (creator + subscribed) that already contain the supplied
+	// entity, each paired with the collection_item id (so the popover can
+	// pre-check rows AND remove them by item id). Backs the multi-select
+	// Add-to-Collection popover (PSY-359; item id added PSY-829). Returns
+	// empty slice for userID == 0.
+	GetUserCollectionsContainingEntity(userID uint, entityType string, entityID uint) ([]ContainingCollectionItem, error)
 	// GetEntityCollections returns collections that contain the given
 	// entity. Public collections are returned to all viewers; the viewer's
 	// own private collections are included when viewerID > 0. Pass

--- a/frontend/components/shared/AddToCollectionButton.test.tsx
+++ b/frontend/components/shared/AddToCollectionButton.test.tsx
@@ -604,7 +604,7 @@ describe('AddToCollectionButton', () => {
     })
   })
 
-  // ── PSY-829 D2/D3: client-side filter input above a long list ──
+  // ── PSY-829: client-side filter input above a long list ──
   describe('search filter', () => {
     const manyCollections = Array.from({ length: 10 }, (_, i) => ({
       id: i + 1,
@@ -645,6 +645,28 @@ describe('AddToCollectionButton', () => {
 
       expect(screen.getByText('Desert Psych')).toBeInTheDocument()
       expect(screen.queryByText('Collection 2')).not.toBeInTheDocument()
+    })
+
+    it('shows the no-match empty state when the filter excludes every row', async () => {
+      mockMyCollections.mockReturnValue({
+        data: { collections: manyCollections },
+        isLoading: false,
+      })
+      const user = userEvent.setup()
+      render(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+      await user.click(screen.getByRole('button', { name: /add to collection/i }))
+
+      const filter = await screen.findByRole('textbox', {
+        name: /filter collections/i,
+      })
+      await user.type(filter, 'zzzznomatch')
+
+      expect(screen.getByText(/No collections match/)).toBeInTheDocument()
+      // No rows rendered, but the panel didn't crash and the filter persists.
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+      expect(filter).toHaveValue('zzzznomatch')
     })
   })
 

--- a/frontend/components/shared/AddToCollectionButton.test.tsx
+++ b/frontend/components/shared/AddToCollectionButton.test.tsx
@@ -28,28 +28,71 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/releases/test-release',
 }))
 
-// Mock collection hooks
-const mockMutateAsync = vi.fn()
-const mockMyCollections = vi.fn(() => ({
-  data: {
-    collections: [
-      { id: 1, slug: 'my-favorites', title: 'My Favorites' },
-      { id: 2, slug: 'best-of-2026', title: 'Best of 2026' },
-      { id: 3, slug: 'arizona-shows', title: 'Arizona Shows' },
-    ],
+// Mock @tanstack/react-query's useQueryClient — the component invalidates the
+// contains + backlinks caches after a remove. The test doesn't mount a real
+// QueryClientProvider, so stub the client.
+const mockInvalidateQueries = vi.fn()
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  }
+})
+
+// Mock collection hooks. Collections carry item_count + is_public +
+// cover_image_url so the rich-row subtitle ("N items · Public/Private") and
+// thumbnail render (PSY-829 D2).
+const DEFAULT_COLLECTIONS = [
+  {
+    id: 1,
+    slug: 'my-favorites',
+    title: 'My Favorites',
+    item_count: 12,
+    is_public: true,
+    cover_image_url: null,
   },
+  {
+    id: 2,
+    slug: 'best-of-2026',
+    title: 'Best of 2026',
+    item_count: 1,
+    is_public: false,
+    cover_image_url: null,
+  },
+  {
+    id: 3,
+    slug: 'arizona-shows',
+    title: 'Arizona Shows',
+    item_count: 7,
+    is_public: true,
+    cover_image_url: null,
+  },
+]
+const mockMutateAsync = vi.fn()
+const mockRemoveMutateAsync = vi.fn()
+const mockMyCollections = vi.fn(() => ({
+  data: { collections: DEFAULT_COLLECTIONS },
   isLoading: false,
 }))
-const mockContainingIds = vi.fn(() => ({
-  data: new Set<number>(),
+// PSY-829: contains query returns a Map (collectionId → collection_item id).
+const mockContaining = vi.fn(() => ({
+  data: new Map<number, number>(),
   isLoading: false,
 }))
 
 vi.mock('@/features/collections/hooks', () => ({
   useMyCollections: () => mockMyCollections(),
-  useUserCollectionsContaining: () => mockContainingIds(),
+  useUserCollectionsContaining: () => mockContaining(),
   useAddCollectionItem: () => ({
     mutateAsync: mockMutateAsync,
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  }),
+  useRemoveCollectionItem: () => ({
+    mutateAsync: mockRemoveMutateAsync,
     isPending: false,
     isError: false,
     error: null as Error | null,
@@ -83,20 +126,17 @@ describe('AddToCollectionButton', () => {
       logout: vi.fn(),
     })
     mockMyCollections.mockReturnValue({
-      data: {
-        collections: [
-          { id: 1, slug: 'my-favorites', title: 'My Favorites' },
-          { id: 2, slug: 'best-of-2026', title: 'Best of 2026' },
-          { id: 3, slug: 'arizona-shows', title: 'Arizona Shows' },
-        ],
-      },
+      data: { collections: DEFAULT_COLLECTIONS },
       isLoading: false,
     })
-    mockContainingIds.mockReturnValue({
-      data: new Set<number>(),
+    mockContaining.mockReturnValue({
+      data: new Map<number, number>(),
       isLoading: false,
     })
-    mockMutateAsync.mockResolvedValue(undefined)
+    // The add hook resolves to the created item (incl. its `id`) — PSY-829
+    // captures it so a same-session uncheck→remove knows the item id.
+    mockMutateAsync.mockResolvedValue({ id: 999 })
+    mockRemoveMutateAsync.mockResolvedValue(undefined)
   })
 
   it('renders nothing when not authenticated', () => {
@@ -139,9 +179,9 @@ describe('AddToCollectionButton', () => {
     }
   })
 
-  it('pre-checks collections that already contain the entity', async () => {
-    mockContainingIds.mockReturnValue({
-      data: new Set<number>([2]),
+  it('pre-checks collections that already contain the entity + shows "Added"', async () => {
+    mockContaining.mockReturnValue({
+      data: new Map<number, number>([[2, 20]]),
       isLoading: false,
     })
 
@@ -158,6 +198,22 @@ describe('AddToCollectionButton', () => {
     const bestOfCheckbox = screen.getByRole('checkbox', { name: /best of 2026/i })
     expect(favoritesCheckbox).toHaveAttribute('aria-checked', 'false')
     expect(bestOfCheckbox).toHaveAttribute('aria-checked', 'true')
+    // The already-in row carries the "Added" indicator (PSY-829 D2).
+    expect(screen.getByText('Added')).toBeInTheDocument()
+  })
+
+  it('renders the rich-row subtitle "N items · Public/Private" (PSY-829 D2)', async () => {
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+    )
+
+    await user.click(screen.getByRole('button', { name: /add to collection/i }))
+
+    // My Favorites: 12 items · Public; Best of 2026: 1 item (singular) · Private.
+    expect(await screen.findByText('12 items · Public')).toBeInTheDocument()
+    expect(screen.getByText('1 item · Private')).toBeInTheDocument()
+    expect(screen.getByText('7 items · Public')).toBeInTheDocument()
   })
 
   it('shows entity name in popover header', async () => {
@@ -224,7 +280,7 @@ describe('AddToCollectionButton', () => {
       ({ slug }: { slug: string }) =>
         slug === 'arizona-shows'
           ? Promise.reject(new Error('Already in collection'))
-          : Promise.resolve(undefined)
+          : Promise.resolve({ id: 111 })
     )
 
     const user = userEvent.setup()
@@ -247,15 +303,110 @@ describe('AddToCollectionButton', () => {
     expect(mockMutateAsync).toHaveBeenCalledTimes(2)
   })
 
+  it('unchecks a failed-add row and drops it from the batch (PSY-829 code-review)', async () => {
+    // The failed row must NOT stay checked — the row state should match
+    // reality (not added) while the inline error explains why.
+    mockMutateAsync.mockImplementation(({ slug }: { slug: string }) =>
+      slug === 'arizona-shows'
+        ? Promise.reject(new Error('Server error'))
+        : Promise.resolve({ id: 111 })
+    )
+
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton entityType="artist" entityId={42} entityName="Test Artist" />
+    )
+
+    await user.click(screen.getByRole('button', { name: /add to collection/i }))
+    await user.click(
+      await screen.findByRole('checkbox', { name: /my favorites/i })
+    )
+    await user.click(screen.getByRole('checkbox', { name: /arizona shows/i }))
+    await user.click(
+      screen.getByRole('button', { name: /add to 2 collections/i })
+    )
+
+    expect(await screen.findByText('Server error')).toBeInTheDocument()
+    // The failed row is back to unchecked; the succeeded row shows Added.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('checkbox', { name: /arizona shows/i })
+      ).toHaveAttribute('aria-checked', 'false')
+    )
+    expect(
+      screen.getByRole('checkbox', { name: /my favorites/i })
+    ).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('same-session add → remove uses the item id captured from the add (PSY-829 code-review)', async () => {
+    // Race the code-review flagged: after a Submit add, `containing` hasn't
+    // refetched yet, so confirmRemove must fall back to the item id captured
+    // from the add response (here: 555) — not silently no-op.
+    mockMutateAsync.mockResolvedValue({ id: 555 })
+    // containing stays EMPTY (the refetch hasn't landed) for the whole test.
+    mockContaining.mockReturnValue({
+      data: new Map<number, number>(),
+      isLoading: false,
+    })
+
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton entityType="artist" entityId={42} entityName="Test Artist" />
+    )
+
+    await user.click(screen.getByRole('button', { name: /add to collection/i }))
+    await user.click(
+      await screen.findByRole('checkbox', { name: /my favorites/i })
+    )
+    await user.click(screen.getByRole('button', { name: /add to 1 collection/i }))
+
+    // Row now shows Added; uncheck → confirm → Remove.
+    await waitFor(() => expect(screen.getByText('Added')).toBeInTheDocument())
+    await user.click(screen.getByRole('checkbox', { name: /my favorites/i }))
+    await user.click(screen.getByRole('button', { name: /^remove$/i }))
+
+    await waitFor(() => {
+      expect(mockRemoveMutateAsync).toHaveBeenCalledWith({
+        slug: 'my-favorites',
+        itemId: 555,
+      })
+    })
+  })
+
+  it('clears never-submitted pending checks when the popover closes (PSY-829 code-review)', async () => {
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+    )
+
+    // Open, check a new row, then close WITHOUT submitting.
+    await user.click(screen.getByRole('button', { name: /add to collection/i }))
+    await user.click(
+      await screen.findByRole('checkbox', { name: /my favorites/i })
+    )
+    expect(
+      screen.getByRole('checkbox', { name: /my favorites/i })
+    ).toHaveAttribute('aria-checked', 'true')
+    await user.keyboard('{Escape}')
+
+    // Reopen — the never-submitted check must not leak into the new session.
+    await user.click(screen.getByRole('button', { name: /add to collection/i }))
+    await waitFor(() =>
+      expect(
+        screen.getByRole('checkbox', { name: /my favorites/i })
+      ).toHaveAttribute('aria-checked', 'false')
+    )
+  })
+
   // Lock in the "Adding…" loading state. Earlier the only assertion around
   // the submitting UX was the failure-surface message; that would pass even
   // if the submit button stopped switching to its loading copy mid-flight.
   it('shows the "Adding…" loading state while the submit promises are in flight', async () => {
     // Hold every add open so the submitting=true window is observable.
-    let resolveOne!: () => void
+    let resolveOne!: (v: { id: number }) => void
     mockMutateAsync.mockImplementation(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<{ id: number }>((resolve) => {
           resolveOne = resolve
         })
     )
@@ -283,7 +434,7 @@ describe('AddToCollectionButton', () => {
     }
 
     // Resolve so the test doesn't hang on the pending promise.
-    resolveOne()
+    resolveOne({ id: 1 })
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledTimes(1)
     })
@@ -302,7 +453,7 @@ describe('AddToCollectionButton', () => {
     expect(link.closest('a')).toHaveAttribute('href', '/collections')
   })
 
-  it('shows empty state when user has no collections', async () => {
+  it('shows empty state with a primary Create CTA when user has no collections (D5)', async () => {
     mockMyCollections.mockReturnValue({
       data: { collections: [] },
       isLoading: false,
@@ -315,7 +466,16 @@ describe('AddToCollectionButton', () => {
 
     await user.click(screen.getByRole('button', { name: /add to collection/i }))
 
-    expect(await screen.findByText('No collections yet')).toBeInTheDocument()
+    expect(
+      await screen.findByText('No collections yet — start one.')
+    ).toBeInTheDocument()
+    // D5: Create is promoted to a primary action (a link styled as a button).
+    const createLink = screen.getByRole('link', {
+      name: /create new collection/i,
+    })
+    expect(createLink).toHaveAttribute('href', '/collections')
+    // No submit row / no checkbox list in the empty state.
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
   })
 
   it('toggling a checkbox via the keyboard (Space) flips its state', async () => {
@@ -333,6 +493,159 @@ describe('AddToCollectionButton', () => {
 
     await user.keyboard(' ')
     expect(checkbox).toHaveAttribute('aria-checked', 'true')
+  })
+
+  // ── PSY-829 D1: uncheck an already-in row → remove-with-confirm ──
+  // The pre-PSY-829 popover only fanned out newly-checked IDs, so unchecking
+  // an already-in row did nothing (dead affordance). Now it opens an inline
+  // confirm and, on Remove, DELETEs by the collection_item id the contains
+  // query supplies.
+  describe('remove-with-confirm (D1)', () => {
+    it('unchecking a saved row opens the confirm (no removal yet)', async () => {
+      mockContaining.mockReturnValue({
+        data: new Map<number, number>([[2, 20]]),
+        isLoading: false,
+      })
+      const user = userEvent.setup()
+      render(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+
+      await user.click(screen.getByRole('button', { name: /add to collection/i }))
+      await user.click(
+        await screen.findByRole('checkbox', { name: /best of 2026/i })
+      )
+
+      expect(
+        screen.getByText('Remove from this collection?')
+      ).toBeInTheDocument()
+      // Nothing deleted until the user confirms.
+      expect(mockRemoveMutateAsync).not.toHaveBeenCalled()
+    })
+
+    it('Cancel dismisses the confirm and keeps the row added', async () => {
+      mockContaining.mockReturnValue({
+        data: new Map<number, number>([[2, 20]]),
+        isLoading: false,
+      })
+      const user = userEvent.setup()
+      render(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+
+      await user.click(screen.getByRole('button', { name: /add to collection/i }))
+      await user.click(
+        await screen.findByRole('checkbox', { name: /best of 2026/i })
+      )
+      await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+      expect(
+        screen.queryByText('Remove from this collection?')
+      ).not.toBeInTheDocument()
+      expect(mockRemoveMutateAsync).not.toHaveBeenCalled()
+      // Row stays checked + Added.
+      expect(
+        screen.getByRole('checkbox', { name: /best of 2026/i })
+      ).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('Remove DELETEs by the collection_item id and clears the Added state', async () => {
+      mockContaining.mockReturnValue({
+        data: new Map<number, number>([[2, 20]]),
+        isLoading: false,
+      })
+      const user = userEvent.setup()
+      render(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+
+      await user.click(screen.getByRole('button', { name: /add to collection/i }))
+      await user.click(
+        await screen.findByRole('checkbox', { name: /best of 2026/i })
+      )
+      await user.click(screen.getByRole('button', { name: /^remove$/i }))
+
+      await waitFor(() => {
+        expect(mockRemoveMutateAsync).toHaveBeenCalledWith({
+          slug: 'best-of-2026',
+          itemId: 20,
+        })
+      })
+      // Row is no longer Added; checkbox unchecked.
+      await waitFor(() =>
+        expect(
+          screen.getByRole('checkbox', { name: /best of 2026/i })
+        ).toHaveAttribute('aria-checked', 'false')
+      )
+    })
+
+    it('surfaces a remove failure inline without clearing the Added state', async () => {
+      mockContaining.mockReturnValue({
+        data: new Map<number, number>([[2, 20]]),
+        isLoading: false,
+      })
+      mockRemoveMutateAsync.mockRejectedValueOnce(new Error('Network down'))
+      const user = userEvent.setup()
+      render(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+
+      await user.click(screen.getByRole('button', { name: /add to collection/i }))
+      await user.click(
+        await screen.findByRole('checkbox', { name: /best of 2026/i })
+      )
+      await user.click(screen.getByRole('button', { name: /^remove$/i }))
+
+      expect(await screen.findByText('Network down')).toBeInTheDocument()
+      // Still added — the row didn't lose its membership on a failed remove.
+      expect(
+        screen.getByRole('checkbox', { name: /best of 2026/i })
+      ).toHaveAttribute('aria-checked', 'true')
+    })
+  })
+
+  // ── PSY-829 D2/D3: client-side filter input above a long list ──
+  describe('search filter', () => {
+    const manyCollections = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      slug: `coll-${i + 1}`,
+      title: i === 0 ? 'Desert Psych' : `Collection ${i + 1}`,
+      item_count: i + 1,
+      is_public: true,
+      cover_image_url: null,
+    }))
+
+    it('shows the filter only when the list exceeds the threshold', async () => {
+      const user = userEvent.setup()
+      // Default fixture has 3 collections — below threshold → no filter.
+      render(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+      await user.click(screen.getByRole('button', { name: /add to collection/i }))
+      expect(
+        screen.queryByRole('textbox', { name: /filter collections/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('filters rows by title (case-insensitive)', async () => {
+      mockMyCollections.mockReturnValue({
+        data: { collections: manyCollections },
+        isLoading: false,
+      })
+      const user = userEvent.setup()
+      render(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+      await user.click(screen.getByRole('button', { name: /add to collection/i }))
+
+      const filter = await screen.findByRole('textbox', {
+        name: /filter collections/i,
+      })
+      await user.type(filter, 'desert')
+
+      expect(screen.getByText('Desert Psych')).toBeInTheDocument()
+      expect(screen.queryByText('Collection 2')).not.toBeInTheDocument()
+    })
   })
 
   // ── Regression: unauthenticated → authenticated transition (PSY-466) ──

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -3,20 +3,25 @@
 import { useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
-import { Library, Check, Plus, Loader2, AlertCircle } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Library, Check, Plus, Loader2, AlertCircle, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { BracketLink } from './BracketLink'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { CollectionCoverImage } from '@/features/collections/components/CollectionCoverImage'
 import {
   useMyCollections,
   useAddCollectionItem,
+  useRemoveCollectionItem,
   useUserCollectionsContaining,
 } from '@/features/collections/hooks'
+import { queryKeys } from '@/lib/queryClient'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import type { CollectionEntityType } from '@/features/collections/types'
 
@@ -36,9 +41,15 @@ interface AddToCollectionButtonProps {
 type SubmitError = { collectionId: number; message: string }
 
 // Sentinel for the adjust-during-render contains-sync below: a value
-// guaranteed distinct from any real `containingIds`, so the guard also fires
+// guaranteed distinct from any real `containing` Map, so the guard also fires
 // on the FIRST render (the prior effect always ran on mount and seeded).
 const UNSET = Symbol('unset')
+
+// PSY-829 D2/D3: a client-side filter input only earns its space once the list
+// is long enough to scroll. Below this count the 4–8 rows fit at a glance, so
+// the input would be noise (matches the locked design — the default-open mock
+// has no search box; the "search active" mock implies a larger library).
+const SEARCH_THRESHOLD = 8
 
 function describeError(reason: unknown): string {
   if (reason instanceof Error && reason.message) return reason.message
@@ -60,68 +71,106 @@ export function AddToCollectionButton({
   const { isAuthenticated } = useAuthContext()
   const router = useRouter()
   const pathname = usePathname()
+  const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
 
   // The contains query is gated on `open` so we don't fetch on every
   // entity page render — only when the user actually opens the popover.
   const { data: myCollectionsData, isLoading: collectionsLoading } =
     useMyCollections()
-  const { data: containingIds, isLoading: containingLoading } =
+  // collectionId → collection_item id (PSY-829): the Map keys drive the
+  // pre-check; the values give the item id to DELETE on uncheck→remove.
+  const { data: containing, isLoading: containingLoading } =
     useUserCollectionsContaining(entityType, entityId, { enabled: open })
   const addMutation = useAddCollectionItem()
+  const removeMutation = useRemoveCollectionItem()
 
-  const [selected, setSelected] = useState<Set<number>>(new Set())
-  // Server's last-known truth. `selected` minus `savedIds` is the diff the
-  // Submit handler needs to fan out.
+  // `pendingAdds` — rows the user has checked that are NOT yet on the server
+  // (the Submit batch). `savedIds` — the server's last-known truth (seeded
+  // from `containing`, plus session adds, minus session removes). A row is
+  // checked when it's in either set; "✓ Added" shows for `savedIds`.
+  const [pendingAdds, setPendingAdds] = useState<Set<number>>(new Set())
   const [savedIds, setSavedIds] = useState<Set<number>>(new Set())
+  // collectionId → collection_item id captured from this session's adds. The
+  // contains query refetch (triggered by addMutation) eventually supplies the
+  // same ids, but until it lands `containing` has no entry for a just-added
+  // row — this lets a same-session uncheck→remove of that row still DELETE
+  // the correct item instead of silently no-op'ing.
+  const [sessionItemIds, setSessionItemIds] = useState<Map<number, number>>(
+    new Map()
+  )
   const [submitErrors, setSubmitErrors] = useState<SubmitError[]>([])
   const [submitting, setSubmitting] = useState(false)
-  // IDs successfully added during the current popover session. Persists
-  // through `containingIds` cache invalidations so the green chip doesn't
-  // flicker off mid-refetch; cleared on popover close.
-  const [justSaved, setJustSaved] = useState<Set<number>>(new Set())
+  const [search, setSearch] = useState('')
+  // D1 remove-with-confirm: the already-in row currently showing its inline
+  // "Remove from this collection?" confirm, the in-flight removal, and any
+  // remove error to surface on that row.
+  const [removeConfirmId, setRemoveConfirmId] = useState<number | null>(null)
+  const [removingId, setRemovingId] = useState<number | null>(null)
+  const [removeError, setRemoveError] = useState<SubmitError | null>(null)
 
-  // Seed `selected`/`savedIds` from the server's contains-truth whenever the
-  // query resolves (or returns a fresh reference). React 19.2: adjust state
-  // during render via the canonical previous-value-guard idiom instead of a
-  // cascading effect. The tracker starts at a sentinel so the guard also fires
-  // on the FIRST render when `containingIds` is already resolved (matching the
-  // prior effect, which always ran on mount). Otherwise this preserves the
-  // prior effect's `[containingIds]`-dependency semantics exactly.
-  const [prevContainingIds, setPrevContainingIds] = useState<
-    typeof containingIds | typeof UNSET
+  // Seed `savedIds` from the server's contains-truth whenever the query
+  // resolves (or returns a fresh reference — e.g. after an add/remove
+  // invalidation). React 19.2: adjust state during render via the canonical
+  // previous-value-guard idiom instead of a cascading effect. The tracker
+  // starts at a sentinel so the guard also fires on the FIRST render when
+  // `containing` is already resolved (matching the prior effect, which always
+  // ran on mount). Pending adds not yet saved are PRESERVED across the
+  // re-seed (a containing refetch triggered by removing one row must not wipe
+  // a different row the user just checked but hasn't submitted).
+  const [prevContaining, setPrevContaining] = useState<
+    typeof containing | typeof UNSET
   >(UNSET)
-  if (containingIds !== prevContainingIds) {
-    setPrevContainingIds(containingIds)
-    if (containingIds) {
-      setSelected(new Set(containingIds))
-      setSavedIds(new Set(containingIds))
-      setSubmitErrors([])
+  if (containing !== prevContaining) {
+    setPrevContaining(containing)
+    if (containing) {
+      const serverKeys = new Set(containing.keys())
+      setSavedIds(serverKeys)
+      setPendingAdds((prev) => {
+        const next = new Set<number>()
+        for (const id of prev) if (!serverKeys.has(id)) next.add(id)
+        return next
+      })
+      // NOTE: do NOT clear submitErrors here. A successful add inside a mixed
+      // batch invalidates the contains query → this guard fires on the
+      // refetch; clearing here would wipe the still-relevant error for a
+      // SIBLING row whose add failed. submitErrors are cleared on close, on
+      // row toggle, and at the start of the next submit instead.
     }
   }
 
-  // Clear the per-session "just saved" chips and any submit errors when the
-  // popover closes. React 19.2: adjust state during render on the open→close
-  // transition instead of a cascading effect (covers both close paths —
-  // onOpenChange and the "Create new collection" link's setOpen(false)).
+  // Clear per-session state when the popover closes. React 19.2: adjust state
+  // during render on the open→close transition instead of a cascading effect
+  // (covers both close paths — onOpenChange and any setOpen(false)).
   const [prevOpen, setPrevOpen] = useState(open)
   if (open !== prevOpen) {
     setPrevOpen(open)
     if (!open) {
-      setJustSaved(new Set())
+      // Clear ALL session-scoped intent so a never-submitted check (or stale
+      // session item id) can't leak into the next open — the contains query
+      // stays cached within its staleTime, so the re-seed guard won't fire on
+      // reopen to reconcile it.
+      setPendingAdds(new Set())
+      setSessionItemIds(new Map())
       setSubmitErrors([])
+      setSearch('')
+      setRemoveConfirmId(null)
+      setRemoveError(null)
     }
   }
 
-  const collections = myCollectionsData?.collections ?? []
+  const collections = useMemo(
+    () => myCollectionsData?.collections ?? [],
+    [myCollectionsData]
+  )
 
-  const newlyChecked = useMemo(() => {
-    const result: number[] = []
-    for (const id of selected) {
-      if (!savedIds.has(id)) result.push(id)
-    }
-    return result
-  }, [selected, savedIds])
+  const pendingCount = pendingAdds.size
+
+  const filteredCollections = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return collections
+    return collections.filter((c) => c.title.toLowerCase().includes(q))
+  }, [collections, search])
 
   // Unauthenticated bracket variant — render the public [Add to collection]
   // affordance and redirect to /auth on click, mirroring FollowButton /
@@ -148,27 +197,97 @@ export function AddToCollectionButton({
     submitErrors.map((e) => [e.collectionId, e.message])
   )
 
-  const handleToggle = (collectionId: number) => {
-    setSelected((prev) => {
-      const next = new Set(prev)
-      if (next.has(collectionId)) {
-        next.delete(collectionId)
-      } else {
-        next.add(collectionId)
+  const isChecked = (id: number) => savedIds.has(id) || pendingAdds.has(id)
+
+  // A checkbox flip. Unchecking a SAVED row routes to the remove-confirm (D1)
+  // rather than silently no-op'ing — the pre-PSY-829 popover only fanned out
+  // newly-checked IDs, so unchecking an already-in row did nothing (dead
+  // affordance). Unchecking a not-yet-saved row just drops it from the batch.
+  const handleCheckedChange = (collectionId: number, checked: boolean) => {
+    if (checked) {
+      if (!savedIds.has(collectionId)) {
+        setPendingAdds((prev) => new Set(prev).add(collectionId))
       }
+      return
+    }
+    // checked === false
+    if (savedIds.has(collectionId)) {
+      setRemoveConfirmId(collectionId)
+      setRemoveError(null)
+      return
+    }
+    setPendingAdds((prev) => {
+      const next = new Set(prev)
+      next.delete(collectionId)
       return next
     })
-    setSubmitErrors((prev) => prev.filter((e) => e.collectionId !== collectionId))
+    setSubmitErrors((prev) =>
+      prev.filter((e) => e.collectionId !== collectionId)
+    )
+  }
+
+  const cancelRemove = () => {
+    setRemoveConfirmId(null)
+    setRemoveError(null)
+  }
+
+  const confirmRemove = async (collectionId: number) => {
+    const collection = collections.find((c) => c.id === collectionId)
+    // Prefer the server-confirmed item id; fall back to one captured from a
+    // same-session add whose contains-refetch hasn't landed yet.
+    const itemId = containing?.get(collectionId) ?? sessionItemIds.get(collectionId)
+    if (!collection || itemId === undefined) {
+      // Shouldn't happen — the confirm only opens for a saved row, and a saved
+      // row's item id comes from either `containing` or `sessionItemIds`. Fail
+      // safe by closing the confirm.
+      setRemoveConfirmId(null)
+      return
+    }
+    setRemovingId(collectionId)
+    setRemoveError(null)
+    try {
+      await removeMutation.mutateAsync({ slug: collection.slug, itemId })
+      setSavedIds((prev) => {
+        const next = new Set(prev)
+        next.delete(collectionId)
+        return next
+      })
+      setPendingAdds((prev) => {
+        const next = new Set(prev)
+        next.delete(collectionId)
+        return next
+      })
+      setSessionItemIds((prev) => {
+        const next = new Map(prev)
+        next.delete(collectionId)
+        return next
+      })
+      setRemoveConfirmId(null)
+      // Refresh the contains-check + public backlinks for this entity so a
+      // reopen (and the entity page's "appears in" list) reflect the removal.
+      // The re-seed guard above preserves any un-submitted pending adds, so
+      // this refetch can't clobber the user's in-progress selection.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.containing(entityType, entityId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.entity(entityType, entityId),
+      })
+    } catch (err) {
+      setRemoveError({ collectionId, message: describeError(err) })
+    } finally {
+      setRemovingId(null)
+    }
   }
 
   // Fan out via Promise.allSettled so one failure doesn't kill the rest.
   const handleSubmit = async () => {
-    if (newlyChecked.length === 0 || submitting) return
+    if (pendingAdds.size === 0 || submitting) return
 
     setSubmitting(true)
     setSubmitErrors([])
 
-    const targets = newlyChecked
+    const targets = [...pendingAdds]
       .map((id) => collections.find((c) => c.id === id))
       .filter((c) => c !== undefined)
 
@@ -181,7 +300,7 @@ export function AddToCollectionButton({
             entityId,
           })
           .then(
-            () => ({ id: collection.id }),
+            (item) => ({ id: collection.id, itemId: item.id }),
             (err: unknown) => {
               throw { id: collection.id, error: err }
             }
@@ -189,41 +308,47 @@ export function AddToCollectionButton({
       )
     )
 
-    const newlySaved = new Set(savedIds)
-    const sessionSavedIds = new Set(justSaved)
+    const nextSaved = new Set(savedIds)
+    const nextPending = new Set(pendingAdds)
+    const nextSessionItemIds = new Map(sessionItemIds)
     const errors: SubmitError[] = []
 
     for (const result of results) {
       if (result.status === 'fulfilled') {
-        newlySaved.add(result.value.id)
-        sessionSavedIds.add(result.value.id)
+        nextSaved.add(result.value.id)
+        nextPending.delete(result.value.id)
+        nextSessionItemIds.set(result.value.id, result.value.itemId)
       } else {
         const reason = result.reason as { id: number; error: unknown }
-        errors.push({ collectionId: reason.id, message: describeError(reason.error) })
+        // Drop the failed row out of the add batch so it unchecks (matching
+        // the row state to reality); the inline error explains why.
+        nextPending.delete(reason.id)
+        errors.push({
+          collectionId: reason.id,
+          message: describeError(reason.error),
+        })
       }
     }
 
-    setSavedIds(newlySaved)
-    setJustSaved(sessionSavedIds)
-    // Drop failures back out of `selected` so the row state matches reality.
-    if (errors.length > 0) {
-      setSelected((prev) => {
-        const next = new Set(prev)
-        for (const e of errors) next.delete(e.collectionId)
-        return next
-      })
-    }
+    setSavedIds(nextSaved)
+    setPendingAdds(nextPending)
+    setSessionItemIds(nextSessionItemIds)
     setSubmitErrors(errors)
     setSubmitting(false)
+    // addMutation.onSuccess also invalidates the contains query → the re-seed
+    // guard re-syncs savedIds with the server's item ids; sessionItemIds
+    // bridges the gap until that refetch lands.
   }
 
   const isLoading = collectionsLoading || (open && containingLoading)
-  const submitDisabled = submitting || newlyChecked.length === 0
+  const submitDisabled = submitting || pendingCount === 0
   const submitLabel = submitting
     ? 'Adding…'
-    : newlyChecked.length > 0
-      ? `Add to ${newlyChecked.length} ${newlyChecked.length === 1 ? 'collection' : 'collections'}`
+    : pendingCount > 0
+      ? `Add to ${pendingCount} ${pendingCount === 1 ? 'collection' : 'collections'}`
       : 'Add'
+  const showSearch = collections.length > SEARCH_THRESHOLD
+  const hasCollections = collections.length > 0
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -247,62 +372,170 @@ export function AddToCollectionButton({
           </Button>
         )}
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="end">
+      <PopoverContent className="w-[360px] p-0" align="end">
         <div className="p-3 border-b border-border">
-          <h4 className="text-sm font-display font-semibold">Add to Collection</h4>
+          <h4 className="text-sm font-display font-semibold">
+            Add to Collection
+          </h4>
           <p className="text-xs text-muted-foreground mt-0.5 truncate">
             {entityName}
           </p>
         </div>
 
+        {showSearch && (
+          <div className="p-2 border-b border-border">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+              <Input
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value)
+                  // Filtering can hide the row whose remove-confirm is open,
+                  // orphaning it (no Cancel until the filter clears). Dismiss
+                  // the confirm whenever the visible set changes.
+                  if (removeConfirmId !== null) {
+                    setRemoveConfirmId(null)
+                    setRemoveError(null)
+                  }
+                }}
+                placeholder="Filter collections…"
+                aria-label="Filter collections"
+                className="h-8 pl-8 text-sm"
+              />
+            </div>
+          </div>
+        )}
+
         <div
-          className="max-h-64 overflow-y-auto p-1"
+          className="max-h-72 overflow-y-auto p-1"
           role="group"
           aria-label="Your collections"
         >
           {isLoading ? (
-            <div className="flex items-center justify-center py-4">
+            <div className="flex items-center justify-center py-6">
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>
-          ) : collections.length === 0 ? (
-            <div className="py-3 px-2 text-center">
-              <p className="text-sm text-muted-foreground">No collections yet</p>
+          ) : !hasCollections ? (
+            // D5: empty state promotes Create as the primary action.
+            <div className="px-3 py-5 text-center">
+              <p className="text-sm text-muted-foreground mb-3">
+                No collections yet — start one.
+              </p>
+              <Button asChild size="sm" className="w-full">
+                <Link href="/collections" onClick={() => setOpen(false)}>
+                  <Plus className="h-3.5 w-3.5 mr-1.5" />
+                  Create new collection
+                </Link>
+              </Button>
+            </div>
+          ) : filteredCollections.length === 0 ? (
+            <div className="py-4 px-2 text-center">
+              <p className="text-sm text-muted-foreground">
+                No collections match “{search.trim()}”
+              </p>
             </div>
           ) : (
-            collections.map((collection) => {
-              const isChecked = selected.has(collection.id)
-              const wasJustSaved = justSaved.has(collection.id)
+            filteredCollections.map((collection) => {
+              const checked = isChecked(collection.id)
+              const added = savedIds.has(collection.id)
               const errorMessage = errorByCollection.get(collection.id)
+              const rowRemoveError =
+                removeError?.collectionId === collection.id
+                  ? removeError.message
+                  : undefined
               const checkboxId = `collection-checkbox-${collection.id}`
+              const isConfirming = removeConfirmId === collection.id
+              const isRemoving = removingId === collection.id
+              const subtitle = `${collection.item_count} ${collection.item_count === 1 ? 'item' : 'items'} · ${collection.is_public ? 'Public' : 'Private'}`
 
               return (
                 <div key={collection.id} className="px-1">
                   <label
                     htmlFor={checkboxId}
-                    className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 transition-colors cursor-pointer"
+                    className="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 transition-colors cursor-pointer"
                   >
                     <Checkbox
                       id={checkboxId}
-                      checked={isChecked}
-                      onCheckedChange={() => handleToggle(collection.id)}
-                      disabled={submitting}
+                      checked={checked}
+                      onCheckedChange={(value) =>
+                        handleCheckedChange(collection.id, value === true)
+                      }
+                      disabled={submitting || isRemoving}
                       aria-describedby={
-                        errorMessage ? `${checkboxId}-error` : undefined
+                        errorMessage || rowRemoveError
+                          ? `${checkboxId}-error`
+                          : undefined
                       }
                     />
-                    <Library className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                    <span className="flex-1 truncate">{collection.title}</span>
-                    {wasJustSaved && (
-                      <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400 shrink-0" />
+                    <CollectionCoverImage
+                      url={collection.cover_image_url}
+                      alt=""
+                      className="h-7 w-7 shrink-0 rounded bg-muted/50"
+                      fallback={
+                        <div className="flex h-full w-full items-center justify-center rounded bg-muted/50">
+                          <Library className="h-3.5 w-3.5 text-muted-foreground" />
+                        </div>
+                      }
+                    />
+                    <span className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate font-medium leading-tight">
+                        {collection.title}
+                      </span>
+                      <span className="text-xs text-muted-foreground leading-tight">
+                        {subtitle}
+                      </span>
+                    </span>
+                    {added && !isConfirming && (
+                      <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400 shrink-0">
+                        <Check className="h-3.5 w-3.5" />
+                        Added
+                      </span>
                     )}
                   </label>
-                  {errorMessage && (
+
+                  {/* D1: inline remove-with-confirm for an already-in row. */}
+                  {isConfirming && (
+                    <div className="ml-8 mr-2 mb-1.5 flex items-center justify-between gap-2">
+                      <span className="text-xs text-muted-foreground">
+                        Remove from this collection?
+                      </span>
+                      <span className="flex items-center gap-1.5 shrink-0">
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="sm"
+                          className="h-6 px-2 text-xs"
+                          onClick={() => confirmRemove(collection.id)}
+                          disabled={isRemoving}
+                        >
+                          {isRemoving && (
+                            <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                          )}
+                          Remove
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-xs"
+                          onClick={cancelRemove}
+                          disabled={isRemoving}
+                        >
+                          Cancel
+                        </Button>
+                      </span>
+                    </div>
+                  )}
+
+                  {(errorMessage || rowRemoveError) && (
                     <div
                       id={`${checkboxId}-error`}
                       className="ml-8 mr-2 mb-1 flex items-start gap-1 text-xs text-destructive"
                     >
                       <AlertCircle className="h-3 w-3 shrink-0 mt-0.5" />
-                      <span className="flex-1">{errorMessage}</span>
+                      <span className="flex-1">
+                        {errorMessage ?? rowRemoveError}
+                      </span>
                     </div>
                   )}
                 </div>
@@ -311,33 +544,39 @@ export function AddToCollectionButton({
           )}
         </div>
 
-        {/* Submit row */}
-        {collections.length > 0 && (
-          <div className="p-2 border-t border-border flex items-center gap-2">
+        {/* Submit row — only for newly-checked rows awaiting an add. */}
+        {hasCollections && (
+          <div className="p-2 border-t border-border">
             <Button
               type="button"
               size="sm"
-              className="flex-1"
+              className="w-full"
               onClick={handleSubmit}
               disabled={submitDisabled}
             >
-              {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />}
+              {submitting && (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+              )}
               {submitLabel}
             </Button>
           </div>
         )}
 
-        {/* Create new link */}
-        <div className="p-2 border-t border-border">
-          <Link
-            href="/collections"
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-            onClick={() => setOpen(false)}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            Create new collection
-          </Link>
-        </div>
+        {/* Create new link. PSY-829 defers the create-from-entity pre-fill
+            (D4) to a follow-up — this stays a plain link to the collections
+            page until the Create drawer is reachable from entity pages. */}
+        {hasCollections && (
+          <div className="p-2 border-t border-border">
+            <Link
+              href="/collections"
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              onClick={() => setOpen(false)}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Create new collection
+            </Link>
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   )

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
@@ -45,10 +45,12 @@ type SubmitError = { collectionId: number; message: string }
 // on the FIRST render (the prior effect always ran on mount and seeded).
 const UNSET = Symbol('unset')
 
-// PSY-829 D2/D3: a client-side filter input only earns its space once the list
-// is long enough to scroll. Below this count the 4–8 rows fit at a glance, so
-// the input would be noise (matches the locked design — the default-open mock
-// has no search box; the "search active" mock implies a larger library).
+// PSY-829: the client-side filter input only earns its space once the list is
+// long enough to scroll. Below this count the rows fit at a glance, so the
+// input would be noise. This matches the locked PSY-893 design, whose
+// default-open mock (4 rows) has NO search box while its "search active" mock
+// depicts a larger library — i.e. the input is conditional, not always-on. The
+// exact cutoff is a judgment call (the design doesn't specify a number).
 const SEARCH_THRESHOLD = 8
 
 function describeError(reason: unknown): string {
@@ -108,6 +110,12 @@ export function AddToCollectionButton({
   const [removeConfirmId, setRemoveConfirmId] = useState<number | null>(null)
   const [removingId, setRemovingId] = useState<number | null>(null)
   const [removeError, setRemoveError] = useState<SubmitError | null>(null)
+  // Synchronous in-flight guards: the `submitting`/`removingId` state disables
+  // the buttons, but that only takes effect after React commits — two clicks in
+  // the same tick both read the stale state and fire duplicate mutations. Refs
+  // flip synchronously so the second click bails immediately.
+  const submitInFlightRef = useRef(false)
+  const removeInFlightRef = useRef(false)
 
   // Seed `savedIds` from the server's contains-truth whenever the query
   // resolves (or returns a fresh reference — e.g. after an add/remove
@@ -208,6 +216,11 @@ export function AddToCollectionButton({
       if (!savedIds.has(collectionId)) {
         setPendingAdds((prev) => new Set(prev).add(collectionId))
       }
+      // Re-checking a row that just failed to add clears its stale error so the
+      // checked row doesn't keep displaying "it failed" until the next submit.
+      setSubmitErrors((prev) =>
+        prev.filter((e) => e.collectionId !== collectionId)
+      )
       return
     }
     // checked === false
@@ -232,17 +245,23 @@ export function AddToCollectionButton({
   }
 
   const confirmRemove = async (collectionId: number) => {
+    if (removeInFlightRef.current) return
     const collection = collections.find((c) => c.id === collectionId)
     // Prefer the server-confirmed item id; fall back to one captured from a
     // same-session add whose contains-refetch hasn't landed yet.
     const itemId = containing?.get(collectionId) ?? sessionItemIds.get(collectionId)
     if (!collection || itemId === undefined) {
       // Shouldn't happen — the confirm only opens for a saved row, and a saved
-      // row's item id comes from either `containing` or `sessionItemIds`. Fail
-      // safe by closing the confirm.
-      setRemoveConfirmId(null)
+      // row's item id comes from either `containing` or `sessionItemIds`.
+      // Surface an error rather than silently closing, so the user isn't left
+      // with a checked-but-unremovable row (the dead-affordance class D1 fixes).
+      setRemoveError({
+        collectionId,
+        message: 'Could not resolve this item — reopen and try again.',
+      })
       return
     }
+    removeInFlightRef.current = true
     setRemovingId(collectionId)
     setRemoveError(null)
     try {
@@ -263,6 +282,13 @@ export function AddToCollectionButton({
         return next
       })
       setRemoveConfirmId(null)
+      // Cancel any in-flight contains refetch first: a just-submitted add fires
+      // its own contains refetch, and if that GET (sent before this DELETE
+      // committed) lands after the delete it would briefly re-seed this row as
+      // "Added". Cancelling it before we invalidate avoids that flicker.
+      queryClient.cancelQueries({
+        queryKey: queryKeys.collections.containing(entityType, entityId),
+      })
       // Refresh the contains-check + public backlinks for this entity so a
       // reopen (and the entity page's "appears in" list) reflect the removal.
       // The re-seed guard above preserves any un-submitted pending adds, so
@@ -276,14 +302,16 @@ export function AddToCollectionButton({
     } catch (err) {
       setRemoveError({ collectionId, message: describeError(err) })
     } finally {
+      removeInFlightRef.current = false
       setRemovingId(null)
     }
   }
 
   // Fan out via Promise.allSettled so one failure doesn't kill the rest.
   const handleSubmit = async () => {
-    if (pendingAdds.size === 0 || submitting) return
+    if (pendingAdds.size === 0 || submitting || submitInFlightRef.current) return
 
+    submitInFlightRef.current = true
     setSubmitting(true)
     setSubmitErrors([])
 
@@ -335,6 +363,7 @@ export function AddToCollectionButton({
     setSessionItemIds(nextSessionItemIds)
     setSubmitErrors(errors)
     setSubmitting(false)
+    submitInFlightRef.current = false
     // addMutation.onSuccess also invalidates the contains query → the re-seed
     // guard re-syncs savedIds with the server's item ids; sessionItemIds
     // bridges the gap until that refetch lands.
@@ -544,7 +573,8 @@ export function AddToCollectionButton({
           )}
         </div>
 
-        {/* Submit row — only for newly-checked rows awaiting an add. */}
+        {/* Submit row: always present when the user has collections; the
+            button is disabled (label "Add") until ≥1 new row is checked. */}
         {hasCollections && (
           <div className="p-2 border-t border-border">
             <Button
@@ -562,9 +592,13 @@ export function AddToCollectionButton({
           </div>
         )}
 
-        {/* Create new link. PSY-829 defers the create-from-entity pre-fill
-            (D4) to a follow-up — this stays a plain link to the collections
-            page until the Create drawer is reachable from entity pages. */}
+        {/* Create new link. Two PSY-893 decisions are deferred to follow-ups
+            (see the PR's Deferred section for the ticket ids):
+            - D3 (recently-used promotion above a separator) — needs an
+              add-recency signal the data model doesn't carry yet.
+            - D4 (create-from-entity pre-fill) — needs the Create drawer to be
+              reachable from entity pages; until then this stays a plain link to
+              the collections page rather than "Create … with {entity}". */}
         {hasCollections && (
           <div className="p-2 border-t border-border">
             <Link

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -235,8 +235,14 @@ describe('Collection query hooks', () => {
   })
 
   describe('useUserCollectionsContaining', () => {
-    it('returns the response IDs as a Set for O(1) membership checks', async () => {
-      mockApiRequest.mockResolvedValueOnce({ collection_ids: [3, 7, 9] })
+    it('returns the response as a Map of collectionId → itemId (PSY-829)', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        items: [
+          { collection_id: 3, item_id: 30 },
+          { collection_id: 7, item_id: 70 },
+          { collection_id: 9, item_id: 90 },
+        ],
+      })
 
       const { result } = renderHook(
         () => useUserCollectionsContaining('artist', 42),
@@ -244,12 +250,13 @@ describe('Collection query hooks', () => {
       )
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
-      // Built as a Set so the popover's `selected.has(id)` check is O(1)
-      // rather than O(N) on every render.
-      expect(result.current.data).toBeInstanceOf(Set)
+      // Built as a Map so the popover's `containing.has(id)` pre-check is O(1)
+      // AND `containing.get(id)` yields the collection_item id to DELETE on
+      // uncheck (PSY-829), without re-allocating per render.
+      expect(result.current.data).toBeInstanceOf(Map)
       expect(result.current.data?.has(3)).toBe(true)
-      expect(result.current.data?.has(7)).toBe(true)
-      expect(result.current.data?.has(9)).toBe(true)
+      expect(result.current.data?.get(7)).toBe(70)
+      expect(result.current.data?.get(9)).toBe(90)
       expect(result.current.data?.has(99)).toBe(false)
 
       // URL is encoded — entity_type goes through encodeURIComponent so a
@@ -257,6 +264,19 @@ describe('Collection query hooks', () => {
       expect(mockApiRequest).toHaveBeenCalledWith(
         '/auth/collections/contains?entity_type=artist&entity_id=42'
       )
+    })
+
+    it('tolerates a missing items key (empty Map, no crash)', async () => {
+      mockApiRequest.mockResolvedValueOnce({})
+
+      const { result } = renderHook(
+        () => useUserCollectionsContaining('artist', 42),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data).toBeInstanceOf(Map)
+      expect(result.current.data?.size).toBe(0)
     })
 
     it('skips the request when disabled', async () => {

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -363,6 +363,12 @@ export function useAddCollectionItem() {
           variables.entityId
         ),
       })
+      // PSY-829: the user's collection list carries item_count, now surfaced as
+      // the "N items" subtitle in the Add-to-Collection popover — refresh it so
+      // the count isn't stale right after an add.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.my,
+      })
     },
   })
 }
@@ -484,6 +490,15 @@ export function useRemoveCollectionItem() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.collections.detail(variables.slug),
+      })
+      // PSY-829: the user's collection list carries item_count, surfaced as the
+      // "N items" subtitle in the Add-to-Collection popover — refresh it so the
+      // count isn't stale after a remove. (The popover additionally invalidates
+      // the contains + entity-backlink caches itself, since the remove is keyed
+      // by {slug, itemId} and this hook doesn't know the entity coordinates
+      // those caches require.)
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.my,
       })
     },
   })

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -153,15 +153,18 @@ export function useMyCollections(params?: { search?: string }) {
 }
 
 /**
- * PSY-359: list of the authenticated user's own collection IDs that already
- * contain the given entity. Backs the pre-check state on the multi-select
- * Add-to-Collection popover so it can render the right boxes ticked in a
- * single round-trip (no N+1 contains-check fan-out across cards).
+ * PSY-359: the authenticated user's own collections that already contain the
+ * given entity, each mapped to the collection_item id. Backs the pre-check
+ * state on the multi-select Add-to-Collection popover so it can render the
+ * right boxes ticked in a single round-trip (no N+1 contains-check fan-out
+ * across cards).
  *
- * Returns a `Set<number>` (constructed once per response) so callers can
- * check membership in O(1) without re-allocating per render. `enabled`
- * defaults to `true`; pass `false` to defer the request until the popover
- * opens — saves a fetch on every entity page render.
+ * Returns a `Map<number, number>` (collectionId → collection_item id),
+ * constructed once per response. Callers use `.has(id)` for the O(1)
+ * pre-check and `.get(id)` for the item id to DELETE when the user unchecks
+ * an already-in row (PSY-829's uncheck→remove affordance). `enabled` defaults
+ * to `true`; pass `false` to defer the request until the popover opens —
+ * saves a fetch on every entity page render.
  */
 export function useUserCollectionsContaining(
   entityType: string,
@@ -172,8 +175,12 @@ export function useUserCollectionsContaining(
     queryKey: queryKeys.collections.containing(entityType, entityId),
     queryFn: async () => {
       const url = `${API_ENDPOINTS.COLLECTIONS.CONTAINS}?entity_type=${encodeURIComponent(entityType)}&entity_id=${entityId}`
-      const data = await apiRequest<{ collection_ids: number[] }>(url)
-      return new Set<number>(data.collection_ids ?? [])
+      const data = await apiRequest<{
+        items: { collection_id: number; item_id: number }[]
+      }>(url)
+      return new Map<number, number>(
+        (data.items ?? []).map((i) => [i.collection_id, i.item_id])
+      )
     },
     enabled: (options?.enabled ?? true) && entityId > 0,
     staleTime: 5 * 60 * 1000,
@@ -325,7 +332,10 @@ export function useAddCollectionItem() {
       entityId: number
       notes?: string
     }) =>
-      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.ITEMS(slug), {
+      // Returns the created collection_item (incl. its `id`) so callers can
+      // act on the new item without waiting for the contains-cache refetch —
+      // e.g. AddToCollectionButton's same-session uncheck→remove (PSY-829).
+      apiRequest<{ id: number }>(API_ENDPOINTS.COLLECTIONS.ITEMS(slug), {
         method: 'POST',
         body: JSON.stringify({
           entity_type: entityType,


### PR DESCRIPTION
Closes PSY-829.
Closes PSY-893.

## Summary

Redesigns the **AddToCollectionButton popover** — the highest-traffic collection affordance, on every entity detail page (artist/release/label/show/venue/festival) — to the locked PSY-893 design (Figma node `192:9`). Implements the in-scope decisions **D1, D2, D5** + the client-side filter; **D3 and D4 are deferred** to follow-ups (see below).

**Frontend (`AddToCollectionButton.tsx`):**
- **D2 — wider 360px popover, rich rows**: cover thumbnail + title + a `N items · Public/Private` subtitle, with a green **`✓ Added`** indicator on rows the entity is already in.
- **D1 — uncheck → remove-with-confirm**: unchecking an already-in row opens an inline *"Remove from this collection?"* confirm (Remove / Cancel); Remove DELETEs by `collection_item` id. **This fixes today's dead uncheck** — the old popover only fanned out newly-checked ids, so unchecking an already-in row did nothing.
- **D5 — empty state** promotes Create as a primary (filled) action with *"No collections yet — start one."*
- **Client-side filter** input, shown once the list exceeds 8 collections (matches the locked design's conditional search).

**Backend (contains endpoint):** `GET /auth/collections/contains` now returns `{items: [{collection_id, item_id}]}` instead of `{collection_ids: []}`, so the popover can both pre-check rows AND remove by item id in one round-trip. The query already JOINs `collection_items`; the `UNIQUE(collection_id, entity_type, entity_id)` constraint (migration `000047`) guarantees one row per collection, so `Distinct` was dropped. `useUserCollectionsContaining` now returns `Map<collectionId, itemId>`; `useAddCollectionItem` returns the created item so a same-session uncheck→remove knows the new item id before the contains refetch lands.

## Deferred (per pre-implementation Q&A)

- **D3 — recently-used promotion** — no add-recency signal exists in the data model (`updated_at` bumps on any edit; no `last_item_added_at`). Filed **PSY-960**.
- **D4 — create-from-entity pre-fill** — the Create drawer (PSY-823) is mounted only on `/collections`, not reachable from entity pages, and `CreateCollectionForm` has no pre-fill prop. Filed **PSY-961**. Until then the CTA stays a plain "Create new collection" link.
- **Original PSY-829 drawer-polish layer** (thumbnail strip / per-row chips / animations) — split off so this popover redesign could ship focused. Filed **PSY-962** (includes the PSY-898 graph-hide coordination note).

## Adversarial review

`/adversarial-review` — BLOCK → all findings addressed in commit `2fc4dfb8`. Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

- [HIGH, raised by 2 lenses] The new `N items` subtitle went stale after an in-popover add/remove → both `useAddCollectionItem` and `useRemoveCollectionItem` now invalidate `queryKeys.collections.my`.
- [HIGH] D3/D4 deferred without tracked follow-ups → filed **PSY-960** + **PSY-961** (+ PSY-962 for the drawer-polish layer); referenced here.
- [MEDIUM] Same-session add→remove could briefly re-assert "Added" via an in-flight contains refetch → `confirmRemove` now `cancelQueries(containing)` before invalidating.
- [MEDIUM] The filtered-empty ("No collections match") branch had no test → added.
- [LOW×4] `confirmRemove` silent no-op when the item id is unresolvable → inline error; double-click could fire duplicate mutations → synchronous in-flight ref guards; re-checking a failed-add row left a stale error → cleared on re-check; stale Submit-row comment + a "D3" mislabel on the search input → corrected, with in-code deferral notes for D3/D4.
- **Security: CLEAN** — verified the remove path is authz'd (`RemoveItem` checks creator/adder/admin — no IDOR) and the contains endpoint only returns the caller's own/subscribed collections; `item_id` is a non-secret PK re-validated on every DELETE.

## Test plan

- [x] `cd backend && go build ./...` — clean; `go test ./internal/services/community/... ./internal/api/handlers/community/...` — pass (contains integration tests updated to the `{items}` shape + assert non-zero item ids)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean for all changed/new files (PSY-955 gate)
- [x] `bun run test:run features/collections components/shared` — **698/698 passing**
  - `AddToCollectionButton.test.tsx` (31): rich-row subtitle, `✓ Added`, D1 remove-with-confirm (open / cancel / confirm-DELETEs-by-item-id / failure-inline), same-session add→remove uses captured item id, failed-add unchecks, pending-clears-on-close, search filter incl. no-match empty state, D5 empty-state CTA, + preserved PSY-466/PSY-663 regressions
  - `features/collections/hooks/index.test.tsx` (40): contains hook returns `Map`, tolerates missing `items` key
- [x] `/code-review` (xhigh) — addressed (the same add→remove race, submitErrors wipe, pending leak, failed-add state, confirm-orphaned-on-filter; the "no UNIQUE constraint" finding was refuted — the constraint exists at migration `000047:31`)
- [x] `/adversarial-review` — BLOCK → addressed; fixes in separate commit `2fc4dfb8`
- [x] `/psy-self-review` — see below
- [x] Manual repro against the local dev stack (logged in as admin, Amyl and The Sniffers artist page, 4 real collections): default popover renders 4 rich rows with `N items · Public/Private` subtitles + `✓ Added` on the 2 containing rows; unchecking an Added row opens the inline remove-confirm. Screenshots below.

## Screenshots

**Default open — rich rows + `✓ Added`** (4 real collections; 2 already contain the artist):

![AddToCollectionButton popover default](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-8e0a1557d37e0b9a7783/psy-829-popover-default-crop.png)

**D1 — uncheck an already-in row → inline remove-confirm** (fixes the dead uncheck):

![AddToCollectionButton remove confirm](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-8e0a1557d37e0b9a7783/psy-829-popover-confirm-crop.png)

## Coverage gaps

Honest disclosure of what the screenshots / manual repro do NOT cover:

- **Empty state (D5)** and the **search filter** are not screenshotted (the admin account has 4 collections — below the search threshold, and non-empty). Both are unit-tested (`shows empty state with a primary Create CTA`; `filters rows by title` + `shows the no-match empty state`).
- **The actual Remove DELETE round-trip** was not exercised in the manual repro (I opened the confirm but didn't confirm, to keep the seed data intact for the screenshot) — it is covered by the `confirm-DELETEs-by-item-id` unit test and the backend integration tests.
- **Deferred D3/D4/drawer-polish** are out of scope (PSY-960 / PSY-961 / PSY-962).
- **The subscribed-but-not-creator dead-remove edge** (Security lens noted): for a collaborative collection where another user added the item, the popover offers remove but the DELETE 403s — surfaced gracefully as an inline error (not silent). Acceptable; can be hardened in a follow-up if it surfaces in dogfooding.
- **Cross-consumer cache effect**: the new `collections.my` invalidation in `useRemoveCollectionItem` also fires from its other consumers (`CollectionItemsList`, `CollectionItemCard`) — a benign extra list-refetch on remove there, not just the popover.
- **The filter-dismisses-an-open-confirm guard** (typing in the search box closes a dangling remove-confirm) is implemented but only covered indirectly by the search tests — no dedicated unit test asserts the dismiss.
