### PR TITLE
PSY-660: ReleaseDetail user-facing [Add link] + dialog

### DIFF
--- a/backend/internal/api/handlers/catalog/release.go
+++ b/backend/internal/api/handlers/catalog/release.go
@@ -12,10 +12,25 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/services/admin"
 	"psychic-homily-backend/internal/services/contracts"
 	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
 )
+
+// canAddReleaseLink reports whether the user may add an external link to a
+// release (PSY-660). Admins always may; otherwise the user must be a trusted
+// contributor or local ambassador. A nil user (which the rc.Protected JWT
+// middleware should already have rejected with 401) fails closed.
+func canAddReleaseLink(user *authm.User) bool {
+	if user == nil {
+		return false
+	}
+	return user.IsAdmin ||
+		user.UserTier == admin.TierTrustedContributor ||
+		user.UserTier == admin.TierLocalAmbassador
+}
 
 type ReleaseHandler struct {
 	releaseService  contracts.ReleaseServiceInterface
@@ -506,6 +521,13 @@ func (h *ReleaseHandler) AddExternalLinkHandler(ctx context.Context, req *AddExt
 	requestID := logger.GetRequestID(ctx)
 
 	user := middleware.GetUserFromContext(ctx)
+
+	// PSY-660: this route is on rc.Protected (JWT only), so authorize the tier
+	// here. Admins, trusted contributors, and local ambassadors may add links;
+	// everyone else is forbidden.
+	if !canAddReleaseLink(user) {
+		return nil, huma.Error403Forbidden("You do not have permission to add release links")
+	}
 
 	releaseID, err := strconv.ParseUint(req.ReleaseID, 10, 32)
 	if err != nil {

--- a/backend/internal/api/handlers/catalog/release_integration_test.go
+++ b/backend/internal/api/handlers/catalog/release_integration_test.go
@@ -325,6 +325,91 @@ func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_ReleaseNotFound() {
 	testhelpers.AssertHumaError(s.T(), err, 404)
 }
 
+// --- AddExternalLinkHandler authorization matrix (PSY-660) ---
+//
+// The POST /releases/{id}/links route lives on rc.Protected (JWT only), so the
+// handler authorizes the tier itself. Admin, trusted_contributor, and
+// local_ambassador may add links; new_user and contributor (and any
+// unauthenticated request) must be rejected. TestAddExternalLink_Success above
+// covers the admin case.
+
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_TrustedContributorSuccess() {
+	user := testhelpers.CreateUserWithTier(s.deps.DB, "trusted_contributor")
+	release := s.createReleaseViaService("Trusted Link Album")
+
+	ctx := testhelpers.CtxWithUser(user)
+	req := &AddExternalLinkRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Platform = "bandcamp"
+	req.Body.URL = "https://trusted.bandcamp.com/album/test"
+
+	resp, err := s.handler.AddExternalLinkHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("bandcamp", resp.Body.Platform)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_LocalAmbassadorSuccess() {
+	user := testhelpers.CreateUserWithTier(s.deps.DB, "local_ambassador")
+	release := s.createReleaseViaService("Ambassador Link Album")
+
+	ctx := testhelpers.CtxWithUser(user)
+	req := &AddExternalLinkRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Platform = "spotify"
+	req.Body.URL = "https://open.spotify.com/album/abc"
+
+	resp, err := s.handler.AddExternalLinkHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("spotify", resp.Body.Platform)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_NewUserForbidden() {
+	user := testhelpers.CreateUserWithTier(s.deps.DB, "new_user")
+	release := s.createReleaseViaService("Forbidden Link Album")
+
+	ctx := testhelpers.CtxWithUser(user)
+	req := &AddExternalLinkRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Platform = "bandcamp"
+	req.Body.URL = "https://new.bandcamp.com/album/test"
+
+	_, err := s.handler.AddExternalLinkHandler(ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 403)
+}
+
+// TestAddExternalLink_ContributorForbidden guards the lower-trust boundary: a
+// plain "contributor" (one tier below trusted_contributor) must NOT be able to
+// add links. Without this, accidentally widening the gate to include
+// contributor would slip through unnoticed.
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_ContributorForbidden() {
+	user := testhelpers.CreateUserWithTier(s.deps.DB, "contributor")
+	release := s.createReleaseViaService("Contributor Link Album")
+
+	ctx := testhelpers.CtxWithUser(user)
+	req := &AddExternalLinkRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Platform = "bandcamp"
+	req.Body.URL = "https://contributor.bandcamp.com/album/test"
+
+	_, err := s.handler.AddExternalLinkHandler(ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 403)
+}
+
+// TestAddExternalLink_UnauthenticatedForbidden documents the handler's
+// fail-closed behavior when no user is in context. In production the
+// rc.Protected JWT middleware returns 401 before the handler runs, so the
+// handler never sees a nil user on a real request; this asserts the
+// defense-in-depth 403 if that invariant is ever violated.
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_UnauthenticatedForbidden() {
+	release := s.createReleaseViaService("Anon Link Album")
+
+	// s.deps.Ctx carries no user.
+	req := &AddExternalLinkRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Platform = "bandcamp"
+	req.Body.URL = "https://anon.bandcamp.com/album/test"
+
+	_, err := s.handler.AddExternalLinkHandler(s.deps.Ctx, req)
+	testhelpers.AssertHumaError(s.T(), err, 403)
+}
+
 // --- RemoveExternalLinkHandler ---
 
 func (s *ReleaseHandlerIntegrationSuite) TestRemoveExternalLink_Success() {

--- a/backend/internal/api/handlers/shared/testhelpers/integration_deps.go
+++ b/backend/internal/api/handlers/shared/testhelpers/integration_deps.go
@@ -175,6 +175,22 @@ func CreateTestUser(db *gorm.DB) *authm.User {
 	return user
 }
 
+// CreateUserWithTier inserts a normal (non-admin) verified user at the given
+// user tier (e.g. "new_user", "trusted_contributor", "local_ambassador") and
+// returns it. Used by handlers that gate behavior on UserTier.
+func CreateUserWithTier(db *gorm.DB, tier string) *authm.User {
+	user := &authm.User{
+		Email:         StringPtr(fmt.Sprintf("user-%s-%d@test.com", tier, time.Now().UnixNano())),
+		FirstName:     StringPtr("Tier"),
+		LastName:      StringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+		UserTier:      tier,
+	}
+	db.Create(user)
+	return user
+}
+
 // CreateAdminUser inserts an admin user with a unique email and returns it.
 func CreateAdminUser(db *gorm.DB) *authm.User {
 	user := &authm.User{

--- a/backend/internal/api/routes/releases.go
+++ b/backend/internal/api/routes/releases.go
@@ -20,6 +20,11 @@ func setupReleaseRoutes(rc RouteContext) {
 	huma.Post(rc.Admin, "/releases", releaseHandler.CreateReleaseHandler)
 	huma.Put(rc.Admin, "/releases/{release_id}", releaseHandler.UpdateReleaseHandler)
 	huma.Delete(rc.Admin, "/releases/{release_id}", releaseHandler.DeleteReleaseHandler)
-	huma.Post(rc.Admin, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
+
+	// PSY-660: adding a release link is open to trusted contributors and local
+	// ambassadors (plus admins), so it registers on rc.Protected (JWT only) and
+	// AddExternalLinkHandler authorizes the tier itself. Deleting a link stays
+	// admin-only on rc.Admin.
+	huma.Post(rc.Protected, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
 	huma.Delete(rc.Admin, "/releases/{release_id}/links/{link_id}", releaseHandler.RemoveExternalLinkHandler)
 }

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -51,6 +51,7 @@ import {
 import {
   RELEASE_TYPES,
   RELEASE_TYPE_LABELS,
+  EXTERNAL_LINK_PLATFORMS,
   getReleaseTypeLabel,
   type ReleaseType,
   type ReleaseDetail,
@@ -68,16 +69,6 @@ const ARTIST_ROLES = [
   { value: 'remixer', label: 'Remixer' },
   { value: 'composer', label: 'Composer' },
   { value: 'dj', label: 'DJ' },
-] as const
-
-const EXTERNAL_LINK_PLATFORMS = [
-  { value: 'bandcamp', label: 'Bandcamp' },
-  { value: 'spotify', label: 'Spotify' },
-  { value: 'apple_music', label: 'Apple Music' },
-  { value: 'youtube', label: 'YouTube' },
-  { value: 'discogs', label: 'Discogs' },
-  { value: 'tidal', label: 'Tidal' },
-  { value: 'soundcloud', label: 'SoundCloud' },
 ] as const
 
 type DialogMode = 'create' | 'edit' | 'delete' | null

--- a/frontend/features/releases/components/AddReleaseLinkDialog.test.tsx
+++ b/frontend/features/releases/components/AddReleaseLinkDialog.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, within, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { AddReleaseLinkDialog } from './AddReleaseLinkDialog'
+
+// Capture the add-link mutation so flows can assert wiring without a backend.
+const mockMutate = vi.fn()
+const mockReset = vi.fn()
+let mutationState = {
+  mutate: mockMutate,
+  reset: mockReset,
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+  error: null as Error | null,
+}
+vi.mock('../hooks/useAdminReleases', () => ({
+  useAddReleaseLink: () => mutationState,
+}))
+
+function renderDialog() {
+  return renderWithProviders(
+    <AddReleaseLinkDialog
+      open
+      onOpenChange={vi.fn()}
+      releaseId={42}
+      releaseTitle="In Rainbows"
+    />
+  )
+}
+
+describe('AddReleaseLinkDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutationState = {
+      mutate: mockMutate,
+      reset: mockReset,
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    }
+  })
+
+  it('renders the dialog header quoting the release title', () => {
+    renderDialog()
+    const dialog = screen.getByRole('dialog')
+    // "Add link" also labels the submit button, so target the title heading.
+    expect(
+      within(dialog).getByRole('heading', { name: /Add link/ })
+    ).toBeInTheDocument()
+    expect(within(dialog).getByText(/In Rainbows/)).toBeInTheDocument()
+  })
+
+  it('offers all 7 external link platforms in the Select', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.click(screen.getByRole('combobox', { name: 'Link platform' }))
+
+    // Radix renders options into a portaled listbox.
+    const listbox = await screen.findByRole('listbox')
+    const options = within(listbox).getAllByRole('option')
+    expect(options).toHaveLength(7)
+    expect(within(listbox).getByText('Bandcamp')).toBeInTheDocument()
+    expect(within(listbox).getByText('Spotify')).toBeInTheDocument()
+    expect(within(listbox).getByText('Apple Music')).toBeInTheDocument()
+    expect(within(listbox).getByText('YouTube')).toBeInTheDocument()
+    expect(within(listbox).getByText('Discogs')).toBeInTheDocument()
+    expect(within(listbox).getByText('Tidal')).toBeInTheDocument()
+    expect(within(listbox).getByText('SoundCloud')).toBeInTheDocument()
+  })
+
+  it('shows a validation error and blocks submit for a malformed URL', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    const urlInput = screen.getByLabelText('URL')
+    await user.type(urlInput, 'not-a-url')
+
+    expect(
+      screen.getByText(/Enter a valid URL starting with http/i)
+    ).toBeInTheDocument()
+
+    const submit = screen.getByRole('button', { name: /Add link/i })
+    expect(submit).toBeDisabled()
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('keeps submit disabled while the URL is empty', () => {
+    renderDialog()
+    const submit = screen.getByRole('button', { name: /Add link/i })
+    expect(submit).toBeDisabled()
+  })
+
+  it('submits the platform + URL for a valid entry', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    const urlInput = screen.getByLabelText('URL')
+    await user.type(urlInput, 'https://radiohead.bandcamp.com/album/in-rainbows')
+
+    const submit = screen.getByRole('button', { name: /Add link/i })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+
+    expect(mockMutate).toHaveBeenCalledTimes(1)
+    const [payload] = mockMutate.mock.calls[0]
+    expect(payload).toMatchObject({
+      releaseId: 42,
+      platform: 'bandcamp',
+      url: 'https://radiohead.bandcamp.com/album/in-rainbows',
+    })
+  })
+
+  it('renders a success banner and Close button after a successful add', async () => {
+    const user = userEvent.setup()
+    // Drive the success path: mutate fires its onSuccess callback (the real
+    // hook does this after the POST resolves), and the mutation reports success.
+    mockMutate.mockImplementation((_payload, opts) => {
+      mutationState = { ...mutationState, isSuccess: true }
+      opts?.onSuccess?.()
+    })
+    mutationState = { ...mutationState, isSuccess: true }
+    renderDialog()
+
+    const urlInput = screen.getByLabelText('URL')
+    await user.type(urlInput, 'https://radiohead.bandcamp.com/album/x')
+    const submit = screen.getByRole('button', { name: /Add link/i })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+
+    // Form is replaced by the success banner; the footer Close button appears.
+    // (Radix Dialog also renders a built-in close "X" with an sr-only "Close"
+    // label, so there are two "Close" buttons — assert the footer one exists.)
+    expect(screen.getByText('Link added')).toBeInTheDocument()
+    expect(screen.queryByLabelText('URL')).not.toBeInTheDocument()
+    const closeButtons = screen.getAllByRole('button', { name: 'Close' })
+    const footerClose = closeButtons.find(
+      (b) => b.getAttribute('data-slot') === 'button'
+    )
+    expect(footerClose).toBeDefined()
+  })
+
+  it('shows the backend error message when the mutation fails', () => {
+    mutationState = {
+      ...mutationState,
+      isError: true,
+      error: new Error('You do not have permission to add release links'),
+    }
+    renderDialog()
+    expect(
+      screen.getByText('You do not have permission to add release links')
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/features/releases/components/AddReleaseLinkDialog.tsx
+++ b/frontend/features/releases/components/AddReleaseLinkDialog.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import { useState } from 'react'
+import { ExternalLink, Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { StatusBanner } from '@/components/shared'
+// validateUrlField is not re-exported from the contributions barrel; import it
+// from the types module directly (the canonical home shared with edit forms).
+import { validateUrlField } from '@/features/contributions/types'
+import { useAddReleaseLink } from '../hooks/useAdminReleases'
+import { EXTERNAL_LINK_PLATFORMS } from '../types'
+
+interface AddReleaseLinkDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  releaseId: number
+  /**
+   * Release title, quoted in the dialog description so the curator knows which
+   * release they're attaching a link to.
+   */
+  releaseTitle: string
+}
+
+/**
+ * User-facing dialog for adding an external (Listen / Buy) link to a release
+ * (PSY-660). Mirrors {@link ReportEntityDialog}'s shell: `sm:max-w-md`,
+ * DialogHeader (title + description), a platform Select + URL Input body, and a
+ * Cancel / Add footer.
+ *
+ * Authorization is enforced backend-side (admin + trusted_contributor +
+ * local_ambassador on POST /releases/{id}/links). The caller is responsible
+ * for only rendering the trigger to authorized viewers; this dialog surfaces
+ * whatever error the backend returns (e.g. a 403) via the destructive banner.
+ */
+export function AddReleaseLinkDialog({
+  open,
+  onOpenChange,
+  releaseId,
+  releaseTitle,
+}: AddReleaseLinkDialogProps) {
+  const [platform, setPlatform] = useState<string>(
+    EXTERNAL_LINK_PLATFORMS[0].value
+  )
+  const [url, setUrl] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+  const addLink = useAddReleaseLink()
+
+  // Client-side URL validation is UX-only; the backend remains the source of
+  // truth. Empty is invalid here (the field is required to add a link), unlike
+  // validateUrlField's "empty = clear-the-field" intent on edit forms.
+  const trimmedUrl = url.trim()
+  const urlFormatError = validateUrlField(url)
+  const canSubmit =
+    trimmedUrl.length > 0 && urlFormatError === null && !addLink.isPending
+
+  const handleSubmit = () => {
+    if (!canSubmit) return
+    addLink.mutate(
+      { releaseId, platform, url: trimmedUrl },
+      {
+        onSuccess: () => {
+          setSubmitted(true)
+        },
+      }
+    )
+  }
+
+  const handleClose = (newOpen: boolean) => {
+    if (!newOpen) {
+      // Reset state when closing so the next open starts fresh.
+      setPlatform(EXTERNAL_LINK_PLATFORMS[0].value)
+      setUrl('')
+      setSubmitted(false)
+      addLink.reset()
+    }
+    onOpenChange(newOpen)
+  }
+
+  const showSuccess = submitted && addLink.isSuccess
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ExternalLink className="h-5 w-5 text-primary" />
+            Add link
+          </DialogTitle>
+          <DialogDescription>
+            Add a Listen / Buy link to &quot;{releaseTitle}&quot;.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Success state */}
+        {showSuccess && (
+          <StatusBanner variant="success">
+            <div>
+              <span className="font-medium text-success-foreground">
+                Link added
+              </span>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Your link now appears in the release&apos;s Listen / Buy
+                section.
+              </p>
+            </div>
+          </StatusBanner>
+        )}
+
+        {/* Error state — mirrors ReportEntityDialog's destructive block.
+            StatusBanner has no error variant (success / pending only). */}
+        {addLink.isError && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {(addLink.error as Error)?.message ||
+              'Failed to add link. Please try again.'}
+          </div>
+        )}
+
+        {/* Form */}
+        {!showSuccess && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="add-link-platform">Platform</Label>
+              <Select value={platform} onValueChange={setPlatform}>
+                <SelectTrigger
+                  id="add-link-platform"
+                  className="w-full"
+                  aria-label="Link platform"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {EXTERNAL_LINK_PLATFORMS.map((p) => (
+                    <SelectItem key={p.value} value={p.value}>
+                      {p.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="add-link-url">URL</Label>
+              <Input
+                id="add-link-url"
+                placeholder="https://..."
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleSubmit()
+                  }
+                }}
+                aria-invalid={urlFormatError !== null}
+              />
+              {urlFormatError && (
+                <p className="text-sm text-destructive">{urlFormatError}</p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {!showSuccess && (
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => handleClose(false)}
+              disabled={addLink.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={!canSubmit}>
+              {addLink.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Adding...
+                </>
+              ) : (
+                <>
+                  <ExternalLink className="h-4 w-4 mr-2" />
+                  Add link
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        )}
+
+        {showSuccess && (
+          <DialogFooter>
+            <Button onClick={() => handleClose(false)}>Close</Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/features/releases/components/ReleaseDetail.test.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.test.tsx
@@ -136,6 +136,21 @@ vi.mock('@/features/tags', () => ({
     open ? <div data-testid="add-tag-dialog">Add Tag</div> : null,
 }))
 
+// PSY-660: the add-link dialog renders only when opened via the [Add link]
+// bracket (which is itself tier-gated).
+vi.mock('./AddReleaseLinkDialog', () => ({
+  AddReleaseLinkDialog: ({
+    open,
+    releaseTitle,
+  }: {
+    open: boolean
+    releaseTitle: string
+  }) =>
+    open ? (
+      <div data-testid="add-link-dialog">Add link to {releaseTitle}</div>
+    ) : null,
+}))
+
 vi.mock('@/features/radio', () => ({
   AsHeardOn: ({
     entityType,
@@ -368,6 +383,13 @@ describe('ReleaseDetail', () => {
       render(<ReleaseDetail idOrSlug="in-rainbows" />)
       expect(screen.queryByTitle('Report an issue')).not.toBeInTheDocument()
     })
+
+    // PSY-660: the add-link affordance is tier-gated, so anonymous users never
+    // see it.
+    it('does not render the Add link bracket for anonymous users', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.queryByText('Add link')).not.toBeInTheDocument()
+    })
   })
 
   describe('contributor affordances', () => {
@@ -411,6 +433,86 @@ describe('ReleaseDetail', () => {
       })
       render(<ReleaseDetail idOrSlug="in-rainbows" />)
       expect(screen.getByText('Suggest description')).toBeInTheDocument()
+    })
+
+    // PSY-660: the [Add link] bracket is gated to admin / trusted_contributor /
+    // local_ambassador — the same tiers the backend authorizes. A plain
+    // contributor (and new_user) must NOT see it, since the backend would 403.
+    it('does not show the Add link bracket for a plain contributor', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'contributor' },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.queryByText('Add link')).not.toBeInTheDocument()
+    })
+
+    it('does not show the Add link bracket for a new_user', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'new_user' },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.queryByText('Add link')).not.toBeInTheDocument()
+    })
+
+    it('shows the Add link bracket for a trusted_contributor and opens the dialog', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'trusted_contributor' },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+
+      const addLink = screen.getByText('Add link')
+      expect(addLink).toBeInTheDocument()
+      // Dialog is closed until the bracket is clicked.
+      expect(screen.queryByTestId('add-link-dialog')).not.toBeInTheDocument()
+
+      fireEvent.click(addLink)
+      expect(screen.getByText('Add link to In Rainbows')).toBeInTheDocument()
+    })
+
+    it('shows the Add link bracket for a local_ambassador', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'local_ambassador' },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.getByText('Add link')).toBeInTheDocument()
+    })
+
+    it('shows the Add link bracket for an admin', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: true },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.getByText('Add link')).toBeInTheDocument()
     })
 
     // PSY-661: signed-in users get a [Report] affordance that opens the

--- a/frontend/features/releases/components/ReleaseDetail.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/shared'
 import { AttributionLine, ContributionPrompt, EntityEditDrawer, EntitySaveSuccessBanner, ReportEntityDialog, useEntitySaveSuccessBanner } from '@/features/contributions'
 import { EntityTagList, AddTagDialog } from '@/features/tags'
+import { AddReleaseLinkDialog } from './AddReleaseLinkDialog'
 import { AsHeardOn } from '@/features/radio'
 import { EntityCollections } from '@/features/collections'
 import { CommentThread } from '@/features/comments'
@@ -71,9 +72,15 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
     user?.user_tier === 'trusted_contributor' ||
     user?.user_tier === 'local_ambassador'
   )
+  // PSY-660: adding an external link is gated to admin + trusted_contributor +
+  // local_ambassador (the same tiers the backend authorizes on POST
+  // /releases/{id}/links). Gating on the tier — not plain isAuthenticated —
+  // keeps a new_user from seeing a [Add link] bracket the backend would 403.
+  const canAddLink = !!canEditDirectly
   const [isEditing, setIsEditing] = useState(false)
   const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [addTagDialogOpen, setAddTagDialogOpen] = useState(false)
+  const [addLinkDialogOpen, setAddLinkDialogOpen] = useState(false)
   const [isReportOpen, setIsReportOpen] = useState(false)
   const saveBanner = useEntitySaveSuccessBanner()
 
@@ -268,6 +275,13 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
                       }}
                     />
                   )}
