### PR TITLE
PSY-666: add label entity to the reporting subsystem

### DIFF
--- a/backend/internal/api/handlers/community/entity_report.go
+++ b/backend/internal/api/handlers/community/entity_report.go
@@ -89,6 +89,13 @@ func (h *EntityReportHandler) ReportReleaseHandler(ctx context.Context, req *Rep
 	return h.reportEntity(ctx, "release", req)
 }
 
+// ReportLabelHandler handles POST /labels/{entity_id}/report.
+// PSY-666. EntityID is the label's numeric ID; the moderation queue
+// resolves it back to a slug-based public link via resolveEntityNameAndSlug.
+func (h *EntityReportHandler) ReportLabelHandler(ctx context.Context, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	return h.reportEntity(ctx, "label", req)
+}
+
 // reportEntity is the shared implementation for all report endpoints.
 func (h *EntityReportHandler) reportEntity(ctx context.Context, entityType string, req *ReportEntityRequest) (*ReportEntityResponse, error) {
 	user := middleware.GetUserFromContext(ctx)

--- a/backend/internal/api/handlers/community/entity_report_test.go
+++ b/backend/internal/api/handlers/community/entity_report_test.go
@@ -298,6 +298,48 @@ func TestReportRelease_InvalidReportType(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 422)
 }
 
