### PR TITLE
PSY-961: create-from-entity drawer pre-fill (PSY-893 D4)

### DIFF
--- a/frontend/components/layout/providers.test.tsx
+++ b/frontend/components/layout/providers.test.tsx
@@ -20,6 +20,12 @@ vi.mock('@/features/auth', () => ({
   useLogout: () => mockUseLogout(),
 }))
 
+// PSY-961: Providers now mounts CreateCollectionDrawerProvider, which reads
+// useRouter() — stub it so the provider tree mounts without a Next router.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 describe('Providers', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/components/layout/providers.tsx
+++ b/frontend/components/layout/providers.tsx
@@ -3,6 +3,11 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import { getQueryClient } from '@/lib/queryClient'
 import { AuthProvider } from '@/lib/context/AuthContext'
+// PSY-961: app-level Create-collection drawer, openable from any surface
+// (the /collections button + the AddToCollectionButton "Create … with
+// {entity}" CTA). Its heavy form is lazy-loaded inside the provider, so this
+// import only adds the Sheet shell + context to the root chunk.
+import { CreateCollectionDrawerProvider } from '@/features/collections/components/CreateCollectionDrawer'
 
 interface ProvidersProps {
     children: React.ReactNode
@@ -13,7 +18,11 @@ export function Providers({ children }: ProvidersProps) {
 
     return (
         <QueryClientProvider client={queryClient}>
-            <AuthProvider>{children}</AuthProvider>
+            <AuthProvider>
+                <CreateCollectionDrawerProvider>
+                    {children}
+                </CreateCollectionDrawerProvider>
+            </AuthProvider>
         </QueryClientProvider>
     )
 }

--- a/frontend/components/shared/AddToCollectionButton.test.tsx
+++ b/frontend/components/shared/AddToCollectionButton.test.tsx
@@ -116,6 +116,12 @@ vi.mock('next/link', () => ({
   ),
 }))
 
+// PSY-961: the "Create … with {entity}" CTA opens the app-level Create drawer.
+const mockOpenCreateDrawer = vi.fn()
+vi.mock('@/features/collections/components/CreateCollectionDrawer', () => ({
+  useCreateCollectionDrawer: () => ({ openCreateDrawer: mockOpenCreateDrawer }),
+}))
+
 describe('AddToCollectionButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -440,7 +446,7 @@ describe('AddToCollectionButton', () => {
     })
   })
 
