### PR TITLE
PSY-968: ContributionPrompt no longer flush against header

### DIFF
--- a/frontend/features/contributions/components/ContributionPrompt.tsx
+++ b/frontend/features/contributions/components/ContributionPrompt.tsx
@@ -88,7 +88,7 @@ export function ContributionPrompt({
 
   return (
     <div
-      className="flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm"
+      className="mt-4 flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm"
       data-testid="contribution-prompt"
     >
       <Lightbulb className="h-4 w-4 text-primary shrink-0" />


### PR DESCRIPTION
Closes PSY-968.

## Summary
- The shared `ContributionPrompt` banner ("Help complete this <entity>'s profile") rendered **flush** against the row above it on the entity detail pages that use `EntityDetailLayout` (artist / release / label / festival). It sits as a bare block-flow sibling inside `<header className="mb-6">`, and its previous sibling (`EntityHeader`) has no bottom margin — so when the optional rows above it (`AttributionLine`, `EntityTagList`) are all absent, the prompt butted directly against the header subtitle (e.g. a release with no description/tags).
- Fix: add `mt-4` to the shared `ContributionPrompt` root. One shared change fixes all the affected pages at once. This follows the existing convention in this header region where alert/callout banners own their own margin — the peer `EntitySaveSuccessBanner` already owns `mb-4` (via `StatusBanner`).

## Verification of the spacing interaction (the ticket's key risk)
The ticket flagged that margins might **add** vs **collapse** depending on the parent. Verified empirically in the running app, both cases:

| Page state | Gap above prompt | Notes |
| --- | --- | --- |
| Empty (no tags/attribution) — the bug | **0px → 16px** | `mt-4` vs the marginless `EntityHeader`. Clean, no longer flush. |
| Tagged (`EntityTagList` present) | **16px → 32px** | `EntityTagList` root is `py-4` (padding, doesn't collapse with margin), so the 16px tag padding + 16px `mt-4` = 32px. Verified in-app: reads as balanced, **not** over-large — matches the prompt→Artists rhythm below it. |
| VenueDetail (outlier — see below) | **32px → 32px (unchanged)** | No regression. |

I also tested the ticket's suggested fallback (`mt-3`): it makes the tagged case 28px (visually indistinguishable from 32px) but tightens the empty case to a cramped 12px — making the *primary* fix worse. So `mt-4` is the right value; the tagged-case "over-spacing" the static reviewers feared does not materialize visually.

## VenueDetail asymmetry (heads up)
The ticket listed all 5 entity pages as "bare siblings with no wrapper spacing," but `VenueDetail.tsx` is a structural **outlier**: it doesn't use `EntityDetailLayout` — it has a custom layout and renders the prompt in its own `<div className="mb-4">` wrapper *after* a `<header className="mb-8">` (`VenueDetail.tsx:182,270`). The new `mt-4` collapses up through the bare wrapper and adjacent-collapses with the header's `mb-8` (block-flow margin collapsing → `max(32,16)=32px`), so the venue gap stays **32px, unchanged** — verified in-app (DOM measurement + screenshot). VenueDetail was never flush, so it didn't have the bug and doesn't regress. Its `<div className="mb-4">` wrapper is now slightly redundant with the component's `mt-4`, but harmless (the `mb-4` governs the gap *below* the prompt) — left as-is to keep this margin-only ticket scoped.

## Adversarial review
`/adversarial-review` — CONCERNS, investigated and resolved; **no code change** (the review confirmed the original choice).
- [HIGH] "Venue double-spaces to 48px (mb-8 + mt-4)" (Future-Maintainer) → **refuted with empirical evidence**: adjacent/parent-child margins *collapse* in block flow, not add — measured 32px in-app, unchanged.
- [MEDIUM] "Additive 32px on tagged pages (py-4 + mt-4)" (raised by all 3 lenses) → mechanism confirmed, but rendered result verified balanced/not over-large; tested the suggested `mt-3` alternative and found it worse for the primary (empty-case) fix. Kept `mt-4`, disclosed above.
- [LOW] "Venue wrapper `mb-4` now redundant" → disclosed above; harmless, left as-is.

Panel: Saboteur · Future-Maintainer · Completeness. Reviewers ran with no prior session context against the branch diff. (Security lens omitted — purely presentational CSS, no input/auth/trust boundary.)

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/contributions` — 104/104 passing (no test pins the prompt root className)
- [x] `bun run lint` — 0 errors (154 pre-existing warnings, none in `ContributionPrompt.tsx`)
- [x] `/code-review` — surfaced the VenueDetail asymmetry; investigated + disclosed above
- [x] `/adversarial-review` — CONCERNS resolved (see above); no fixes commit
- [x] Manual repro (authenticated admin, local dev stack): empty release (`/releases/gods-country`, `/releases/blue-rev`), tagged release (`/releases/blue-rev` + shoegaze tag), and venue (`/venues/crescent-ballroom-phoenix-az`) — DOM-measured margins + screenshots, both themes (margin is theme-independent: identical `16px` in dark mode).

## Screenshots
Empty case — the fix. Prompt now has a clean 16px gap below the "LP 2022" subtitle (was flush):

![Empty release with clean gap above the prompt](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-78107eb57712e747f3b7/psy-968-empty-release.png)

Tagged case — no over-spacing. Balanced gap with the tag section above:

![Tagged release with balanced gap](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-78107eb57712e747f3b7/psy-968-populated-release.png)

VenueDetail (outlier) — unchanged, no regression:

![Venue page, prompt spacing unchanged](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-78107eb57712e747f3b7/psy-968-venue-noregression.png)

## Coverage gaps
- **Verified on release + venue pages; artist/label/festival not screenshotted individually.** The fix is in the *shared* component, rendered identically as a bare block-flow sibling inside `EntityDetailLayout`'s header on artist/release/label/festival (confirmed by reading each call site). Behavior is uniform across those 4; the release screenshot is representative.
- **Tagged-case 32px gap is data-dependent** (16px tagless vs 32px tagged on the same page type). This is structural — `EntityTagList`'s `py-4` internal padding, not the margin — and inherent regardless of margin value. Not fixed here (would require touching `EntityTagList`, out of scope for a margin-only polish ticket); both states verified to look acceptable.
