### PR TITLE
PSY-965: rebind StatusBanner to theme-aware success/pending tokens

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -52,6 +52,12 @@
   --color-border: var(--border);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  /* PSY-965: theme-aware success/pending tokens for StatusBanner (replaces the
+   * hardcoded dark-mode greens/ambers that broke on the light newsprint theme). */
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-pending: var(--pending);
+  --color-pending-foreground: var(--pending-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -109,6 +115,11 @@
   --accent-foreground: #1a1714;
   --destructive: #9c2a1a;
   --destructive-foreground: #f4f1ea;
+  /* PSY-965: editorial sage-green success / warm-amber pending (light). */
+  --success: #dde8d8;
+  --success-foreground: #2f5d3a;
+  --pending: #f0e6cf;
+  --pending-foreground: #7a5a1e;
   --border: #cabe9f;
   --input: #ddd6c8;
   --ring: #d2541b;
@@ -150,6 +161,11 @@
   --accent-foreground: #0d0805;
   --destructive: #f14d4c;
   --destructive-foreground: #0d0805;
+  /* PSY-965: editorial sage-green success / warm-amber pending (dark). */
+  --success: #1c2a20;
+  --success-foreground: #8fc6a0;
+  --pending: #2a2316;
+  --pending-foreground: #d6b06a;
   --border: #221b15;
   --input: #221b15;
   --ring: #dc9064;

--- a/frontend/components/shared/StatusBanner.test.tsx
+++ b/frontend/components/shared/StatusBanner.test.tsx
@@ -51,22 +51,24 @@ describe('StatusBanner', () => {
       const banner = screen.getByRole('status')
       expect(banner).toHaveClass('mb-4')
       // Variant chrome survives the merge.
-      expect(banner).toHaveClass('border-green-800', 'bg-green-950/50')
+      expect(banner).toHaveClass('border-success-foreground', 'bg-success')
     })
   })
 
   describe('variant: success', () => {
-    it('applies the green Tailwind chrome', () => {
+    it('applies the success token chrome (theme-aware, PSY-965)', () => {
       render(<StatusBanner variant="success">Saved</StatusBanner>)
 
       const banner = screen.getByRole('status')
       expect(banner).toHaveClass(
         'rounded-md',
         'border',
-        'border-green-800',
-        'bg-green-950/50',
+        'border-success-foreground',
+        'bg-success',
         'p-4'
       )
+      // The old hardcoded dark-mode greens must be gone.
+      expect(banner).not.toHaveClass('border-green-800', 'bg-green-950/50')
     })
 
     it('renders the default Check icon when no icon prop is supplied', () => {
@@ -77,22 +79,24 @@ describe('StatusBanner', () => {
       // Lucide renders as <svg class="lucide lucide-check ...">
       const icon = container.querySelector('svg.lucide-check')
       expect(icon).toBeInTheDocument()
-      expect(icon).toHaveClass('text-green-400')
+      expect(icon).toHaveClass('text-success-foreground')
     })
   })
 
   describe('variant: pending', () => {
-    it('applies the amber Tailwind chrome', () => {
+    it('applies the pending token chrome (theme-aware, PSY-965)', () => {
       render(<StatusBanner variant="pending">Awaiting moderation</StatusBanner>)
 
       const banner = screen.getByRole('status')
       expect(banner).toHaveClass(
         'rounded-md',
         'border',
-        'border-amber-700/50',
-        'bg-amber-950/40',
+        'border-pending-foreground',
+        'bg-pending',
         'p-3'
       )
+      // The old hardcoded dark-mode ambers must be gone.
+      expect(banner).not.toHaveClass('border-amber-700/50', 'bg-amber-950/40')
     })
 
     it('renders the default Clock icon when no icon prop is supplied', () => {
@@ -102,7 +106,7 @@ describe('StatusBanner', () => {
 
       const icon = container.querySelector('svg.lucide-clock')
       expect(icon).toBeInTheDocument()
-      expect(icon).toHaveClass('text-amber-500')
+      expect(icon).toHaveClass('text-pending-foreground')
     })
   })
 

--- a/frontend/components/shared/StatusBanner.tsx
+++ b/frontend/components/shared/StatusBanner.tsx
@@ -9,10 +9,16 @@ export type StatusBannerVariant = 'success' | 'pending'
 export interface StatusBannerProps {
   /**
    * Visual tone:
-   * - `success` — green, used for completed mutations (Changes saved,
+   * - `success` — sage green, used for completed mutations (Changes saved,
    *   Report submitted, Approve / Reject success).
-   * - `pending` — amber, used for "submitted, awaiting review" states
+   * - `pending` — warm amber, used for "submitted, awaiting review" states
    *   (pending edits, pending comments, pending field notes).
+   *
+   * Both tones are theme-aware (PSY-965) — they resolve to the
+   * `--success`/`--pending` semantic tokens, which carry distinct light /
+   * dark values, so callers should use `text-success-foreground` /
+   * `text-pending-foreground` for inner title typography rather than raw
+   * Tailwind greens/ambers.
    */
   variant: StatusBannerVariant
 
@@ -52,11 +58,17 @@ export interface StatusBannerProps {
 }
 
 /**
- * Inline status banner — green for success, amber for pending review.
- * Replaces 4–5 hand-rolled banners that used the same Tailwind chrome
- * (PSY-575). The codebase has no toast library; inline banners on the
- * affected surface are the project convention — see
+ * Inline status banner — sage green for success, warm amber for pending
+ * review. Replaces 4–5 hand-rolled banners that used the same Tailwind
+ * chrome (PSY-575). The codebase has no toast library; inline banners on
+ * the affected surface are the project convention — see
  * `pattern_mutation_feedback.md`.
+ *
+ * PSY-965: the chrome is now bound to the theme-aware `--success` /
+ * `--pending` semantic tokens (light + dark values) instead of the
+ * dark-mode-only Tailwind greens/ambers PSY-575 had preserved verbatim —
+ * those rendered as a muddy olive box with low-contrast text on the light
+ * newsprint theme.
  *
  * Layout: `<icon>` + free-form children. Outer chrome (border + bg +
  * padding) and the default icon colour come from the variant. Inner
@@ -105,15 +117,19 @@ export function StatusBanner({
 
   if (hidden) return null
 
-  // Variant chrome — kept verbatim from the pre-PSY-575 hand-rolled
-  // banners so the visual is byte-identical post-migration:
-  //   success: border-green-800 / bg-green-950/50 / p-4 / icon text-green-400
-  //   pending: border-amber-700/50 / bg-amber-950/40 / p-3 / icon text-amber-500
+  // Variant chrome — theme-aware semantic tokens (PSY-965). The fill is the
+  // `/{tone}` token, the border + default icon use the `/{tone}-foreground`
+  // tone. Both resolve to distinct light/dark values so the banner reads
+  // cleanly on the newsprint (light) theme, not just the vinyl (dark) one:
+  //   success: bg-success / border-success-foreground / p-4 / icon text-success-foreground
+  //   pending: bg-pending / border-pending-foreground / p-3 / icon text-pending-foreground
   const isSuccess = variant === 'success'
-  const iconColorClass = isSuccess ? 'text-green-400' : 'text-amber-500'
+  const iconColorClass = isSuccess
+    ? 'text-success-foreground'
+    : 'text-pending-foreground'
   const containerClass = isSuccess
-    ? 'border-green-800 bg-green-950/50 p-4'
-    : 'border-amber-700/50 bg-amber-950/40 p-3'
+    ? 'bg-success border-success-foreground p-4'
+    : 'bg-pending border-pending-foreground p-3'
 
   const defaultIcon = isSuccess ? (
     <Check className={cn('h-4 w-4 mt-0.5 shrink-0', iconColorClass)} aria-hidden="true" />

--- a/frontend/components/shared/StatusBanner.tsx
+++ b/frontend/components/shared/StatusBanner.tsx
@@ -16,9 +16,10 @@ export interface StatusBannerProps {
    *
    * Both tones are theme-aware (PSY-965) — they resolve to the
    * `--success`/`--pending` semantic tokens, which carry distinct light /
-   * dark values, so callers should use `text-success-foreground` /
-   * `text-pending-foreground` for inner title typography rather than raw
-   * Tailwind greens/ambers.
+   * dark values. For a toned inner title, use `text-success-foreground` /
+   * `text-pending-foreground` (never raw Tailwind greens/ambers, which were
+   * dark-mode-only). A plain `text-foreground` title is also fine — some
+   * callers (e.g. the admin worklists) intentionally keep an untoned title.
    */
   variant: StatusBannerVariant
 

--- a/frontend/features/artists/components/ReportArtistDialog.tsx
+++ b/frontend/features/artists/components/ReportArtistDialog.tsx
@@ -90,7 +90,7 @@ export function ReportArtistDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Flag className="h-5 w-5 text-orange-500" />
+            <Flag className="h-5 w-5 text-primary" />
             Report Issue
           </DialogTitle>
           <DialogDescription>

--- a/frontend/features/comments/components/CommentThread.tsx
+++ b/frontend/features/comments/components/CommentThread.tsx
@@ -141,7 +141,7 @@ export function CommentThread({ entityType, entityId }: CommentThreadProps) {
           testId="pending-review-banner"
           className="mb-4"
         >
-          <p className="text-sm text-amber-200">
+          <p className="text-sm text-pending-foreground">
             Comment submitted — awaiting moderation. You&apos;ll see it here once an admin approves it.
           </p>
         </StatusBanner>

--- a/frontend/features/comments/components/FieldNotesSection.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.tsx
@@ -138,7 +138,7 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
               testId="pending-review-banner"
               className="mb-4"
             >
-              <p className="text-sm text-amber-200">
+              <p className="text-sm text-pending-foreground">
                 Field note submitted — awaiting moderation. You&apos;ll see it here once an admin approves it.
               </p>
             </StatusBanner>

--- a/frontend/features/contributions/components/EntityEditDrawer.tsx
+++ b/frontend/features/contributions/components/EntityEditDrawer.tsx
@@ -265,12 +265,12 @@ export function EntityEditDrawer({
         {submitted && editMutation.isSuccess && (
           editMutation.data?.applied ? (
             <StatusBanner variant="success" className="mx-4">
-              <span className="font-medium text-green-400">Changes applied!</span>
+              <span className="font-medium text-success-foreground">Changes applied!</span>
             </StatusBanner>
           ) : (
             <StatusBanner variant="pending" className="mx-4">
               <div>
-                <span className="font-medium text-amber-200">Edit submitted for review</span>
+                <span className="font-medium text-pending-foreground">Edit submitted for review</span>
                 <p className="mt-1 text-sm text-muted-foreground">
                   An admin will review your changes. You can track your pending edits in your profile.
                 </p>

--- a/frontend/features/contributions/components/EntitySaveSuccessBanner.tsx
+++ b/frontend/features/contributions/components/EntitySaveSuccessBanner.tsx
@@ -52,7 +52,7 @@ export function EntitySaveSuccessBanner({
 
   return (
     <StatusBanner variant="success" className="mb-4">
-      <span className="font-medium text-green-400">{message}</span>
+      <span className="font-medium text-success-foreground">{message}</span>
     </StatusBanner>
   )
 }

--- a/frontend/features/contributions/components/ReportEntityDialog.test.tsx
+++ b/frontend/features/contributions/components/ReportEntityDialog.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ReportEntityDialog } from './ReportEntityDialog'
+
+// useReportEntity is a useMutation hook; mock it so we can drive the dialog
+// into each render state without a live QueryClient or network.
+let mockMutation: {
+  mutate: ReturnType<typeof vi.fn>
+  reset: ReturnType<typeof vi.fn>
+  isError: boolean
+  isSuccess: boolean
+  isPending: boolean
+  error: Error | null
+}
+
+vi.mock('../hooks/useReportEntity', () => ({
+  useReportEntity: () => mockMutation,
+}))
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  entityType: 'artist' as const,
+  entityId: 1,
+  entityName: 'Test Artist',
+}
+
+beforeEach(() => {
+  mockMutation = {
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isError: false,
+    isSuccess: false,
+    isPending: false,
+    error: null,
+  }
+})
+
+describe('ReportEntityDialog', () => {
+  it('renders the form (report-type options) in the idle state', () => {
+    render(<ReportEntityDialog {...baseProps} />)
+
+    expect(screen.getByText("What's the issue?")).toBeInTheDocument()
+    // Artist taxonomy option present.
+    expect(screen.getByText('Inaccurate Information')).toBeInTheDocument()
+    // No duplicate banner in the idle state.
+    expect(
+      screen.queryByTestId('report-duplicate-banner')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the duplicate state as a theme-aware pending StatusBanner (PSY-965)', () => {
+    mockMutation.isError = true
+    mockMutation.error = new Error('You have already reported this entity')
+
+    render(<ReportEntityDialog {...baseProps} />)
+
+    // PSY-965: the old hardcoded-orange div is now a StatusBanner (role=status).
+    const banner = screen.getByTestId('report-duplicate-banner')
+    expect(banner).toHaveAttribute('role', 'status')
+    expect(banner).toHaveClass('bg-pending', 'border-pending-foreground')
+    expect(banner).not.toHaveClass('border-orange-800', 'bg-orange-950/50')
+    expect(screen.getByText('Already reported')).toBeInTheDocument()
+
+    // The form is suppressed while the duplicate notice is shown.
+    expect(screen.queryByText("What's the issue?")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/contributions/components/ReportEntityDialog.test.tsx
+++ b/frontend/features/contributions/components/ReportEntityDialog.test.tsx
@@ -51,7 +51,12 @@ describe('ReportEntityDialog', () => {
 
   it('shows the duplicate state as a theme-aware pending StatusBanner (PSY-965)', () => {
     mockMutation.isError = true
-    mockMutation.error = new Error('You have already reported this entity')
+    // The exact production message from
+    // backend/internal/errors/entity_report.go (ErrEntityReportDuplicatePending),
+    // so this test guards the `isDuplicateError` regex against the real contract.
+    mockMutation.error = new Error(
+      'you already have a pending report for this entity'
+    )
 
     render(<ReportEntityDialog {...baseProps} />)
 
@@ -64,5 +69,20 @@ describe('ReportEntityDialog', () => {
 
     // The form is suppressed while the duplicate notice is shown.
     expect(screen.queryByText("What's the issue?")).not.toBeInTheDocument()
+  })
+
+  it('routes a non-duplicate error to the generic error block, not the pending banner', () => {
+    mockMutation.isError = true
+    mockMutation.error = new Error('Server unavailable')
+
+    render(<ReportEntityDialog {...baseProps} />)
+
+    // A generic error must NOT trip the duplicate (pending) banner...
+    expect(
+      screen.queryByTestId('report-duplicate-banner')
+    ).not.toBeInTheDocument()
+    // ...it surfaces the error message, and the form stays available to retry.
+    expect(screen.getByText('Server unavailable')).toBeInTheDocument()
+    expect(screen.getByText("What's the issue?")).toBeInTheDocument()
   })
 })

--- a/frontend/features/contributions/components/ReportEntityDialog.tsx
+++ b/frontend/features/contributions/components/ReportEntityDialog.tsx
@@ -94,7 +94,7 @@ export function ReportEntityDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Flag className="h-5 w-5 text-orange-500" />
+            <Flag className="h-5 w-5 text-primary" />
             Report Issue
           </DialogTitle>
           <DialogDescription>
@@ -107,7 +107,7 @@ export function ReportEntityDialog({
         {submitted && reportMutation.isSuccess && (
           <StatusBanner variant="success">
             <div>
-              <span className="font-medium text-green-400">Report submitted</span>
+              <span className="font-medium text-success-foreground">Report submitted</span>
               <p className="mt-1 text-sm text-muted-foreground">
                 Thank you for helping improve our data. An admin will review your report.
               </p>
@@ -115,18 +115,28 @@ export function ReportEntityDialog({
           </StatusBanner>
         )}
 
-        {/* Duplicate report error — show message only, no form */}
+        {/* Duplicate report state — PSY-965: pending StatusBanner with a Flag
+            icon (was a hardcoded dark-only orange div). Shows message only,
+            no form. */}
         {isDuplicateError && (
-          <div className="rounded-md border border-orange-800 bg-orange-950/50 p-4">
-            <div className="flex items-center gap-2 text-orange-400">
-              <Flag className="h-4 w-4" />
-              <span className="font-medium">Already reported</span>
+          <StatusBanner
+            variant="pending"
+            icon={
+              <Flag
+                className="h-4 w-4 mt-0.5 shrink-0 text-pending-foreground"
+                aria-hidden="true"
+              />
+            }
+            testId="report-duplicate-banner"
+          >
+            <div>
+              <span className="font-medium text-pending-foreground">Already reported</span>
+              <p className="mt-1 text-sm text-muted-foreground">
+                You&apos;ve already reported this entity. An admin will review your
+                existing report.
+              </p>
             </div>
-            <p className="mt-1 text-sm text-muted-foreground">
-              You&apos;ve already reported this entity. An admin will review your
-              existing report.
-            </p>
-          </div>
+          </StatusBanner>
         )}
 
         {/* Other error state */}

--- a/frontend/features/shows/components/ReportShowDialog.tsx
+++ b/frontend/features/shows/components/ReportShowDialog.tsx
@@ -94,7 +94,7 @@ export function ReportShowDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Flag className="h-5 w-5 text-orange-500" />
+            <Flag className="h-5 w-5 text-primary" />
             Report Issue
           </DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- Adds theme-aware `--success` / `--success-foreground` / `--pending` / `--pending-foreground` tokens to `globals.css` (Light + Dark), mirroring the `--destructive` wiring. Values match the published DS Figma tokens.
- Rebinds the shared `StatusBanner` primitive to those tokens — drops the hardcoded dark-mode-only `green-*`/`amber-*` that rendered as a muddy olive box with low-contrast text on the light newsprint theme.
- `ReportEntityDialog`: success title → `text-success-foreground`; migrates the duplicate "Already reported" box off a hardcoded orange div to a `StatusBanner variant="pending"` (Flag icon); header flag → `text-primary`.
- Switches hardcoded title colors in the other 4 StatusBanner callers (EntitySaveSuccessBanner, EntityEditDrawer, CommentThread, FieldNotesSection) to the foreground tokens.

One primitive fix corrects all 7 StatusBanner surfaces at once.

## Test plan
- [x] `bun run typecheck` — passed
- [x] `bun run test:run components/shared features/contributions features/comments` — 650 passed
- [x] `bun run test:run components/shared/StatusBanner features/contributions/components/ReportEntityDialog features/artists/components/ReportArtistDialog features/shows/components/ReportShowDialog` — 50 passed (incl. the new duplicate-state + non-duplicate-error cases; sibling dialogs unaffected)
- [x] `bun run lint` — 0 errors
- [x] `/adversarial-review` — CONCERNS, addressed in separate commit `f1e85b0f`

## Manual repro
**Disclosure — orchestrator takeover (psy-dispatch stall carveout).** The dispatched agent completed the full implementation but stalled at the 600s watchdog **before committing/testing**; the orchestrator took over: reviewed the diff, added the tests the agent didn't reach, ran the full gate, and ran `/code-review` + `/adversarial-review`.

This is a render-only token/CSS change. Verification is: (1) unit tests assert the exact token classes are applied per variant and that the old `green-*`/`amber-*`/`orange-*` classes are **gone** (`.not.toHaveClass`); (2) the visual was pre-validated against the **DS StatusBanner component you approved** (sage-green success / warm-amber pending, both themes). A full browser login+report flow was **not** re-driven from the orchestrator. **Recommended pre-merge:** eyeball the Vercel preview's report dialog (success + duplicate states) on the light theme.

## Screenshots
Design reference (approved): DS StatusBanner — `https://www.figma.com/design/isfHz0oyFK1ALX19IRGg51/?node-id=204-7` ; ReportEntityDialog states — `https://www.figma.com/design/XakQQ0nYGqnt77PrHKO9IE/?node-id=373-50`

## Code review
`/code-review` (xhigh, 4 parallel angles: ReportEntityDialog migration · Tailwind-v4 token validity · caller sweep · tests) — **no findings**. Confirmed the div→StatusBanner migration preserves the success/duplicate/error mutual-exclusion exactly, the `@theme inline` token mapping generates valid utilities, both themes have all 4 tokens, and no StatusBanner caller was missed.

## Adversarial review
`/adversarial-review` — CONCERNS, addressed in commit `f1e85b0f`. Panel: Saboteur · Future-Maintainer · Security · Completeness (Security + Completeness CLEAN). Reviewers ran with no prior session context against the branch diff.
- [HIGH, corroborated ×2] Header flag moved to `text-primary` in ReportEntityDialog but sibling ReportArtistDialog/ReportShowDialog stayed on off-palette `text-orange-500` → **fixed**: migrated both siblings to `text-primary` (the 3 report dialogs are now consistent + fully theme-aware).
- [MEDIUM] Duplicate-state test asserted an invented error string → **fixed**: now uses the real backend message (`you already have a pending report for this entity`) + added a non-duplicate-error case asserting a generic error routes to the destructive block, not the pending banner.
- [LOW] StatusBanner docstring implied the foreground token was mandatory → **fixed**: clarified plain `text-foreground` titles are acceptable.
- [LOW, deferred] `isDuplicateError` matches the backend's free-text message rather than its `error_code` — pre-existing coupling, untouched here; worth a follow-up but out of scope.

## Follow-up (out of scope)
~10 non-StatusBanner components still use raw `green-*`/`amber-*` (FieldNoteCard, CommentCard, RadioPlayRow, etc.) — a separate sweep ticket to migrate them to the new tokens.

Closes PSY-965
