### PR TITLE
PSY-867: rename AI tab to From text (AI) + explainer tooltip

### DIFF
--- a/frontend/features/collections/components/AddItemsPicker.test.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.test.tsx
@@ -315,6 +315,10 @@ describe('AddItemsPicker', () => {
         /paste any text, and the ai will do its best to extract/i
       )
     ).not.toBeInTheDocument()
+    // ...and the tab still activates — it routes to the AI pane (stubbed).
+    expect(
+      screen.getByTestId('ai-collection-filler-stub')
+    ).toBeInTheDocument()
   })
 
   it('shows the search empty-state copy by default', () => {

--- a/frontend/features/collections/components/AddItemsPicker.test.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.test.tsx
@@ -147,6 +147,12 @@ vi.mock('@/components/shared', () => ({
   }) => <div data-testid={testId}>{children}</div>,
 }))
 
+// The AI pane pulls in useCollectionExtraction (not mocked here); stub it so
+// the AC#3 guard can activate the AI tab without dragging in that dependency.
+vi.mock('./AICollectionFiller', () => ({
+  AICollectionFiller: () => <div data-testid="ai-collection-filler-stub" />,
+}))
+
 // ──────────────────────────────────────────────
 // parsePasteLine — pure function tests
 // ──────────────────────────────────────────────
