### PR TITLE
PSY-958: route remaining banner timers onto shared primitive

### DIFF
--- a/frontend/components/shared/StatusBanner.test.tsx
+++ b/frontend/components/shared/StatusBanner.test.tsx
@@ -217,5 +217,38 @@ describe('StatusBanner', () => {
 
       expect(screen.getByRole('status')).toBeInTheDocument()
     })
+
+    it('switching dismissAfterMs from a number to undefined keeps it visible (no spurious onDismiss)', () => {
+      // PSY-958 regression guard: the timed→untimed transition must drop the
+      // live timer, not fire it at 0ms. Old code returned early in the effect
+      // when dismissAfterMs was undefined; the primitive-backed version clears
+      // the entry on the transition.
+      vi.useFakeTimers()
+      const onDismiss = vi.fn()
+
+      const { rerender } = render(
+        <StatusBanner variant="success" dismissAfterMs={5000} onDismiss={onDismiss}>
+          Saved
+        </StatusBanner>
+      )
+      expect(screen.getByRole('status')).toBeInTheDocument()
+
+      // Hand control to the parent partway through the window.
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+      rerender(
+        <StatusBanner variant="success" onDismiss={onDismiss}>
+          Saved
+        </StatusBanner>
+      )
+
+      // No timer should fire now — banner stays, onDismiss never called.
+      act(() => {
+        vi.advanceTimersByTime(10_000)
+      })
+      expect(screen.getByRole('status')).toBeInTheDocument()
+      expect(onDismiss).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/components/shared/StatusBanner.tsx
+++ b/frontend/components/shared/StatusBanner.tsx
@@ -1,8 +1,13 @@
 'use client'
 
-import { useEffect, useState, type ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Check, Clock } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useAutoDismissFlag } from '@/lib/hooks/common/useAutoDismissBanner'
+
+// Sentinel so the start-visible guard below fires on the FIRST render too
+// (a real `dismissAfterMs` — number or undefined — never equals it).
+const DISMISS_UNSET = Symbol('dismiss-unset')
 
 export type StatusBannerVariant = 'success' | 'pending'
 
@@ -75,35 +80,32 @@ export function StatusBanner({
   testId,
   className,
 }: StatusBannerProps) {
-  const [hidden, setHidden] = useState(false)
+  // PSY-958: the show-then-auto-dismiss timer is the shared
+  // useAutoDismissFlag primitive. Two modes:
+  //   - timed (`dismissAfterMs` set): start visible, auto-hide after the
+  //     delay, and fire `onDismiss` when it elapses (via `onAutoDismiss`).
+  //   - untimed (`dismissAfterMs` undefined): parent-controlled — render until
+  //     the parent unmounts us; no timer is ever armed.
+  const [shown, triggerShow] = useAutoDismissFlag(dismissAfterMs ?? 0, {
+    onAutoDismiss: onDismiss,
+  })
 
-  // Reset visibility when the timer config changes so callers that re-arm
-  // (dismissAfterMs changes from one number to another) get the banner back.
-  // React 19.2: adjust state during render via the previous-value-guard idiom
-  // instead of a synchronous setState in the effect (cascading render). The
-  // reset keys on `dismissAfterMs` — the documented re-arm trigger; the timer
-  // itself still re-arms on any dep change in the effect below.
-  const [prevDismissAfterMs, setPrevDismissAfterMs] = useState(dismissAfterMs)
+  // Start visible — and re-arm if a caller changes `dismissAfterMs` to a new
+  // number — by triggering the flag. React 19.2: adjust state during render via
+  // the previous-value-guard idiom instead of a mount/update effect. The
+  // sentinel makes the guard fire on the FIRST render too (so timed banners
+  // show on first paint; the trigger's render-phase setState re-renders before
+  // commit, so there's no visible flicker).
+  const [prevDismissAfterMs, setPrevDismissAfterMs] = useState<
+    number | undefined | typeof DISMISS_UNSET
+  >(DISMISS_UNSET)
   if (dismissAfterMs !== prevDismissAfterMs) {
     setPrevDismissAfterMs(dismissAfterMs)
-    setHidden(false)
+    if (dismissAfterMs !== undefined) triggerShow()
   }
 
-  // Arm the auto-dismiss timer; clear it on unmount (and on re-arm) so we
-  // never setState on an unmounted component. The `setHidden(true)` here is
-  // inside the deferred timer callback, not synchronous in the effect body.
-  useEffect(() => {
-    if (dismissAfterMs === undefined) return
-
-    const timer = setTimeout(() => {
-      setHidden(true)
-      onDismiss?.()
-    }, dismissAfterMs)
-
-    return () => clearTimeout(timer)
-  }, [dismissAfterMs, onDismiss])
-
-  if (hidden) return null
+  // Timed mode hides once the flag auto-dismisses; untimed mode always renders.
+  if (dismissAfterMs !== undefined && !shown) return null
 
   // Variant chrome — kept verbatim from the pre-PSY-575 hand-rolled
   // banners so the visual is byte-identical post-migration:

--- a/frontend/components/shared/StatusBanner.tsx
+++ b/frontend/components/shared/StatusBanner.tsx
@@ -31,9 +31,17 @@ export interface StatusBannerProps {
   icon?: ReactNode
 
   /**
-   * If set, the banner auto-hides after this many milliseconds. The
-   * timer is cleared on unmount and on re-render with a different value.
-   * `onDismiss` (if provided) fires when the timer elapses.
+   * If set, the banner auto-hides after this many milliseconds, and
+   * `onDismiss` (if provided) fires when the timer elapses. The timer is
+   * cleared on unmount, and re-arms when `dismissAfterMs` itself changes value.
+   *
+   * IMPORTANT: the window does NOT re-arm when only the banner's `children`
+   * change while it stays mounted. If you keep one StatusBanner mounted and
+   * swap its message per event (e.g. sequential success confirmations), pass a
+   * `key` that changes per message so each gets a fresh window — the idiomatic
+   * React identity reset (see StreamingWorklist's `key={recentMutation.nonce}`).
+   * Without a changing key, a second message inherits the first's remaining
+   * countdown.
    *
    * Omitting this prop means the banner stays visible until the parent
    * unmounts it — the right call for in-drawer banners (drawer dismiss

--- a/frontend/components/shared/StatusBanner.tsx
+++ b/frontend/components/shared/StatusBanner.tsx
@@ -3,7 +3,7 @@
 import { useState, type ReactNode } from 'react'
 import { Check, Clock } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useAutoDismissFlag } from '@/lib/hooks/common/useAutoDismissBanner'
+import { useAutoDismissBanner } from '@/lib/hooks/common/useAutoDismissBanner'
 
 // Sentinel so the start-visible guard below fires on the FIRST render too
 // (a real `dismissAfterMs` — number or undefined — never equals it).
@@ -81,31 +81,43 @@ export function StatusBanner({
   className,
 }: StatusBannerProps) {
   // PSY-958: the show-then-auto-dismiss timer is the shared
-  // useAutoDismissFlag primitive. Two modes:
+  // useAutoDismissBanner primitive. Two modes:
   //   - timed (`dismissAfterMs` set): start visible, auto-hide after the
   //     delay, and fire `onDismiss` when it elapses (via `onAutoDismiss`).
   //   - untimed (`dismissAfterMs` undefined): parent-controlled — render until
   //     the parent unmounts us; no timer is ever armed.
-  const [shown, triggerShow] = useAutoDismissFlag(dismissAfterMs ?? 0, {
+  // NOTE: content-change reset is the consumer's responsibility via `key` (the
+  // idiomatic React identity reset). A consumer that swaps the banner's
+  // children while keeping it mounted with a constant `dismissAfterMs` should
+  // pass a `key` that changes per message so each gets a fresh window (see
+  // StreamingWorklist) — StatusBanner intentionally doesn't diff children.
+  const {
+    value: shown,
+    show: triggerShow,
+    clear: clearShow,
+  } = useAutoDismissBanner<true>(dismissAfterMs ?? 0, {
     onAutoDismiss: onDismiss,
   })
 
   // Start visible — and re-arm if a caller changes `dismissAfterMs` to a new
-  // number — by triggering the flag. React 19.2: adjust state during render via
+  // number — by triggering the timer. React 19.2: adjust state during render via
   // the previous-value-guard idiom instead of a mount/update effect. The
   // sentinel makes the guard fire on the FIRST render too (so timed banners
   // show on first paint; the trigger's render-phase setState re-renders before
-  // commit, so there's no visible flicker).
+  // commit, so there's no visible flicker). Transitioning to untimed
+  // (`dismissAfterMs` → undefined) clears any live timer so it can't fire a
+  // spurious auto-dismiss / onDismiss.
   const [prevDismissAfterMs, setPrevDismissAfterMs] = useState<
     number | undefined | typeof DISMISS_UNSET
   >(DISMISS_UNSET)
   if (dismissAfterMs !== prevDismissAfterMs) {
     setPrevDismissAfterMs(dismissAfterMs)
-    if (dismissAfterMs !== undefined) triggerShow()
+    if (dismissAfterMs !== undefined) triggerShow(true)
+    else clearShow()
   }
 
-  // Timed mode hides once the flag auto-dismisses; untimed mode always renders.
-  if (dismissAfterMs !== undefined && !shown) return null
+  // Timed mode hides once the timer auto-dismisses; untimed mode always renders.
+  if (dismissAfterMs !== undefined && shown !== true) return null
 
   // Variant chrome — kept verbatim from the pre-PSY-575 hand-rolled
   // banners so the visual is byte-identical post-migration:

--- a/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.test.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 
 import type {
@@ -212,6 +212,65 @@ describe('StreamingWorklist', () => {
         screen.getByTestId('streaming-worklist-success-banner')
       ).toBeInTheDocument()
     })
+  })
+
+  // PSY-958: each success must get its own fresh 4s window. The success banner
+  // stays mounted with a constant dismissAfterMs, so it relies on the
+  // `key={recentMutation.nonce}` remount to re-arm — deleting the key/nonce
+  // would silently regress this (a 2nd success would inherit the 1st's
+  // countdown). This guards that consumer-side contract.
+  it('re-arms the success banner window on a second success (key/nonce remount)', () => {
+    vi.useFakeTimers()
+    try {
+      mockWorklistData({ entries: [makeEntry({ artist_id: 7 })], total: 1 })
+      mockMutate.mockImplementation((_input, callbacks) => {
+        callbacks?.onSuccess?.()
+      })
+
+      renderWithProviders(<StreamingWorklist />)
+
+      const submitSkipped = () => {
+        fireEvent.click(screen.getByTestId('streaming-worklist-open-skipped-7'))
+        fireEvent.click(screen.getByTestId('streaming-worklist-submit-7-skipped'))
+      }
+
+      // First success → banner shows (4s window).
+      submitSkipped()
+      expect(
+        screen.getByTestId('streaming-worklist-success-banner')
+      ).toBeInTheDocument()
+
+      // 3s into the first window.
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+      expect(
+        screen.getByTestId('streaming-worklist-success-banner')
+      ).toBeInTheDocument()
+
+      // Second success → nonce bumps → key remount → fresh 4s window.
+      submitSkipped()
+
+      // Past the FIRST window's original 4s deadline (3000+1500), but only
+      // 1500ms into the SECOND window — still visible because it re-armed.
+      act(() => {
+        vi.advanceTimersByTime(1500)
+      })
+      expect(
+        screen.getByTestId('streaming-worklist-success-banner')
+      ).toBeInTheDocument()
+
+      // A full 4s after the second success → dismisses.
+      act(() => {
+        vi.advanceTimersByTime(2500)
+      })
+      expect(
+        screen.queryByTestId('streaming-worklist-success-banner')
+      ).not.toBeInTheDocument()
+    } finally {
+      vi.runOnlyPendingTimers()
+      vi.useRealTimers()
+    }
   })
 
   it('passes null reason when the textarea is left empty', () => {

--- a/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
@@ -372,6 +372,12 @@ export function StreamingWorklist() {
   const [recentMutation, setRecentMutation] = useState<{
     artistName: string
     action: StreamingWorklistAction
+    // Monotonic id so each success remounts the StatusBanner (via `key`),
+    // giving every confirmation its own fresh auto-dismiss window — even two
+    // rapid successes for the same artist+action. Without this, a second
+    // success within the window would inherit the first banner's countdown
+    // (PSY-958: the timer re-arms on banner identity, not on content change).
+    nonce: number
   } | null>(null)
 
   const { data, isLoading, isError, error } = useStreamingWorklist({
@@ -419,7 +425,11 @@ export function StreamingWorklist() {
 
   const handleActionSuccess = useCallback(
     (entry: StreamingWorklistEntry, action: StreamingWorklistAction) => {
-      setRecentMutation({ artistName: entry.artist_name, action })
+      setRecentMutation((prev) => ({
+        artistName: entry.artist_name,
+        action,
+        nonce: (prev?.nonce ?? 0) + 1,
+      }))
     },
     []
   )
@@ -454,6 +464,7 @@ export function StreamingWorklist() {
             Inline + ephemeral so it doesn't clutter the table. */}
         {recentMutation && (
           <StatusBanner
+            key={recentMutation.nonce}
             variant="success"
             dismissAfterMs={4000}
             onDismiss={() => setRecentMutation(null)}

--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -37,7 +37,6 @@ vi.mock('../hooks', async () => {
     useVoteComment: () => mockUseVoteComment(),
     useUnvoteComment: () => mockUseUnvoteComment(),
     useCommentThread: () => ({ data: undefined as unknown }),
-    useAutoDismissError: actual.useAutoDismissError,
     formatCommentSubmissionError: actual.formatCommentSubmissionError,
   }
 })

--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -25,9 +25,9 @@ const mockUseVoteComment = vi.fn()
 const mockUseUnvoteComment = vi.fn()
 
 vi.mock('../hooks', async () => {
-  // Bring through formatCommentSubmissionError (PSY-589) and
-  // useAutoDismissError (PSY-608) so the card renders the canonical
-  // inline-banner copy and the auto-dismiss vote banner state in tests.
+  // Bring through formatCommentSubmissionError (PSY-589) so the card renders
+  // the canonical inline-banner copy. The vote auto-dismiss banner uses the
+  // shared useAutoDismissBanner primitive directly now (PSY-958, unmocked).
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useReplyToComment: () => mockUseReplyToComment(),
@@ -507,9 +507,9 @@ describe('CommentCard — mutation error surfacing (PSY-608)', () => {
       user: { id: '7', email: 'other@user.com' },
     })
     // Mock vote mutation that fires onError synchronously when mutate() is
-    // called — emulates the rollback path. The auto-dismiss banner reads
-    // from useAutoDismissError state, so a synchronous onError populates it
-    // before the next render.
+    // called — emulates the rollback path. The auto-dismiss banner reads from
+    // the shared useAutoDismissBanner value (PSY-958), so a synchronous
+    // onError populates it before the next render.
     const voteError = Object.assign(new Error('rate limited'), {
       status: 429,
       retryAfter: 60,

--- a/frontend/features/comments/components/CommentThread.test.tsx
+++ b/frontend/features/comments/components/CommentThread.test.tsx
@@ -28,7 +28,6 @@ vi.mock('../hooks', async () => {
     useVoteComment: () => defaultMutationReturn,
     useUnvoteComment: () => defaultMutationReturn,
     useCommentThread: () => ({ data: undefined as unknown }),
-    useAutoDismissError: actual.useAutoDismissError,
     formatCommentSubmissionError: actual.formatCommentSubmissionError,
   }
 })

--- a/frontend/features/comments/components/CommentThread.test.tsx
+++ b/frontend/features/comments/components/CommentThread.test.tsx
@@ -14,9 +14,9 @@ const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 vi.mock('../hooks', async () => {
   // PSY-589: bring through the real formatCommentSubmissionError so the
   // CommentThread test can assert on the exact banner copy under 429.
-  // PSY-608: also bring through useAutoDismissError so the CommentCard
-  // children rendered inside CommentThread can call the auto-dismiss
-  // banner state hook without panicking on undefined.
+  // PSY-958: the vote auto-dismiss banner now uses the shared
+  // useAutoDismissBanner primitive directly (unmocked), so the mock no longer
+  // needs to forward a comments-local hook for it.
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useComments: (...args: unknown[]) => mockUseComments(...args),

--- a/frontend/features/comments/components/CommentVoteControls.test.tsx
+++ b/frontend/features/comments/components/CommentVoteControls.test.tsx
@@ -21,8 +21,9 @@ const mockUseVoteComment = vi.fn()
 const mockUseUnvoteComment = vi.fn()
 
 vi.mock('../hooks', async () => {
-  // Real useAutoDismissError + formatCommentSubmissionError so the banner
-  // exercises canonical state + copy paths.
+  // Real formatCommentSubmissionError so the banner exercises canonical copy.
+  // The auto-dismiss banner itself now comes from the unmocked shared
+  // useAutoDismissBanner primitive (PSY-958), not a comments-local hook.
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useVoteComment: () => mockUseVoteComment(),
@@ -138,8 +139,9 @@ describe('CommentVoteControls', () => {
   })
 
   // PSY-608: optimistic vote/unvote rollback hides the failure visually.
-  // The primitive surfaces a brief auto-dismiss banner via useAutoDismissError
-  // so the user knows the action was reverted.
+  // The component surfaces a brief auto-dismiss banner via the shared
+  // useAutoDismissBanner primitive (PSY-958) so the user knows the action was
+  // reverted.
   describe('auto-dismiss vote-error banner (PSY-608)', () => {
     it('renders the banner when useVoteComment rejects via onError', () => {
       mockAuthContext.mockReturnValue({

--- a/frontend/features/comments/components/CommentVoteControls.test.tsx
+++ b/frontend/features/comments/components/CommentVoteControls.test.tsx
@@ -27,7 +27,6 @@ vi.mock('../hooks', async () => {
   return {
     useVoteComment: () => mockUseVoteComment(),
     useUnvoteComment: () => mockUseUnvoteComment(),
-    useAutoDismissError: actual.useAutoDismissError,
     formatCommentSubmissionError: actual.formatCommentSubmissionError,
   }
 })

--- a/frontend/features/comments/components/CommentVoteControls.tsx
+++ b/frontend/features/comments/components/CommentVoteControls.tsx
@@ -8,9 +8,9 @@ import { MutationErrorBanner } from './MutationErrorBanner'
 import {
   useVoteComment,
   useUnvoteComment,
-  useAutoDismissError,
   formatCommentSubmissionError,
 } from '../hooks'
+import { useAutoDismissBanner } from '@/lib/hooks/common/useAutoDismissBanner'
 import { type Comment } from '../types'
 
 interface CommentVoteControlsProps {
@@ -70,20 +70,23 @@ export function CommentVoteControls({
   const unvoteMutation = useUnvoteComment()
   // PSY-608: optimistic vote/unvote rollback hides the failure visually.
   // Show a brief auto-dismissing banner so the user knows the action was
-  // reverted, mirroring SaveButton / FavoriteVenueButton (~3s).
-  const voteError = useAutoDismissError()
+  // reverted, mirroring SaveButton / FavoriteVenueButton (~3s). PSY-958:
+  // routed through the shared useAutoDismissBanner primitive (was a
+  // comments-local useAutoDismissError, now removed).
+  const { value: voteError, show: showVoteError } =
+    useAutoDismissBanner<unknown>(3000)
 
   const handleVote = (direction: 1 | -1) => {
     if (!isAuthenticated) return
     if (comment.user_vote === direction) {
       unvoteMutation.mutate(
         { commentId: comment.id, entityType, entityId },
-        { onError: (err) => voteError.show(err) }
+        { onError: (err) => showVoteError(err) }
       )
     } else {
       voteMutation.mutate(
         { commentId: comment.id, direction, entityType, entityId },
-        { onError: (err) => voteError.show(err) }
+        { onError: (err) => showVoteError(err) }
       )
     }
   }
@@ -132,12 +135,12 @@ export function CommentVoteControls({
       {/* PSY-608: auto-dismiss banner for vote/unvote failures. The
           optimistic-rollback restores the cached state silently; without
           this, the user sees the icon flip back with no explanation. */}
-      {voteError.error !== null && (
+      {voteError !== null && (
         <MutationErrorBanner
           testId="vote-error-banner"
           marginTop={marginTop}
           message={
-            formatCommentSubmissionError(voteError.error) ??
+            formatCommentSubmissionError(voteError) ??
             'Vote failed. Please try again.'
           }
         />

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -32,7 +32,6 @@ vi.mock('../hooks', async () => {
     useVoteComment: () => mockUseVoteComment(),
     useUnvoteComment: () => mockUseUnvoteComment(),
     useCommentThread: () => ({ data: undefined as unknown }),
-    useAutoDismissError: actual.useAutoDismissError,
     formatCommentSubmissionError: actual.formatCommentSubmissionError,
   }
 })

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -21,9 +21,10 @@ const mockUseVoteComment = vi.fn()
 const mockUseUnvoteComment = vi.fn()
 
 vi.mock('../hooks', async () => {
-  // PSY-608: bring through the real formatCommentSubmissionError +
-  // useAutoDismissError so the FieldNoteCard renders the canonical inline
-  // error banner copy in tests.
+  // PSY-589: bring through the real formatCommentSubmissionError so the
+  // FieldNoteCard renders the canonical inline error banner copy. The vote
+  // auto-dismiss banner uses the shared useAutoDismissBanner primitive
+  // directly now (PSY-958, unmocked).
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useReplyToComment: () => mockUseReplyToComment(),

--- a/frontend/features/comments/components/FieldNotesSection.test.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.test.tsx
@@ -38,7 +38,6 @@ vi.mock('../hooks', async () => {
     useVoteComment: () => defaultMutationReturn,
     useUnvoteComment: () => defaultMutationReturn,
     useCommentThread: () => ({ data: undefined as unknown }),
-    useAutoDismissError: actual.useAutoDismissError,
     formatCommentSubmissionError: actual.formatCommentSubmissionError,
   }
 })

--- a/frontend/features/comments/hooks/index.test.ts
+++ b/frontend/features/comments/hooks/index.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { act, renderHook } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
 import type { ApiError } from '@/lib/api'
-import { formatCommentSubmissionError, useAutoDismissError } from './index'
+import { formatCommentSubmissionError } from './index'
 
 // PSY-589: the hook's 429 path must surface an inline error message
 // (instead of silently swallowing the failure and clearing the form).
@@ -54,89 +53,8 @@ describe('formatCommentSubmissionError (PSY-589)', () => {
   })
 })
 
-// PSY-608: auto-dismiss banner state for optimistic-rollback mutations.
-// The hook keeps the rollback's silent cache restore but surfaces a brief
-// "action was reverted" message so the user knows what happened.
-describe('useAutoDismissError (PSY-608)', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('starts with no error', () => {
-    const { result } = renderHook(() => useAutoDismissError())
-    expect(result.current.error).toBeNull()
-  })
-
-  it('exposes the error after show() is called', () => {
-    const { result } = renderHook(() => useAutoDismissError(3000))
-    const err = new Error('boom')
-
-    act(() => {
-      result.current.show(err)
-    })
-
-    expect(result.current.error).toBe(err)
-  })
-
-  it('clears the error after the timeout elapses', () => {
-    const { result } = renderHook(() => useAutoDismissError(3000))
-
-    act(() => {
-      result.current.show(new Error('boom'))
-    })
-    expect(result.current.error).not.toBeNull()
-
-    act(() => {
-      vi.advanceTimersByTime(3000)
-    })
-
-    expect(result.current.error).toBeNull()
-  })
-
-  it('resets the timer when show() is called again before timeout', () => {
-    const { result } = renderHook(() => useAutoDismissError(3000))
-
-    act(() => {
-      result.current.show(new Error('first'))
-    })
-    act(() => {
-      vi.advanceTimersByTime(2000)
-    })
-    // Re-trigger before timeout — second error visible, timer reset.
-    const second = new Error('second')
-    act(() => {
-      result.current.show(second)
-    })
-    expect(result.current.error).toBe(second)
-
-    // Original timeout would have fired by now, but the reset delays it.
-    act(() => {
-      vi.advanceTimersByTime(2000)
-    })
-    expect(result.current.error).toBe(second)
-
-    // Full second-timeout window completes.
-    act(() => {
-      vi.advanceTimersByTime(1000)
-    })
-    expect(result.current.error).toBeNull()
-  })
-
-  it('clears the pending timeout on unmount (no setState on unmounted component)', () => {
-    const { result, unmount } = renderHook(() => useAutoDismissError(3000))
-
-    act(() => {
-      result.current.show(new Error('boom'))
-    })
-    unmount()
-
-    // Advancing past the dismiss window must not throw or warn.
-    act(() => {
-      vi.advanceTimersByTime(5000)
-    })
-  })
-})
+// PSY-958: the comments-local `useAutoDismissError` (PSY-608) was removed and
+// its banner now uses the shared `useAutoDismissBanner` primitive. The
+// auto-dismiss timer lifecycle is tested in
+// `lib/hooks/common/useAutoDismissBanner.test.ts`; the vote-banner wiring is
+// covered by `CommentVoteControls.test.tsx`.

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiRequest, type ApiError } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
@@ -63,41 +62,11 @@ export function formatCommentSubmissionError(error: unknown): string | null {
   return 'Something went wrong. Please try again.'
 }
 
-/**
- * PSY-608: auto-dismiss banner state for optimistic-rollback mutations
- * (vote / unvote). Mirrors the SaveButton / FavoriteVenueButton pattern:
- * keep the rollback's silent cache restore, but surface a brief "action
- * was reverted" message so the user knows what just happened.
- *
- * - `error`: latest mutation error (or null when displayed window has
- *   elapsed). Use this in JSX to gate banner rendering.
- * - `show(error)`: call from `onError` with the failure to display it.
- *   Subsequent calls reset the timer.
- *
- * Cleans up the pending timeout on unmount and on each new `show()` call
- * so we never call setState on an unmounted component.
- */
-export function useAutoDismissError(timeoutMs = 3000): {
-  error: unknown
-  show: (error: unknown) => void
-} {
-  const [error, setError] = useState<unknown>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    }
-  }, [])
-
-  const show = (next: unknown) => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    setError(next)
-    timeoutRef.current = setTimeout(() => setError(null), timeoutMs)
-  }
-
-  return { error, show }
-}
+// PSY-958: the comments-local `useAutoDismissError` (PSY-608) was removed —
+// its vote/unvote banner now uses the shared `useAutoDismissBanner` primitive
+// (`@/lib/hooks/common/useAutoDismissBanner`) directly from
+// `CommentVoteControls`. This also resolves the name collision with
+// collections' (differently-shaped) `useAutoDismissError`.
 
 // ============================================================================
 // Queries

--- a/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.test.tsx
+++ b/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.test.tsx
@@ -62,6 +62,34 @@ describe('useEntitySaveSuccessBanner', () => {
     expect(result.current.isVisible).toBe(false)
   })
 
+  it('re-arms a full window when a second direct save lands while still visible (PSY-958)', () => {
+    // PSY-958 behavior note: the primitive re-arms on every trigger, so a
+    // repeat save extends the window to a fresh 5s from the latest save (the
+    // pre-PSY-958 [isVisible]-keyed effect did not re-arm).
+    const { result } = renderHook(() => useEntitySaveSuccessBanner())
+
+    act(() => {
+      result.current.handleSaveSuccess({ applied: true })
+    })
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    // Second save 3s in — must re-arm, not inherit the first window.
+    act(() => {
+      result.current.handleSaveSuccess({ applied: true })
+    })
+    // Past the FIRST save's original 5s deadline, still visible (re-armed).
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(result.current.isVisible).toBe(true)
+    // A full 5s after the second save, it dismisses.
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current.isVisible).toBe(false)
+  })
+
   it('clears the pending timer on unmount (no post-unmount state update)', () => {
     const { result, unmount } = renderHook(() =>
       useEntitySaveSuccessBanner()

--- a/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.ts
+++ b/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.ts
@@ -32,12 +32,16 @@ interface UseEntitySaveSuccessBannerResult {
  * Why a hook (not a `<Banner>` ref-component): the banner needs to outlive the
  * drawer (which closes on direct save) and live on the detail page itself, so
  * the timer + state must be owned by the page component. Putting it behind a
- * hook keeps the wiring at each of the 5 detail pages to one line.
+ * hook keeps the wiring at each of the 6 entity detail pages to one line.
  *
  * PSY-958: the show-then-auto-dismiss timer is the shared
  * {@link useAutoDismissFlag} primitive now; this hook keeps its name + shape
  * (the 6 detail-page consumers are untouched) and adds only the
- * `result.applied` gate on top.
+ * `result.applied` gate on top. Behavior note: a second direct save while the
+ * banner is still up now RE-ARMS the 5s window (the primitive re-arms on every
+ * `trigger()`); the pre-PSY-958 effect keyed on `[isVisible]` did not, so it
+ * let the original window run out. The re-armed behavior is the more correct
+ * one (each save gets a full window).
  */
 export function useEntitySaveSuccessBanner(): UseEntitySaveSuccessBannerResult {
   const [isVisible, trigger] = useAutoDismissFlag(AUTO_DISMISS_MS)

--- a/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.ts
+++ b/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.ts
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useCallback } from 'react'
+import { useAutoDismissFlag } from '@/lib/hooks/common/useAutoDismissBanner'
 import type { EntityEditSuccess } from '../types'
 
 /**
@@ -32,27 +33,25 @@ interface UseEntitySaveSuccessBannerResult {
  * drawer (which closes on direct save) and live on the detail page itself, so
  * the timer + state must be owned by the page component. Putting it behind a
  * hook keeps the wiring at each of the 5 detail pages to one line.
+ *
+ * PSY-958: the show-then-auto-dismiss timer is the shared
+ * {@link useAutoDismissFlag} primitive now; this hook keeps its name + shape
+ * (the 6 detail-page consumers are untouched) and adds only the
+ * `result.applied` gate on top.
  */
 export function useEntitySaveSuccessBanner(): UseEntitySaveSuccessBannerResult {
-  const [isVisible, setIsVisible] = useState(false)
+  const [isVisible, trigger] = useAutoDismissFlag(AUTO_DISMISS_MS)
 
-  const handleSaveSuccess = useCallback((result: EntityEditSuccess) => {
-    // Only flash on direct saves. Pending submissions keep the in-drawer
-    // amber "submitted for review" banner — the drawer stays open.
-    if (result.applied) {
-      setIsVisible(true)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!isVisible) return
-
-    const timer = setTimeout(() => {
-      setIsVisible(false)
-    }, AUTO_DISMISS_MS)
-
-    return () => clearTimeout(timer)
-  }, [isVisible])
+  const handleSaveSuccess = useCallback(
+    (result: EntityEditSuccess) => {
+      // Only flash on direct saves. Pending submissions keep the in-drawer
+      // amber "submitted for review" banner — the drawer stays open.
+      if (result.applied) {
+        trigger()
+      }
+    },
+    [trigger]
+  )
 
   return { isVisible, handleSaveSuccess }
 }

--- a/frontend/lib/hooks/common/useAutoDismissBanner.test.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.test.ts
@@ -254,6 +254,36 @@ describe('useAutoDismissBanner (PSY-957)', () => {
       expect(result.current.value).toBe('persist')
     })
 
+    it('fires once per elapsed window on re-show (not twice from the cancelled first timer)', () => {
+      // StatusBanner's re-arm path depends on this: a re-show cancels the
+      // first timer, so onAutoDismiss fires exactly once — when the SECOND
+      // window elapses.
+      const onAutoDismiss = vi.fn()
+      const { result } = renderHook(() =>
+        useAutoDismissBanner<string>(3000, { onAutoDismiss })
+      )
+
+      act(() => {
+        result.current.show('first')
+      })
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+      act(() => {
+        result.current.show('second')
+      })
+      // The first window's original deadline passes — must NOT fire (cancelled).
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(onAutoDismiss).not.toHaveBeenCalled()
+      // The second window completes — fires exactly once.
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+      expect(onAutoDismiss).toHaveBeenCalledTimes(1)
+    })
+
     it('uses the latest onAutoDismiss without re-arming the timer', () => {
       // An unmemoized callback must not reset the countdown each render.
       const first = vi.fn()

--- a/frontend/lib/hooks/common/useAutoDismissBanner.test.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.test.ts
@@ -182,6 +182,103 @@ describe('useAutoDismissBanner (PSY-957)', () => {
     expect(result.current.showSticky).toBe(showSticky)
     expect(result.current.clear).toBe(clear)
   })
+
+  // PSY-958: onAutoDismiss fires ONLY when the timer elapses — not on a manual
+  // clear, a sticky replacement, or unmount. StatusBanner maps its onDismiss
+  // prop onto this.
+  describe('onAutoDismiss (PSY-958)', () => {
+    it('fires when the auto-dismiss timer elapses', () => {
+      const onAutoDismiss = vi.fn()
+      const { result } = renderHook(() =>
+        useAutoDismissBanner<string>(3000, { onAutoDismiss })
+      )
+
+      act(() => {
+        result.current.show('x')
+      })
+      expect(onAutoDismiss).not.toHaveBeenCalled()
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+      expect(onAutoDismiss).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT fire on manual clear()', () => {
+      const onAutoDismiss = vi.fn()
+      const { result } = renderHook(() =>
+        useAutoDismissBanner<string>(3000, { onAutoDismiss })
+      )
+
+      act(() => {
+        result.current.show('x')
+      })
+      act(() => {
+        result.current.clear()
+      })
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(onAutoDismiss).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fire on unmount', () => {
+      const onAutoDismiss = vi.fn()
+      const { result, unmount } = renderHook(() =>
+        useAutoDismissBanner<string>(3000, { onAutoDismiss })
+      )
+
+      act(() => {
+        result.current.show('x')
+      })
+      unmount()
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(onAutoDismiss).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fire on showSticky()', () => {
+      const onAutoDismiss = vi.fn()
+      const { result } = renderHook(() =>
+        useAutoDismissBanner<string>(3000, { onAutoDismiss })
+      )
+
+      act(() => {
+        result.current.showSticky('persist')
+      })
+      act(() => {
+        vi.advanceTimersByTime(10_000)
+      })
+      expect(onAutoDismiss).not.toHaveBeenCalled()
+      expect(result.current.value).toBe('persist')
+    })
+
+    it('uses the latest onAutoDismiss without re-arming the timer', () => {
+      // An unmemoized callback must not reset the countdown each render.
+      const first = vi.fn()
+      const second = vi.fn()
+      const { result, rerender } = renderHook(
+        ({ cb }: { cb: () => void }) =>
+          useAutoDismissBanner<string>(3000, { onAutoDismiss: cb }),
+        { initialProps: { cb: first } }
+      )
+
+      act(() => {
+        result.current.show('x')
+      })
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+      // Swap the callback partway through — must NOT extend the window.
+      rerender({ cb: second })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(first).not.toHaveBeenCalled()
+      expect(second).toHaveBeenCalledTimes(1)
+    })
+  })
 })
 
 describe('useAutoDismissFlag (PSY-957)', () => {

--- a/frontend/lib/hooks/common/useAutoDismissBanner.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.ts
@@ -1,6 +1,17 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+interface AutoDismissOptions {
+  /**
+   * Fires when the auto-dismiss timer elapses and clears the value (NOT on a
+   * manual `clear()`, a `showSticky()` replacement, or unmount). Lets a
+   * caller react to "the banner timed out on its own" — e.g. `StatusBanner`'s
+   * `onDismiss` prop. The latest reference is always used, so it need not be
+   * memoized.
+   */
+  onAutoDismiss?: () => void
+}
 
 /**
  * PSY-957: the one timer implementation behind auto-dismiss banners. Holds a
@@ -29,14 +40,17 @@ import { useState, useEffect, useCallback } from 'react'
  * adjust-state-during-render idiom (collections' `useAutoDismissError` relies
  * on this).
  *
- * Scope note: this is the shared consolidation target named in PSY-957.
- * Collections adopts it now (its 5 banner call sites). The pre-existing
- * per-feature auto-dismiss timers — comments' `useAutoDismissError`
- * (`features/comments/hooks`), contributions' `useEntitySaveSuccessBanner`,
- * and `StatusBanner`'s embedded `dismissAfterMs` — are tracked for migration
- * onto this primitive separately so the refactor stays reviewable.
+ * Scope note: this is the shared auto-dismiss timer for the whole app. PSY-957
+ * landed it with collections as the first adopter; PSY-958 routed the
+ * remaining timers through it — comments' vote-error banner
+ * (`CommentVoteControls`), contributions' `useEntitySaveSuccessBanner`, and
+ * `StatusBanner`'s `dismissAfterMs` mode (via `onAutoDismiss`). New
+ * auto-dismiss banners should use this primitive, not a hand-rolled timer.
  */
-export function useAutoDismissBanner<T>(delayMs: number): {
+export function useAutoDismissBanner<T>(
+  delayMs: number,
+  options?: AutoDismissOptions
+): {
   value: T | null
   show: (value: T) => void
   showSticky: (value: T) => void
@@ -50,11 +64,26 @@ export function useAutoDismissBanner<T>(delayMs: number): {
     autoDismiss: boolean
   } | null>(null)
 
+  // Latest-ref the callback so an unmemoized `onAutoDismiss` doesn't sit in
+  // the timer effect's deps (which would re-arm — and reset — the countdown
+  // on every render). The timer still always invokes the current callback.
+  // The ref is updated in an effect (not during render) per React 19.2's
+  // no-ref-writes-during-render rule.
+  const onAutoDismissRef = useRef(options?.onAutoDismiss)
+  useEffect(() => {
+    onAutoDismissRef.current = options?.onAutoDismiss
+  })
+
   useEffect(() => {
     if (entry === null || !entry.autoDismiss) return
-    const timer = setTimeout(() => setEntry(null), delayMs)
+    const timer = setTimeout(() => {
+      setEntry(null)
+      onAutoDismissRef.current?.()
+    }, delayMs)
     // Cleanup covers every cancellation path: re-show (effect re-runs),
-    // sticky replacement, manual clear, and unmount.
+    // sticky replacement, manual clear, and unmount. onAutoDismiss fires ONLY
+    // on the timer callback above — never from this cleanup — so a re-show /
+    // clear / unmount does not spuriously signal "dismissed".
     return () => clearTimeout(timer)
   }, [entry, delayMs])
 
@@ -83,10 +112,14 @@ export function useAutoDismissBanner<T>(delayMs: number): {
  * sites read as `const [shown, show] = ...`. (The base hook returns an object
  * because it exposes three methods; the tuple here is the intentional
  * exception, not drift.) `trigger` is referentially stable, so it's safe in
- * dependency arrays.
+ * dependency arrays. Pass `options.onAutoDismiss` to react to the flag
+ * timing out (PSY-958 — `StatusBanner` maps its `onDismiss` prop this way).
  */
-export function useAutoDismissFlag(delayMs: number): [boolean, () => void] {
-  const { value, show } = useAutoDismissBanner<true>(delayMs)
+export function useAutoDismissFlag(
+  delayMs: number,
+  options?: AutoDismissOptions
+): [boolean, () => void] {
+  const { value, show } = useAutoDismissBanner<true>(delayMs, options)
   const trigger = useCallback(() => show(true), [show])
   return [value === true, trigger]
 }

--- a/frontend/lib/hooks/common/useAutoDismissBanner.ts
+++ b/frontend/lib/hooks/common/useAutoDismissBanner.ts
@@ -112,14 +112,11 @@ export function useAutoDismissBanner<T>(
  * sites read as `const [shown, show] = ...`. (The base hook returns an object
  * because it exposes three methods; the tuple here is the intentional
  * exception, not drift.) `trigger` is referentially stable, so it's safe in
- * dependency arrays. Pass `options.onAutoDismiss` to react to the flag
- * timing out (PSY-958 — `StatusBanner` maps its `onDismiss` prop this way).
+ * dependency arrays. Callers needing `onAutoDismiss` / `clear` (e.g.
+ * `StatusBanner`) use `useAutoDismissBanner` directly.
  */
-export function useAutoDismissFlag(
-  delayMs: number,
-  options?: AutoDismissOptions
-): [boolean, () => void] {
-  const { value, show } = useAutoDismissBanner<true>(delayMs, options)
+export function useAutoDismissFlag(delayMs: number): [boolean, () => void] {
+  const { value, show } = useAutoDismissBanner<true>(delayMs)
   const trigger = useCallback(() => show(true), [show])
   return [value === true, trigger]
 }


### PR DESCRIPTION
Closes PSY-958.

## Summary

Completes the cross-feature rollout PSY-957 started: the **collections** banners already used the shared `useAutoDismissBanner` / `useAutoDismissFlag` primitive (`@/lib/hooks/common/useAutoDismissBanner`); this routes the remaining three onto it.

- **comments** — deleted the comments-local `useAutoDismissError` (PSY-608); `CommentVoteControls` now uses `useAutoDismissBanner<unknown>(3000)` directly. **Resolves the name collision** with collections' (differently-shaped) `useAutoDismissError`.
- **contributions** — `useEntitySaveSuccessBanner` rebuilt on `useAutoDismissFlag` (keeps its name + `{ isVisible, handleSaveSuccess }` shape; the 6 entity-detail-page consumers are untouched), with only the `result.applied` gate on top.
- **StatusBanner** — its `dismissAfterMs` timed mode now runs through `useAutoDismissBanner`; the untimed (parent-controlled) mode renders unchanged.

To absorb StatusBanner, the primitive gains an optional **`onAutoDismiss`** callback that fires ONLY when the timer elapses (not on manual `clear()` / `showSticky()` / unmount) — mapped to StatusBanner's `onDismiss` prop. The callback is held in a latest-ref updated in an effect (per React 19.2's no-ref-writes-during-render rule) so an unmemoized callback never re-arms the countdown.

Pure behavior-preserving refactor; **no UI change**. Delays (3000/5000/4000), clear-on-unmount, and the `result.applied` gate are all preserved.

## Behavior notes (disclosed)

The shared primitive re-arms on every `show()`/`trigger()` (vs some of the old hand-rolled timers). Two consequences, both documented in code:

1. **contributions** — a second direct save while the banner is still up now re-arms the full 5s window (the old `[isVisible]`-keyed effect let the original window run out). More correct; pinned by a new test.
2. **StatusBanner content-change** — the window no longer re-arms when only the banner's `children` change while it stays mounted with a constant `dismissAfterMs`. A consumer that swaps a message per event must pass a `key` per message (idiomatic React identity reset). Caught by `/code-review`: **StreamingWorklist** did exactly this, so it now passes `key={recentMutation.nonce}` for a fresh window per success (FeaturedAdmin already null-then-sets, so it remounts naturally). The `dismissAfterMs` JSDoc now documents this contract.

## Deferred (filed as follow-up)

- **Other hand-rolled auto-dismiss banner timers** outside the cohesion-pass scope (ModerationQueue, PrivacySettingsPanel, RadioManagement, profile) — filed **PSY-966** to audit/consolidate. `SaveButton` / `FavoriteVenueButton` stay hand-rolled per the existing single-button-surface convention.

## Adversarial review

`/adversarial-review` — CONCERNS; all findings addressed in commit `fd5045de`. Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

- [HIGH, Saboteur] Claimed FeaturedAdmin's 3 banners lost re-arm → **REFUTED**: `handleSave` calls `setSuccessMessage(null)` synchronously before the async `mutate`, so a repeat save unmounts→remounts (fresh window). Verified against the actual handler; no fix needed.
- [MEDIUM] StatusBanner `dismissAfterMs` JSDoc stale + the `key`-per-message requirement invisible → rewrote the JSDoc.
- [MEDIUM] contributions re-arm change undocumented + untested → documented + added a test; fixed a stale "5 detail pages" count (it's 6).
- [MEDIUM] StreamingWorklist key/nonce re-arm untested → added an integration test (two successes → fresh window).
- [MEDIUM, Completeness] "remaining" over-claimed → filed PSY-966 (above), disclosed.
- [LOW] Stale `useAutoDismissError` comments in 4 comment test mocks → corrected.
- **Security: CLEAN** — client-side timer refactor; banner text is JSX-escaped; no new data flows; `onAutoDismiss` is per-instance, fires only on timer elapse.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (154 pre-existing warnings in unrelated files; PSY-955 gate)
- [x] `bun run test:run lib/hooks/common components/shared features/comments features/contributions features/admin/components/StreamingWorklist` — **782/782 passing**
  - `useAutoDismissBanner.test.ts` — new `onAutoDismiss` coverage (fires-once-on-elapse; NOT on clear/unmount/sticky; re-arm fires once for the 2nd window; latest-callback-without-re-arm)
  - `StatusBanner.test.tsx` — all 4 existing auto-dismiss behaviors still green against the rebuilt impl + new timed→untimed-stays-visible-no-onDismiss test
  - `useEntitySaveSuccessBanner.test.tsx` — existing suite green + new re-arm-on-repeat test
  - `StreamingWorklist.test.tsx` — new key/nonce re-arm integration test
  - `CommentVoteControls.test.tsx` + the comment-card suites — green against the unmocked shared primitive
  - `comments/hooks/index.test.ts` — `formatCommentSubmissionError` retained; the deleted `useAutoDismissError` lifecycle tests are covered by the primitive's own suite
- [x] `/code-review` (xhigh) — addressed (StatusBanner re-show regression → StreamingWorklist key fix; timed→untimed spurious onDismiss → clear-on-transition; reverted the unused `useAutoDismissFlag` options param)
- [x] `/adversarial-review` — CONCERNS addressed; fixes in separate commit `fd5045de`
- [x] `/psy-self-review` — see below
- [x] No UI surface change — all banners render byte-identically; only the timer lifecycle moved behind the shared primitive. Verified via the test suites above (incl. StatusBanner chrome assertions) rather than screenshots.

## Coverage gaps

- **Real browser timing** — auto-dismiss/sticky/re-arm verified with fake timers in jsdom, not a real clock.
- **No rendered screenshots** — pure refactor, no visual change (the banners' Tailwind chrome is asserted in `StatusBanner.test.tsx`).
- **The 4 deferred hand-rolled timers** (PSY-966) are untouched and out of scope.
- **Two StatusBanner mechanisms are exercised but not named by a dedicated test**: timed-mode first-paint visibility (the render-phase `DISMISS_UNSET` guard) is covered incidentally by the transition test's initial `getByRole('status')` assertion; the untimed `delayMs=0` path (no timer armed — gated on `dismissAfterMs !== undefined`, not the delay value) is covered by the "stays visible when dismissAfterMs unset" + timed→untimed tests.