+// PSY-666: labels accept the same shape as the other entity types.
+// The taxonomy is label-tailored (inaccurate/duplicate/wrong_image/
+// missing_info) — see entity_report.go for the rationale. "Defunct" is
+// intentionally NOT a report type (it's a status-field edit).
+func TestReportLabel_Success(t *testing.T) {
+	expected := makeEntityReportResponse(8, "label", "wrong_image")
+	h := NewEntityReportHandler(
+		&testhelpers.MockEntityReportService{
+			CreateEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				if req.EntityType != "label" {
+					t.Errorf("expected entity_type=label, got %s", req.EntityType)
+				}
+				if req.ReportType != "wrong_image" {
+					t.Errorf("expected report_type=wrong_image, got %s", req.ReportType)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "wrong_image"
+
+	resp, err := h.ReportLabelHandler(entityReportUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.EntityType != "label" {
+		t.Errorf("expected entity_type=label, got %s", resp.Body.EntityType)
+	}
+}
+
+func TestReportLabel_InvalidReportType(t *testing.T) {
+	// e.g. "wrong_venue" is valid for shows but not for labels.
+	h := testEntityReportHandler()
+	req := &ReportEntityRequest{EntityID: "1"}
+	req.Body.ReportType = "wrong_venue"
+	_, err := h.ReportLabelHandler(entityReportUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
 // ============================================================================
 // Tests: Report Entity — Error Cases
 // ============================================================================

--- a/backend/internal/api/routes/reports.go
+++ b/backend/internal/api/routes/reports.go
@@ -101,6 +101,9 @@ func setupEntityReportRoutes(rc RouteContext) {
 		// PSY-661: report a release. EntityID is the numeric release ID; the
 		// moderation queue deep-links via the resolved slug.
 		huma.Post(reportAPI, "/releases/{entity_id}/report", entityReportHandler.ReportReleaseHandler)
+		// PSY-666: report a label. EntityID is the numeric label ID; the
+		// moderation queue deep-links via the resolved slug.
+		huma.Post(reportAPI, "/labels/{entity_id}/report", entityReportHandler.ReportLabelHandler)
 	})
 
 	// Admin: entity report management (PSY-423: rc.Admin enforces auth + IsAdmin)

--- a/backend/internal/models/community/entity_report.go
+++ b/backend/internal/models/community/entity_report.go
@@ -24,6 +24,7 @@ const (
 	EntityReportEntityComment    = "comment"
 	EntityReportEntityCollection = "collection"
 	EntityReportEntityRelease    = "release"
+	EntityReportEntityLabel      = "label"
 )
 
 // Valid report types per entity type.
@@ -95,6 +96,21 @@ var validReportTypes = map[string]map[string]bool{
 		"wrong_artist_attribution": true,
 		"missing_info":             true,
 	},
+	// PSY-666: label-tailored taxonomy. Like the PSY-578 collection and
+	// PSY-661 release sets, this is intentionally tailored rather than
+	// reusing the generic artist/venue vocabulary:
+	//   - duplicate: the same label entered twice under a different entry.
+	//   - wrong_image: the label logo/image is incorrect (labels carry an
+	//     image_url; "inaccurate" would bury that field-specific report).
+	//   - inaccurate / missing_info: catch-alls for name/bio/other data.
+	// "Defunct label" is deliberately NOT a report type — label lifecycle is
+	// a `status` field edit (active/defunct), not a moderation report.
+	EntityReportEntityLabel: {
+		"inaccurate":   true,
+		"duplicate":    true,
+		"wrong_image":  true,
+		"missing_info": true,
+	},
 }
 
 // EntityReport represents a user report about an entity issue.
@@ -129,6 +145,7 @@ func ValidEntityReportEntityTypes() []string {
 		EntityReportEntityComment,
 		EntityReportEntityCollection,
 		EntityReportEntityRelease,
+		EntityReportEntityLabel,
 	}
 }
 

--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -30,9 +30,9 @@ func TestEntityReportModel_Validation(t *testing.T) {
 	assert.True(t, communitym.IsValidEntityReportEntityType("collection"))
 	// PSY-661: releases are now reportable.
 	assert.True(t, communitym.IsValidEntityReportEntityType("release"))
+	// PSY-666: labels are now reportable.
+	assert.True(t, communitym.IsValidEntityReportEntityType("label"))
 	assert.False(t, communitym.IsValidEntityReportEntityType(""))
-	// label is still not a reportable entity type (see PSY-666).
-	assert.False(t, communitym.IsValidEntityReportEntityType("label"))
 
 	// Valid report types per entity
 	assert.True(t, communitym.IsValidReportType("artist", "inaccurate"))
@@ -80,8 +80,17 @@ func TestEntityReportModel_Validation(t *testing.T) {
 	assert.False(t, communitym.IsValidReportType("release", "wrong_image"))
 	assert.False(t, communitym.IsValidReportType("release", "cancelled"))
 
-	// Still-invalid entity type (label is not reportable — see PSY-666).
-	assert.False(t, communitym.IsValidReportType("label", "inaccurate"))
+	// PSY-666: label-tailored taxonomy (inaccurate/duplicate/wrong_image/
+	// missing_info). "Defunct" is intentionally NOT a report type — it's a
+	// status-field edit.
+	assert.True(t, communitym.IsValidReportType("label", "inaccurate"))
+	assert.True(t, communitym.IsValidReportType("label", "duplicate"))
+	assert.True(t, communitym.IsValidReportType("label", "wrong_image"))
+	assert.True(t, communitym.IsValidReportType("label", "missing_info"))
+	// Types from other taxonomies are not valid for labels.
+	assert.False(t, communitym.IsValidReportType("label", "removal_request"))
+	assert.False(t, communitym.IsValidReportType("label", "defunct"))
+	assert.False(t, communitym.IsValidReportType("label", "cancelled"))
 }
 
 func TestValidReportTypesForEntity(t *testing.T) {
@@ -105,14 +114,18 @@ func TestValidReportTypesForEntity(t *testing.T) {
 	releaseTypes := communitym.ValidReportTypesForEntity("release")
 	assert.Len(t, releaseTypes, 6)
 
-	// label remains unsupported (see PSY-666).
-	unknownTypes := communitym.ValidReportTypesForEntity("label")
+	// PSY-666: label-tailored taxonomy has 4 types.
+	labelTypes := communitym.ValidReportTypesForEntity("label")
+	assert.Len(t, labelTypes, 4)
+
+	// An entity type with no taxonomy still returns nil.
+	unknownTypes := communitym.ValidReportTypesForEntity("nonsense")
 	assert.Nil(t, unknownTypes)
 }
 
 func TestValidEntityReportEntityTypes(t *testing.T) {
 	types := communitym.ValidEntityReportEntityTypes()
-	assert.Len(t, types, 7)
+	assert.Len(t, types, 8)
 	assert.Contains(t, types, "artist")
 	assert.Contains(t, types, "venue")
 	assert.Contains(t, types, "festival")
@@ -121,6 +134,8 @@ func TestValidEntityReportEntityTypes(t *testing.T) {
 	assert.Contains(t, types, "collection")
 	// PSY-661
 	assert.Contains(t, types, "release")
+	// PSY-666
+	assert.Contains(t, types, "label")
 }
 
 // =============================================================================
@@ -152,6 +167,7 @@ func (s *EntityReportServiceIntegrationTestSuite) TearDownTest() {
 	_, _ = sqlDB.Exec("DELETE FROM venues")
 	_, _ = sqlDB.Exec("DELETE FROM festivals")
 	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 
@@ -237,6 +253,18 @@ func (s *EntityReportServiceIntegrationTestSuite) createTestRelease(title string
 	err := s.db.Create(release).Error
 	s.Require().NoError(err)
 	return release
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) createTestLabel(name string) *catalogm.Label {
+	slug := fmt.Sprintf("test-label-%d", time.Now().UnixNano())
+	label := &catalogm.Label{
+		Name:   name,
+		Slug:   &slug,
+		Status: catalogm.LabelStatusActive,
+	}
+	err := s.db.Create(label).Error
+	s.Require().NoError(err)
+	return label
 }
 
 func (s *EntityReportServiceIntegrationTestSuite) createReport(entityType string, entityID, userID uint, reportType string) *contracts.EntityReportResponse {
@@ -421,13 +449,35 @@ func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_Release
 	s.NotEmpty(*resp.EntitySlug)
 }
 
+// PSY-666: end-to-end create + entity-name/slug resolution for labels.
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_LabelSuccess() {
+	user := s.createTestUser()
+	label := s.createTestLabel("Test Label")
+
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "label",
+		EntityID:   label.ID,
+		UserID:     user.ID,
+		ReportType: "wrong_image",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("label", resp.EntityType)
+	s.Equal("wrong_image", resp.ReportType)
+	// The moderation queue deep-links via the resolved name + slug.
+	s.Equal("Test Label", resp.EntityName)
+	s.Require().NotNil(resp.EntitySlug)
+	s.NotEmpty(*resp.EntitySlug)
+}
+
 func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_InvalidEntityType() {
 	user := s.createTestUser()
 
-	// `label` is not a reportable entity type (PSY-661 added `release`;
-	// labels are tracked separately under PSY-666).
+	// `widget` is not a reportable entity type (PSY-661 added `release`,
+	// PSY-666 added `label`; this stays the canonical never-valid example).
 	_, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
-		EntityType: "label",
+		EntityType: "widget",
 		EntityID:   1,
 		UserID:     user.ID,
 		ReportType: "inaccurate",

--- a/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
@@ -104,6 +104,23 @@ const mockReleaseReport: EntityReportResponse = {
   created_at: '2026-04-06T00:00:00Z',
 }
 
+// PSY-666: label-typed report payload. Includes entity_slug so the generic
+// EntityReportCard can deep-link to the public /labels/{slug} page.
+const mockLabelReport: EntityReportResponse = {
+  id: 8,
+  entity_type: 'label',
+  entity_id: 80,
+  entity_name: 'Run For Cover Records',
+  entity_slug: 'run-for-cover-records',
+  reported_by: 8,
+  reporter_name: 'reporter5',
+  reporter_username: null,
+  report_type: 'wrong_image',
+  details: 'The label logo is wrong',
+  status: 'pending',
+  created_at: '2026-04-07T00:00:00Z',
+}
+
 // --- Mocks ---
 
 const mockUseAdminPendingEdits = vi.fn()
@@ -278,6 +295,21 @@ describe('ModerationQueue', () => {
     expect(screen.getByText('Wrong Cover Art')).toBeInTheDocument()
     const link = screen.getByText('In Rainbows').closest('a')
     expect(link).toHaveAttribute('href', '/releases/in-rainbows')
+  })
+
+  // PSY-666: label reports flow through the generic EntityReportCard (no
+  // bespoke moderation action), the same path as releases. The card must show
+  // the entity-type badge, the label-tailored report-type label, and a
+  // slug-based deep-link.
+  it('renders label report via the generic entity report card', () => {
+    setDefaultMocks({ reports: [mockLabelReport] })
+
+    render(<ModerationQueue />)
+
+    expect(screen.getByText('Label')).toBeInTheDocument()
+    expect(screen.getByText('Wrong Image')).toBeInTheDocument()
+    const link = screen.getByText('Run For Cover Records').closest('a')
+    expect(link).toHaveAttribute('href', '/labels/run-for-cover-records')
   })
 
   it('shows correct counts in filter buttons', () => {

--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -63,6 +63,10 @@ function getEntityUrl(entityType: string, entityId: number, entitySlug?: string)
     // onto report.entity_slug; fall back to '#' if it couldn't be resolved.
     case 'release':
       return entitySlug ? `/releases/${entitySlug}` : '#'
+    // PSY-666: labels are addressed by slug. The backend resolves the slug
+    // onto report.entity_slug; fall back to '#' if it couldn't be resolved.
+    case 'label':
+      return entitySlug ? `/labels/${entitySlug}` : '#'
     default:
       return '#'
   }
@@ -103,7 +107,7 @@ function renderValue(value: unknown): string {
 // ─── Filter Types ────────────────────────────────────────────────────────────
 
 type ItemTypeFilter = 'all' | 'edits' | 'reports' | 'comments'
-type EntityTypeFilter = '' | 'artist' | 'venue' | 'festival' | 'show' | 'collection' | 'release'
+type EntityTypeFilter = '' | 'artist' | 'venue' | 'festival' | 'show' | 'collection' | 'release' | 'label'
 
 // ─── Unified Item Type ───────────────────────────────────────────────────────
 
@@ -893,6 +897,7 @@ export function ModerationQueue() {
           <option value="show">Shows</option>
           <option value="collection">Collections</option>
           <option value="release">Releases</option>
+          <option value="label">Labels</option>
         </select>
 
         {/* Summary count */}

--- a/frontend/features/contributions/hooks/useReportEntity.ts
+++ b/frontend/features/contributions/hooks/useReportEntity.ts
@@ -37,6 +37,7 @@ const REPORT_PLURAL: Record<ReportableEntityType, string> = {
   comment: 'comments',
   collection: 'collections',
   release: 'releases',
+  label: 'labels',
 }
 
 /**
@@ -54,6 +55,7 @@ const REPORT_SUFFIX: Record<ReportableEntityType, string> = {
   comment: 'report',
   collection: 'report',
   release: 'report',
+  label: 'report',
 }
 
 export const useReportEntity = () => {

--- a/frontend/features/contributions/types.ts
+++ b/frontend/features/contributions/types.ts
@@ -163,7 +163,7 @@ export function validateUrlField(value: string): string | null {
   return null
 }
 
-export type ReportableEntityType = 'artist' | 'venue' | 'festival' | 'show' | 'comment' | 'collection' | 'release'
+export type ReportableEntityType = 'artist' | 'venue' | 'festival' | 'show' | 'comment' | 'collection' | 'release' | 'label'
 
 export interface ReportTypeOption {
   value: string
@@ -229,6 +229,18 @@ export const REPORT_TYPES: Record<ReportableEntityType, ReportTypeOption[]> = {
     { value: 'wrong_cover_art', label: 'Wrong Cover Art', description: 'The cover image is incorrect' },
     { value: 'wrong_release_date', label: 'Wrong Release Date', description: 'The release date or year is incorrect' },
     { value: 'wrong_artist_attribution', label: 'Wrong Artist', description: 'This release is attributed to the wrong artist' },
+    { value: 'missing_info', label: 'Missing Information', description: 'Important information is missing' },
+  ],
+  // PSY-666: label-tailored taxonomy (mirrors the PSY-578 collection +
+  // PSY-661 release precedent of tailoring per entity). Aligned with the
+  // backend allow list in
+  // backend/internal/models/community/entity_report.go — `value` strings
+  // must match byte-for-byte. "Defunct" is deliberately omitted: label
+  // lifecycle is a `status` field edit, not a moderation report.
+  label: [
+    { value: 'inaccurate', label: 'Inaccurate Information', description: 'Name, bio, or other info is wrong' },
+    { value: 'duplicate', label: 'Duplicate Label', description: 'This label already exists under a different entry' },
+    { value: 'wrong_image', label: 'Wrong Image', description: 'The label image is incorrect' },
     { value: 'missing_info', label: 'Missing Information', description: 'Important information is missing' },
   ],
 }

--- a/frontend/features/labels/components/LabelDetail.test.tsx
+++ b/frontend/features/labels/components/LabelDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 import type { LabelDetail as LabelDetailType } from '../types'
 
@@ -79,6 +79,22 @@ vi.mock('@/features/contributions', () => ({
     open ? <div data-testid="edit-drawer">Edit Drawer</div> : null,
   EntitySaveSuccessBanner: ({ visible }: { visible: boolean }) =>
     visible ? <div data-testid="save-success-banner">Saved</div> : null,
+  // PSY-666: report dialog renders only when opened; the test toggles it via
+  // the [Report] bracket link.
+  ReportEntityDialog: ({
+    open,
+    entityType,
+    entityName,
+  }: {
+    open: boolean
+    entityType: string
+    entityName: string
+  }) =>
+    open ? (
+      <div data-testid="report-dialog">
+        Report {entityType} {entityName}
+      </div>
+    ) : null,
   useEntitySaveSuccessBanner: () => ({
     isVisible: false,
     handleSaveSuccess: vi.fn(),
@@ -397,11 +413,13 @@ describe('LabelDetail', () => {
       )
     })
 
-    it('does not render edit / add-tag bracket links for unauthenticated users', () => {
+    it('does not render edit / add-tag / report bracket links for unauthenticated users', () => {
       renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
       expect(screen.queryByTestId('bracket-Edit')).not.toBeInTheDocument()
       expect(screen.queryByTestId('bracket-Suggest edit')).not.toBeInTheDocument()
       expect(screen.queryByTestId('bracket-Add tag')).not.toBeInTheDocument()
+      // PSY-666: the report affordance is auth-gated.
+      expect(screen.queryByTestId('bracket-Report')).not.toBeInTheDocument()
     })
 
     it('shows a Suggest edit link for an authenticated non-trusted user', () => {
@@ -436,6 +454,26 @@ describe('LabelDetail', () => {
 
       renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
       expect(screen.getByTestId('bracket-Suggest description')).toBeInTheDocument()
+    })
+
+    // PSY-666: signed-in users get a [Report] affordance that opens the
+    // report dialog bound to the label.
+    it('shows the Report bracket link and opens the report dialog', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+
+      const reportLink = screen.getByTestId('bracket-Report')
+      expect(reportLink).toBeInTheDocument()
+      // Dialog is closed until the link is clicked.
+      expect(screen.queryByTestId('report-dialog')).not.toBeInTheDocument()
+
+      fireEvent.click(reportLink)
+      expect(screen.getByText('Report label Sub Pop')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -24,7 +24,7 @@ import { CommentThread } from '@/features/comments'
 import { EntityTagList, AddTagDialog } from '@/features/tags'
 import { NotifyMeButton } from '@/features/notifications'
 import { useIsAuthenticated } from '@/features/auth'
-import { AttributionLine, ContributionPrompt, EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner } from '@/features/contributions'
+import { AttributionLine, ContributionPrompt, EntityEditDrawer, EntitySaveSuccessBanner, ReportEntityDialog, useEntitySaveSuccessBanner } from '@/features/contributions'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { queryKeys } from '@/lib/queryClient'
@@ -75,6 +75,7 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [addTagDialogOpen, setAddTagDialogOpen] = useState(false)
+  const [isReportOpen, setIsReportOpen] = useState(false)
   const saveBanner = useEntitySaveSuccessBanner()
 
   if (isLoading) {
@@ -254,6 +255,13 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
                     onClick={() => setAddTagDialogOpen(true)}
                   />
                 )}
+                {isAuthenticated && (
+                  <BracketLink
+                    label="Report"
+                    title="Report an issue"
+                    onClick={() => setIsReportOpen(true)}
+                  />
+                )}
               </div>
             }
           />
@@ -402,6 +410,17 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
         entityId={label.id}
         open={addTagDialogOpen}
         onOpenChange={setAddTagDialogOpen}
+      />
+    )}
+
+    {/* Report Dialog (authenticated users) — PSY-666 */}
+    {isAuthenticated && (
+      <ReportEntityDialog
+        open={isReportOpen}
+        onOpenChange={setIsReportOpen}
+        entityType="label"
+        entityId={label.id}
+        entityName={label.name}
       />
     )}
   </>


### PR DESCRIPTION
Closes PSY-666

## Summary

Wire **labels** into the generalized entity-report subsystem, mirroring the merged PSY-661 release template (PR #973). Authenticated users can now report a label from its detail page; reports flow into the existing admin moderation queue with a slug-based deep-link.

The label report taxonomy is **tailored** (4 types), following the PSY-578 collection + PSY-661 release precedent of per-entity taxonomies rather than reusing the generic artist/venue vocabulary:

- `inaccurate` — Inaccurate Information (name, bio, or other info is wrong)
- `duplicate` — Duplicate Label (already exists under a different entry)
- `wrong_image` — Wrong Image (the label image is incorrect)
- `missing_info` — Missing Information

**"Defunct label" is intentionally NOT a report type** — label lifecycle is a `status` field edit (active/defunct), not a moderation report.

## Changes

**Backend**
- `models/community/entity_report.go`: `EntityReportEntityLabel` constant, `validReportTypes["label"]` (4 tailored types, documented rationale), added to `ValidEntityReportEntityTypes()`.
- `handlers/community/entity_report.go`: `ReportLabelHandler` (mirrors `ReportReleaseHandler`).
- `routes/reports.go`: registered `POST /labels/{entity_id}/report` in the rate-limited `reportAPI` group (5/min/IP).
- `resolveEntityNameAndSlug` already handled `label` (table `labels`) per the PSY-661 handoff — verified, no change needed.

**Frontend**
- `features/contributions/types.ts`: `'label'` added to `ReportableEntityType` (forces the exhaustive maps via typecheck); `REPORT_TYPES['label']` with values matching the backend allow-list byte-for-byte.
- `features/contributions/hooks/useReportEntity.ts`: `label` entries in `REPORT_PLURAL` + `REPORT_SUFFIX` → endpoint `/labels/{id}/report`.
- `features/labels/components/LabelDetail.tsx`: `[Report]` BracketLink (auth-only) + page-level `<ReportEntityDialog entityType="label">`.
- `app/admin/moderation/_components/ModerationQueue.tsx`: `label` case in `getEntityUrl` (`/labels/{slug}`) + Labels filter option + `EntityTypeFilter` union member. Label reports render through the generic `EntityReportCard` (same path as releases).

## Tests

- `go build ./...` ✓
- Backend `models/community` + `api/handlers/community` + `services/admin` (incl. testcontainers integration suite) + `api/routes` ✓. Flipped the PSY-661 `// see PSY-666` placeholder assertions from "label still invalid" to "label valid (4 types)"; added `createTestLabel` + `TestCreateEntityReport_LabelSuccess` (create + slug resolution) and `TestReportLabel_Success` / `_InvalidReportType` handler tests; switched the canonical invalid-entity-type example to `widget`.
- `bun run typecheck` ✓
- `bun run test:run features/contributions features/labels app/admin/moderation` — 250 tests ✓ (added LabelDetail report-link test + ModerationQueue `/labels/{slug}` deep-link test).
- `bun run lint` — 0 errors ✓

## Screenshots

Manual repro on an isolated fullstack dispatch stack: regular seeded user reported a seeded label (`run-for-cover-records`, `wrong_image`), then the seeded admin saw it in `/admin/moderation`.

**1. Label header with `[Report]` link (authenticated)**
![label header](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-db9296553467ff23960e/01-label-header-report-link.png)

**2. Report dialog — the 4 tailored label types**
![report dialog](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-db9296553467ff23960e/02-report-dialog-4-types.png)

**3. Report submitted**
![submitted](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-db9296553467ff23960e/03-report-submitted-success.png)

**4. Admin moderation queue — label report with `/labels/{slug}` deep-link**
![moderation queue](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-db9296553467ff23960e/04-moderation-queue-label-report.png)

**5. Moderation queue — Labels entity-type filter applied**
![labels filter](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-db9296553467ff23960e/05-moderation-labels-filter.png)

## Code review

`/code-review` (3 lenses, inline) — surfaced one peer-component test asymmetry: ModerationQueue had a release deep-link test but none for labels. Fixed in a separate commit (`renders label report via the generic entity report card`).

## Adversarial review

`/adversarial-review` — **CLEAN**, no findings. Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran inline (dispatched sub-agent, no Agent tool) against the branch diff with no prior session context. Probed: missing-slug deep-link fallback, report-type allow-list enforcement (422), auth-gating (backend 401 is the real gate; FE gating is UX-only), test teardown FK safety, and all four acceptance criteria + byte-for-byte taxonomy match. All held up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