+                  {canAddLink && (
+                    <BracketLink
+                      label="Add link"
+                      title="Add a Listen / Buy link"
+                      onClick={() => setAddLinkDialogOpen(true)}
+                    />
+                  )}
                   {isAuthenticated && (
                     <BracketLink
                       label="Add tag"
@@ -412,6 +426,17 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
           entityId={release.id}
           open={addTagDialogOpen}
           onOpenChange={setAddTagDialogOpen}
+        />
+      )}
+
+      {/* Add link dialog — PSY-660. Gated to admin/trusted/local_ambassador;
+          backend enforces the same tier on POST /releases/{id}/links. */}
+      {canAddLink && (
+        <AddReleaseLinkDialog
+          releaseId={release.id}
+          releaseTitle={release.title}
+          open={addLinkDialogOpen}
+          onOpenChange={setAddLinkDialogOpen}
         />
       )}
 

--- a/frontend/features/releases/types.ts
+++ b/frontend/features/releases/types.ts
@@ -49,6 +49,23 @@ export interface ReleaseExternalLink {
   url: string
 }
 
+/**
+ * Platforms offered when adding an external link to a release. Shared by the
+ * admin release editor (`features/releases/admin/ReleaseManagement.tsx`) and
+ * the user-facing add-link dialog (`AddReleaseLinkDialog`, PSY-660) so the two
+ * surfaces never drift apart. Keep in sync with the backend's accepted
+ * platform values.
+ */
+export const EXTERNAL_LINK_PLATFORMS = [
+  { value: 'bandcamp', label: 'Bandcamp' },
+  { value: 'spotify', label: 'Spotify' },
+  { value: 'apple_music', label: 'Apple Music' },
+  { value: 'youtube', label: 'YouTube' },
+  { value: 'discogs', label: 'Discogs' },
+  { value: 'tidal', label: 'Tidal' },
+  { value: 'soundcloud', label: 'SoundCloud' },
+] as const
+
 export interface ReleaseLabel {
   id: number
   name: string


### PR DESCRIPTION
## Summary

Opens `POST /releases/{id}/links` to **trusted contributors and local
ambassadors** (in addition to admins) and adds a user-facing **[Add link]**
affordance on the release detail page so those tiers can attach Listen / Buy
links without the admin editor. `DELETE` stays admin-only.

**Backend** (`backend/internal/api/...`)
- `routes/releases.go`: move `POST /releases/{id}/links` from `rc.Admin` to
  `rc.Protected` (JWT only); `DELETE` unchanged on `rc.Admin`.
- `handlers/catalog/release.go`: new `canAddReleaseLink` helper authorizes
  `IsAdmin || user_tier == trusted_contributor || user_tier == local_ambassador`
  (using the canonical `admin.Tier*` constants); a nil user fails closed (403).
  Gate runs before the existing audit-log `user.ID` access, so moving off the
  admin group can't nil-deref.
- `handlers/shared/testhelpers/integration_deps.go`: new `CreateUserWithTier`.

**Frontend** (`frontend/features/releases/...`)
- `types.ts`: lift `EXTERNAL_LINK_PLATFORMS` here (was private to
  `admin/ReleaseManagement.tsx`); the admin editor and the new dialog now share
  one definition.
- `components/AddReleaseLinkDialog.tsx` (new): platform `Select` + URL `Input` +
  client-side `validateUrlField`, mirroring `ReportEntityDialog`'s shell
  (`sm:max-w-md`, header, Cancel / Add footer). Success → `StatusBanner`;
  backend errors → the destructive block (`StatusBanner` has no error variant).
- `components/ReleaseDetail.tsx`: `[Add link]` BracketLink in the header linkbox
  between `[Suggest description]` and `[Add tag]`, plus the page-level dialog —
  both gated on `canAddLink` (admin / trusted / ambassador), not plain
  `isAuthenticated`, so a `new_user` never sees a bracket the backend would 403.

## Test plan

- [x] `cd backend && go build ./...` — pass
- [x] `cd backend && go test ./internal/api/handlers/catalog/... ./internal/api/routes/...` — pass (catalog 18.8s incl. authz-matrix suite; routes pass)
- [x] Backend authz-matrix integration tests: admin / trusted_contributor / local_ambassador → 200; contributor / new_user / no-user → 403
- [x] `cd frontend && bun run typecheck` — pass (0 errors)
- [x] `cd frontend && bun run test:run features/releases` — pass (137 tests, incl. 7 new dialog tests + 6 new bracket-gating tests)
- [x] `cd frontend && bun run lint` — pass (0 errors; pre-existing repo warnings only)

## Manual repro

Isolated dispatch stack (`stack-up.sh --mode=isolated`); promoted a seeded user
to `trusted_contributor` via `psql ... UPDATE users SET
user_tier='trusted_contributor' WHERE email='e2e-user-1@test.local'`.

- Signed in as the trusted user, opened `/releases/futures`: `[Add link]`
  renders between `[Suggest description]` and `[Add tag]`.
- Clicked `[Add link]`, picked Bandcamp, entered a URL, submitted → success
  banner; the link appears in the **Listen / Buy** section.
- Verified persistence:
  `SELECT platform, url FROM release_external_links WHERE url LIKE '%futures-test%'`
  → `bandcamp | https://psychichomily.bandcamp.com/album/futures-test`.
- **Negative check:** demoted another seeded user to `new_user`, signed in,
  reloaded the release — the `[Add link]` bracket is absent (only
  `[Suggest edit] [Suggest description] [Add tag] [Report]` show).

Stack torn down with `stack-down.sh`.

## Screenshots

| | |
|---|---|
| Header (trusted) — `[Add link]` between `[Suggest description]` and `[Add tag]` | ![header](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-823b6de1a2d694d3181c/01-release-header-trusted.png) |
| Add-link dialog | ![dialog](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-823b6de1a2d694d3181c/02-add-link-dialog.png) |
| Success banner | ![success](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-823b6de1a2d694d3181c/03-link-added-success.png) |
| Link in Listen / Buy | ![listen-buy](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-823b6de1a2d694d3181c/04-listen-buy-with-added-link.png) |
| `new_user` — no `[Add link]` bracket (negative check) | ![new-user](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-823b6de1a2d694d3181c/05-new-user-no-add-link.png) |

## Code review

`/code-review` (3 lenses, inline — no Agent tool in worktree). Clean, no fixes:
- **Correctness:** the load-bearing risk (nil `user.ID` at the audit-log site
  after leaving `rc.Admin`) is closed by the `canAddReleaseLink` 403 guard
  running first; no import cycle (`go build` passes); `canSubmit` correctly
  requires a non-empty, well-formed URL.
- **Reuse:** `canAddLink = !!canEditDirectly` reuses the existing predicate
  instead of duplicating the tier check; the lifted constant removes the fork.
- **Efficiency:** no wasted work; invalidation reuses the existing `['releases']`
  key.

## Adversarial review

`/adversarial-review` (4 lenses, inline) — **CLEAN**, no fixes (no separate
commit). Panel: Saboteur · Future-Maintainer · Security · Completeness, run
against the branch diff with no prior session context.
- **Saboteur:** whitespace-only / empty / malformed URLs are all blocked by
  `canSubmit`; double-submit guarded by `!isPending`; close always resets state
  via Radix `onOpenChange`.
- **Security:** authz enforced server-side (route + handler tier gate), DELETE
  unchanged; the UI gate is defense-in-depth; 403 message leaks nothing.
- **Future-Maintainer / Completeness:** all acceptance criteria met; only
  LOW notes (the intentional `canAddLink`/`canEditDirectly` alias; the
  `services/admin` tier-constant import), no changes warranted.

Closes PSY-660
