### PR TITLE
PSY-869: entity_requests polymorphic table + payload schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
             exit 1
           fi
 
+      # PSY-869: every entity_type the entity_requests CHECK constraint accepts
+      # must have a matching Go payload struct (and vice versa). Catches a new
+      # enum value added in a migration without a typed payload to validate it.
+      - name: Check entity_requests payload-struct parity
+        run: bash scripts/check_entity_request_payloads.sh
+
   migration-reversibility:
     name: Migration Reversibility
     runs-on: ubuntu-latest

--- a/backend/db/migrations/20260601000000_create_entity_requests.down.sql
+++ b/backend/db/migrations/20260601000000_create_entity_requests.down.sql
@@ -1,0 +1,4 @@
+-- Reverse PSY-869. The table was created EMPTY (no backfill — see the .up.sql
+-- header), so reversal is a clean DROP with no data to restore. Indexes drop
+-- with the table.
+DROP TABLE IF EXISTS entity_requests;

--- a/backend/db/migrations/20260601000000_create_entity_requests.up.sql
+++ b/backend/db/migrations/20260601000000_create_entity_requests.up.sql
@@ -1,0 +1,90 @@
+-- PSY-869: entity_requests — a polymorphic moderation queue for
+-- user-requested ENTITY CREATION (not the existing `requests` wishlist).
+--
+-- Architectural decision (LOCKED 2026-05-26): a SINGLE polymorphic table,
+-- NOT per-type request tables. Polymorphism lives in the table; typing
+-- lives in Go (one payload struct per entity_type, validated on read via
+-- UnmarshalPayload[T]). This foundation lets PSY-853 (AICollectionFiller)
+-- and PSY-845 (AddItemsPicker) ship independently on top of it without
+-- colliding on a migration.
+--
+-- Why this is NOT the existing `requests` table (migration 000049):
+--   * `requests` is a community WISHLIST / voting surface — "I wish artist
+--     X existed, vote it up" — with title/description/upvotes/fulfillment.
+--   * `entity_requests` carries the DATA needed to CREATE an entity, queued
+--     for admin moderation, with a typed JSONB payload per entity_type and
+--     a trust-tier-gated auto-approve flow. Different lifecycle, different
+--     payload, different consumers. They are deliberately separate tables.
+--
+-- Backfill note: the ticket asked to backfill an `artist_requests` table.
+-- No such table exists in this schema (verified against db/migrations and
+-- internal/models — the only request table is `requests`, which is the
+-- wishlist feature above). Backfilling wishlist rows into this creation
+-- queue would conflate two distinct features and seed the queue with rows
+-- that have no creation payload, so this migration intentionally creates
+-- the table EMPTY. See the PR body for the surfaced open question.
+--
+-- Polymorphic envelope mirrors pending_entity_edits (the canonical
+-- polymorphic moderation table in this codebase): TEXT discriminator +
+-- CHECK constraint for the enum, JSONB payload, nullable decision columns.
+
+CREATE TABLE entity_requests (
+    id BIGSERIAL PRIMARY KEY,
+
+    -- Discriminator for the typed Go payload. CHECK-constrained rather than
+    -- a Postgres ENUM type so adding a new entity_type is a one-line CHECK
+    -- change in a follow-up migration (no ALTER TYPE ... ADD VALUE, which
+    -- can't run in a transaction). Keep aligned with the Go payload registry
+    -- in internal/models/community/entity_request_payloads.go — the CI
+    -- parity check (scripts/check_entity_request_payloads.sh) fails the build
+    -- if a value is added here without a matching payload struct.
+    entity_type TEXT NOT NULL CHECK (
+        entity_type IN ('artist', 'release', 'label', 'show', 'venue', 'festival')
+    ),
+
+    -- Type-specific fields, shape determined by entity_type and validated by
+    -- the corresponding Go struct on read (UnmarshalPayload fails loud on
+    -- schema drift / unknown fields). NOT NULL: a creation request with no
+    -- payload is meaningless.
+    payload JSONB NOT NULL,
+
+    requester_id BIGINT NOT NULL REFERENCES users(id),
+
+    -- How the request originated. CHECK-constrained enum, extensible the
+    -- same way as entity_type.
+    source_context TEXT NOT NULL DEFAULT 'manual' CHECK (
+        source_context IN ('ai_extraction', 'paste_mode', 'manual')
+    ),
+
+    -- Moderation state. Trust-tier gating (service layer) decides whether a
+    -- row lands 'pending' (queued for admin) or 'approved' (auto-approved
+    -- for admin / trusted_contributor / local_ambassador).
+    decision_state TEXT NOT NULL DEFAULT 'pending' CHECK (
+        decision_state IN ('pending', 'approved', 'rejected')
+    ),
+
+    -- Who/when/why the decision was made. NULL while pending. decided_by is
+    -- the admin (or the requester themselves on auto-approve) who resolved it.
+    decided_by BIGINT REFERENCES users(id),
+    decided_at TIMESTAMPTZ,
+    decision_note TEXT,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Admin moderation queue scans by state (default view = pending) and often
+-- filters by entity_type. The composite covers both the state-only and the
+-- state+type access patterns.
+CREATE INDEX idx_entity_requests_decision_state
+    ON entity_requests (decision_state);
+CREATE INDEX idx_entity_requests_state_type
+    ON entity_requests (decision_state, entity_type);
+
+-- "My requests" / requester-scoped lookups.
+CREATE INDEX idx_entity_requests_requester_id
+    ON entity_requests (requester_id);
+
+-- Newest-first listing.
+CREATE INDEX idx_entity_requests_created_at
+    ON entity_requests (created_at DESC);

--- a/backend/internal/api/handlers/admin/test_fixtures_allowlist_test.go
+++ b/backend/internal/api/handlers/admin/test_fixtures_allowlist_test.go
@@ -70,6 +70,7 @@ var testFixturesAllowlistContractSkips = map[string]string{
 
 	// Content creation not exercised by the mutating E2E flows we care about.
 	"pending_entity_edits":  "entity-edit drawer has its own moderation tests with explicit cleanup",
+	"entity_requests":       "polymorphic entity-creation queue (PSY-869); covered by its own service integration tests with explicit cleanup; not yet part of E2E mutating flows (PSY-853/845 add the UI)",
 	"entity_reports":        "report flow has its own tests with explicit cleanup",
 	"artist_reports":        "report flow has its own tests with explicit cleanup",
 	"show_reports":          "report flow has its own tests with explicit cleanup",

--- a/backend/internal/errors/entity_request.go
+++ b/backend/internal/errors/entity_request.go
@@ -1,0 +1,95 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// PSY-869: errors for the polymorphic entity_requests creation queue. These
+// mirror the RequestError shape (Code + Message + Internal + Unwrap) so the
+// downstream PSY-853/PSY-845 handlers can map them to HTTP status the same
+// way the existing request errors are mapped. The HTTP-status mapper wiring
+// is intentionally deferred to those tickets (this foundation ticket has no
+// HTTP handler yet).
+
+// Entity-request error codes.
+const (
+	CodeEntityRequestNotFound        = "ENTITY_REQUEST_NOT_FOUND"
+	CodeEntityRequestInvalidType     = "ENTITY_REQUEST_INVALID_TYPE"
+	CodeEntityRequestInvalidSource   = "ENTITY_REQUEST_INVALID_SOURCE"
+	CodeEntityRequestEmptyPayload    = "ENTITY_REQUEST_EMPTY_PAYLOAD"
+	CodeEntityRequestInvalidDecision = "ENTITY_REQUEST_INVALID_DECISION"
+	CodeEntityRequestInvalidState    = "ENTITY_REQUEST_INVALID_STATE"
+)
+
+// EntityRequestError represents an entity-request error with context.
+type EntityRequestError struct {
+	Code      string
+	Message   string
+	Internal  error
+	RequestID uint
+}
+
+// Error implements the error interface.
+func (e *EntityRequestError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *EntityRequestError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrEntityRequestNotFound creates a not-found error.
+func ErrEntityRequestNotFound(requestID uint) *EntityRequestError {
+	return &EntityRequestError{
+		Code:      CodeEntityRequestNotFound,
+		Message:   fmt.Sprintf("Entity request %d not found", requestID),
+		RequestID: requestID,
+	}
+}
+
+// ErrEntityRequestInvalidType creates an unknown-entity-type error.
+func ErrEntityRequestInvalidType(entityType string) *EntityRequestError {
+	return &EntityRequestError{
+		Code:    CodeEntityRequestInvalidType,
+		Message: fmt.Sprintf("Unsupported entity request type: %q", entityType),
+	}
+}
+
+// ErrEntityRequestInvalidSource creates an unknown-source-context error.
+func ErrEntityRequestInvalidSource(sourceContext string) *EntityRequestError {
+	return &EntityRequestError{
+		Code:    CodeEntityRequestInvalidSource,
+		Message: fmt.Sprintf("Unsupported source context: %q", sourceContext),
+	}
+}
+
+// ErrEntityRequestEmptyPayload creates an empty-payload error.
+func ErrEntityRequestEmptyPayload(entityType string) *EntityRequestError {
+	return &EntityRequestError{
+		Code:    CodeEntityRequestEmptyPayload,
+		Message: fmt.Sprintf("Empty payload for %s entity request", entityType),
+	}
+}
+
+// ErrEntityRequestInvalidDecision creates an error for a decision target that
+// is not 'approved' or 'rejected'.
+func ErrEntityRequestInvalidDecision(state string) *EntityRequestError {
+	return &EntityRequestError{
+		Code:    CodeEntityRequestInvalidDecision,
+		Message: fmt.Sprintf("Invalid decision state: %q (expected approved or rejected)", state),
+	}
+}
+
+// ErrEntityRequestInvalidState creates an error when deciding a request that is
+// not pending.
+func ErrEntityRequestInvalidState(requestID uint, currentState string) *EntityRequestError {
+	return &EntityRequestError{
+		Code:      CodeEntityRequestInvalidState,
+		Message:   fmt.Sprintf("Entity request %d is %s, expected pending", requestID, currentState),
+		RequestID: requestID,
+	}
+}

--- a/backend/internal/models/community/entity_request.go
+++ b/backend/internal/models/community/entity_request.go
@@ -1,0 +1,55 @@
+package community
+
+import (
+	"encoding/json"
+	"time"
+
+	"psychic-homily-backend/internal/models/auth"
+)
+
+// PSY-869: entity_requests — a polymorphic moderation queue for user-requested
+// ENTITY CREATION. Distinct from the `requests` wishlist (community.Request):
+// see the migration header for the rationale. The envelope columns are shared
+// across all entity types; the per-type shape lives in the JSONB payload,
+// typed by the structs in entity_request_payloads.go.
+
+// EntityRequestDecisionState enumerates moderation outcomes.
+type EntityRequestDecisionState string
+
+const (
+	EntityRequestStatePending  EntityRequestDecisionState = "pending"
+	EntityRequestStateApproved EntityRequestDecisionState = "approved"
+	EntityRequestStateRejected EntityRequestDecisionState = "rejected"
+)
+
+// Source context enumerates how a request originated. Extensible the same way
+// as entity_type — add a value here AND in the migration's CHECK constraint.
+const (
+	EntityRequestSourceAIExtraction = "ai_extraction"
+	EntityRequestSourcePasteMode    = "paste_mode"
+	EntityRequestSourceManual       = "manual"
+)
+
+// EntityRequest is the polymorphic envelope row. Payload is stored as
+// *json.RawMessage (project convention for JSONB — datatypes.JSON is not in
+// go.mod; mirrors admin.AuditLog / admin.PendingEntityEdit).
+type EntityRequest struct {
+	ID            uint                       `json:"id" gorm:"primaryKey"`
+	EntityType    string                     `json:"entity_type" gorm:"column:entity_type;not null"`
+	Payload       *json.RawMessage           `json:"payload" gorm:"column:payload;type:jsonb;not null"`
+	RequesterID   uint                       `json:"requester_id" gorm:"column:requester_id;not null"`
+	SourceContext string                     `json:"source_context" gorm:"column:source_context;not null;default:'manual'"`
+	DecisionState EntityRequestDecisionState `json:"decision_state" gorm:"column:decision_state;not null;default:'pending'"`
+	DecidedBy     *uint                      `json:"decided_by,omitempty" gorm:"column:decided_by"`
+	DecidedAt     *time.Time                 `json:"decided_at,omitempty" gorm:"column:decided_at"`
+	DecisionNote  *string                    `json:"decision_note,omitempty" gorm:"column:decision_note"`
+	CreatedAt     time.Time                  `json:"created_at"`
+	UpdatedAt     time.Time                  `json:"updated_at"`
+
+	// Relationships
+	Requester auth.User  `json:"-" gorm:"foreignKey:RequesterID"`
+	Decider   *auth.User `json:"-" gorm:"foreignKey:DecidedBy"`
+}
+
+// TableName specifies the table name for EntityRequest.
+func (EntityRequest) TableName() string { return "entity_requests" }

--- a/backend/internal/models/community/entity_request_payloads.go
+++ b/backend/internal/models/community/entity_request_payloads.go
@@ -1,0 +1,207 @@
+package community
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// PSY-869: typed payload schemas for the polymorphic entity_requests table.
+//
+// Architectural decision (LOCKED 2026-05-26): polymorphism lives in the
+// table (one row shape, JSONB payload, entity_type discriminator); typing
+// lives HERE in Go — one struct per entity_type. The DB stores the payload
+// opaquely; this file is the single source of truth for what each
+// entity_type's payload looks like.
+//
+// These payloads describe the USER-SUPPLIED fields for creating an entity —
+// the data a requester provides. Server-controlled fields (slug, provenance,
+// approval-workflow status, verified flags, IDs) are intentionally NOT part
+// of the payload: they're set when the request is fulfilled into a real
+// catalog row, not when it's requested.
+
+// EntityRequestEntityType enumerates the entity_type discriminator values.
+// MUST stay aligned with:
+//   - the CHECK constraint in the entity_requests migration, and
+//   - payloadRegistry below (the CI parity check
+//     scripts/check_entity_request_payloads.sh fails the build on drift).
+const (
+	EntityRequestArtist   = "artist"
+	EntityRequestRelease  = "release"
+	EntityRequestLabel    = "label"
+	EntityRequestShow     = "show"
+	EntityRequestVenue    = "venue"
+	EntityRequestFestival = "festival"
+)
+
+// EntityRequestPayload is the marker interface implemented by every
+// per-entity payload struct. It exists purely to make the payload registry
+// and the generic UnmarshalPayload helper type-safe and discoverable.
+type EntityRequestPayload interface {
+	// entityRequestType returns the entity_type discriminator the payload
+	// belongs to. Unexported so the set of payload types is closed to this
+	// package — a new entity_type must add a struct here, which the CI
+	// parity check enforces against the migration's CHECK constraint.
+	entityRequestType() string
+}
+
+// ArtistRequestPayload carries the user-supplied fields to create an artist.
+type ArtistRequestPayload struct {
+	Name             string  `json:"name"`
+	City             *string `json:"city,omitempty"`
+	State            *string `json:"state,omitempty"`
+	Country          *string `json:"country,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	ImageURL         *string `json:"image_url,omitempty"`
+	BandcampEmbedURL *string `json:"bandcamp_embed_url,omitempty"`
+}
+
+func (ArtistRequestPayload) entityRequestType() string { return EntityRequestArtist }
+
+// ReleaseRequestPayload carries the user-supplied fields to create a release.
+type ReleaseRequestPayload struct {
+	Title       string  `json:"title"`
+	ReleaseType *string `json:"release_type,omitempty"` // 'lp', 'ep', 'single', etc. (defaults applied at fulfillment)
+	ReleaseYear *int    `json:"release_year,omitempty"`
+	ReleaseDate *string `json:"release_date,omitempty"` // YYYY-MM-DD
+	CoverArtURL *string `json:"cover_art_url,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+func (ReleaseRequestPayload) entityRequestType() string { return EntityRequestRelease }
+
+// LabelRequestPayload carries the user-supplied fields to create a label.
+type LabelRequestPayload struct {
+	Name        string  `json:"name"`
+	City        *string `json:"city,omitempty"`
+	State       *string `json:"state,omitempty"`
+	Country     *string `json:"country,omitempty"`
+	FoundedYear *int    `json:"founded_year,omitempty"`
+	Description *string `json:"description,omitempty"`
+	ImageURL    *string `json:"image_url,omitempty"`
+}
+
+func (LabelRequestPayload) entityRequestType() string { return EntityRequestLabel }
+
+// ShowRequestPayload carries the user-supplied fields to create a show.
+type ShowRequestPayload struct {
+	Title          string   `json:"title"`
+	EventDate      string   `json:"event_date"` // RFC3339 / YYYY-MM-DD; parsed at fulfillment
+	City           *string  `json:"city,omitempty"`
+	State          *string  `json:"state,omitempty"`
+	Price          *float64 `json:"price,omitempty"`
+	AgeRequirement *string  `json:"age_requirement,omitempty"`
+	Description    *string  `json:"description,omitempty"`
+	TicketURL      *string  `json:"ticket_url,omitempty"`
+	ImageURL       *string  `json:"image_url,omitempty"`
+}
+
+func (ShowRequestPayload) entityRequestType() string { return EntityRequestShow }
+
+// VenueRequestPayload carries the user-supplied fields to create a venue.
+// City + State are required on the catalog model, so they are non-pointer here.
+type VenueRequestPayload struct {
+	Name        string  `json:"name"`
+	City        string  `json:"city"`
+	State       string  `json:"state"`
+	Address     *string `json:"address,omitempty"`
+	Country     *string `json:"country,omitempty"`
+	Zipcode     *string `json:"zipcode,omitempty"`
+	Description *string `json:"description,omitempty"`
+	ImageURL    *string `json:"image_url,omitempty"`
+}
+
+func (VenueRequestPayload) entityRequestType() string { return EntityRequestVenue }
+
+// FestivalRequestPayload carries the user-supplied fields to create a festival.
+type FestivalRequestPayload struct {
+	Name         string  `json:"name"`
+	EditionYear  int     `json:"edition_year"`
+	StartDate    string  `json:"start_date"` // YYYY-MM-DD
+	EndDate      string  `json:"end_date"`   // YYYY-MM-DD
+	Description  *string `json:"description,omitempty"`
+	LocationName *string `json:"location_name,omitempty"`
+	City         *string `json:"city,omitempty"`
+	State        *string `json:"state,omitempty"`
+	Country      *string `json:"country,omitempty"`
+	Website      *string `json:"website,omitempty"`
+	TicketURL    *string `json:"ticket_url,omitempty"`
+	FlyerURL     *string `json:"flyer_url,omitempty"`
+}
+
+func (FestivalRequestPayload) entityRequestType() string { return EntityRequestFestival }
+
+// payloadRegistry is the authoritative map from entity_type discriminator to
+// a zero-value of its payload struct. It is the runtime mirror of the
+// migration's CHECK constraint and the anchor for the CI parity check
+// (scripts/check_entity_request_payloads.sh greps the keys of this literal
+// against the CHECK constraint's IN-list). Adding an entity_type WITHOUT
+// adding it here is the exact drift the CI check exists to block.
+var payloadRegistry = map[string]EntityRequestPayload{
+	EntityRequestArtist:   ArtistRequestPayload{},
+	EntityRequestRelease:  ReleaseRequestPayload{},
+	EntityRequestLabel:    LabelRequestPayload{},
+	EntityRequestShow:     ShowRequestPayload{},
+	EntityRequestVenue:    VenueRequestPayload{},
+	EntityRequestFestival: FestivalRequestPayload{},
+}
+
+// IsValidEntityRequestType reports whether entityType has a registered payload
+// struct. Use at the trust boundary (request creation) before persisting.
+func IsValidEntityRequestType(entityType string) bool {
+	_, ok := payloadRegistry[entityType]
+	return ok
+}
+
+// ValidEntityRequestTypes returns the registered entity_type discriminators.
+// Order is not guaranteed (map iteration); callers that need a stable order
+// should sort.
+func ValidEntityRequestTypes() []string {
+	out := make([]string, 0, len(payloadRegistry))
+	for k := range payloadRegistry {
+		out = append(out, k)
+	}
+	return out
+}
+
+// MarshalPayload serializes a typed payload to json.RawMessage for storage in
+// the entity_requests.payload JSONB column. It is the write-side counterpart
+// to UnmarshalPayload.
+func MarshalPayload(p EntityRequestPayload) (json.RawMessage, error) {
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s payload: %w", p.entityRequestType(), err)
+	}
+	return json.RawMessage(raw), nil
+}
+
+// UnmarshalPayload decodes a stored JSONB payload into the typed struct T,
+// failing LOUDLY on schema drift rather than silently returning a zero value.
+//
+// "Fail loud" means: an unknown field in the stored JSON (a field the struct
+// T does not declare) is an ERROR, not a silently-dropped value. This is the
+// schema-drift guard the ticket requires — if the on-disk payload shape ever
+// diverges from the Go struct (e.g. a producer wrote a field a later struct
+// version removed, or the wrong T is used for the row's entity_type), the
+// caller gets an error instead of a struct missing data.
+//
+// nil/empty input is an error: a creation request with no payload is invalid,
+// and the column is NOT NULL, so empty here signals corruption.
+func UnmarshalPayload[T EntityRequestPayload](raw json.RawMessage) (T, error) {
+	var out T
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return out, fmt.Errorf("unmarshal %s payload: empty payload", out.entityRequestType())
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&out); err != nil {
+		return out, fmt.Errorf("unmarshal %s payload: %w", out.entityRequestType(), err)
+	}
+	// Reject trailing data after the first JSON value (e.g. concatenated
+	// objects) — another corruption signal DisallowUnknownFields won't catch.
+	if dec.More() {
+		return out, fmt.Errorf("unmarshal %s payload: unexpected trailing data", out.entityRequestType())
+	}
+	return out, nil
+}

--- a/backend/internal/models/community/entity_request_payloads_test.go
+++ b/backend/internal/models/community/entity_request_payloads_test.go
@@ -1,0 +1,223 @@
+package community
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strptr(s string) *string   { return &s }
+func intptr(i int) *int         { return &i }
+func fltptr(f float64) *float64 { return &f }
+
+// TestRoundTrip_AllFieldsSet serializes a fully-populated payload of each type,
+// deserializes it back via UnmarshalPayload, and asserts NO field-level data
+// loss. This is the core "polymorphism in the table, typing in the code"
+// guarantee — what goes into the JSONB column comes back out identically.
+func TestRoundTrip_AllFieldsSet(t *testing.T) {
+	t.Run("artist", func(t *testing.T) {
+		in := ArtistRequestPayload{
+			Name:             "Sun City Girls",
+			City:             strptr("Phoenix"),
+			State:            strptr("AZ"),
+			Country:          strptr("USA"),
+			Description:      strptr("Experimental trio."),
+			ImageURL:         strptr("https://img.example/scg.jpg"),
+			BandcampEmbedURL: strptr("https://bandcamp.example/scg"),
+		}
+		raw, err := MarshalPayload(in)
+		require.NoError(t, err)
+		out, err := UnmarshalPayload[ArtistRequestPayload](raw)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("release", func(t *testing.T) {
+		in := ReleaseRequestPayload{
+			Title:       "Torch of the Mystics",
+			ReleaseType: strptr("lp"),
+			ReleaseYear: intptr(1990),
+			ReleaseDate: strptr("1990-01-01"),
+			CoverArtURL: strptr("https://img.example/totm.jpg"),
+			Description: strptr("Classic."),
+		}
+		raw, err := MarshalPayload(in)
+		require.NoError(t, err)
+		out, err := UnmarshalPayload[ReleaseRequestPayload](raw)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("label", func(t *testing.T) {
+		in := LabelRequestPayload{
+			Name:        "Abduction",
+			City:        strptr("Seattle"),
+			State:       strptr("WA"),
+			Country:     strptr("USA"),
+			FoundedYear: intptr(1996),
+			Description: strptr("Reissue label."),
+			ImageURL:    strptr("https://img.example/abduction.jpg"),
+		}
+		raw, err := MarshalPayload(in)
+		require.NoError(t, err)
+		out, err := UnmarshalPayload[LabelRequestPayload](raw)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("show", func(t *testing.T) {
+		in := ShowRequestPayload{
+			Title:          "Secret Show",
+			EventDate:      "2026-07-04T20:00:00Z",
+			City:           strptr("Tucson"),
+			State:          strptr("AZ"),
+			Price:          fltptr(15.5),
+			AgeRequirement: strptr("21+"),
+			Description:    strptr("BYO."),
+			TicketURL:      strptr("https://tix.example/secret"),
+			ImageURL:       strptr("https://img.example/secret.jpg"),
+		}
+		raw, err := MarshalPayload(in)
+		require.NoError(t, err)
+		out, err := UnmarshalPayload[ShowRequestPayload](raw)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("venue", func(t *testing.T) {
+		in := VenueRequestPayload{
+			Name:        "The Trunk Space",
+			City:        "Phoenix",
+			State:       "AZ",
+			Address:     strptr("1124 N 3rd St"),
+			Country:     strptr("USA"),
+			Zipcode:     strptr("85004"),
+			Description: strptr("All-ages DIY."),
+			ImageURL:    strptr("https://img.example/trunk.jpg"),
+		}
+		raw, err := MarshalPayload(in)
+		require.NoError(t, err)
+		out, err := UnmarshalPayload[VenueRequestPayload](raw)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("festival", func(t *testing.T) {
+		in := FestivalRequestPayload{
+			Name:         "Desert Daze",
+			EditionYear:  2026,
+			StartDate:    "2026-09-25",
+			EndDate:      "2026-09-27",
+			Description:  strptr("Psych fest."),
+			LocationName: strptr("Lake Perris"),
+			City:         strptr("Perris"),
+			State:        strptr("CA"),
+			Country:      strptr("USA"),
+			Website:      strptr("https://desertdaze.example"),
+			TicketURL:    strptr("https://tix.example/dd"),
+			FlyerURL:     strptr("https://img.example/dd.jpg"),
+		}
+		raw, err := MarshalPayload(in)
+		require.NoError(t, err)
+		out, err := UnmarshalPayload[FestivalRequestPayload](raw)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+}
+
+// TestRoundTrip_OnlyRequiredFields proves optional pointer fields round-trip as
+// nil (omitempty drops them from JSON, and they come back nil — not "" or a
+// zero pointer-to-empty). Confirms the absence of a field is preserved, not
+// silently coerced.
+func TestRoundTrip_OnlyRequiredFields(t *testing.T) {
+	in := ArtistRequestPayload{Name: "Minimal"}
+	raw, err := MarshalPayload(in)
+	require.NoError(t, err)
+
+	// omitempty: optional fields should not appear in the wire form.
+	var asMap map[string]any
+	require.NoError(t, json.Unmarshal(raw, &asMap))
+	assert.Equal(t, map[string]any{"name": "Minimal"}, asMap)
+
+	out, err := UnmarshalPayload[ArtistRequestPayload](raw)
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+	assert.Nil(t, out.City)
+	assert.Nil(t, out.Description)
+}
+
+// TestUnmarshalPayload_FailsLoudOnUnknownField is the schema-drift guard: a
+// stored payload carrying a field the struct does not declare must ERROR, not
+// silently drop the field and return a partial struct.
+func TestUnmarshalPayload_FailsLoudOnUnknownField(t *testing.T) {
+	raw := json.RawMessage(`{"name":"X","bogus_field":"surprise"}`)
+	_, err := UnmarshalPayload[ArtistRequestPayload](raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "artist")
+}
+
+// TestUnmarshalPayload_FailsLoudOnWrongType guards against decoding a row's
+// payload with the WRONG T for its entity_type. A festival payload (which has
+// edition_year / start_date the artist struct doesn't declare) decoded as an
+// artist must error rather than silently returning an artist with just a name.
+func TestUnmarshalPayload_FailsLoudOnWrongType(t *testing.T) {
+	festival := FestivalRequestPayload{Name: "DD", EditionYear: 2026, StartDate: "2026-09-25", EndDate: "2026-09-27"}
+	raw, err := MarshalPayload(festival)
+	require.NoError(t, err)
+
+	_, err = UnmarshalPayload[ArtistRequestPayload](raw)
+	require.Error(t, err, "decoding a festival payload as an artist must fail loud")
+}
+
+// TestUnmarshalPayload_FailsLoudOnEmpty rejects empty/whitespace input — the
+// column is NOT NULL so empty signals corruption, not a valid empty request.
+func TestUnmarshalPayload_FailsLoudOnEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(""), json.RawMessage("   ")} {
+		_, err := UnmarshalPayload[VenueRequestPayload](raw)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	}
+}
+
+// TestUnmarshalPayload_FailsLoudOnTrailingData rejects concatenated/garbage
+// trailing content after a valid JSON object.
+func TestUnmarshalPayload_FailsLoudOnTrailingData(t *testing.T) {
+	raw := json.RawMessage(`{"name":"X"}{"name":"Y"}`)
+	_, err := UnmarshalPayload[ArtistRequestPayload](raw)
+	require.Error(t, err)
+}
+
+// TestPayloadRegistry_MatchesEntityTypeConstants asserts the registry keys
+// equal the entity_type discriminator constants — the Go-side anchor the CI
+// parity check compares against the migration CHECK constraint.
+func TestPayloadRegistry_MatchesEntityTypeConstants(t *testing.T) {
+	want := map[string]bool{
+		EntityRequestArtist:   true,
+		EntityRequestRelease:  true,
+		EntityRequestLabel:    true,
+		EntityRequestShow:     true,
+		EntityRequestVenue:    true,
+		EntityRequestFestival: true,
+	}
+	got := map[string]bool{}
+	for _, et := range ValidEntityRequestTypes() {
+		got[et] = true
+	}
+	assert.Equal(t, want, got)
+
+	// Every registered payload reports its own entity_type back, so the map
+	// key and the struct can't drift.
+	for et, p := range payloadRegistry {
+		assert.Equal(t, et, p.entityRequestType(), "payload for %q reports wrong type", et)
+	}
+}
+
+// TestIsValidEntityRequestType covers the trust-boundary validator.
+func TestIsValidEntityRequestType(t *testing.T) {
+	assert.True(t, IsValidEntityRequestType(EntityRequestArtist))
+	assert.True(t, IsValidEntityRequestType(EntityRequestFestival))
+	assert.False(t, IsValidEntityRequestType("podcast"))
+	assert.False(t, IsValidEntityRequestType(""))
+}

--- a/backend/internal/services/community/entityrequest.go
+++ b/backend/internal/services/community/entityrequest.go
@@ -193,6 +193,19 @@ func (s *EntityRequestService) ListPending(entityType string, limit, offset int)
 // Decide records an admin's moderation decision on a pending request. Only
 // 'approved' or 'rejected' are valid targets; the request MUST currently be
 // 'pending' (re-deciding a resolved request returns ErrEntityRequestInvalidState).
+//
+// Admin authorization is the CALLER's responsibility — this service has only
+// the adminID, not the user record. The HTTP handlers added by PSY-853/PSY-845
+// MUST register this on an admin-gated route (rc.Admin middleware) per the
+// project's admin-gating pattern; the adminID here is recorded as the decider,
+// not authenticated by the service.
+//
+// The state transition is applied ATOMICALLY with a conditional UPDATE
+// (... WHERE decision_state = 'pending'), so two concurrent Decide calls on
+// the same row can't both win: the second observes RowsAffected == 0 and gets
+// the invalid-state conflict instead of silently clobbering the first
+// decision. The pre-read distinguishes not-found from already-decided so the
+// caller gets the right error.
 func (s *EntityRequestService) Decide(
 	requestID, adminID uint,
 	newState communitym.EntityRequestDecisionState,
@@ -226,8 +239,25 @@ func (s *EntityRequestService) Decide(
 	if note != nil {
 		updates["decision_note"] = *note
 	}
-	if err := s.db.Model(&req).Updates(updates).Error; err != nil {
-		return nil, fmt.Errorf("failed to record decision: %w", err)
+
+	// Conditional update guards the read-modify-write against a concurrent
+	// decision on the same row. WHERE decision_state = 'pending' so only the
+	// first writer flips it; a racing second writer matches 0 rows.
+	result := s.db.Model(&communitym.EntityRequest{}).
+		Where("id = ? AND decision_state = ?", requestID, communitym.EntityRequestStatePending).
+		Updates(updates)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to record decision: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		// Lost the race (or the row was decided between our read and write):
+		// re-read to report the current state. Fall back to the pre-read state
+		// if the re-read fails so we still surface a conflict, not a 500.
+		current := string(req.DecisionState)
+		if fresh, ferr := s.GetRequest(requestID); ferr == nil && fresh != nil {
+			current = string(fresh.DecisionState)
+		}
+		return nil, apperrors.ErrEntityRequestInvalidState(requestID, current)
 	}
 
 	return s.GetRequest(requestID)

--- a/backend/internal/services/community/entityrequest.go
+++ b/backend/internal/services/community/entityrequest.go
@@ -125,8 +125,12 @@ func (s *EntityRequestService) CreateRequest(
 
 	if autoApproves(user, confirmed) {
 		now := time.Now().UTC()
+		// Copy to a local before taking its address — &user.ID would alias the
+		// caller's struct field, which is a footgun if the caller later reuses
+		// or mutates the user value.
+		deciderID := user.ID
 		req.DecisionState = communitym.EntityRequestStateApproved
-		req.DecidedBy = &user.ID
+		req.DecidedBy = &deciderID
 		req.DecidedAt = &now
 	}
 

--- a/backend/internal/services/community/entityrequest.go
+++ b/backend/internal/services/community/entityrequest.go
@@ -1,0 +1,242 @@
+package community
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
+	authm "psychic-homily-backend/internal/models/auth"
+	communitym "psychic-homily-backend/internal/models/community"
+)
+
+// PSY-869: EntityRequestService implements the trust-tier-gated creation flow
+// for the polymorphic entity_requests moderation queue.
+//
+// Trust-tier gating (the core behavior this service adds over a plain insert):
+//   - admin / local_ambassador  → auto-approve on create (skip the queue).
+//   - trusted_contributor       → the confirm step is FE-side; the backend
+//     auto-approves on a confirmed request (same effect as the auto-approve
+//     tiers — a confirmed trusted request does not wait in the queue).
+//   - contributor / new_user    → inserted as 'pending', queued for an admin.
+//
+// Tier names are mirrored from internal/services/admin/auto_promotion.go
+// (TierNewUser/TierContributor/...). We mirror rather than import to match
+// the existing community-service convention (see collection.go's
+// collectionTierLimits) and avoid coupling community → admin. The CI
+// parity check guards the payload structs, not these tier strings; the
+// admin package is the canonical source if they ever change.
+const (
+	tierNewUser            = "new_user"
+	tierContributor        = "contributor"
+	tierTrustedContributor = "trusted_contributor"
+	tierLocalAmbassador    = "local_ambassador"
+)
+
+// EntityRequestService handles entity-creation request business logic.
+type EntityRequestService struct {
+	db *gorm.DB
+}
+
+// NewEntityRequestService creates a new entity-request service.
+func NewEntityRequestService(database *gorm.DB) *EntityRequestService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &EntityRequestService{db: database}
+}
+
+// autoApproves reports whether a request from this user/confirmation state
+// skips the admin queue. The decision is the single place trust-tier policy
+// lives — keep it small and total so a new tier is an obvious one-line change.
+//
+//   - Admins always auto-approve.
+//   - local_ambassador auto-approves (highest non-admin trust).
+//   - trusted_contributor auto-approves ONLY on a FE-confirmed request; an
+//     unconfirmed trusted request still queues (the FE confirm step is the
+//     trusted-tier gate per the ticket).
+//   - contributor / new_user never auto-approve.
+func autoApproves(user *authm.User, confirmed bool) bool {
+	if user.IsAdmin {
+		return true
+	}
+	switch user.UserTier {
+	case tierLocalAmbassador:
+		return true
+	case tierTrustedContributor:
+		return confirmed
+	case tierContributor, tierNewUser:
+		return false
+	default:
+		// Unknown tier → fail closed (queue it). Never auto-approve a tier
+		// we don't recognize.
+		return false
+	}
+}
+
+// CreateRequest persists a typed entity-creation request, applying trust-tier
+// gating to decide whether it auto-approves or queues for admin review.
+//
+// payload is the typed, already-marshalled JSONB body (build it with
+// communitym.MarshalPayload(typedStruct) at the call site so the entity_type
+// and the payload shape can't drift). entityType MUST have a registered
+// payload struct; sourceContext is the origin discriminator.
+//
+// confirmed reflects the FE-side confirm step relevant to trusted_contributor
+// (ignored for other tiers). On auto-approve, decided_by is stamped with the
+// requester's own ID and decided_at with now — the request didn't pass through
+// an admin, but the columns must record WHO/WHEN the auto-decision happened
+// for the audit trail.
+func (s *EntityRequestService) CreateRequest(
+	user *authm.User,
+	entityType string,
+	payload []byte,
+	sourceContext string,
+	confirmed bool,
+) (*communitym.EntityRequest, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	if user == nil {
+		return nil, fmt.Errorf("user is required")
+	}
+	if !communitym.IsValidEntityRequestType(entityType) {
+		return nil, apperrors.ErrEntityRequestInvalidType(entityType)
+	}
+	if !isValidSourceContext(sourceContext) {
+		return nil, apperrors.ErrEntityRequestInvalidSource(sourceContext)
+	}
+	if len(payload) == 0 {
+		return nil, apperrors.ErrEntityRequestEmptyPayload(entityType)
+	}
+
+	raw := json.RawMessage(payload)
+	req := &communitym.EntityRequest{
+		EntityType:    entityType,
+		Payload:       &raw,
+		RequesterID:   user.ID,
+		SourceContext: sourceContext,
+		DecisionState: communitym.EntityRequestStatePending,
+	}
+
+	if autoApproves(user, confirmed) {
+		now := time.Now().UTC()
+		req.DecisionState = communitym.EntityRequestStateApproved
+		req.DecidedBy = &user.ID
+		req.DecidedAt = &now
+	}
+
+	if err := s.db.Create(req).Error; err != nil {
+		return nil, fmt.Errorf("failed to create entity request: %w", err)
+	}
+	return req, nil
+}
+
+// GetRequest retrieves an entity request by ID with requester + decider
+// preloaded. Returns (nil, nil) when not found.
+func (s *EntityRequestService) GetRequest(requestID uint) (*communitym.EntityRequest, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var req communitym.EntityRequest
+	err := s.db.Preload("Requester").Preload("Decider").First(&req, requestID).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get entity request: %w", err)
+	}
+	return &req, nil
+}
+
+// ListPending returns pending requests (the admin moderation queue), optionally
+// filtered by entity_type, newest-first.
+func (s *EntityRequestService) ListPending(entityType string, limit, offset int) ([]communitym.EntityRequest, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&communitym.EntityRequest{}).
+		Where("decision_state = ?", communitym.EntityRequestStatePending)
+	if entityType != "" {
+		query = query.Where("entity_type = ?", entityType)
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count entity requests: %w", err)
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	var reqs []communitym.EntityRequest
+	if err := query.Preload("Requester").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&reqs).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to list entity requests: %w", err)
+	}
+	return reqs, total, nil
+}
+
+// Decide records an admin's moderation decision on a pending request. Only
+// 'approved' or 'rejected' are valid targets; the request MUST currently be
+// 'pending' (re-deciding a resolved request returns ErrEntityRequestInvalidState).
+func (s *EntityRequestService) Decide(
+	requestID, adminID uint,
+	newState communitym.EntityRequestDecisionState,
+	note *string,
+) (*communitym.EntityRequest, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	if newState != communitym.EntityRequestStateApproved && newState != communitym.EntityRequestStateRejected {
+		return nil, apperrors.ErrEntityRequestInvalidDecision(string(newState))
+	}
+
+	var req communitym.EntityRequest
+	if err := s.db.First(&req, requestID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrEntityRequestNotFound(requestID)
+		}
+		return nil, fmt.Errorf("failed to get entity request: %w", err)
+	}
+
+	if req.DecisionState != communitym.EntityRequestStatePending {
+		return nil, apperrors.ErrEntityRequestInvalidState(requestID, string(req.DecisionState))
+	}
+
+	now := time.Now().UTC()
+	updates := map[string]interface{}{
+		"decision_state": newState,
+		"decided_by":     adminID,
+		"decided_at":     now,
+	}
+	if note != nil {
+		updates["decision_note"] = *note
+	}
+	if err := s.db.Model(&req).Updates(updates).Error; err != nil {
+		return nil, fmt.Errorf("failed to record decision: %w", err)
+	}
+
+	return s.GetRequest(requestID)
+}
+
+// isValidSourceContext reports whether sourceContext is a recognized origin.
+func isValidSourceContext(sourceContext string) bool {
+	switch sourceContext {
+	case communitym.EntityRequestSourceAIExtraction,
+		communitym.EntityRequestSourcePasteMode,
+		communitym.EntityRequestSourceManual:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/services/community/entityrequest_test.go
+++ b/backend/internal/services/community/entityrequest_test.go
@@ -242,6 +242,34 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_AlreadyResolve
 	suite.Require().Error(err)
 }
 
+// A second decision on a request that was already decided loses: the atomic
+// WHERE decision_state='pending' guard matches 0 rows and the call returns an
+// invalid-state conflict reporting the CURRENT (first-winner) state — it does
+// NOT silently clobber the first decision. This is the sequential proxy for
+// the concurrent double-decide race the conditional UPDATE guards against.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_SecondDecisionDoesNotClobber() {
+	requester := suite.createUser("req3", tierNewUser, false)
+	admin := suite.createUser("mod4", tierNewUser, true)
+
+	pending, err := suite.service.CreateRequest(requester, communitym.EntityRequestArtist,
+		suite.marshalArtist("Contested"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	// First decision wins: approve.
+	decided, err := suite.service.Decide(pending.ID, admin.ID, communitym.EntityRequestStateApproved, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(communitym.EntityRequestStateApproved, decided.DecisionState)
+
+	// Second decision (reject) must fail and leave the row APPROVED.
+	_, err = suite.service.Decide(pending.ID, admin.ID, communitym.EntityRequestStateRejected, nil)
+	suite.Require().Error(err)
+
+	fetched, err := suite.service.GetRequest(pending.ID)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(communitym.EntityRequestStateApproved, fetched.DecisionState,
+		"first decision must survive; second must not clobber it")
+}
+
 // Decide rejects a non-approve/reject target state.
 func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_InvalidTargetState() {
 	requester := suite.createUser("req2", tierNewUser, false)

--- a/backend/internal/services/community/entityrequest_test.go
+++ b/backend/internal/services/community/entityrequest_test.go
@@ -1,0 +1,311 @@
+package community
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	authm "psychic-homily-backend/internal/models/auth"
+	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// PSY-869 — EntityRequestService trust-tier-gated creation flow
+// =============================================================================
+
+type EntityRequestServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *EntityRequestService
+}
+
+func (suite *EntityRequestServiceIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.service = NewEntityRequestService(suite.testDB.DB)
+}
+
+func (suite *EntityRequestServiceIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *EntityRequestServiceIntegrationTestSuite) SetupTest() {
+	sqlDB, _ := suite.db.DB()
+	_, _ = sqlDB.Exec("DELETE FROM entity_requests")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+// createUser seeds a user pinned to the given tier and admin flag.
+func (suite *EntityRequestServiceIntegrationTestSuite) createUser(name, tier string, isAdmin bool) *authm.User {
+	email := fmt.Sprintf("%s-%d@test.com", name, time.Now().UnixNano())
+	user := &authm.User{
+		Email:         &email,
+		FirstName:     &name,
+		IsActive:      true,
+		EmailVerified: true,
+		UserTier:      tier,
+		IsAdmin:       isAdmin,
+	}
+	suite.Require().NoError(suite.db.Create(user).Error)
+	return user
+}
+
+// marshalArtist builds a typed artist payload for the request body.
+func (suite *EntityRequestServiceIntegrationTestSuite) marshalArtist(name string) []byte {
+	raw, err := communitym.MarshalPayload(communitym.ArtistRequestPayload{Name: name})
+	suite.Require().NoError(err)
+	return raw
+}
+
+// --- Trust-tier gating -------------------------------------------------------
+
+// new_user → queued for admin (pending), no decision stamped.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_NewUser_Pending() {
+	user := suite.createUser("newbie", tierNewUser, false)
+
+	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Pending Band"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(req)
+
+	suite.Assert().Equal(communitym.EntityRequestStatePending, req.DecisionState)
+	suite.Assert().Nil(req.DecidedBy)
+	suite.Assert().Nil(req.DecidedAt)
+	suite.Assert().Equal(user.ID, req.RequesterID)
+	suite.Assert().Equal(communitym.EntityRequestArtist, req.EntityType)
+}
+
+// contributor → queued for admin (pending). This is the AC's canonical
+// "contributor request → pending" assertion.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_Contributor_Pending() {
+	user := suite.createUser("contrib", tierContributor, false)
+
+	req, err := suite.service.CreateRequest(user, communitym.EntityRequestVenue,
+		mustMarshalVenue(suite, "The Pending Room"), communitym.EntityRequestSourcePasteMode, false)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(communitym.EntityRequestStatePending, req.DecisionState)
+	suite.Assert().Nil(req.DecidedBy)
+}
+
+// admin → auto-approved on create, decision stamped with the admin's own id.
+// This is the AC's canonical "admin request → auto-approved" assertion.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_Admin_AutoApproved() {
+	user := suite.createUser("boss", tierNewUser, true) // tier irrelevant; IsAdmin wins
+
+	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Auto Approved Band"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(communitym.EntityRequestStateApproved, req.DecisionState)
+	suite.Require().NotNil(req.DecidedBy)
+	suite.Assert().Equal(user.ID, *req.DecidedBy)
+	suite.Require().NotNil(req.DecidedAt)
+}
+
+// local_ambassador → auto-approved on create (highest non-admin trust).
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_LocalAmbassador_AutoApproved() {
+	user := suite.createUser("amb", tierLocalAmbassador, false)
+
+	req, err := suite.service.CreateRequest(user, communitym.EntityRequestLabel,
+		mustMarshalLabel(suite, "Ambassador Records"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(communitym.EntityRequestStateApproved, req.DecisionState)
+	suite.Require().NotNil(req.DecidedBy)
+	suite.Assert().Equal(user.ID, *req.DecidedBy)
+}
+
+// trusted_contributor + confirmed → auto-approved (FE confirm step is the gate).
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_TrustedConfirmed_AutoApproved() {
+	user := suite.createUser("trusted", tierTrustedContributor, false)
+
+	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Trusted Confirmed Band"), communitym.EntityRequestSourceManual, true)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(communitym.EntityRequestStateApproved, req.DecisionState)
+	suite.Require().NotNil(req.DecidedBy)
+}
+
+// trusted_contributor + NOT confirmed → still queued (pending). The confirm
+// step is what unlocks auto-approve for this tier.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_TrustedUnconfirmed_Pending() {
+	user := suite.createUser("trusted2", tierTrustedContributor, false)
+
+	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Trusted Unconfirmed Band"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(communitym.EntityRequestStatePending, req.DecisionState)
+	suite.Assert().Nil(req.DecidedBy)
+}
+
+// --- Payload integrity through the DB ---------------------------------------
+
+// An artist-type row written through the service reads back as a clean
+// ArtistRequestPayload with no field loss after a full DB round-trip. This is
+// the substantive guarantee behind the ticket's "a backfilled artist row reads
+// back cleanly as ArtistRequestPayload" AC — adapted to a freshly-created row
+// because there is no artist_requests source table to backfill (see PR body).
+func (suite *EntityRequestServiceIntegrationTestSuite) TestArtistPayload_RoundTripsThroughDB() {
+	user := suite.createUser("rt", tierNewUser, false)
+
+	full := communitym.ArtistRequestPayload{
+		Name:             "Round Trip Band",
+		City:             strptr("Phoenix"),
+		State:            strptr("AZ"),
+		Country:          strptr("USA"),
+		Description:      strptr("Full payload."),
+		ImageURL:         strptr("https://img.example/rt.jpg"),
+		BandcampEmbedURL: strptr("https://bandcamp.example/rt"),
+	}
+	raw, err := communitym.MarshalPayload(full)
+	suite.Require().NoError(err)
+
+	created, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		raw, communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	// Re-fetch from the DB (not the in-memory struct) to prove JSONB persistence.
+	fetched, err := suite.service.GetRequest(created.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(fetched)
+	suite.Require().NotNil(fetched.Payload)
+
+	out, err := communitym.UnmarshalPayload[communitym.ArtistRequestPayload](*fetched.Payload)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(full, out)
+}
+
+// --- Validation --------------------------------------------------------------
+
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_InvalidEntityType() {
+	user := suite.createUser("bad", tierNewUser, false)
+	_, err := suite.service.CreateRequest(user, "podcast",
+		suite.marshalArtist("X"), communitym.EntityRequestSourceManual, false)
+	suite.Require().Error(err)
+}
+
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_InvalidSourceContext() {
+	user := suite.createUser("bad2", tierNewUser, false)
+	_, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("X"), "telepathy", false)
+	suite.Require().Error(err)
+}
+
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_EmptyPayload() {
+	user := suite.createUser("bad3", tierNewUser, false)
+	_, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		nil, communitym.EntityRequestSourceManual, false)
+	suite.Require().Error(err)
+}
+
+// --- Moderation decisions ----------------------------------------------------
+
+// Admin approves a pending request → state flips, decider stamped.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_ApprovePending() {
+	requester := suite.createUser("req", tierNewUser, false)
+	admin := suite.createUser("mod", tierNewUser, true)
+
+	pending, err := suite.service.CreateRequest(requester, communitym.EntityRequestArtist,
+		suite.marshalArtist("Needs Review"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+	suite.Require().Equal(communitym.EntityRequestStatePending, pending.DecisionState)
+
+	note := "looks good"
+	decided, err := suite.service.Decide(pending.ID, admin.ID, communitym.EntityRequestStateApproved, &note)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(communitym.EntityRequestStateApproved, decided.DecisionState)
+	suite.Require().NotNil(decided.DecidedBy)
+	suite.Assert().Equal(admin.ID, *decided.DecidedBy)
+	suite.Require().NotNil(decided.DecisionNote)
+	suite.Assert().Equal(note, *decided.DecisionNote)
+}
+
+// Deciding a non-pending request is rejected (idempotency / no double-decide).
+func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_AlreadyResolved() {
+	admin := suite.createUser("mod2", tierNewUser, true)
+
+	// Admin-created request is already approved on create.
+	approved, err := suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
+		suite.marshalArtist("Already Approved"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+	suite.Require().Equal(communitym.EntityRequestStateApproved, approved.DecisionState)
+
+	_, err = suite.service.Decide(approved.ID, admin.ID, communitym.EntityRequestStateRejected, nil)
+	suite.Require().Error(err)
+}
+
+// Decide rejects a non-approve/reject target state.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_InvalidTargetState() {
+	requester := suite.createUser("req2", tierNewUser, false)
+	admin := suite.createUser("mod3", tierNewUser, true)
+	pending, err := suite.service.CreateRequest(requester, communitym.EntityRequestArtist,
+		suite.marshalArtist("X"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	_, err = suite.service.Decide(pending.ID, admin.ID, communitym.EntityRequestStatePending, nil)
+	suite.Require().Error(err)
+}
+
+// --- Listing -----------------------------------------------------------------
+
+// ListPending returns only pending rows, newest-first, and respects the
+// entity_type filter.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestListPending_FiltersAndExcludesApproved() {
+	newbie := suite.createUser("lister", tierNewUser, false)
+	admin := suite.createUser("listmod", tierNewUser, true)
+
+	// One pending artist (new_user), one pending venue (new_user), one approved
+	// artist (admin auto-approve) that must NOT appear.
+	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
+		suite.marshalArtist("Pending A"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+	_, err = suite.service.CreateRequest(newbie, communitym.EntityRequestVenue,
+		mustMarshalVenue(suite, "Pending V"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+	_, err = suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
+		suite.marshalArtist("Approved A"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	all, total, err := suite.service.ListPending("", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(2), total, "approved row must be excluded")
+	suite.Assert().Len(all, 2)
+
+	artistsOnly, total, err := suite.service.ListPending(communitym.EntityRequestArtist, 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Require().Len(artistsOnly, 1)
+	suite.Assert().Equal(communitym.EntityRequestArtist, artistsOnly[0].EntityType)
+}
+
+// strptr is a local pointer helper for the entity-request payload fixtures.
+// (collection_test.go has strPtrCollection but it's collection-scoped; keep
+// this one named for its own use site.)
+func strptr(s string) *string { return &s }
+
+func mustMarshalVenue(suite *EntityRequestServiceIntegrationTestSuite, name string) []byte {
+	raw, err := communitym.MarshalPayload(communitym.VenueRequestPayload{Name: name, City: "Phoenix", State: "AZ"})
+	suite.Require().NoError(err)
+	return raw
+}
+
+func mustMarshalLabel(suite *EntityRequestServiceIntegrationTestSuite, name string) []byte {
+	raw, err := communitym.MarshalPayload(communitym.LabelRequestPayload{Name: name})
+	suite.Require().NoError(err)
+	return raw
+}
+
+func TestEntityRequestServiceIntegrationTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	suite.Run(t, new(EntityRequestServiceIntegrationTestSuite))
+}

--- a/scripts/check_entity_request_payloads.sh
+++ b/scripts/check_entity_request_payloads.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scripts/check_entity_request_payloads.sh
+#
+# PSY-869 CI parity check: every entity_type accepted by the entity_requests
+# table's CHECK constraint MUST have a matching Go payload struct registered in
+# payloadRegistry, and vice versa. Drift in either direction fails the build.
+#
+# This mirrors the grep-based migration-policy checks in .github/workflows/ci.yml
+# (duplicate-version / missing-down checks). It is intentionally a dumb,
+# dependency-free text comparison so it runs anywhere with bash + grep + sort.
+#
+# Sources of truth (kept deliberately close together so drift is a one-file
+# diff in review):
+#   1. The newest entity_requests CHECK constraint — the `entity_type IN (...)`
+#      list across all *_entity_requests migrations. We scan ALL such migrations
+#      and union the values so a follow-up migration that ALTERs the CHECK to
+#      add a value is picked up.
+#   2. payloadRegistry in
+#      internal/models/community/entity_request_payloads.go — the map literal
+#      whose keys are the EntityRequest* constants.
+#
+# Exit non-zero (failing CI) on any mismatch, printing the offending values.
+
+set -euo pipefail
+
+# Resolve repo paths relative to this script so it works from any cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATIONS_DIR="$REPO_ROOT/backend/db/migrations"
+PAYLOADS_FILE="$REPO_ROOT/backend/internal/models/community/entity_request_payloads.go"
+
+if [ ! -f "$PAYLOADS_FILE" ]; then
+  echo "ERROR: payload registry file not found: $PAYLOADS_FILE" >&2
+  exit 1
+fi
+
+# --- 1. entity_type values from the migration CHECK constraint(s) ------------
+# Grep every migration that mentions entity_requests, pull the
+# `entity_type IN ('a', 'b', ...)` list, and extract the quoted values. We
+# scope to lines that pair `entity_type` with `IN (` to avoid matching the
+# source_context / decision_state CHECK lists in the same file.
+CHECK_VALUES="$(grep -rhoE "entity_type[[:space:]]+IN[[:space:]]*\([^)]*\)" \
+                  "$MIGRATIONS_DIR"/*entity_requests*.up.sql 2>/dev/null \
+                | grep -oE "'[a-z_]+'" \
+                | tr -d "'" \
+                | sort -u || true)"
+
+if [ -z "$CHECK_VALUES" ]; then
+  echo "ERROR: could not extract any entity_type values from the" >&2
+  echo "       entity_requests CHECK constraint in $MIGRATIONS_DIR." >&2
+  echo "       Did the migration filename or CHECK shape change?" >&2
+  exit 1
+fi
+
+# --- 2. registered payload entity_types from the Go registry -----------------
+# payloadRegistry maps EntityRequest<Type> constants to payload structs. Pull
+# the constant values from their `const` definitions so we compare the actual
+# string values (not the Go identifiers).
+#
+# Constant block looks like:
+#   EntityRequestArtist = "artist"
+REGISTRY_VALUES="$(grep -oE 'EntityRequest[A-Z][a-zA-Z]+[[:space:]]*=[[:space:]]*"[a-z_]+"' \
+                     "$PAYLOADS_FILE" \
+                   | grep -oE '"[a-z_]+"' \
+                   | tr -d '"' \
+                   | sort -u || true)"
+
+if [ -z "$REGISTRY_VALUES" ]; then
+  echo "ERROR: could not extract any EntityRequest* constant values from" >&2
+  echo "       $PAYLOADS_FILE." >&2
+  exit 1
+fi
+
+# --- 3. compare ---------------------------------------------------------------
+# In the CHECK but missing a payload constant → a request of that type would be
+# accepted by the DB but have no typed payload struct (the exact bug this guards).
+MISSING_STRUCT="$(comm -23 <(printf '%s\n' "$CHECK_VALUES") <(printf '%s\n' "$REGISTRY_VALUES"))"
+# Registered in Go but not allowed by the DB CHECK → an insert would fail at the
+# DB. Also a drift worth failing on.
+MISSING_CHECK="$(comm -13 <(printf '%s\n' "$CHECK_VALUES") <(printf '%s\n' "$REGISTRY_VALUES"))"
+
+STATUS=0
+if [ -n "$MISSING_STRUCT" ]; then
+  echo "ERROR: entity_type(s) allowed by the entity_requests CHECK constraint" >&2
+  echo "       but missing a payload struct in entity_request_payloads.go:" >&2
+  printf '         %s\n' $MISSING_STRUCT >&2
+  echo "       Add an EntityRequest<Type> const + a <Type>RequestPayload struct" >&2
+  echo "       and register it in payloadRegistry." >&2
+  STATUS=1
+fi
+if [ -n "$MISSING_CHECK" ]; then
+  echo "ERROR: entity_type(s) registered in payloadRegistry but NOT allowed by" >&2
+  echo "       the entity_requests CHECK constraint:" >&2
+  printf '         %s\n' $MISSING_CHECK >&2
+  echo "       Add the value to the CHECK constraint via a new migration." >&2
+  STATUS=1
+fi
+
+if [ "$STATUS" -eq 0 ]; then
+  echo "OK: entity_requests entity_type CHECK constraint and payloadRegistry agree:"
+  printf '  %s\n' $CHECK_VALUES
+fi
+
+exit "$STATUS"


### PR DESCRIPTION
## Summary
- Land the polymorphic **`entity_requests`** moderation-queue foundation for user-requested entity creation, so **PSY-853** (AICollectionFiller) and **PSY-845** (AddItemsPicker) can build their queues on top without colliding on a migration.
- Architecture (LOCKED 2026-05-26): a **single polymorphic table** — polymorphism in the table (one row shape, JSONB `payload`, `entity_type` discriminator); typing in Go (one payload struct per `entity_type`, validated on read).
- Migration `20260601000000_create_entity_requests` (+down): shared envelope (`entity_type` / `payload` JSONB / `requester_id` / `source_context` / `decision_state` / `decided_by`/`_at`/`_note`), CHECK-constrained enums, queue indexes. Down is a clean `DROP TABLE`.
- Per-type payload structs (artist/release/label/show/venue/festival) + `MarshalPayload` / `UnmarshalPayload[T]` (fails **loud** on schema drift via `DisallowUnknownFields` + trailing-data + empty checks) + `payloadRegistry`, in `internal/models/community/entity_request_payloads.go`.
- `EntityRequest` model using `*json.RawMessage` for JSONB (project convention, mirrors `admin.AuditLog` / `admin.PendingEntityEdit`).
- `EntityRequestService` with trust-tier gating: `admin` / `local_ambassador` auto-approve; `trusted_contributor` auto-approves on an FE-confirmed request; `contributor` / `new_user` queue as `pending`. Plus `Decide` (atomic), `ListPending`, `GetRequest`. Tier names mirrored from `services/admin/auto_promotion.go` (no new tier names invented).
- Typed errors in `internal/errors/entity_request.go` (HTTP-status mapper wiring deferred to PSY-853/845, which add the handlers).
- **CI parity check** `scripts/check_entity_request_payloads.sh`, wired into the `migration-lint` job: fails the build if an `entity_type` is added to the CHECK constraint without a matching payload struct (or vice versa). Verified to fail in both drift directions.

### ⚠️ Backfill deviation — open question for review
The ticket asked to backfill an **`artist_requests`** table into `entity_requests`. **No such table exists** — verified against `db/migrations`, `internal/models`, and the live isolated DB (`to_regclass('public.artist_requests')` → NULL). The only request table is **`requests`**, which is the community **wishlist/voting** feature (`community.Request`: title/description/upvotes/fulfillment), **not** an entity-creation queue. Backfilling it would conflate two distinct features and seed the new queue with payload-less rows. So the table is created **empty** (creation-queue pre/post row count = 0/0, trivially equal). Flagging for a maintainer decision — if there's a real source of artist-creation requests I missed, point me at it and I'll add the backfill.

Docs deliverable returned to the orchestrator (`docs/` is gitignored in this repo).

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `go test ./internal/services/community/... ./internal/models/... ./internal/api/handlers/community/...` — passed
- [x] migration up→down→up round-trip (migrate CLI v4.19.1 against isolated DB) — clean
- [x] CI parity check fails on both drift directions, passes when aligned
- [x] `/adversarial-review` — CONCERNS addressed in separate commit `3a53b49d`

## Manual repro
Stack mode `isolated` (backend + migration). Migrate CLI v4.19.1 against the isolated DB (`localhost:50367`):

```
=== current schema_migrations version (after stack-up) ===
20260601000000|f          (dirty=f)

=== artist_requests table exists? (ticket premise check) ===
(empty)                   -- to_regclass('public.artist_requests') → NULL

=== entity_requests row count (backfill check) ===
0
=== requests WHERE entity_type='artist' (the real wishlist table) ===
0

=== STEP 1: migrate down 1 (revert entity_requests) ===
20260601000000/d create_entity_requests (15.5ms)   exit=0
entity_requests gone? → (empty)
version after down → 20260531202754|f

=== STEP 2: migrate up (re-apply) ===
20260601000000/u create_entity_requests (10.7ms)   exit=0
entity_requests back? → entity_requests
version after up → 20260601000000|f

=== CHECK constraints created ===
entity_requests_entity_type_check    CHECK (entity_type IN ('artist','release','label','show','venue','festival'))
entity_requests_decision_state_check CHECK (decision_state IN ('pending','approved','rejected'))
entity_requests_source_context_check CHECK (source_context IN ('ai_extraction','paste_mode','manual'))
=== indexes ===
entity_requests_pkey, idx_entity_requests_created_at, idx_entity_requests_decision_state,
idx_entity_requests_requester_id, idx_entity_requests_state_type
```

Backfill row-count match: creation-queue source rows (none — no `artist_requests` table) = 0; `entity_requests` post-migration = 0. **0 == 0, match.**

Trust-tier integration tests (the manual repro for service behavior, PSY-592 pattern) — all PASS:
- `TestCreate_NewUser_Pending` → `decision_state=pending`, no decider stamped
- `TestCreate_Contributor_Pending` → `pending` (the AC's canonical "contributor → pending")
- `TestCreate_Admin_AutoApproved` → `approved`, `decided_by` = requester's own id, `decided_at` set (the AC's canonical "admin → auto-approved")
- `TestCreate_LocalAmbassador_AutoApproved` → `approved`
- `TestCreate_TrustedConfirmed_AutoApproved` → `approved` (FE confirm unlocks auto-approve)
- `TestCreate_TrustedUnconfirmed_Pending` → `pending` (unconfirmed trusted still queues)
- `TestArtistPayload_RoundTripsThroughDB` → artist payload written via the service re-reads from the DB as a clean `ArtistRequestPayload`, no field loss (the substantive guarantee behind the "backfilled artist row reads back cleanly" AC, adapted to a fresh row since there's no source table)
- `TestDecide_ApprovePending` / `TestDecide_AlreadyResolved` / `TestDecide_SecondDecisionDoesNotClobber` / `TestDecide_InvalidTargetState` → moderation decision path + atomic no-clobber
- `TestListPending_FiltersAndExcludesApproved` → queue excludes approved rows, respects entity_type filter
- Plus model unit tests: round-trip per type (no field loss) + fail-loud guards (unknown field / wrong type / empty / trailing data) — all PASS.

## Code review
`/code-review` — 1 finding: `&user.ID` aliased the caller's struct field when stamping `DecidedBy`; fixed by copying to a local (`6984303d`).

## Adversarial review
`/adversarial-review` — CONCERNS, addressed in separate commit `3a53b49d`. Panel run inline (no Agent tool in a worktree).
- **[HIGH] Saboteur** — `Decide()` had a TOCTOU race (non-atomic read-check-write); two concurrent decisions could both pass the pending check and the second silently clobbered the first. → Fixed with a conditional `UPDATE ... WHERE decision_state='pending'`; racing writer matches 0 rows and gets an invalid-state conflict. Added `TestDecide_SecondDecisionDoesNotClobber`.
- **[MEDIUM] Security** — `Decide()` trusts the caller for admin authz (it has only `adminID`). → Documented the trust assumption; PSY-853/845 handlers MUST register it on an `rc.Admin`-gated route per the project admin-gating pattern. No service-level gate (the service has no user record; the boundary is the HTTP middleware).
- **Held up well:** fail-loud `UnmarshalPayload`, the parity-check guard (verified failing both directions), `autoApproves` fail-closed default, the empty `down.sql` reversibility.

### Known limitation (disclosed)
The parity script greps migrations matching `*entity_requests*.up.sql`. A future migration that `ALTER`s the CHECK constraint from a differently-named file would be missed — name CHECK-altering migrations with `entity_requests` in the filename, or extend the glob.

Closes PSY-869
