### PR TITLE
PSY-960: recently-used promotion in AddToCollectionButton popover

### DIFF
--- a/frontend/components/shared/AddToCollectionButton.test.tsx
+++ b/frontend/components/shared/AddToCollectionButton.test.tsx
@@ -872,3 +872,263 @@ describe('AddToCollectionButton — bracket variant (PSY-641)', () => {
     }
   )
 })
+
+describe('AddToCollectionButton — recently-used promotion (PSY-960)', () => {
+  // 9 collections so the grouping (>=5) AND the search box (>8) are both
+  // active — lets us exercise the searching-collapses-grouping rule too.
+  const NAMES = [
+    'Alpha',
+    'Bravo',
+    'Charlie',
+    'Delta',
+    'Echo',
+    'Foxtrot',
+    'Golf',
+    'Hotel',
+    'India',
+  ]
+  const MANY_COLLECTIONS = NAMES.map((title, i) => ({
+    id: i + 1,
+    slug: `c${i + 1}`,
+    title,
+    item_count: 3,
+    is_public: true,
+    cover_image_url: null,
+  }))
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+    mockAuthContext.mockReturnValue({
+      user: { id: '1' },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    mockContaining.mockReturnValue({
+      data: new Map<number, number>(),
+      isLoading: false,
+    })
+    mockMutateAsync.mockResolvedValue({ id: 999 })
+    mockRemoveMutateAsync.mockResolvedValue(undefined)
+  })
+
+  const openPopover = async () => {
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton
+        entityType="artist"
+        entityId={1}
+        entityName="Test Artist"
+      />
+    )
+    await user.click(
+      screen.getByRole('button', { name: /add to collection/i })
+    )
+    return user
+  }
+
+  it('promotes recently-used collections above a separator, newest first', async () => {
+    mockMyCollections.mockReturnValue({
+      data: { collections: MANY_COLLECTIONS },
+      isLoading: false,
+    })
+    // Charlie (id 3) added most recently, then Alpha (id 1).
+    window.localStorage.setItem(
+      'psy:collection-add-recency',
+      JSON.stringify({ '3': 2000, '1': 1000 })
+    )
+
+    await openPopover()
+
+    expect(await screen.findByText('Recently used')).toBeInTheDocument()
+    expect(screen.getByText('All collections')).toBeInTheDocument()
+
+    // Promoted rows render first, newest-first: Charlie then Alpha.
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(9)
+    expect(checkboxes[0]).toHaveAccessibleName(/charlie/i)
+    expect(checkboxes[1]).toHaveAccessibleName(/alpha/i)
+    // The third row is the start of the (un-promoted) remainder.
+    expect(checkboxes[2]).not.toHaveAccessibleName(/charlie|alpha/i)
+    // Each section is its own a11y group, labelled by its header.
+    const labelledGroups = screen
+      .getAllByRole('group')
+      .filter((g) => g.hasAttribute('aria-labelledby'))
+    expect(labelledGroups).toHaveLength(2)
+  })
+
+  it('orders a multi-select batch newest-first (last-checked promoted highest)', async () => {
+    mockMyCollections.mockReturnValue({
+      data: { collections: MANY_COLLECTIONS },
+      isLoading: false,
+    })
+
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+    )
+    const trigger = screen.getByRole('button', { name: /add to collection/i })
+
+    await user.click(trigger)
+    // Check Bravo (id 2) THEN Delta (id 4) in one batch — Delta is checked
+    // last, so it must get the newer stamp (strictly-increasing per batch).
+    await user.click(await screen.findByRole('checkbox', { name: /bravo/i }))
+    await user.click(screen.getByRole('checkbox', { name: /delta/i }))
+    await user.click(screen.getByRole('button', { name: /add to 2 collections/i }))
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem('psy:collection-add-recency') ?? '{}'
+      )
+      expect(stored['2']).toBeGreaterThan(0)
+      // Delta (last-checked) is strictly newer than Bravo, not a Date.now() tie.
+      expect(stored['4']).toBeGreaterThan(stored['2'])
+    })
+
+    // Reopen — Delta promoted above Bravo under "Recently used".
+    await user.click(trigger)
+    await user.click(trigger)
+    expect(await screen.findByText('Recently used')).toBeInTheDocument()
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes[0]).toHaveAccessibleName(/delta/i)
+    expect(checkboxes[1]).toHaveAccessibleName(/bravo/i)
+  })
+
+  it('stays flat (no grouping) below the collection threshold', async () => {
+    // DEFAULT_COLLECTIONS has 3 (< RECENTLY_USED_MIN_COLLECTIONS); recency is
+    // present but must be ignored.
+    mockMyCollections.mockReturnValue({
+      data: { collections: DEFAULT_COLLECTIONS },
+      isLoading: false,
+    })
+    window.localStorage.setItem(
+      'psy:collection-add-recency',
+      JSON.stringify({ '1': 1000 })
+    )
+
+    await openPopover()
+
+    expect(await screen.findByText('My Favorites')).toBeInTheDocument()
+    expect(screen.queryByText('Recently used')).not.toBeInTheDocument()
+    expect(screen.queryByText('All collections')).not.toBeInTheDocument()
+  })
+
+  it('stays flat on a cold start (no add-recency yet)', async () => {
+    mockMyCollections.mockReturnValue({
+      data: { collections: MANY_COLLECTIONS },
+      isLoading: false,
+    })
+    // localStorage intentionally empty.
+
+    await openPopover()
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument()
+    expect(screen.queryByText('Recently used')).not.toBeInTheDocument()
+  })
+
+  it('collapses to a flat filtered list while searching', async () => {
+    mockMyCollections.mockReturnValue({
+      data: { collections: MANY_COLLECTIONS },
+      isLoading: false,
+    })
+    window.localStorage.setItem(
+      'psy:collection-add-recency',
+      JSON.stringify({ '3': 2000 })
+    )
+
+    const user = await openPopover()
+    // Grouped before searching.
+    expect(await screen.findByText('Recently used')).toBeInTheDocument()
+
+    // Type a filter — the section headers disappear, results go flat.
+    await user.type(
+      screen.getByRole('textbox', { name: /filter collections/i }),
+      'char'
+    )
+    expect(screen.queryByText('Recently used')).not.toBeInTheDocument()
+    expect(screen.queryByText('All collections')).not.toBeInTheDocument()
+    expect(screen.getByText('Charlie')).toBeInTheDocument()
+  })
+
+  it('records the add in localStorage on a successful submit', async () => {
+    mockMyCollections.mockReturnValue({
+      data: { collections: MANY_COLLECTIONS },
+      isLoading: false,
+    })
+
+    const user = await openPopover()
+    // Check Delta (id 4) and submit.
+    await user.click(
+      await screen.findByRole('checkbox', { name: /delta/i })
+    )
+    await user.click(
+      screen.getByRole('button', { name: /add to 1 collection/i })
+    )
+
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem('psy:collection-add-recency') ?? '{}'
+      )
+      expect(stored['4']).toBeGreaterThan(0)
+    })
+  })
+
+  it('surfaces a collection under "Recently used" after an add + reopen', async () => {
+    mockMyCollections.mockReturnValue({
+      data: { collections: MANY_COLLECTIONS },
+      isLoading: false,
+    })
+
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+    )
+    const trigger = screen.getByRole('button', { name: /add to collection/i })
+
+    // First open: cold start, flat (no grouping).
+    await user.click(trigger)
+    expect(await screen.findByText('Echo')).toBeInTheDocument()
+    expect(screen.queryByText('Recently used')).not.toBeInTheDocument()
+
+    // Add to Echo (id 5) and submit.
+    await user.click(screen.getByRole('checkbox', { name: /echo/i }))
+    await user.click(screen.getByRole('button', { name: /add to 1 collection/i }))
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem('psy:collection-add-recency') ?? '{}'
+      )
+      expect(stored['5']).toBeGreaterThan(0)
+    })
+
+    // Close and reopen — Echo now promoted to the top of "Recently used".
+    await user.click(trigger)
+    await user.click(trigger)
+    expect(await screen.findByText('Recently used')).toBeInTheDocument()
+    expect(screen.getAllByRole('checkbox')[0]).toHaveAccessibleName(/echo/i)
+  })
+
+  it('caps "Recently used" at 5 and overflows extra stamped collections into "All collections"', async () => {
+    mockMyCollections.mockReturnValue({
+      data: { collections: MANY_COLLECTIONS },
+      isLoading: false,
+    })
+    // Six collections stamped (ids 1–6), distinct increasing timestamps.
+    window.localStorage.setItem(
+      'psy:collection-add-recency',
+      JSON.stringify({ '1': 1000, '2': 2000, '3': 3000, '4': 4000, '5': 5000, '6': 6000 })
+    )
+
+    await openPopover()
+
+    expect(await screen.findByText('Recently used')).toBeInTheDocument()
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(9)
+    // Promoted = the newest 5: Foxtrot(6) Echo(5) Delta(4) Charlie(3) Bravo(2).
+    expect(checkboxes[0]).toHaveAccessibleName(/foxtrot/i)
+    expect(checkboxes[4]).toHaveAccessibleName(/bravo/i)
+    // Alpha (id 1, oldest stamp) exceeds the cap → overflows into the
+    // remainder, NOT promoted, and is not duplicated.
+    expect(checkboxes[5]).not.toHaveAccessibleName(/foxtrot|echo|delta|charlie|bravo/i)
+    expect(screen.getAllByText('Alpha')).toHaveLength(1)
+  })
+})

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useRef, useState } from 'react'
+import { useId, useMemo, useRef, useState, type ReactNode } from 'react'
 import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