@@ -256,6 +262,59 @@ describe('AddItemsPicker', () => {
     expect(screen.getByTestId('tab-paste')).toBeInTheDocument()
     expect(screen.getByTestId('tab-ai')).toBeInTheDocument()
     expect(screen.getByTestId('tab-ai')).not.toBeDisabled()
+  })
+
+  it('labels the AI tab "From text (AI)" with an ⓘ explainer as a SIBLING of the tab', () => {
+    // PSY-867: "From article (AI)" was misleadingly narrow — the route
+    // accepts any text. The ⓘ must be a SIBLING of the tab trigger (its own
+    // focus stop), NOT nested inside the trigger <button> (interactive
+    // content inside a button is invalid). The not.toContainElement guard
+    // is what fails if a refactor nests the glyph back into the tab.
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    expect(screen.getByText('From text (AI)')).toBeInTheDocument()
+    expect(screen.queryByText(/From article/i)).not.toBeInTheDocument()
+    expect(screen.getByTestId('ai-tab-info')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-ai')).not.toContainElement(
+      screen.getByTestId('ai-tab-info')
+    )
+  })
+
+  it('opens the AI explainer tooltip on keyboard focus of the ⓘ glyph', async () => {
+    // AC: tooltip renders the locked copy on keyboard focus of the glyph.
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await act(async () => {
+      screen.getByTestId('ai-tab-info').focus()
+    })
+    // Radix renders the copy twice (visible content + a visually-hidden
+    // role="tooltip" span for screen readers), so match all and assert ≥1.
+    const matches = await screen.findAllByText(
+      /paste any text, and the ai will do its best to extract/i
+    )
+    expect(matches.length).toBeGreaterThan(0)
+  })
+
+  it('opens the AI explainer tooltip on hover of the ⓘ glyph', async () => {
+    // AC: tooltip also renders on hover (the path real pointer users hit).
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await user.hover(screen.getByTestId('ai-tab-info'))
+    const matches = await screen.findAllByText(
+      /paste any text, and the ai will do its best to extract/i
+    )
+    expect(matches.length).toBeGreaterThan(0)
+  })
+
+  it('does not open the explainer when the AI tab itself is activated', async () => {
+    // AC: the trigger surface is JUST the ⓘ glyph — activating the tab must
+    // not surface the explainer.
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await user.click(screen.getByTestId('tab-ai'))
+    expect(
+      screen.queryByText(
+        /paste any text, and the ai will do its best to extract/i
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('shows the search empty-state copy by default', () => {

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -192,10 +192,14 @@ const AI_TAB_TOOLTIP_COPY =
  * still switches modes.
  *
  * The Tooltip composition mirrors the canonical `TransitiveTagTooltip`
- * (TagFacetPanel.tsx). The placement as a non-tab sibling INSIDE the
- * Radix tablist is specific to this tab context — Radix tolerates it and
- * the glyph stays keyboard-reachable as its own Tab stop; a future shared
- * `InfoTooltip` extraction (PSY follow-up) would standardize this.
+ * (TagFacetPanel.tsx). The placement as a non-tab sibling INSIDE the Radix
+ * tablist is specific to this tab context: Radix's roving-tabindex only
+ * governs `role="tab"` descendants, so the glyph stays an ordinary Tab stop
+ * rather than joining the arrow-key tab cycle. Verified manually in-browser
+ * (arrow keys still move between the three tabs; the glyph is its own Tab
+ * stop) — the unit tests mock `@/components/ui/tabs`, so they do not cover
+ * the real-Radix focus path. A future shared `InfoTooltip` extraction (PSY
+ * follow-up) would standardize this.
  */
 function AiTabInfoTooltip() {
   return (
@@ -224,8 +228,8 @@ export function AddItemsPicker({
   stagedItems,
   onStagedItemsChange,
 }: AddItemsPickerProps) {
-  // Active mode tab. AI tab is intentionally disabled in V1 — see file
-  // header for the PSY-824 link.
+  // Active mode tab — all three modes (search | paste | ai) are live; the
+  // AI tab was enabled in PSY-824.
   const [tab, setTab] = useState<'search' | 'paste' | 'ai'>('search')
 
   // ─── Search mode state ───
@@ -419,7 +423,7 @@ export function AddItemsPicker({
               not a child of the tab trigger — nesting a focusable element
               inside the trigger <button> would be invalid. See
               AiTabInfoTooltip. */}
-          <div className="inline-flex flex-1 items-center justify-center gap-1">
+          <div className="inline-flex min-w-0 flex-1 items-center justify-center gap-1">
             <TabsTrigger value="ai" className="flex-none">
               From text (AI)
             </TabsTrigger>

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -34,11 +34,18 @@ import {
   AlertCircle,
   Library,
   Loader2,
+  Info,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { InlineErrorBanner } from '@/components/shared'
 import {
   useEntitySearch,
@@ -168,6 +175,49 @@ export interface AddItemsPickerProps {
 /** Maximum visible rows in the staged list before scrolling. Tracks the
  *  Figma's 10-row visible window on state 05. */
 const STAGED_LIST_MAX_VISIBLE = 10
+
+/** Locked copy (PSY-867 design review, 2026-05-26). The "From text (AI)"
+ *  tab accepts any pasted text, not just articles — this explainer sets
+ *  the expectation (any text in, best-effort extraction out) and the
+ *  honest caveat that the model is fallible. */
+const AI_TAB_TOOLTIP_COPY =
+  'Paste any text, and the AI will do its best to extract any artists or releases referenced. AI can and will make mistakes.'
+
+/**
+ * The ⓘ explainer for the "From text (AI)" tab. Rendered as a SIBLING of
+ * the tab trigger (not a child) — the trigger is a `<button>` and nesting
+ * another focusable element inside it would be invalid interactive-content
+ * nesting. As a sibling it gets its own focus stop, so the tooltip opens on
+ * hover AND keyboard focus of just the glyph, while clicking the tab itself
+ * still switches modes.
+ *
+ * The Tooltip composition mirrors the canonical `TransitiveTagTooltip`
+ * (TagFacetPanel.tsx). The placement as a non-tab sibling INSIDE the
+ * Radix tablist is specific to this tab context — Radix tolerates it and
+ * the glyph stays keyboard-reachable as its own Tab stop; a future shared
+ * `InfoTooltip` extraction (PSY follow-up) would standardize this.
+ */
+function AiTabInfoTooltip() {
+  return (
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="What can I paste into the AI tab?"
+            className="inline-flex items-center rounded-full p-0.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            data-testid="ai-tab-info"
+          >
+            <Info className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs text-xs">
+          {AI_TAB_TOOLTIP_COPY}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
 
 export function AddItemsPicker({
   existingItems = [],
@@ -364,7 +414,17 @@ export function AddItemsPicker({
         <TabsList className="w-full justify-start">
           <TabsTrigger value="search">Search</TabsTrigger>
           <TabsTrigger value="paste">Paste URLs</TabsTrigger>
-          <TabsTrigger value="ai">From article (AI)</TabsTrigger>
+          {/* The AI tab + its ⓘ explainer share one flex slot so they read
+              as "From text (AI) ⓘ". The info trigger is a sibling button,
+              not a child of the tab trigger — nesting a focusable element
+              inside the trigger <button> would be invalid. See
+              AiTabInfoTooltip. */}
+          <div className="inline-flex flex-1 items-center justify-center gap-1">
+            <TabsTrigger value="ai" className="flex-none">
+              From text (AI)
+            </TabsTrigger>
+            <AiTabInfoTooltip />
+          </div>
         </TabsList>
 
         {tab === 'search' && (


### PR DESCRIPTION
Closes PSY-867.

## Summary
- Rename the `AddItemsPicker` AI-extraction tab from **"From article (AI)"** to **"From text (AI)"** — the underlying `/api/ai/extract-collection` route accepts any pasted text (emails, lyrics, lists, prose), not just article-shaped content, so "From article" read as misleadingly narrow.
- Add an **ⓘ explainer tooltip** with the design-locked copy: *"Paste any text, and the AI will do its best to extract any artists or releases referenced. AI can and will make mistakes."* It opens on **hover and keyboard focus** of the glyph.
- The ⓘ is a **sibling button** of the tab trigger (wrapped in one flex slot so it reads as "From text (AI) ⓘ"), not nested inside the `<button>` — nesting a focusable element inside the trigger would be invalid interactive-content nesting. Activating the tab still switches modes as before.
- Tooltip composition reuses the canonical `TransitiveTagTooltip` shape (TagFacetPanel.tsx).

## Deferred (per review)
- **Shared `InfoTooltip` primitive** — `AiTabInfoTooltip` is now the 2nd local copy of this ⓘ-explainer pattern (`TransitiveTagTooltip` is the 1st). Flagged by `/code-review` + `/adversarial-review` as a reuse opportunity, kept out of scope here. Filed **PSY-969** to extract `components/shared/InfoTooltip` and refactor both call sites.

## Adversarial review
`/adversarial-review` — CONCERNS, 4 findings addressed in separate commit `c5a0341e`. Panel: Saboteur · Future-Maintainer · Security · Completeness (Security CLEAN, Completeness CLEAN — all 5 ACs MET). Reviewers ran with no prior session context against the branch diff.
- [MEDIUM] (Saboteur + Future-Maintainer) Stale comment claiming the AI tab is "intentionally disabled in V1" → corrected; the tab has been enabled since PSY-824.
- [MEDIUM] (Saboteur + Future-Maintainer) Doc-comment overclaimed "Radix tolerates it" as fact → softened to state the real-Radix keyboard path is manually browser-verified (arrow-nav + glyph-as-own-Tab-stop), not unit-tested (Tabs is mocked).
- [LOW] Narrow-drawer overflow risk on the `flex-none` AI slot → added `min-w-0` to the flex wrapper.
- [LOW] (Completeness) Tab-click guard test only asserted the tooltip stays closed → now also positively asserts the AI pane renders (tab still activates).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/collections` — 347/347 passing (4 new AddItemsPicker tests)
- [x] `/code-review` — no production-code defects; test-coverage findings addressed (sibling-structure guard via `not.toContainElement`, hover test added, AC#3 guard added)
- [x] `/adversarial-review` — CONCERNS; 4 findings fixed in separate commit `c5a0341e`
- [x] Manual repro against local dev stack: logged in, opened the Create Collection drawer, confirmed the tab reads "From text (AI) ⓘ", hovered the glyph → tooltip showed the locked copy; verified in-browser that ArrowRight nav still reaches + activates the wrapped AI tab and the ⓘ is a separate Tab stop.

## Screenshots
The Create Collection drawer's Add-items tabs, with the renamed tab and the explainer tooltip open on hover of the ⓘ:

![Create Collection drawer — "From text (AI) ⓘ" tab with the explainer tooltip open showing the locked copy](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-509f87da4e411cdef1e0/02-tooltip-open.png)

Default state (tooltip closed):

![Add-items tabs: Search | Paste URLs | From text (AI) ⓘ](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-509f87da4e411cdef1e0/01-tabs-default.png)

## Coverage gaps
Honest disclosure of what the tests/manual repro do NOT cover:
- **Real-Radix focus order is not unit-tested.** The unit tests mock `@/components/ui/tabs`, so the "ⓘ is keyboard-reachable as its own Tab stop within a real Radix tablist" claim rests on manual in-browser verification this session (arrow-nav reached + activated the AI tab; the glyph was a separate Tab stop), not on an automated integration test. The `not.toContainElement` guard *does* catch the sibling-vs-nested regression even under the mock.
- **Hover was exercised in jsdom** (`user.hover`) and **in the live browser** (screenshot), but the screenshot captures the hover state, not the keyboard-focus state (the focus path is covered by unit test).
- Tooltip placement/collision at very narrow mobile drawer widths not visually exercised beyond the `min-w-0` overflow guard; the Radix `Portal` keeps the content out of the drawer's `overflow-y-auto` clip.
- **Tooltip dismiss/close path not exercised.** Tests assert open-on-focus and open-on-hover only. Radix's auto-close on blur / mouse-leave / Escape is unmodified default behavior — the diff adds no custom `open`/`onOpenChange`, so the close path is untested but also unowned (no project code governs it).