-  it('shows "Create new collection" link', async () => {
+  it('opens the Create drawer pre-filled with the entity from the main CTA (D4)', async () => {
     const user = userEvent.setup()
     render(
       <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
@@ -448,12 +454,18 @@ describe('AddToCollectionButton', () => {
 
     await user.click(screen.getByRole('button', { name: /add to collection/i }))
 
-    const link = await screen.findByText('Create new collection')
-    expect(link).toBeInTheDocument()
-    expect(link.closest('a')).toHaveAttribute('href', '/collections')
+    const cta = await screen.findByRole('button', {
+      name: /create new collection with test artist/i,
+    })
+    await user.click(cta)
+    expect(mockOpenCreateDrawer).toHaveBeenCalledWith({
+      initialStagedItems: [
+        { entityType: 'artist', entityId: 1, name: 'Test Artist', subtitle: null },
+      ],
+    })
   })
 
-  it('shows empty state with a primary Create CTA when user has no collections (D5)', async () => {
+  it('shows a primary Create CTA that pre-fills the entity in the empty state (D5)', async () => {
     mockMyCollections.mockReturnValue({
       data: { collections: [] },
       isLoading: false,
@@ -469,11 +481,15 @@ describe('AddToCollectionButton', () => {
     expect(
       await screen.findByText('No collections yet — start one.')
     ).toBeInTheDocument()
-    // D5: Create is promoted to a primary action (a link styled as a button).
-    const createLink = screen.getByRole('link', {
-      name: /create new collection/i,
+    // D5: Create is the primary action and pre-fills the current entity.
+    await user.click(
+      screen.getByRole('button', { name: /create with test artist/i })
+    )
+    expect(mockOpenCreateDrawer).toHaveBeenCalledWith({
+      initialStagedItems: [
+        { entityType: 'artist', entityId: 1, name: 'Test Artist', subtitle: null },
+      ],
     })
-    expect(createLink).toHaveAttribute('href', '/collections')
     // No submit row / no checkbox list in the empty state.
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
   })

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useMemo, useRef, useState } from 'react'
-import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
 import { Library, Check, Plus, Loader2, AlertCircle, Search } from 'lucide-react'
@@ -24,6 +23,7 @@ import {
 import { queryKeys } from '@/lib/queryClient'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import type { CollectionEntityType } from '@/features/collections/types'
+import { useCreateCollectionDrawer } from '@/features/collections/components/CreateCollectionDrawer'
 
 interface AddToCollectionButtonProps {
   entityType: CollectionEntityType
@@ -74,7 +74,20 @@ export function AddToCollectionButton({
   const router = useRouter()
   const pathname = usePathname()
   const queryClient = useQueryClient()
+  const { openCreateDrawer } = useCreateCollectionDrawer()
   const [open, setOpen] = useState(false)
+
+  // PSY-961 / PSY-893 D4: close the popover and open the app-level Create
+  // drawer pre-filled with this entity as item 1 — "I'm reading about this
+  // artist, start a collection around them" without leaving the page.
+  const handleCreateWithEntity = () => {
+    setOpen(false)
+    openCreateDrawer({
+      initialStagedItems: [
+        { entityType, entityId, name: entityName, subtitle: null },
+      ],
+    })
+  }
 
   // The contains query is gated on `open` so we don't fetch on every
   // entity page render — only when the user actually opens the popover.
@@ -450,11 +463,13 @@ export function AddToCollectionButton({
               <p className="text-sm text-muted-foreground mb-3">
                 No collections yet — start one.
               </p>
-              <Button asChild size="sm" className="w-full">
-                <Link href="/collections" onClick={() => setOpen(false)}>
-                  <Plus className="h-3.5 w-3.5 mr-1.5" />
-                  Create new collection
-                </Link>
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={handleCreateWithEntity}
+              >
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Create with {entityName}
               </Button>
             </div>
           ) : filteredCollections.length === 0 ? (
@@ -592,23 +607,20 @@ export function AddToCollectionButton({
           </div>
         )}
 
-        {/* Create new link. Two PSY-893 decisions are deferred to follow-ups
-            (see the PR's Deferred section for the ticket ids):
-            - D3 (recently-used promotion above a separator) — needs an
-              add-recency signal the data model doesn't carry yet.
-            - D4 (create-from-entity pre-fill) — needs the Create drawer to be
-              reachable from entity pages; until then this stays a plain link to
-              the collections page rather than "Create … with {entity}". */}
+        {/* Create-from-entity CTA (PSY-893 D4, shipped PSY-961): opens the
+            app-level Create drawer pre-filled with this entity as item 1,
+            in place (no navigation). D3 (recently-used promotion) ships
+            separately in PSY-960. */}
         {hasCollections && (
           <div className="p-2 border-t border-border">
-            <Link
-              href="/collections"
-              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-              onClick={() => setOpen(false)}
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              onClick={handleCreateWithEntity}
             >
               <Plus className="h-3.5 w-3.5" />
-              Create new collection
-            </Link>
+              Create new collection with {entityName}
+            </button>
           </div>
         )}
       </PopoverContent>

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -79,7 +79,10 @@ export function AddToCollectionButton({
 
   // PSY-961 / PSY-893 D4: close the popover and open the app-level Create
   // drawer pre-filled with this entity as item 1 — "I'm reading about this
-  // artist, start a collection around them" without leaving the page.
+  // artist, start a collection around them". The drawer opens IN PLACE (no
+  // navigation); on successful create it routes to the new collection's page
+  // (consistent with the /collections create flow) so the user can keep
+  // curating it.
   const handleCreateWithEntity = () => {
     setOpen(false)
     openCreateDrawer({
@@ -608,9 +611,10 @@ export function AddToCollectionButton({
         )}
 
         {/* Create-from-entity CTA (PSY-893 D4, shipped PSY-961): opens the
-            app-level Create drawer pre-filled with this entity as item 1,
-            in place (no navigation). D3 (recently-used promotion) ships
-            separately in PSY-960. */}
+            app-level Create drawer pre-filled with this entity as item 1.
+            D3 (recently-used promotion above the separator) is tracked in
+            PSY-960 and lands in this same create-CTA region — whichever PR
+            merges second reconciles these comments. */}
         {hasCollections && (
           <div className="p-2 border-t border-border">
             <button

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -53,7 +53,7 @@ import {
   type EntitySearchResult,
 } from '@/lib/hooks/common/useEntitySearch'
 import { useResolveCollectionItems } from '../hooks'
-import { getEntityTypeLabel } from '../types'
+import { getEntityTypeLabel, type CollectionEntityType } from '../types'
 import { cn } from '@/lib/utils'
 import { AICollectionFiller } from './AICollectionFiller'
 
@@ -61,18 +61,11 @@ import { AICollectionFiller } from './AICollectionFiller'
 // Types
 // ──────────────────────────────────────────────
 
-/**
- * The six KG entity types that collections accept. Mirrors the backend
- * communitym.CollectionEntity* enum. Keep in sync with backend
- * IsValidCollectionEntityType.
- */
-export type CollectionEntityType =
-  | 'artist'
-  | 'release'
-  | 'label'
-  | 'show'
-  | 'venue'
-  | 'festival'
+// Re-exported so existing importers of this symbol from AddItemsPicker keep
+// working; `../types` (derived from COLLECTION_ENTITY_TYPES) is the single
+// backend-synced source of truth — there is no second hand-written union to
+// drift (PSY-961 adversarial-review fix).
+export type { CollectionEntityType }
 
 /**
  * A staged item that's queued for bulk-add but not yet committed. The

--- a/frontend/features/collections/components/CollectionList.test.tsx
+++ b/frontend/features/collections/components/CollectionList.test.tsx
@@ -40,32 +40,14 @@ vi.mock('use-debounce', () => ({
 // Mock collection hooks
 const mockUseCollections = vi.fn()
 const mockUseMyCollections = vi.fn()
-const mockCreateMutate = vi.fn()
 
+// PSY-961: CollectionList no longer renders the create form (moved to the
+// app-level CreateCollectionDrawer), so it only needs the browse-list hooks.
 vi.mock('../hooks', () => ({
   useCollections: (params: unknown) => mockUseCollections(params),
   // PSY-580: Yours-tab hook now takes an optional `{ search }` arg. Forward
   // it to the spy so tests can assert the search box is wired through.
   useMyCollections: (params: unknown) => mockUseMyCollections(params),
-  useCreateCollection: () => ({
-    mutate: mockCreateMutate,
-    // PSY-823: form now uses mutateAsync to chain create → bulk-add.
-    // Resolve with a slug shape so the sequel doesn't blow up.
-    mutateAsync: (data: unknown) => {
-      mockCreateMutate(data)
-      return Promise.resolve({ slug: 'test-slug' })
-    },
-    isPending: false,
-    error: null as Error | null,
-  }),
-  // PSY-823: bulk-add mutation used after create to commit staged items.
-  // Tests don't exercise the staged-items flow today; resolve with an empty
-  // partial-success response so the chain proceeds cleanly.
-  useBulkAddCollectionItems: () => ({
-    mutateAsync: () => Promise.resolve({ added: [], errors: [] }),
-    isPending: false,
-    error: null as Error | null,
-  }),
 }))
 
 // Mock child components
@@ -94,32 +76,11 @@ vi.mock('@/components/ui/input', () => ({
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
 }))
 
-vi.mock('@/components/ui/textarea', () => ({
-  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
-}))
-
-// PSY-823: the Create flow swapped its Dialog for a Sheet drawer. Mock the
-// Sheet so the form children render synchronously without a portal — tests
-// can assert against the form fields directly via getByLabelText.
-vi.mock('@/components/ui/sheet', () => ({
-  Sheet: ({ children, open }: { children: React.ReactNode; open: boolean }) => (
-    <div data-testid="sheet" data-open={open}>{children}</div>
-  ),
-  SheetContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="sheet-content">{children}</div>
-  ),
-  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
-  SheetTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
-    <>{children}</>
-  ),
-}))
-
-// PSY-823: stub the picker so create-form tests don't have to provision
-// useEntitySearch / useResolveCollectionItems. The picker has its own
-// test file (AddItemsPicker.test.tsx) for that surface.
-vi.mock('./AddItemsPicker', () => ({
-  AddItemsPicker: () => <div data-testid="add-items-picker-stub" />,
+// PSY-961: the Create drawer is now app-level; CollectionList's button just
+// opens it. The form itself is tested in CreateCollectionForm.test.tsx.
+const mockOpenCreateDrawer = vi.fn()
+vi.mock('./CreateCollectionDrawer', () => ({
+  useCreateCollectionDrawer: () => ({ openCreateDrawer: mockOpenCreateDrawer }),
 }))
 
 // Track the active tab value for selective rendering of TabsContent. Also
@@ -496,180 +457,30 @@ describe('CollectionList', () => {
       expect(headerButton).toBeUndefined()
     })
 
-    it('shows create dialog with form', () => {
-      mockAuthContext.mockReturnValue({
-        user: { id: '1' },
-        isAuthenticated: true,
-        isLoading: false,
-        logout: vi.fn(),
-      })
-      mockUseCollections.mockReturnValue({
-        data: { collections: [] },
-        isLoading: false,
-        error: null,
-        refetch: vi.fn(),
-      })
-      render(<CollectionList />)
-      // Dialog content renders (since we mock Dialog to always render children)
-      expect(screen.getByLabelText('Title')).toBeInTheDocument()
-      expect(screen.getByLabelText('Description (optional)')).toBeInTheDocument()
-    })
-
-    it('renders create form with Public checkbox checked by default', () => {
-      mockAuthContext.mockReturnValue({
-        user: { id: '1' },
-        isAuthenticated: true,
-        isLoading: false,
-        logout: vi.fn(),
-      })
-      mockUseCollections.mockReturnValue({
-        data: { collections: [] },
-        isLoading: false,
-        error: null,
-        refetch: vi.fn(),
-      })
-      render(<CollectionList />)
-      const publicCheckbox = screen.getByLabelText('Public') as HTMLInputElement
-      expect(publicCheckbox.checked).toBe(true)
-    })
-
-    it('renders create form with Collaborative checkbox unchecked by default', () => {
-      mockAuthContext.mockReturnValue({
-        user: { id: '1' },
-        isAuthenticated: true,
-        isLoading: false,
-        logout: vi.fn(),
-      })
-      mockUseCollections.mockReturnValue({
-        data: { collections: [] },
-        isLoading: false,
-        error: null,
-        refetch: vi.fn(),
-      })
-      render(<CollectionList />)
-      const collabCheckbox = screen.getByLabelText('Collaborative') as HTMLInputElement
-      expect(collabCheckbox.checked).toBe(false)
-    })
-  })
-
-  // PSY-585: Cover image URL field on the Create modal — parity with Edit.
-  // The field renders, an empty value submits cleanly (no cover key in the
-  // payload), and a valid URL submits with the cover_image_url key set.
-  describe('cover image URL field on create (PSY-585)', () => {
-    beforeEach(() => {
-      mockAuthContext.mockReturnValue({
-        user: { id: '1' },
-        isAuthenticated: true,
-        isLoading: false,
-        logout: vi.fn(),
-      })
-      mockUseCollections.mockReturnValue({
-        data: { collections: [] },
-        isLoading: false,
-        error: null,
-        refetch: vi.fn(),
-      })
-    })
-
-    it('renders the Cover image URL field with the create-only helper text', () => {
-      render(<CollectionList />)
-
-      // Field is present and has the URL input semantics. The accessible
-      // label includes the trailing "(optional)" hint span, so we match
-      // by data-testid to keep the assertion stable against copy tweaks.
-      const input = screen.getByTestId(
-        'create-cover-image-url-input'
-      ) as HTMLInputElement
-      expect(input).toBeInTheDocument()
-      expect(input.type).toBe('url')
-
-      // Helper copy: matches Edit form sans the "remove the current cover"
-      // half (no current cover to remove on create).
-      expect(
-        screen.getByText('Paste a direct image URL (e.g. Bandcamp art).')
-      ).toBeInTheDocument()
-    })
-
-    it('submits with cover_image_url when a valid URL is entered', async () => {
+    it('opens the app-level Create drawer when the Create button is clicked', async () => {
+      // PSY-961: the form moved to the app-level CreateCollectionDrawer (tested
+      // in CreateCollectionForm.test.tsx) — CollectionList's button just opens it.
       const user = userEvent.setup()
-      render(<CollectionList />)
-
-      const titleInput = screen.getByLabelText('Title') as HTMLInputElement
-      await user.type(titleInput, 'My Picks')
-
-      const coverInput = screen.getByTestId(
-        'create-cover-image-url-input'
-      ) as HTMLInputElement
-      await user.type(coverInput, 'https://example.com/cover.jpg')
-
-      // The form's submit button is the only button labeled "Create" (the
-      // header button reads "Create Collection"). Click it to fire submit.
-      const submitButton = screen.getByRole('button', { name: 'Create' })
-      await user.click(submitButton)
-
-      expect(mockCreateMutate).toHaveBeenCalled()
-      const callArgs = mockCreateMutate.mock.calls[0]
-      const payload = callArgs[0] as Record<string, unknown>
-      expect(payload).toMatchObject({
-        title: 'My Picks',
-        is_public: true,
-        collaborative: false,
-        cover_image_url: 'https://example.com/cover.jpg',
+      mockAuthContext.mockReturnValue({
+        user: { id: '1' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
       })
-    })
-
-    it('omits cover_image_url from the payload when the field is empty', async () => {
-      const user = userEvent.setup()
-      render(<CollectionList />)
-
-      const titleInput = screen.getByLabelText('Title') as HTMLInputElement
-      await user.type(titleInput, 'No Cover')
-
-      // Don't touch the cover field — it stays empty.
-      const submitButton = screen.getByRole('button', { name: 'Create' })
-      await user.click(submitButton)
-
-      expect(mockCreateMutate).toHaveBeenCalled()
-      const payload = mockCreateMutate.mock.calls[0][0] as Record<
-        string,
-        unknown
-      >
-      // JSON.stringify in the hook drops `undefined` keys, so we mirror
-      // that: empty cover URL means the key carries `undefined` here and
-      // never appears in the wire body.
-      expect(payload.cover_image_url).toBeUndefined()
-      expect(payload).toMatchObject({
-        title: 'No Cover',
-        is_public: true,
-        collaborative: false,
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
       })
-    })
-
-    it('blocks submit and shows an inline error for an invalid URL', async () => {
-      const user = userEvent.setup()
       render(<CollectionList />)
-
-      const titleInput = screen.getByLabelText('Title') as HTMLInputElement
-      await user.type(titleInput, 'Bad URL Test')
-
-      const coverInput = screen.getByTestId(
-        'create-cover-image-url-input'
-      ) as HTMLInputElement
-      // `not-a-url` fails the WHATWG URL parser → validateCoverImageUrl
-      // returns the "Enter a valid URL..." message.
-      await user.type(coverInput, 'not-a-url')
-      // Blur to flip `coverImageUrlTouched` so the error renders.
-      coverInput.blur()
-
-      // The Create submit button must be disabled while the URL is invalid.
-      const submitButton = screen.getByRole('button', {
-        name: 'Create',
-      }) as HTMLButtonElement
-      expect(submitButton.disabled).toBe(true)
-
-      // Clicking it should be a no-op (mutate must not fire).
-      await user.click(submitButton)
-      expect(mockCreateMutate).not.toHaveBeenCalled()
+      const button = screen
+        .getAllByText('Create Collection')
+        .map((el) => el.closest('button'))
+        .find((b): b is HTMLButtonElement => b !== null)
+      expect(button).toBeTruthy()
+      await user.click(button!)
+      expect(mockOpenCreateDrawer).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -2,39 +2,14 @@
 
 import { useState, useMemo } from 'react'
 import { Plus, Search, Library, Star, Clock, TrendingUp, User, X } from 'lucide-react'
-import Link from 'next/link'
 import { useDebounce } from 'use-debounce'
-import {
-  useCollections,
-  useMyCollections,
-  useCreateCollection,
-  useBulkAddCollectionItems,
-} from '../hooks'
-import {
-  AddItemsPicker,
-  type StagedCollectionItem,
-} from './AddItemsPicker'
+import { useCollections, useMyCollections } from '../hooks'
 import { CollectionCard } from './CollectionCard'
-// MarkdownEditor is lazily loaded (dynamic ssr:false) so its `marked` +
-// `dompurify` deps stay out of the global shared client chunk — see
-// MarkdownEditorLazy / PSY-951.
-import { MarkdownEditor } from './MarkdownEditorLazy'
-import {
-  MAX_COLLECTION_MARKDOWN_LENGTH,
-  MAX_COVER_IMAGE_URL_LENGTH,
-  validateCoverImageUrl,
-} from '../types'
+import { useCreateCollectionDrawer } from './CreateCollectionDrawer'
 import { LoadingSpinner } from '@/components/shared'
 import { badgeVariants } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -45,12 +20,6 @@ import {
   type CollectionEntityType,
 } from '../types'
 import { cn } from '@/lib/utils'
-import {
-  COLLECTION_UNLIMITED,
-  TIERS_HELP_PATH,
-  getCollectionLimitForTier,
-  getTierInfo,
-} from '@/lib/tiers'
 
 // PSY-586: tab values are URL-routable via `?tab=<value>`. Unknown values
 // fall back to `all` silently (no redirect). The `yours` tab is auth-gated;
@@ -76,7 +45,7 @@ export function CollectionList() {
   const { isAuthenticated } = useAuthContext()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const { openCreateDrawer } = useCreateCollectionDrawer()
 
   const activeTab = resolveActiveTab(searchParams.get('tab'), isAuthenticated)
 
@@ -215,37 +184,14 @@ export function CollectionList() {
           />
         </div>
 
-        {/* Create button — PSY-823: drawer (Sheet) replaces the legacy
-            inline Dialog so the integrated AddItemsPicker has room to
-            scroll a 200-row staged list without clipping. */}
+        {/* PSY-961: the Create drawer is now an app-level component
+            (CreateCollectionDrawerProvider, mounted at the root) so it can be
+            opened from entity pages too — this button just opens it. */}
         {isAuthenticated && (
-          <Sheet open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-            <SheetTrigger asChild>
-              <Button size="sm">
-                <Plus className="h-4 w-4 mr-1.5" />
-                Create Collection
-              </Button>
-            </SheetTrigger>
-            <SheetContent
-              side="right"
-              className="w-full sm:max-w-xl flex flex-col overflow-y-auto"
-            >
-              <SheetHeader>
-                <SheetTitle>Create Collection</SheetTitle>
-              </SheetHeader>
-              <div className="px-4 pb-4">
-                <CreateCollectionForm
-                  onSuccess={(newSlug) => {
-                    setCreateDialogOpen(false)
-                    if (newSlug) {
-                      router.push(`/collections/${newSlug}`)
-                    }
-                  }}
-                  onCancel={() => setCreateDialogOpen(false)}
-                />
-              </div>
-            </SheetContent>
-          </Sheet>
+          <Button size="sm" onClick={() => openCreateDrawer()}>
+            <Plus className="h-4 w-4 mr-1.5" />
+            Create Collection
+          </Button>
         )}
       </div>
 
@@ -339,7 +285,7 @@ export function CollectionList() {
                   tab={tab.value}
                   hasSearch={!!searchTerm}
                   isAuthenticated={isAuthenticated}
-                  onCreateClick={() => setCreateDialogOpen(true)}
+                  onCreateClick={() => openCreateDrawer()}
                 />
               }
             />
@@ -512,362 +458,5 @@ function EmptyState({
         </p>
       )}
     </div>
-  )
-}
-
-// ──────────────────────────────────────────────
-// Create Collection Form (inline in dialog)
-// ──────────────────────────────────────────────
-
-function CreateCollectionForm({
-  onSuccess,
-  onCancel,
-}: {
-  onSuccess: (slug?: string) => void
-  /** PSY-823: cancel affordance for the Sheet footer. Optional so legacy
-   *  Dialog callers can still mount the form without a cancel button. */
-  onCancel?: () => void
-}) {
-  const createMutation = useCreateCollection()
-  const bulkAddMutation = useBulkAddCollectionItems()
-  const { user } = useAuthContext()
-  // PSY-358: per-tier owned-collection cap. Read user's collections so we
-  // can render "X of Y collections" before they submit. We filter to OWNED
-  // (creator_id == user.id) and exclude FORKS — same shape the backend
-  // uses for enforcement. Admins bypass the cap entirely.
-  const myCollections = useMyCollections()
-  const ownedCount = useMemo(() => {
-    if (!user?.id) return 0
-    const userId = Number(user.id)
-    return (myCollections.data?.collections ?? []).filter(
-      (c) => c.creator_id === userId && c.forked_from_collection_id == null
-    ).length
-  }, [myCollections.data?.collections, user?.id])
-
-  const tier = user?.user_tier ?? 'new_user'
-  const limit = getCollectionLimitForTier(tier)
-  const isUnlimited = user?.is_admin === true || limit === COLLECTION_UNLIMITED
-  const atOrOverCap = !isUnlimited && ownedCount >= limit
-  const tierLabel = getTierInfo(tier).label
-
-  const [title, setTitle] = useState('')
-  const [description, setDescription] = useState('')
-  const [isPublic, setIsPublic] = useState(true)
-  const [collaborative, setCollaborative] = useState(false)
-  // PSY-823: items staged via the AddItemsPicker. Submitted via the bulk-add
-  // endpoint immediately after the collection is created — sequential because
-  // the bulk endpoint is keyed on the new collection's slug.
-  const [stagedItems, setStagedItems] = useState<StagedCollectionItem[]>([])
-  // Post-create per-row error display from the bulk-add response. Surfaced
-  // inline so the user knows which paste rows didn't commit before they
-  // navigate to the new collection's detail page.
-  const [bulkAddRejectedCount, setBulkAddRejectedCount] = useState(0)
-  // PSY-585: cover image URL on create — mirrors the Edit form's field
-  // shape (validation, preview, clear button) so users can set the cover
-  // in one step instead of create-then-immediately-edit. Empty string is
-  // the "no cover" affordance and is the default; we omit the field from
-  // the request payload entirely when it's empty so the backend stores
-  // null rather than an empty string.
-  const [coverImageUrl, setCoverImageUrl] = useState('')
-  const [coverImageUrlTouched, setCoverImageUrlTouched] = useState(false)
-
-  const trimmedCoverUrl = coverImageUrl.trim()
-  const coverImageUrlError = validateCoverImageUrl(coverImageUrl)
-  const showCoverImageUrlError =
-    coverImageUrlTouched && coverImageUrlError !== null
-  const showCoverImagePreview =
-    trimmedCoverUrl.length > 0 && coverImageUrlError === null
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!title.trim()) return
-    if (coverImageUrlError) return
-
-    // PSY-823: sequential flow — create collection, then bulk-add staged
-    // items. The bulk endpoint requires the collection's slug, so this
-    // pair can't collapse into a single backend hit without a new
-    // composite endpoint (out of scope for V1).
-    try {
-      const newCollection = await createMutation.mutateAsync({
-        title: title.trim(),
-        description: description.trim() || undefined,
-        is_public: isPublic,
-        collaborative,
-        cover_image_url:
-          trimmedCoverUrl.length === 0 ? undefined : trimmedCoverUrl,
-      })
-
-      if (stagedItems.length > 0 && newCollection?.slug) {
-        try {
-          const bulkResp = await bulkAddMutation.mutateAsync({
-            slug: newCollection.slug,
-            items: stagedItems.map((s) => ({
-              entity_type: s.entityType,
-              entity_id: s.entityId,
-            })),
-          })
-          if (bulkResp.errors.length > 0) {
-            // Collection still created; surface the rejected count so the
-            // user can investigate on the detail page.
-            setBulkAddRejectedCount(bulkResp.errors.length)
-          }
-        } catch (bulkErr) {
-          // Bulk-add failed entirely (network/5xx). The collection still
-          // exists. We navigate to the new collection so the user lands
-          // on its detail page (where the empty-state picker prompts a
-          // retry). Inline failure feedback in the drawer would help, but
-          // the drawer auto-closes on onSuccess — surfacing the failure
-          // here would require holding the user in the drawer, which
-          // conflicts with the same-title slug-collision retry path. V1
-          // accepts the silent navigation; follow-up handles total-failure
-          // UX. See PSY-829 / new follow-up.
-          // eslint-disable-next-line no-console
-          console.error('bulk-add failed after collection create', bulkErr)
-        }
-      }
-
-      setTitle('')
-      setDescription('')
-      setCoverImageUrl('')
-      setCoverImageUrlTouched(false)
-      setStagedItems([])
-      onSuccess(newCollection?.slug)
-    } catch {
-      // create-collection failure: the mutation surfaces its error inline
-      // (see the existing createMutation.error render below) — nothing
-      // more to do here.
-    }
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {/* PSY-358: per-tier owned-collection limit explainer. Hidden for
-          admins and unlimited tiers (local_ambassador). */}
-      {!isUnlimited && (
-        <div
-          className={cn(
-            'rounded-md border px-3 py-2 text-xs',
-            atOrOverCap
-              ? 'border-destructive/50 bg-destructive/5 text-destructive'
-              : 'border-border bg-muted/30 text-muted-foreground'
-          )}
-          data-testid="collection-tier-limit-banner"
-        >
-          {atOrOverCap ? (
-            <>
-              You&apos;ve reached your limit of {limit} collections at the{' '}
-              <span className="font-medium">{tierLabel}</span> tier ({ownedCount}/{limit}).{' '}
-              <Link href={TIERS_HELP_PATH} className="underline">
-                Learn how to advance
-              </Link>{' '}
-              or delete an existing collection to make room.
-            </>
-          ) : (
-            <>
-              {ownedCount} of {limit} collections used at the{' '}
-              <span className="font-medium">{tierLabel}</span> tier.{' '}
-              <Link href={TIERS_HELP_PATH} className="underline">
-                Tier limits
-              </Link>
-              .
-            </>
-          )}
-        </div>
-      )}
-
-      <div>
-        <label
-          htmlFor="collection-title"
-          className="text-sm font-medium mb-1.5 block"
-        >
-          Title
-        </label>
-        <Input
-          id="collection-title"
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-          placeholder="My Favorite Artists"
-          required
-          autoFocus
-        />
-      </div>
-
-      <div>
-        <label
-          htmlFor="collection-description"
-          className="text-sm font-medium mb-1.5 block"
-        >
-          Description (optional)
-        </label>
-        <MarkdownEditor
-          id="collection-description"
-          value={description}
-          onChange={setDescription}
-          placeholder="A brief description of this collection... (markdown supported)"
-          rows={3}
-          maxLength={MAX_COLLECTION_MARKDOWN_LENGTH}
-          testId="create-collection-description-editor"
-        />
-      </div>
-
-      {/* PSY-585: Cover image URL (parity with Edit form). Optional; empty
-          submits cleanly with no cover. Validation, inline preview, and
-          clear-button mirror the Edit form's shape — only the helper text
-          differs (no "remove the current cover" half on create). */}
-      <div>
-        <label
-          htmlFor="create-cover-image-url"
-          className="text-sm font-medium mb-1.5 block"
-        >
-          Cover image URL{' '}
-          <span className="text-xs font-normal text-muted-foreground">
-            (optional)
-          </span>
-        </label>
-        <div className="flex gap-2">
-          <Input
-            id="create-cover-image-url"
-            type="url"
-            inputMode="url"
-            value={coverImageUrl}
-            onChange={e => {
-              setCoverImageUrl(e.target.value)
-              setCoverImageUrlTouched(true)
-            }}
-            onBlur={() => setCoverImageUrlTouched(true)}
-            placeholder="https://example.com/cover.jpg"
-            maxLength={MAX_COVER_IMAGE_URL_LENGTH}
-            aria-invalid={showCoverImageUrlError ? true : undefined}
-            aria-describedby={
-              showCoverImageUrlError
-                ? 'create-cover-image-url-error'
-                : 'create-cover-image-url-help'
-            }
-            data-testid="create-cover-image-url-input"
-          />
-          {trimmedCoverUrl.length > 0 && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setCoverImageUrl('')
-                setCoverImageUrlTouched(true)
-              }}
-              data-testid="create-cover-image-url-clear"
-            >
-              <X className="h-4 w-4 mr-1" />
-              Clear
-            </Button>
-          )}
-        </div>
-        {showCoverImageUrlError ? (
-          <p
-            id="create-cover-image-url-error"
-            className="text-xs text-destructive mt-1.5"
-            role="alert"
-          >
-            {coverImageUrlError}
-          </p>
-        ) : (
-          <p
-            id="create-cover-image-url-help"
-            className="text-xs text-muted-foreground mt-1.5"
-          >
-            Paste a direct image URL (e.g. Bandcamp art).
-          </p>
-        )}
-        {showCoverImagePreview && (
-          <div className="mt-2 h-24 w-24 rounded-lg overflow-hidden border border-border/50 bg-muted/50">
-            <img
-              src={trimmedCoverUrl}
-              alt="Cover image preview"
-              className="h-full w-full object-cover"
-              data-testid="create-cover-image-url-preview"
-            />
-          </div>
-        )}
-      </div>
-
-      <div className="flex items-center gap-6">
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <input
-            type="checkbox"
-            checked={isPublic}
-            onChange={e => setIsPublic(e.target.checked)}
-            className="rounded border-border"
-          />
-          Public
-        </label>
-
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <input
-            type="checkbox"
-            checked={collaborative}
-            onChange={e => setCollaborative(e.target.checked)}
-            className="rounded border-border"
-          />
-          Collaborative
-        </label>
-      </div>
-
-      {/* PSY-823: integrated AddItemsPicker — stages items as the user
-          fills the form so they can land a fully populated collection in
-          one drawer interaction. Staged items are POSTed to the bulk-add
-          endpoint immediately after the collection is created. */}
-      <div className="border-t border-border/50 pt-4">
-        <AddItemsPicker
-          existingItems={[]}
-          stagedItems={stagedItems}
-          onStagedItemsChange={setStagedItems}
-        />
-      </div>
-
-      {createMutation.error && (
-        <p className="text-sm text-destructive" data-testid="collection-create-error">
-          {createMutation.error instanceof Error
-            ? createMutation.error.message
-            : 'Failed to create collection'}
-        </p>
-      )}
-
-      {bulkAddRejectedCount > 0 && (
-        <p
-          className="text-sm text-amber-600 dark:text-amber-400"
-          data-testid="collection-create-bulk-rejected"
-        >
-          Collection created, but {bulkAddRejectedCount}{' '}
-          {bulkAddRejectedCount === 1 ? 'item' : 'items'} couldn&apos;t be added.
-          You can retry from the collection page.
-        </p>
-      )}
-
-      <div className="flex justify-end gap-2">
-        {onCancel && (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onCancel}
-            disabled={createMutation.isPending || bulkAddMutation.isPending}
-          >
-            Cancel
-          </Button>
-        )}
-        <Button
-          type="submit"
-          disabled={
-            !title.trim() ||
-            coverImageUrlError !== null ||
-            createMutation.isPending ||
-            bulkAddMutation.isPending ||
-            atOrOverCap
-          }
-        >
-          {createMutation.isPending || bulkAddMutation.isPending
-            ? 'Creating...'
-            : 'Create'}
-        </Button>
-      </div>
-    </form>
   )
 }

--- a/frontend/features/collections/components/CreateCollectionDrawer.test.tsx
+++ b/frontend/features/collections/components/CreateCollectionDrawer.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { type ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  CreateCollectionDrawerProvider,
+  useCreateCollectionDrawer,
+} from './CreateCollectionDrawer'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+// The drawer lazy-loads CreateCollectionForm via next/dynamic. Replace dynamic
+// with a stub component that surfaces the pre-fill so we can assert it without
+// pulling in the real form (+ AddItemsPicker) chunk.
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function MockForm({
+      initialStagedItems,
+    }: {
+      initialStagedItems?: { name: string }[]
+    }) {
+      return (
+        <div data-testid="create-form">
+          form:{(initialStagedItems ?? []).map((s) => s.name).join(',')}
+        </div>
+      )
+    },
+}))
+
+// Render the Sheet's content only when open (no portal/animation in jsdom).
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div data-testid="sheet">{children}</div> : null,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}))
+
+function OpenButton({ name }: { name: string }) {
+  const { openCreateDrawer } = useCreateCollectionDrawer()
+  return (
+    <button
+      onClick={() =>
+        openCreateDrawer({
+          initialStagedItems: [
+            { entityType: 'artist', entityId: 1, name, subtitle: null },
+          ],
+        })
+      }
+    >
+      open
+    </button>
+  )
+}
+
+describe('CreateCollectionDrawer', () => {
+  it('throws when useCreateCollectionDrawer is used outside the provider', () => {
+    function Bare() {
+      useCreateCollectionDrawer()
+      return null
+    }
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<Bare />)).toThrow(/CreateCollectionDrawerProvider/)
+    spy.mockRestore()
+  })
+
+  it('opens the drawer with the pre-filled form when openCreateDrawer is called', async () => {
+    const user = userEvent.setup()
+    render(
+      <CreateCollectionDrawerProvider>
+        <OpenButton name="Amyl and The Sniffers" />
+      </CreateCollectionDrawerProvider>
+    )
+
+    // Closed initially — the form (and its lazy chunk) is not mounted.
+    expect(screen.queryByTestId('create-form')).not.toBeInTheDocument()
+
+    await user.click(screen.getByText('open'))
+
+    expect(await screen.findByTestId('create-form')).toHaveTextContent(
+      'Amyl and The Sniffers'
+    )
+  })
+})

--- a/frontend/features/collections/components/CreateCollectionDrawer.test.tsx
+++ b/frontend/features/collections/components/CreateCollectionDrawer.test.tsx
@@ -1,26 +1,35 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { type ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   CreateCollectionDrawerProvider,
   useCreateCollectionDrawer,
 } from './CreateCollectionDrawer'
 
+const mockPush = vi.fn()
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }))
 
+// Capture the form's onSuccess + the Sheet's onOpenChange so tests can drive
+// the success / user-dismiss paths directly.
+let capturedOnSuccess: ((slug?: string) => void) | undefined
+let capturedOnOpenChange: ((open: boolean) => void) | undefined
+
 // The drawer lazy-loads CreateCollectionForm via next/dynamic. Replace dynamic
-// with a stub component that surfaces the pre-fill so we can assert it without
-// pulling in the real form (+ AddItemsPicker) chunk.
+// with a stub that surfaces the pre-fill + captures onSuccess, without pulling
+// in the real form (+ AddItemsPicker) chunk.
 vi.mock('next/dynamic', () => ({
   default: () =>
     function MockForm({
       initialStagedItems,
+      onSuccess,
     }: {
       initialStagedItems?: { name: string }[]
+      onSuccess?: (slug?: string) => void
     }) {
+      capturedOnSuccess = onSuccess
       return (
         <div data-testid="create-form">
           form:{(initialStagedItems ?? []).map((s) => s.name).join(',')}
@@ -29,10 +38,21 @@ vi.mock('next/dynamic', () => ({
     },
 }))
 
-// Render the Sheet's content only when open (no portal/animation in jsdom).
+// Render the Sheet's content only when open (no portal/animation in jsdom);
+// capture onOpenChange so a test can simulate a user dismiss (Esc/overlay).
 vi.mock('@/components/ui/sheet', () => ({
-  Sheet: ({ open, children }: { open: boolean; children: ReactNode }) =>
-    open ? <div data-testid="sheet">{children}</div> : null,
+  Sheet: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean
+    onOpenChange?: (open: boolean) => void
+    children: ReactNode
+  }) => {
+    capturedOnOpenChange = onOpenChange
+    return open ? <div data-testid="sheet">{children}</div> : null
+  },
   SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
@@ -56,6 +76,12 @@ function OpenButton({ name }: { name: string }) {
 }
 
 describe('CreateCollectionDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedOnSuccess = undefined
+    capturedOnOpenChange = undefined
+  })
+
   it('throws when useCreateCollectionDrawer is used outside the provider', () => {
     function Bare() {
       useCreateCollectionDrawer()
@@ -82,5 +108,37 @@ describe('CreateCollectionDrawer', () => {
     expect(await screen.findByTestId('create-form')).toHaveTextContent(
       'Amyl and The Sniffers'
     )
+  })
+
+  it('navigates to the new collection on a successful create', async () => {
+    const user = userEvent.setup()
+    render(
+      <CreateCollectionDrawerProvider>
+        <OpenButton name="Amyl" />
+      </CreateCollectionDrawerProvider>
+    )
+    await user.click(screen.getByText('open'))
+    await screen.findByTestId('create-form')
+
+    // The form reports success (the user did NOT dismiss the drawer).
+    act(() => capturedOnSuccess?.('amyl-collection'))
+    expect(mockPush).toHaveBeenCalledWith('/collections/amyl-collection')
+  })
+
+  it('skips navigation when the user dismissed the drawer before create resolved', async () => {
+    const user = userEvent.setup()
+    render(
+      <CreateCollectionDrawerProvider>
+        <OpenButton name="Amyl" />
+      </CreateCollectionDrawerProvider>
+    )
+    await user.click(screen.getByText('open'))
+    await screen.findByTestId('create-form')
+
+    // User dismisses (Esc / overlay) while the create is still in flight…
+    act(() => capturedOnOpenChange?.(false))
+    // …then the create resolves — the user must not be yanked away.
+    act(() => capturedOnSuccess?.('amyl-collection'))
+    expect(mockPush).not.toHaveBeenCalled()
   })
 })

--- a/frontend/features/collections/components/CreateCollectionDrawer.tsx
+++ b/frontend/features/collections/components/CreateCollectionDrawer.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from 'react'
+import dynamic from 'next/dynamic'
+import { useRouter } from 'next/navigation'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Loader2 } from 'lucide-react'
+import type { StagedCollectionItem } from './AddItemsPicker'
+
+// PSY-961: lazy-load the form. The provider is mounted app-wide (root layout),
+// so eagerly importing the form would pull AddItemsPicker + its extraction/
+// search deps into the global client chunk. `dynamic(ssr:false)` keeps that
+// weight in a separate chunk fetched only when the drawer first opens — per
+// pattern_turbopack_shared_chunk.
+const CreateCollectionForm = dynamic(
+  () =>
+    import('./CreateCollectionForm').then((m) => m.CreateCollectionForm),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex items-center justify-center py-10">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    ),
+  }
+)
+
+interface OpenCreateDrawerOptions {
+  /** Pre-seed the staged list — create-from-entity passes the entity as item 1. */
+  initialStagedItems?: StagedCollectionItem[]
+}
+
+interface CreateCollectionDrawerContextValue {
+  openCreateDrawer: (options?: OpenCreateDrawerOptions) => void
+}
+
+const CreateCollectionDrawerContext =
+  createContext<CreateCollectionDrawerContextValue | null>(null)
+
+/**
+ * App-level "create a collection" drawer (PSY-961 / PSY-893 D4). Mounted once
+ * near the root so any surface — the /collections "Create Collection" button or
+ * the AddToCollectionButton popover's "Create … with {entity}" CTA — can open
+ * an in-place Create drawer without navigating away. Call `openCreateDrawer()`
+ * from `useCreateCollectionDrawer()`.
+ */
+export function CreateCollectionDrawerProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [initialStagedItems, setInitialStagedItems] = useState<
+    StagedCollectionItem[]
+  >([])
+  // Bumped on every open so the form remounts fresh (new pre-fill, cleared
+  // fields) even if Radix keeps the content mounted between rapid reopens.
+  const [openNonce, setOpenNonce] = useState(0)
+
+  const openCreateDrawer = useCallback(
+    (options?: OpenCreateDrawerOptions) => {
+      setInitialStagedItems(options?.initialStagedItems ?? [])
+      setOpenNonce((n) => n + 1)
+      setOpen(true)
+    },
+    []
+  )
+
+  return (
+    <CreateCollectionDrawerContext.Provider value={{ openCreateDrawer }}>
+      {children}
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="right"
+          className="w-full sm:max-w-xl flex flex-col overflow-y-auto"
+        >
+          <SheetHeader>
+            <SheetTitle>Create Collection</SheetTitle>
+          </SheetHeader>
+          <div className="px-4 pb-4">
+            {/* Only mount the form while open so the lazy chunk + its queries
+                load on first open, not on every page. */}
+            {open && (
+              <CreateCollectionForm
+                key={openNonce}
+                initialStagedItems={initialStagedItems}
+                onSuccess={(newSlug) => {
+                  setOpen(false)
+                  if (newSlug) {
+                    router.push(`/collections/${newSlug}`)
+                  }
+                }}
+                onCancel={() => setOpen(false)}
+              />
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </CreateCollectionDrawerContext.Provider>
+  )
+}
+
+export function useCreateCollectionDrawer(): CreateCollectionDrawerContextValue {
+  const ctx = useContext(CreateCollectionDrawerContext)
+  if (!ctx) {
+    throw new Error(
+      'useCreateCollectionDrawer must be used within a CreateCollectionDrawerProvider'
+    )
+  }
+  return ctx
+}

--- a/frontend/features/collections/components/CreateCollectionDrawer.tsx
+++ b/frontend/features/collections/components/CreateCollectionDrawer.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useRef,
   useState,
   type ReactNode,
 } from 'react'
@@ -65,14 +66,17 @@ export function CreateCollectionDrawerProvider({
   const [initialStagedItems, setInitialStagedItems] = useState<
     StagedCollectionItem[]
   >([])
-  // Bumped on every open so the form remounts fresh (new pre-fill, cleared
-  // fields) even if Radix keeps the content mounted between rapid reopens.
-  const [openNonce, setOpenNonce] = useState(0)
+  // If the user dismisses the drawer (Esc / overlay / X) WHILE a create is
+  // still in flight, skip the post-success navigation so they aren't yanked
+  // off the page they just backed out of. Radix's onOpenChange fires only on
+  // a user-driven close (not on our own setOpen(false)), so it cleanly marks
+  // intent. The collection is still created — the request already fired.
+  const userDismissedRef = useRef(false)
 
   const openCreateDrawer = useCallback(
     (options?: OpenCreateDrawerOptions) => {
+      userDismissedRef.current = false
       setInitialStagedItems(options?.initialStagedItems ?? [])
-      setOpenNonce((n) => n + 1)
       setOpen(true)
     },
     []
@@ -81,7 +85,13 @@ export function CreateCollectionDrawerProvider({
   return (
     <CreateCollectionDrawerContext.Provider value={{ openCreateDrawer }}>
       {children}
-      <Sheet open={open} onOpenChange={setOpen}>
+      <Sheet
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) userDismissedRef.current = true
+          setOpen(next)
+        }}
+      >
         <SheetContent
           side="right"
           className="w-full sm:max-w-xl flex flex-col overflow-y-auto"
@@ -90,15 +100,16 @@ export function CreateCollectionDrawerProvider({
             <SheetTitle>Create Collection</SheetTitle>
           </SheetHeader>
           <div className="px-4 pb-4">
-            {/* Only mount the form while open so the lazy chunk + its queries
-                load on first open, not on every page. */}
+            {/* Only mount the form while open: the lazy chunk + its queries
+                load on first open (not on every page), and unmounting on
+                close resets the form so each open starts fresh with the
+                current pre-fill. */}
             {open && (
               <CreateCollectionForm
-                key={openNonce}
                 initialStagedItems={initialStagedItems}
                 onSuccess={(newSlug) => {
                   setOpen(false)
-                  if (newSlug) {
+                  if (newSlug && !userDismissedRef.current) {
                     router.push(`/collections/${newSlug}`)
                   }
                 }}

--- a/frontend/features/collections/components/CreateCollectionForm.test.tsx
+++ b/frontend/features/collections/components/CreateCollectionForm.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { type ReactNode } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CreateCollectionForm } from './CreateCollectionForm'
+
+// Admin user so the per-tier cap banner / submit-disable is skipped here
+// (cap behavior is the catalog model's concern, not this refactor's).
+const mockUseAuthContext = vi.fn(() => ({
+  user: { id: '1', is_admin: true, user_tier: 'local_ambassador' },
+}))
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}))
+
+const mockCreateMutateAsync = vi.fn()
+const mockBulkAddMutateAsync = vi.fn()
+vi.mock('../hooks', () => ({
+  useCreateCollection: () => ({
+    mutateAsync: mockCreateMutateAsync,
+    isPending: false,
+    error: null as Error | null,
+  }),
+  useBulkAddCollectionItems: () => ({
+    mutateAsync: mockBulkAddMutateAsync,
+    isPending: false,
+    error: null as Error | null,
+  }),
+  useMyCollections: () => ({ data: { collections: [] }, isLoading: false }),
+}))
+
+// Stub the lazy MarkdownEditor (avoids the marked/dompurify load); keep the
+// id so the form's <label htmlFor> association resolves.
+vi.mock('./MarkdownEditorLazy', () => ({
+  MarkdownEditor: ({
+    id,
+    value,
+    onChange,
+  }: {
+    id: string
+    value: string
+    onChange: (v: string) => void
+  }) => (
+    <textarea id={id} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}))
+
+// Stub the picker but surface its staged-items so we can assert the
+// create-from-entity pre-fill (PSY-961).
+vi.mock('./AddItemsPicker', () => ({
+  AddItemsPicker: ({ stagedItems }: { stagedItems: { name: string }[] }) => (
+    <div data-testid="staged-names">
+      {stagedItems.map((s) => s.name).join(', ')}
+    </div>
+  ),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+describe('CreateCollectionForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuthContext.mockReturnValue({
+      user: { id: '1', is_admin: true, user_tier: 'local_ambassador' },
+    })
+  })
+
+  it('renders with Public checked + Collaborative unchecked by default', () => {
+    render(<CreateCollectionForm onSuccess={vi.fn()} />)
+    expect(screen.getByLabelText('Title')).toBeInTheDocument()
+    expect((screen.getByLabelText('Public') as HTMLInputElement).checked).toBe(
+      true
+    )
+    expect(
+      (screen.getByLabelText('Collaborative') as HTMLInputElement).checked
+    ).toBe(false)
+  })
+
+  it('renders the Cover image URL field with the create-only helper text', () => {
+    render(<CreateCollectionForm onSuccess={vi.fn()} />)
+    expect(
+      screen.getByTestId('create-cover-image-url-input')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Paste a direct image URL (e.g. Bandcamp art).')
+    ).toBeInTheDocument()
+  })
+
+  it('pre-fills the staged list from initialStagedItems (create-from-entity)', () => {
+    render(
+      <CreateCollectionForm
+        onSuccess={vi.fn()}
+        initialStagedItems={[
+          {
+            entityType: 'artist',
+            entityId: 42,
+            name: 'Amyl and The Sniffers',
+            subtitle: null,
+          },
+        ]}
+      />
+    )
+    expect(screen.getByTestId('staged-names')).toHaveTextContent(
+      'Amyl and The Sniffers'
+    )
+  })
+
+  it('creates the collection then bulk-adds the staged items, then calls onSuccess', async () => {
+    mockCreateMutateAsync.mockResolvedValue({ slug: 'amyl-collection' })
+    mockBulkAddMutateAsync.mockResolvedValue({ added: [1], errors: [] })
+    const onSuccess = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CreateCollectionForm
+        onSuccess={onSuccess}
+        initialStagedItems={[
+          { entityType: 'artist', entityId: 42, name: 'Amyl', subtitle: null },
+        ]}
+      />
+    )
+
+    await user.type(screen.getByLabelText('Title'), 'Amyl Collection')
+    await user.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Amyl Collection',
+          is_public: true,
+          collaborative: false,
+        })
+      )
+    })
+    // The pre-seeded entity is committed via the bulk-add endpoint.
+    expect(mockBulkAddMutateAsync).toHaveBeenCalledWith({
+      slug: 'amyl-collection',
+      items: [{ entity_type: 'artist', entity_id: 42 }],
+    })
+    expect(onSuccess).toHaveBeenCalledWith('amyl-collection')
+  })
+
+  // PSY-585: cover-image URL payload contract (moved here from CollectionList).
+  it('submits with cover_image_url when a valid URL is entered', async () => {
+    mockCreateMutateAsync.mockResolvedValue({ slug: 's' })
+    mockBulkAddMutateAsync.mockResolvedValue({ added: [], errors: [] })
+    const user = userEvent.setup()
+    render(<CreateCollectionForm onSuccess={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Title'), 'My Picks')
+    await user.type(
+      screen.getByTestId('create-cover-image-url-input'),
+      'https://example.com/cover.jpg'
+    )
+    await user.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'My Picks',
+          cover_image_url: 'https://example.com/cover.jpg',
+        })
+      )
+    })
+  })
+
+  it('omits cover_image_url from the payload when the field is empty', async () => {
+    mockCreateMutateAsync.mockResolvedValue({ slug: 's' })
+    mockBulkAddMutateAsync.mockResolvedValue({ added: [], errors: [] })
+    const user = userEvent.setup()
+    render(<CreateCollectionForm onSuccess={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Title'), 'No Cover')
+    await user.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => expect(mockCreateMutateAsync).toHaveBeenCalled())
+    // JSON.stringify drops undefined keys → an empty cover URL never reaches
+    // the wire body.
+    const payload = mockCreateMutateAsync.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >
+    expect(payload.cover_image_url).toBeUndefined()
+  })
+
+  it('disables submit for an invalid cover URL and never fires the mutation', async () => {
+    const user = userEvent.setup()
+    render(<CreateCollectionForm onSuccess={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Title'), 'Bad URL Test')
+    const coverInput = screen.getByTestId('create-cover-image-url-input')
+    // `not-a-url` fails the WHATWG URL parser → validateCoverImageUrl errors.
+    await user.type(coverInput, 'not-a-url')
+    coverInput.blur()
+
+    const submitButton = screen.getByRole('button', {
+      name: /^create$/i,
+    }) as HTMLButtonElement
+    expect(submitButton.disabled).toBe(true)
+    await user.click(submitButton)
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/collections/components/CreateCollectionForm.tsx
+++ b/frontend/features/collections/components/CreateCollectionForm.tsx
@@ -1,0 +1,397 @@
+'use client'
+
+import { useMemo, useState, type FormEvent } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { X } from 'lucide-react'
+// MarkdownEditor is lazily loaded (dynamic ssr:false) so its `marked` +
+// `dompurify` deps stay out of the global shared client chunk — see
+// MarkdownEditorLazy / PSY-951.
+import { MarkdownEditor } from './MarkdownEditorLazy'
+import { AddItemsPicker, type StagedCollectionItem } from './AddItemsPicker'
+import {
+  MAX_COLLECTION_MARKDOWN_LENGTH,
+  MAX_COVER_IMAGE_URL_LENGTH,
+  validateCoverImageUrl,
+} from '../types'
+import {
+  useCreateCollection,
+  useBulkAddCollectionItems,
+  useMyCollections,
+} from '../hooks'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import {
+  COLLECTION_UNLIMITED,
+  TIERS_HELP_PATH,
+  getCollectionLimitForTier,
+  getTierInfo,
+} from '@/lib/tiers'
+import { cn } from '@/lib/utils'
+
+/**
+ * The create-collection form. Extracted from CollectionList (PSY-961) so it can
+ * be mounted both by the /collections "Create Collection" button and by the
+ * app-level CreateCollectionDrawer (reachable from the AddToCollectionButton
+ * popover's "Create … with {entity}" CTA). `initialStagedItems` seeds the
+ * staged list — the create-from-entity flow passes the current entity as item 1.
+ */
+export function CreateCollectionForm({
+  onSuccess,
+  onCancel,
+  initialStagedItems,
+}: {
+  onSuccess: (slug?: string) => void
+  /** PSY-823: cancel affordance for the Sheet footer. Optional so legacy
+   *  Dialog callers can still mount the form without a cancel button. */
+  onCancel?: () => void
+  /** PSY-961: pre-seed the staged list (create-from-entity passes the current
+   *  entity as item 1). The form is re-mounted per drawer-open, so this only
+   *  needs to be read on mount. */
+  initialStagedItems?: StagedCollectionItem[]
+}) {
+  const createMutation = useCreateCollection()
+  const bulkAddMutation = useBulkAddCollectionItems()
+  const { user } = useAuthContext()
+  // PSY-358: per-tier owned-collection cap. Read user's collections so we
+  // can render "X of Y collections" before they submit. We filter to OWNED
+  // (creator_id == user.id) and exclude FORKS — same shape the backend
+  // uses for enforcement. Admins bypass the cap entirely.
+  const myCollections = useMyCollections()
+  const ownedCount = useMemo(() => {
+    if (!user?.id) return 0
+    const userId = Number(user.id)
+    return (myCollections.data?.collections ?? []).filter(
+      (c) => c.creator_id === userId && c.forked_from_collection_id == null
+    ).length
+  }, [myCollections.data?.collections, user?.id])
+
+  const tier = user?.user_tier ?? 'new_user'
+  const limit = getCollectionLimitForTier(tier)
+  const isUnlimited = user?.is_admin === true || limit === COLLECTION_UNLIMITED
+  const atOrOverCap = !isUnlimited && ownedCount >= limit
+  const tierLabel = getTierInfo(tier).label
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [isPublic, setIsPublic] = useState(true)
+  const [collaborative, setCollaborative] = useState(false)
+  // PSY-823: items staged via the AddItemsPicker. Submitted via the bulk-add
+  // endpoint immediately after the collection is created — sequential because
+  // the bulk endpoint is keyed on the new collection's slug. PSY-961:
+  // pre-seeded from `initialStagedItems` for the create-from-entity flow.
+  const [stagedItems, setStagedItems] = useState<StagedCollectionItem[]>(
+    initialStagedItems ?? []
+  )
+  // Post-create per-row error display from the bulk-add response. Surfaced
+  // inline so the user knows which paste rows didn't commit before they
+  // navigate to the new collection's detail page.
+  const [bulkAddRejectedCount, setBulkAddRejectedCount] = useState(0)
+  // PSY-585: cover image URL on create — mirrors the Edit form's field
+  // shape (validation, preview, clear button) so users can set the cover
+  // in one step instead of create-then-immediately-edit. Empty string is
+  // the "no cover" affordance and is the default; we omit the field from
+  // the request payload entirely when it's empty so the backend stores
+  // null rather than an empty string.
+  const [coverImageUrl, setCoverImageUrl] = useState('')
+  const [coverImageUrlTouched, setCoverImageUrlTouched] = useState(false)
+
+  const trimmedCoverUrl = coverImageUrl.trim()
+  const coverImageUrlError = validateCoverImageUrl(coverImageUrl)
+  const showCoverImageUrlError =
+    coverImageUrlTouched && coverImageUrlError !== null
+  const showCoverImagePreview =
+    trimmedCoverUrl.length > 0 && coverImageUrlError === null
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+    if (coverImageUrlError) return
+
+    // PSY-823: sequential flow — create collection, then bulk-add staged
+    // items. The bulk endpoint requires the collection's slug, so this
+    // pair can't collapse into a single backend hit without a new
+    // composite endpoint (out of scope for V1).
+    try {
+      const newCollection = await createMutation.mutateAsync({
+        title: title.trim(),
+        description: description.trim() || undefined,
+        is_public: isPublic,
+        collaborative,
+        cover_image_url:
+          trimmedCoverUrl.length === 0 ? undefined : trimmedCoverUrl,
+      })
+
+      if (stagedItems.length > 0 && newCollection?.slug) {
+        try {
+          const bulkResp = await bulkAddMutation.mutateAsync({
+            slug: newCollection.slug,
+            items: stagedItems.map((s) => ({
+              entity_type: s.entityType,
+              entity_id: s.entityId,
+            })),
+          })
+          if (bulkResp.errors.length > 0) {
+            // Collection still created; surface the rejected count so the
+            // user can investigate on the detail page.
+            setBulkAddRejectedCount(bulkResp.errors.length)
+          }
+        } catch (bulkErr) {
+          // Bulk-add failed entirely (network/5xx). The collection still
+          // exists. We navigate to the new collection so the user lands
+          // on its detail page (where the empty-state picker prompts a
+          // retry). Inline failure feedback in the drawer would help, but
+          // the drawer auto-closes on onSuccess — surfacing the failure
+          // here would require holding the user in the drawer, which
+          // conflicts with the same-title slug-collision retry path. V1
+          // accepts the silent navigation; follow-up handles total-failure
+          // UX. See PSY-829 / new follow-up.
+          console.error('bulk-add failed after collection create', bulkErr)
+        }
+      }
+
+      setTitle('')
+      setDescription('')
+      setCoverImageUrl('')
+      setCoverImageUrlTouched(false)
+      setStagedItems([])
+      onSuccess(newCollection?.slug)
+    } catch {
+      // create-collection failure: the mutation surfaces its error inline
+      // (see the existing createMutation.error render below) — nothing
+      // more to do here.
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {/* PSY-358: per-tier owned-collection limit explainer. Hidden for
+          admins and unlimited tiers (local_ambassador). */}
+      {!isUnlimited && (
+        <div
+          className={cn(
+            'rounded-md border px-3 py-2 text-xs',
+            atOrOverCap
+              ? 'border-destructive/50 bg-destructive/5 text-destructive'
+              : 'border-border bg-muted/30 text-muted-foreground'
+          )}
+          data-testid="collection-tier-limit-banner"
+        >
+          {atOrOverCap ? (
+            <>
+              You&apos;ve reached your limit of {limit} collections at the{' '}
+              <span className="font-medium">{tierLabel}</span> tier ({ownedCount}/{limit}).{' '}
+              <Link href={TIERS_HELP_PATH} className="underline">
+                Learn how to advance
+              </Link>{' '}
+              or delete an existing collection to make room.
+            </>
+          ) : (
+            <>
+              {ownedCount} of {limit} collections used at the{' '}
+              <span className="font-medium">{tierLabel}</span> tier.{' '}
+              <Link href={TIERS_HELP_PATH} className="underline">
+                Tier limits
+              </Link>
+              .
+            </>
+          )}
+        </div>
+      )}
+
+      <div>
+        <label
+          htmlFor="collection-title"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Title
+        </label>
+        <Input
+          id="collection-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="My Favorite Artists"
+          required
+          autoFocus
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="collection-description"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Description (optional)
+        </label>
+        <MarkdownEditor
+          id="collection-description"
+          value={description}
+          onChange={setDescription}
+          placeholder="A brief description of this collection... (markdown supported)"
+          rows={3}
+          maxLength={MAX_COLLECTION_MARKDOWN_LENGTH}
+          testId="create-collection-description-editor"
+        />
+      </div>
+
+      {/* PSY-585: Cover image URL (parity with Edit form). Optional; empty
+          submits cleanly with no cover. Validation, inline preview, and
+          clear-button mirror the Edit form's shape — only the helper text
+          differs (no "remove the current cover" half on create). */}
+      <div>
+        <label
+          htmlFor="create-cover-image-url"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Cover image URL{' '}
+          <span className="text-xs font-normal text-muted-foreground">
+            (optional)
+          </span>
+        </label>
+        <div className="flex gap-2">
+          <Input
+            id="create-cover-image-url"
+            type="url"
+            inputMode="url"
+            value={coverImageUrl}
+            onChange={(e) => {
+              setCoverImageUrl(e.target.value)
+              setCoverImageUrlTouched(true)
+            }}
+            onBlur={() => setCoverImageUrlTouched(true)}
+            placeholder="https://example.com/cover.jpg"
+            maxLength={MAX_COVER_IMAGE_URL_LENGTH}
+            aria-invalid={showCoverImageUrlError ? true : undefined}
+            aria-describedby={
+              showCoverImageUrlError
+                ? 'create-cover-image-url-error'
+                : 'create-cover-image-url-help'
+            }
+            data-testid="create-cover-image-url-input"
+          />
+          {trimmedCoverUrl.length > 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setCoverImageUrl('')
+                setCoverImageUrlTouched(true)
+              }}
+              data-testid="create-cover-image-url-clear"
+            >
+              <X className="h-4 w-4 mr-1" />
+              Clear
+            </Button>
+          )}
+        </div>
+        {showCoverImageUrlError ? (
+          <p
+            id="create-cover-image-url-error"
+            className="text-xs text-destructive mt-1.5"
+            role="alert"
+          >
+            {coverImageUrlError}
+          </p>
+        ) : (
+          <p
+            id="create-cover-image-url-help"
+            className="text-xs text-muted-foreground mt-1.5"
+          >
+            Paste a direct image URL (e.g. Bandcamp art).
+          </p>
+        )}
+        {showCoverImagePreview && (
+          <div className="mt-2 h-24 w-24 rounded-lg overflow-hidden border border-border/50 bg-muted/50">
+            <img
+              src={trimmedCoverUrl}
+              alt="Cover image preview"
+              className="h-full w-full object-cover"
+              data-testid="create-cover-image-url-preview"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-6">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={(e) => setIsPublic(e.target.checked)}
+            className="rounded border-border"
+          />
+          Public
+        </label>
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={collaborative}
+            onChange={(e) => setCollaborative(e.target.checked)}
+            className="rounded border-border"
+          />
+          Collaborative
+        </label>
+      </div>
+
+      {/* PSY-823: integrated AddItemsPicker — stages items as the user
+          fills the form so they can land a fully populated collection in
+          one drawer interaction. Staged items are POSTed to the bulk-add
+          endpoint immediately after the collection is created. */}
+      <div className="border-t border-border/50 pt-4">
+        <AddItemsPicker
+          existingItems={[]}
+          stagedItems={stagedItems}
+          onStagedItemsChange={setStagedItems}
+        />
+      </div>
+
+      {createMutation.error && (
+        <p className="text-sm text-destructive" data-testid="collection-create-error">
+          {createMutation.error instanceof Error
+            ? createMutation.error.message
+            : 'Failed to create collection'}
+        </p>
+      )}
+
+      {bulkAddRejectedCount > 0 && (
+        <p
+          className="text-sm text-amber-600 dark:text-amber-400"
+          data-testid="collection-create-bulk-rejected"
+        >
+          Collection created, but {bulkAddRejectedCount}{' '}
+          {bulkAddRejectedCount === 1 ? 'item' : 'items'} couldn&apos;t be added.
+          You can retry from the collection page.
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        {onCancel && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={createMutation.isPending || bulkAddMutation.isPending}
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          type="submit"
+          disabled={
+            !title.trim() ||
+            coverImageUrlError !== null ||
+            createMutation.isPending ||
+            bulkAddMutation.isPending ||
+            atOrOverCap
+          }
+        >
+          {createMutation.isPending || bulkAddMutation.isPending
+            ? 'Creating...'
+            : 'Create'}
+        </Button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
Closes PSY-961.

## Summary
- Implements **PSY-893 D4** (deferred from PSY-829): the AddToCollectionButton popover CTA becomes **"Create new collection with {entity}"** (empty-state: "Create with {entity}") and opens a Create drawer **pre-filled with the current entity as item 1** — closing the "I'm reading about this artist, start a collection around them" loop.
- Built as **Option B — an app-level, in-place drawer** (the research-backed choice over query-param navigation): creation happens *without leaving the entity page*. ([2026 UX research](https://www.smashingmagazine.com/2026/03/modal-separate-page-ux-decision-tree/): in-place overlays beat navigating away for context-dependent creation.)

## How it's built
- **Extract** `CreateCollectionForm` out of `CollectionList` into its own file, with an `initialStagedItems` prop that seeds the staged list.
- **New `CreateCollectionDrawer`**: a `CreateCollectionDrawerProvider` (mounted once at the root via `Providers`) exposing `useCreateCollectionDrawer().openCreateDrawer({ initialStagedItems })`. The form is **lazy-loaded** via `dynamic(ssr:false)`, so AddItemsPicker + its extraction/search deps stay out of the root chunk (chunk hygiene — the provider is on every page).
- **Migrate** `CollectionList`'s local Sheet onto the shared drawer (one drawer, not two).
- **Wire** both AddToCollectionButton CTAs (main + D5 empty-state) to `openCreateDrawer` with the entity pre-filled.

## Adversarial review
`/adversarial-review` — CONCERNS, all findings addressed in commit `94bdcab5`. Panel: Saboteur · Future-Maintainer · Security · Completeness (Security **CLEAN** — escaping/URL-validation/authz all preserved; Completeness **CLEAN** — every AC + design property MET).
- **[HIGH]** Two `CollectionEntityType` declarations (types.ts + a hand-written union in AddItemsPicker) that this PR's cross-module pre-fill made load-bearing → AddItemsPicker now imports + re-exports the canonical type from `../types`. One backend-synced source of truth.
- **[MEDIUM]** Closing the drawer mid-create force-navigated the user away after the request resolved → the provider tracks user-dismissal (Radix `onOpenChange` fires only on user-close) and **skips the post-success navigation if the user backed out**. Both paths tested.
- **[MEDIUM]** "in place (no navigation)" comment misled (opening is in-place; success navigates to the new collection) → corrected. Softened the D3/PSY-960 forward-reference to read correctly regardless of merge order.
- **[LOW]** Dropped the redundant `openNonce`/`key` — the `{open && <Form>}` guard already unmounts on close, giving a fresh mount + pre-fill per open.
- `/code-review` (run first): faithful extraction; restored 3 dropped PSY-585 cover-image payload/validation tests (moved into `CreateCollectionForm.test.tsx`); removed dead mocks from `CollectionList.test`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/collections components/shared components/layout` — 945/945 passing
- [x] `npx eslint` on all changed files — 0 errors (eslint is the enforced gate; repo has no prettier config/CI step)
- [x] `/code-review` — extraction faithful; dropped-coverage + dead-mocks fixed
- [x] `/adversarial-review` — CONCERNS, all findings addressed (separate commit `94bdcab5`)
- [x] Manual repro against local dev stack: signed in, opened the Collect popover on an artist page, clicked "Create new collection with Amyl and The Sniffers" — the Create drawer opened **in place** (overlaid on the artist page, not a navigation) **pre-filled** with the artist as item 1 (screenshot below). Verified via DOM: drawer title "Create Collection", "Items (1)", staged row "Amyl and The Sniffers · Artist".

## Screenshots
The in-place Create drawer, opened from the artist page's Collect popover, pre-filled with the entity as item 1 (note the dimmed artist page peeking at the left edge — no navigation):

![Create drawer opened in-place from an artist page, pre-filled with "Amyl and The Sniffers" as item 1](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-19de9f5124b9369c36cf/psy-961-drawer-crop.png)

## Merge-order note (PSY-960 overlap)
This branch is off `main`; **PSY-960 (#986)** is also open and edits the **same create-CTA region** of `AddToCollectionButton.tsx` (it adds the RECENTLY USED / ALL COLLECTIONS grouping above the separator; this PR rewrites the create-CTA link→button below it). A merge conflict in that block is expected — whoever merges second reconciles the two D-decision comments. The behaviors are independent (grouping vs. create-CTA).

## Coverage gaps
- **Lazy-load boundary** (`dynamic(ssr:false)`) is mocked away in the unit test (`next/dynamic` stubbed) — the bundle-split is verified by inspection + the chunk-hygiene rationale, not by a test asserting the chunk loads on first open. A future E2E or a non-mocked render would lock it.
- **Navigate-on-success product call**: after a successful create-from-entity, the drawer routes to the new collection's page (consistent with the existing /collections flow, and lets the user keep curating). If "stay on the entity page" is preferred, that's a product decision + an `onSuccess` override hook — flagged, not assumed.
- The cap-banner / over-cap submit-disable path is exercised at the catalog-model level; the form test uses an admin user (no cap) for the pre-fill/submit cases.