@@ -24,6 +24,10 @@ import {
 import { queryKeys } from '@/lib/queryClient'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import type { CollectionEntityType } from '@/features/collections/types'
+import {
+  readCollectionAddRecency,
+  recordCollectionAdd,
+} from '@/features/collections/collectionAddRecency'
 
 interface AddToCollectionButtonProps {
   entityType: CollectionEntityType
@@ -53,10 +57,33 @@ const UNSET = Symbol('unset')
 // exact cutoff is a judgment call (the design doesn't specify a number).
 const SEARCH_THRESHOLD = 8
 
+// PSY-960 / PSY-893 D3: the popover promotes up to this many recently-used
+// collections above a separator ("up to 5" per the locked design; tunable 3–5).
+const MAX_PROMOTED = 5
+
+// Grouping (RECENTLY USED / ALL COLLECTIONS) only earns its visual overhead
+// once the library is large enough that surfacing recents saves scanning. The
+// locked PSY-893 design draws the default-open mock (4 collections) FLAT and
+// the recently-used mock (5 collections) GROUPED — so the cutoff is 5.
+const RECENTLY_USED_MIN_COLLECTIONS = 5
+
 function describeError(reason: unknown): string {
   if (reason instanceof Error && reason.message) return reason.message
   if (typeof reason === 'string' && reason.length > 0) return reason
   return 'Failed to add to this collection'
+}
+
+/** Uppercase section label for the RECENTLY USED / ALL COLLECTIONS groups.
+ *  `id` lets each section's group reference it via aria-labelledby. */
+function SectionLabel({ id, children }: { id?: string; children: ReactNode }) {
+  return (
+    <p
+      id={id}
+      className="px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+    >
+      {children}
+    </p>
+  )
 }
 
 export function AddToCollectionButton({
@@ -179,6 +206,52 @@ export function AddToCollectionButton({
     if (!q) return collections
     return collections.filter((c) => c.title.toLowerCase().includes(q))
   }, [collections, search])
+
+  // Stable ids so each grouped section can label its own role="group".
+  const recentlyUsedLabelId = useId()
+  const allCollectionsLabelId = useId()
+
+  // Snapshot the add-recency signal when the popover OPENS. Reading per-open
+  // (not per-render) keeps the order stable while open — recording an add must
+  // not make the list jump under the user; the new order shows on next open.
+  // `{}` while closed avoids touching localStorage on SSR / on every
+  // entity-page render of this high-traffic affordance.
+  const recencySnapshot = useMemo<Record<string, number>>(
+    () => (open ? readCollectionAddRecency() : {}),
+    [open]
+  )
+
+  // Partition the (unfiltered) list into a promoted "recently used" group and
+  // the rest. Promoted = collections with a recency stamp, newest first,
+  // capped at MAX_PROMOTED; rest = everything else in the server's order. The
+  // two are disjoint (a promoted row is not repeated below), matching the
+  // locked design. Suppressed while filtering and for small libraries.
+  const { promotedCollections, restCollections, showRecentlyUsed } =
+    useMemo(() => {
+      const searching = search.trim().length > 0
+      if (searching || collections.length < RECENTLY_USED_MIN_COLLECTIONS) {
+        return {
+          promotedCollections: [],
+          restCollections: [],
+          showRecentlyUsed: false,
+        }
+      }
+      const promoted = collections
+        .filter((c) => recencySnapshot[String(c.id)] != null)
+        .sort(
+          (a, b) =>
+            recencySnapshot[String(b.id)] - recencySnapshot[String(a.id)]
+        )
+        .slice(0, MAX_PROMOTED)
+      const promotedIds = new Set(promoted.map((c) => c.id))
+      const rest = collections.filter((c) => !promotedIds.has(c.id))
+      // Need both a promoted item AND a remainder for grouping to add meaning.
+      return {
+        promotedCollections: promoted,
+        restCollections: rest,
+        showRecentlyUsed: promoted.length >= 1 && rest.length >= 1,
+      }
+    }, [collections, recencySnapshot, search])
 
   // Unauthenticated bracket variant — render the public [Add to collection]
   // affordance and redirect to /auth on click, mirroring FollowButton /
@@ -341,11 +414,23 @@ export function AddToCollectionButton({
     const nextSessionItemIds = new Map(sessionItemIds)
     const errors: SubmitError[] = []
 
+    // PSY-960: stamp this batch's adds with strictly-increasing timestamps so
+    // "Recently used" keeps a stable newest-first order across a multi-select
+    // submit — a bare Date.now() per add would tie within the same millisecond
+    // and collapse to server order. `results` is in checked-row order, so the
+    // last-checked collection gets the newest stamp.
+    const recordedAt = Date.now()
+    let addedRank = 0
+
     for (const result of results) {
       if (result.status === 'fulfilled') {
         nextSaved.add(result.value.id)
         nextPending.delete(result.value.id)
         nextSessionItemIds.set(result.value.id, result.value.itemId)
+        // Record the add client-side so this collection promotes to "Recently
+        // used" on the next open of the popover.
+        recordCollectionAdd(result.value.id, recordedAt + addedRank)
+        addedRank += 1
       } else {
         const reason = result.reason as { id: number; error: unknown }
         // Drop the failed row out of the add batch so it unchecks (matching
@@ -378,6 +463,113 @@ export function AddToCollectionButton({
       : 'Add'
   const showSearch = collections.length > SEARCH_THRESHOLD
   const hasCollections = collections.length > 0
+
+  // A single collection row, shared by the flat list and the grouped
+  // (RECENTLY USED / ALL COLLECTIONS) layout so both render identically.
+  const renderRow = (collection: (typeof collections)[number]) => {
+    const checked = isChecked(collection.id)
+    const added = savedIds.has(collection.id)
+    const errorMessage = errorByCollection.get(collection.id)
+    const rowRemoveError =
+      removeError?.collectionId === collection.id
+        ? removeError.message
+        : undefined
+    const checkboxId = `collection-checkbox-${collection.id}`
+    const isConfirming = removeConfirmId === collection.id
+    const isRemoving = removingId === collection.id
+    const subtitle = `${collection.item_count} ${collection.item_count === 1 ? 'item' : 'items'} · ${collection.is_public ? 'Public' : 'Private'}`
+
+    return (
+      <div key={collection.id} className="px-1">
+        <label
+          htmlFor={checkboxId}
+          className="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 transition-colors cursor-pointer"
+        >
+          <Checkbox
+            id={checkboxId}
+            checked={checked}
+            onCheckedChange={(value) =>
+              handleCheckedChange(collection.id, value === true)
+            }
+            disabled={submitting || isRemoving}
+            aria-describedby={
+              errorMessage || rowRemoveError
+                ? `${checkboxId}-error`
+                : undefined
+            }
+          />
+          <CollectionCoverImage
+            url={collection.cover_image_url}
+            alt=""
+            className="h-7 w-7 shrink-0 rounded bg-muted/50"
+            fallback={
+              <div className="flex h-full w-full items-center justify-center rounded bg-muted/50">
+                <Library className="h-3.5 w-3.5 text-muted-foreground" />
+              </div>
+            }
+          />
+          <span className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate font-medium leading-tight">
+              {collection.title}
+            </span>
+            <span className="text-xs text-muted-foreground leading-tight">
+              {subtitle}
+            </span>
+          </span>
+          {added && !isConfirming && (
+            <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400 shrink-0">
+              <Check className="h-3.5 w-3.5" />
+              Added
+            </span>
+          )}
+        </label>
+
+        {/* D1: inline remove-with-confirm for an already-in row. */}
+        {isConfirming && (
+          <div className="ml-8 mr-2 mb-1.5 flex items-center justify-between gap-2">
+            <span className="text-xs text-muted-foreground">
+              Remove from this collection?
+            </span>
+            <span className="flex items-center gap-1.5 shrink-0">
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => confirmRemove(collection.id)}
+                disabled={isRemoving}
+              >
+                {isRemoving && (
+                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                )}
+                Remove
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={cancelRemove}
+                disabled={isRemoving}
+              >
+                Cancel
+              </Button>
+            </span>
+          </div>
+        )}
+
+        {(errorMessage || rowRemoveError) && (
+          <div
+            id={`${checkboxId}-error`}
+            className="ml-8 mr-2 mb-1 flex items-start gap-1 text-xs text-destructive"
+          >
+            <AlertCircle className="h-3 w-3 shrink-0 mt-0.5" />
+            <span className="flex-1">{errorMessage ?? rowRemoveError}</span>
+          </div>
+        )}
+      </div>
+    )
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -463,113 +655,24 @@ export function AddToCollectionButton({
                 No collections match “{search.trim()}”
               </p>
             </div>
+          ) : showRecentlyUsed ? (
+            <>
+              <div role="group" aria-labelledby={recentlyUsedLabelId}>
+                <SectionLabel id={recentlyUsedLabelId}>
+                  Recently used
+                </SectionLabel>
+                {promotedCollections.map(renderRow)}
+              </div>
+              <div className="mx-2 my-1 h-px bg-border" aria-hidden="true" />
+              <div role="group" aria-labelledby={allCollectionsLabelId}>
+                <SectionLabel id={allCollectionsLabelId}>
+                  All collections
+                </SectionLabel>
+                {restCollections.map(renderRow)}
+              </div>
+            </>
           ) : (
-            filteredCollections.map((collection) => {
-              const checked = isChecked(collection.id)
-              const added = savedIds.has(collection.id)
-              const errorMessage = errorByCollection.get(collection.id)
-              const rowRemoveError =
-                removeError?.collectionId === collection.id
-                  ? removeError.message
-                  : undefined
-              const checkboxId = `collection-checkbox-${collection.id}`
-              const isConfirming = removeConfirmId === collection.id
-              const isRemoving = removingId === collection.id
-              const subtitle = `${collection.item_count} ${collection.item_count === 1 ? 'item' : 'items'} · ${collection.is_public ? 'Public' : 'Private'}`
-
-              return (
-                <div key={collection.id} className="px-1">
-                  <label
-                    htmlFor={checkboxId}
-                    className="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 transition-colors cursor-pointer"
-                  >
-                    <Checkbox
-                      id={checkboxId}
-                      checked={checked}
-                      onCheckedChange={(value) =>
-                        handleCheckedChange(collection.id, value === true)
-                      }
-                      disabled={submitting || isRemoving}
-                      aria-describedby={
-                        errorMessage || rowRemoveError
-                          ? `${checkboxId}-error`
-                          : undefined
-                      }
-                    />
-                    <CollectionCoverImage
-                      url={collection.cover_image_url}
-                      alt=""
-                      className="h-7 w-7 shrink-0 rounded bg-muted/50"
-                      fallback={
-                        <div className="flex h-full w-full items-center justify-center rounded bg-muted/50">
-                          <Library className="h-3.5 w-3.5 text-muted-foreground" />
-                        </div>
-                      }
-                    />
-                    <span className="flex min-w-0 flex-1 flex-col">
-                      <span className="truncate font-medium leading-tight">
-                        {collection.title}
-                      </span>
-                      <span className="text-xs text-muted-foreground leading-tight">
-                        {subtitle}
-                      </span>
-                    </span>
-                    {added && !isConfirming && (
-                      <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400 shrink-0">
-                        <Check className="h-3.5 w-3.5" />
-                        Added
-                      </span>
-                    )}
-                  </label>
-
-                  {/* D1: inline remove-with-confirm for an already-in row. */}
-                  {isConfirming && (
-                    <div className="ml-8 mr-2 mb-1.5 flex items-center justify-between gap-2">
-                      <span className="text-xs text-muted-foreground">
-                        Remove from this collection?
-                      </span>
-                      <span className="flex items-center gap-1.5 shrink-0">
-                        <Button
-                          type="button"
-                          variant="destructive"
-                          size="sm"
-                          className="h-6 px-2 text-xs"
-                          onClick={() => confirmRemove(collection.id)}
-                          disabled={isRemoving}
-                        >
-                          {isRemoving && (
-                            <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                          )}
-                          Remove
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 px-2 text-xs"
-                          onClick={cancelRemove}
-                          disabled={isRemoving}
-                        >
-                          Cancel
-                        </Button>
-                      </span>
-                    </div>
-                  )}
-
-                  {(errorMessage || rowRemoveError) && (
-                    <div
-                      id={`${checkboxId}-error`}
-                      className="ml-8 mr-2 mb-1 flex items-start gap-1 text-xs text-destructive"
-                    >
-                      <AlertCircle className="h-3 w-3 shrink-0 mt-0.5" />
-                      <span className="flex-1">
-                        {errorMessage ?? rowRemoveError}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              )
-            })
+            filteredCollections.map(renderRow)
           )}
         </div>
 
@@ -592,13 +695,12 @@ export function AddToCollectionButton({
           </div>
         )}
 
-        {/* Create new link. Two PSY-893 decisions are deferred to follow-ups
-            (see the PR's Deferred section for the ticket ids):
-            - D3 (recently-used promotion above a separator) — needs an
-              add-recency signal the data model doesn't carry yet.
-            - D4 (create-from-entity pre-fill) — needs the Create drawer to be
-              reachable from entity pages; until then this stays a plain link to
-              the collections page rather than "Create … with {entity}". */}
+        {/* Create new link. D3 (recently-used promotion) shipped in PSY-960
+            via a client-side add-recency signal (see the grouped list above).
+            D4 (create-from-entity pre-fill) is still deferred to PSY-961 —
+            needs the Create drawer reachable from entity pages; until then
+            this stays a plain link to the collections page rather than
+            "Create … with {entity}". */}
         {hasCollections && (
           <div className="p-2 border-t border-border">
             <Link

--- a/frontend/features/collections/collectionAddRecency.test.ts
+++ b/frontend/features/collections/collectionAddRecency.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  readCollectionAddRecency,
+  recordCollectionAdd,
+} from './collectionAddRecency'
+
+const KEY = 'psy:collection-add-recency'
+
+describe('collectionAddRecency', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('returns {} when nothing is stored', () => {
+    expect(readCollectionAddRecency()).toEqual({})
+  })
+
+  it('records an add with the given timestamp and reads it back', () => {
+    recordCollectionAdd(42, 1000)
+    expect(readCollectionAddRecency()).toEqual({ '42': 1000 })
+  })
+
+  it('coerces numeric ids to string keys', () => {
+    recordCollectionAdd(7, 500)
+    expect(readCollectionAddRecency()).toEqual({ '7': 500 })
+  })
+
+  it('overwrites the timestamp on a repeat add', () => {
+    recordCollectionAdd(42, 1000)
+    recordCollectionAdd(42, 2000)
+    expect(readCollectionAddRecency()).toEqual({ '42': 2000 })
+  })
+
+  it('degrades to {} on malformed JSON instead of throwing', () => {
+    window.localStorage.setItem(KEY, '{not valid json')
+    expect(readCollectionAddRecency()).toEqual({})
+  })
+
+  it('ignores non-numeric / non-finite values', () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ a: 5, b: 'nope', c: null, d: NaN })
+    )
+    // NaN serializes to null, so only `a` survives.
+    expect(readCollectionAddRecency()).toEqual({ a: 5 })
+  })
+
+  it('prunes to the most-recent 50 entries (oldest dropped)', () => {
+    // ts = i, so higher i == more recent.
+    for (let i = 0; i < 60; i++) recordCollectionAdd(i, i)
+    const map = readCollectionAddRecency()
+    expect(Object.keys(map)).toHaveLength(50)
+    // Newest survive (id 59 = ts 59, id 10 = ts 10); oldest 10 are pruned.
+    expect(map['59']).toBe(59)
+    expect(map['10']).toBe(10)
+    expect(map['9']).toBeUndefined()
+    expect(map['0']).toBeUndefined()
+  })
+
+  it('keeps all 50 at the boundary (no prune until OVER the cap)', () => {
+    for (let i = 0; i < 50; i++) recordCollectionAdd(i, i)
+    expect(Object.keys(readCollectionAddRecency())).toHaveLength(50)
+  })
+
+  it('never prunes the just-recorded entry, even on a timestamp tie at the cap', () => {
+    // 50 collections all stamped at the same instant…
+    for (let i = 0; i < 50; i++) recordCollectionAdd(i, 1000)
+    // …then a 51st at the SAME (tied) timestamp. The naive "sort + slice top
+    // 50" would have dropped it; it must survive.
+    recordCollectionAdd(999, 1000)
+    const map = readCollectionAddRecency()
+    expect(Object.keys(map)).toHaveLength(50)
+    expect(map['999']).toBe(1000)
+  })
+})

--- a/frontend/features/collections/collectionAddRecency.ts
+++ b/frontend/features/collections/collectionAddRecency.ts
@@ -1,0 +1,88 @@
+/**
+ * Client-side "recently added to" signal for the AddToCollectionButton
+ * popover (PSY-960 / PSY-893 D3).
+ *
+ * The data model carries no add-recency: a `Collection` has only
+ * `created_at` / `updated_at`, and `updated_at` bumps on ANY edit (title,
+ * description, items), so it can't answer "which collections did I recently
+ * ADD to". Rather than add a backend column for a sorting nicety, we record
+ * the actual add action client-side — the standard pattern for "recently
+ * used" menus (Mozilla AwesomeBar, Raycast `useFrecencySorting`, VS Code).
+ *
+ * Trade-offs, accepted by design: the signal is per-device and is lost on
+ * cache-clear / private browsing. That's fine here because it only drives a
+ * PROMOTION above an always-present full list — a cold or empty signal simply
+ * degrades to the existing flat list (see AddToCollectionButton).
+ *
+ * Semantics: the stamp is "this COLLECTION was recently added to" (any entity),
+ * not "this entity is in this collection". So removing an entity from a
+ * collection does NOT un-stamp it — the user may have recently added other
+ * things there. A stale stamp self-corrects: adding to other collections
+ * pushes it out of the (capped) promoted group.
+ */
+
+const STORAGE_KEY = 'psy:collection-add-recency'
+
+// Bound the stored blob: keep only the most-recent N collections' timestamps.
+// Far more than the popover ever promotes (5); the cap just stops unbounded
+// growth for a heavy curator over months.
+const MAX_ENTRIES = 50
+
+/** collectionId (stringified) → epoch ms of the last add to that collection. */
+export type CollectionAddRecency = Record<string, number>
+
+/**
+ * Read the recency map from localStorage. Always returns a valid object —
+ * SSR (no `window`), a missing key, malformed JSON, or non-numeric values
+ * all degrade to `{}` rather than throwing.
+ */
+export function readCollectionAddRecency(): CollectionAddRecency {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return {}
+    const out: CollectionAddRecency = {}
+    for (const [id, ts] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof ts === 'number' && Number.isFinite(ts)) out[id] = ts
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Record that the user just added the current entity to `collectionId`,
+ * stamping `now` (injectable for tests). Prunes to the most-recent
+ * MAX_ENTRIES. Best-effort: localStorage failures (quota, disabled,
+ * private mode) are swallowed so they can never break the add itself.
+ */
+export function recordCollectionAdd(
+  collectionId: string | number,
+  now: number = Date.now()
+): void {
+  if (typeof window === 'undefined') return
+  try {
+    const id = String(collectionId)
+    const map = readCollectionAddRecency()
+    map[id] = now
+
+    let next = map
+    if (Object.keys(map).length > MAX_ENTRIES) {
+      // Prune to the newest MAX_ENTRIES, but ALWAYS keep the id we just
+      // recorded — otherwise a same-/older-timestamp tie at the cap could
+      // drop the very thing the user just did. Keep `id` + the newest others.
+      const others = Object.entries(map)
+        .filter(([k]) => k !== id)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, MAX_ENTRIES - 1)
+      next = Object.fromEntries([[id, now], ...others])
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // Recency is a best-effort nicety — never let a storage error surface.
+  }
+}


### PR DESCRIPTION
Closes PSY-960.

## Summary
- Implements **PSY-893 D3** (deferred from PSY-829): the `AddToCollectionButton` popover now promotes up to **5 recently-used collections** under a **RECENTLY USED** header above a separator, then the remainder under **ALL COLLECTIONS** — disjoint sets, matching the locked Figma (node `192:9`).
- Grouping shows **only when not filtering and the library is large enough** (≥5 collections), exactly mirroring the design: the default-open 4-collection mock is flat, the 5-collection mock is grouped. Searching collapses back to a flat filtered list.
- **Recency signal is client-side** (see the decision below): a successful add records `{collectionId: timestamp}` in `localStorage`; the popover snapshots it on open and sorts the promoted group newest-first.

## The recency-signal decision (research-backed)
The data model carries no "added to" recency — only `created_at`/`updated_at`, and `updated_at` bumps on *any* edit. The ticket framed this as "backend column vs. `updated_at` proxy," but [2026 best-practice research](https://en.wikipedia.org/wiki/Frecency) surfaced a third, better option: **record the add client-side**, the standard pattern for "recently used" menus (Mozilla AwesomeBar, Raycast [`useFrecencySorting`](https://developers.raycast.com/utilities/react-hooks/usefrecencysorting), VS Code, fzf). It's *both* accurate (records the real add action, unlike `updated_at`) *and* frontend-only (no migration, no write-path change) — dissolving the "accurate vs. cheap" tradeoff. Accepted trade: per-device, and a cold/cleared signal degrades to the existing flat list. Decision confirmed with the maintainer before building.

## Deferred / related
- **D4 (create-from-entity CTA)** remains tracked by **PSY-961** (needs the Create drawer reachable from entity pages); the stale "D3 deferred" code comment is updated to reflect D3 shipping + D4 still pending.
- **PSY-962** (create-drawer polish) is separate and unaffected.

## Implementation notes
- `frontend/features/collections/collectionAddRecency.ts` — SSR-safe read + best-effort record (swallows quota/private-mode errors) with prune-to-50 that's *correct-by-construction*: it always keeps the just-recorded entry even on a same-millisecond tie at the cap. Semantics are **per-collection add-activity** (not per-entity membership), so a later remove doesn't un-stamp — and a stale stamp self-corrects as newer adds push it out of the capped group.
- Multi-select submits stamp with **strictly-increasing** timestamps (in checked-row order) so "newest first" stays stable across a batch instead of collapsing to server order.
- The popover snapshots recency **on open** (memoized on `open`), so recording an add never reorders the list under the user mid-session — the new order shows on the next open.
- Shared `renderRow` renders both the flat and grouped layouts identically; each grouped section is a `role="group"` with `aria-labelledby` so screen readers announce the boundary.

## Adversarial review
`/adversarial-review` — CONCERNS; all findings addressed (folded into the implementation commit after a rebuild to strip an accidental formatter pass — the repo has no enforced prettier). Panel: Saboteur · Future-Maintainer · Security · Completeness (Security **CLEAN** — prototype-pollution empirically defeated by the number-only value guard + fresh object; Completeness **CLEAN** — all ACs + design properties met).
- [MEDIUM] Batch-add timestamps tie within a millisecond → strictly-increasing per-batch stamps.
- [MEDIUM] Stale stamp after remove → resolved as a documented **per-collection** semantic (not a bug); self-corrects via the cap.
- [MEDIUM] Missing add→reopen→promoted + cap-of-5 regression tests → both added.
- `/code-review` (run first): no correctness defects; nits fixed (prune correct-by-construction + boundary/tie tests; `role="group"` section a11y).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/collections components/shared` — 741/741 passing (9 new `collectionAddRecency` tests + 8 new grouping tests in `AddToCollectionButton`, incl. multi-select batch ordering + `role="group"` a11y)
- [x] `npx eslint` on all changed files — clean (eslint is the enforced gate; repo has no prettier config/CI step)
- [x] `/code-review` — no real bugs; nits applied
- [x] `/adversarial-review` — CONCERNS, all findings addressed
- [x] Manual repro against local dev stack: signed in, created a 5th collection to cross the grouping threshold, injected add-recency for 2 collections via `localStorage`, opened the Collect popover on an artist page — confirmed the grouped RECENTLY USED / ALL COLLECTIONS layout with newest-first promotion and disjoint sets (screenshot below). Throwaway test collection deleted afterward.

## Screenshots
The grouped popover — "Heavy Rotation" + "Test Public Collection" promoted under RECENTLY USED (newest-first), the other three under ALL COLLECTIONS, disjoint:

![AddToCollectionButton popover with RECENTLY USED / ALL COLLECTIONS grouping](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-b56408d6e4be9fd80f27/grouped-cropped.png)

## Coverage gaps
- **Real-Radix Popover open/close in unit tests**: the add→reopen test drives the real Radix `Popover` (close+reopen toggling), but most grouping tests force state via `localStorage` + a single open; the screenshot covers the assembled visual.
- **Cross-tab / cache-clear behavior** not exercised beyond the module's SSR/malformed-JSON unit tests — by design it degrades to the flat list.
- **"Stable while open"** is tested in the positive direction (the new order shows after reopen) but not the negative (the list is asserted not to reorder *before* close); the per-`[open]` memo makes mid-session reordering structurally impossible.
- **Remove-doesn't-unstamp** is guaranteed by the *absence* of any un-stamp path (no `removeCollectionAdd`) and documented as a per-collection semantic, not asserted by a dedicated add→remove→reopen test.
- The promoted section's `flex` sizing at very narrow widths isn't visually exercised (the popover is a fixed 360px).
