### PR TITLE
PSY-971: migrate admin status greens to success/pending tokens

### DIFF
--- a/frontend/components/admin/PendingShowCard.tsx
+++ b/frontend/components/admin/PendingShowCard.tsx
@@ -45,7 +45,7 @@ export function PendingShowCard({
 
   return (
     <>
-      <Card className={`border-amber-500/30 bg-card/50 transition-colors ${selected ? 'ring-2 ring-primary/50 border-primary/50' : ''}`}>
+      <Card className={`border-pending-foreground/30 bg-card/50 transition-colors ${selected ? 'ring-2 ring-primary/50 border-primary/50' : ''}`}>
         <CardHeader className="pb-3">
           <div className="flex items-start justify-between gap-4">
             {onSelectChange && (
@@ -66,7 +66,7 @@ export function PendingShowCard({
               <div className="flex flex-wrap items-center gap-2 mt-1">
                 <Badge
                   variant="outline"
-                  className="text-amber-500 border-amber-500/50"
+                  className="text-pending-foreground border-pending-foreground/50"
                 >
                   Pending Review
                 </Badge>

--- a/frontend/components/admin/ResolveArtistReportDialog.tsx
+++ b/frontend/components/admin/ResolveArtistReportDialog.tsx
@@ -52,7 +52,7 @@ export function ResolveArtistReportDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <CheckCircle className="h-5 w-5 text-green-500" />
+            <CheckCircle className="h-5 w-5 text-success-foreground" />
             Resolve Report
           </DialogTitle>
           <DialogDescription>

--- a/frontend/components/admin/ResolveReportDialog.tsx
+++ b/frontend/components/admin/ResolveReportDialog.tsx
@@ -71,7 +71,7 @@ export function ResolveReportDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <CheckCircle className="h-5 w-5 text-green-500" />
+            <CheckCircle className="h-5 w-5 text-success-foreground" />
             Resolve Report
           </DialogTitle>
           <DialogDescription>

--- a/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
+++ b/frontend/features/admin/components/StreamingWorklist/StreamingWorklist.tsx
@@ -317,7 +317,7 @@ function WorklistRow({ entry, onActionSuccess }: WorklistRowProps) {
             variant="ghost"
             size="sm"
             onClick={() => setOpenAction('linked')}
-            className="gap-1.5 text-green-300 hover:text-green-200"
+            className="gap-1.5 text-success-foreground hover:text-success-foreground/80"
             data-testid={`streaming-worklist-open-linked-${entry.artist_id}`}
           >
             <Link2 className="h-3.5 w-3.5" />

--- a/frontend/features/tags/admin/AliasListing.tsx
+++ b/frontend/features/tags/admin/AliasListing.tsx
@@ -331,7 +331,7 @@ function BulkImportDialog({
 
           {result && (
             <div className="space-y-3">
-              <div className="rounded-lg border border-green-500/30 bg-green-500/10 p-3 text-sm text-green-400 flex items-start gap-2">
+              <div className="rounded-lg border border-success-foreground bg-success p-3 text-sm text-success-foreground flex items-start gap-2">
                 <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" />
                 <span>
                   Imported {result.imported} alias{result.imported === 1 ? '' : 'es'}.
@@ -341,8 +341,8 @@ function BulkImportDialog({
               </div>
 
               {result.skipped.length > 0 && (
-                <div className="rounded-lg border border-amber-500/30">
-                  <div className="bg-amber-500/10 px-3 py-2 text-sm font-medium text-amber-400 flex items-center gap-2 border-b border-amber-500/30">
+                <div className="rounded-lg border border-pending-foreground">
+                  <div className="bg-pending px-3 py-2 text-sm font-medium text-pending-foreground flex items-center gap-2 border-b border-pending-foreground">
                     <X className="h-4 w-4" />
                     Rejected rows
                   </div>
@@ -359,7 +359,7 @@ function BulkImportDialog({
                           <div className="font-mono">
                             {s.alias || '(empty)'} → {s.canonical || '(empty)'}
                           </div>
-                          <div className="text-amber-400 mt-0.5">{s.reason}</div>
+                          <div className="text-pending-foreground mt-0.5">{s.reason}</div>
                         </div>
                       </div>
                     ))}


### PR DESCRIPTION
## Summary

PSY-967 Phase A. Migrates the admin-surface STATUS/FEEDBACK greens & ambers from raw, dark-mode-tuned Tailwind classes (`green-*`/`amber-*`) onto the theme-aware `--success` / `--pending` semantic tokens (added in PSY-965). On the light "newsprint" theme the raw greens/ambers rendered as muddy, low-contrast boxes; the tokens carry distinct light + dark values so these states now read cleanly on both themes. Canonical reference: `frontend/components/shared/StatusBanner.tsx`.

**Presentational className swaps only — no logic changes.**

### Migrated (status / feedback)
- **PendingShowCard** — pending card border + "Pending Review" badge → `border-pending-foreground` / `text-pending-foreground`.
- **ResolveReportDialog** + **ResolveArtistReportDialog** — resolve-success `CheckCircle` → `text-success-foreground`.
- **AliasListing** — bulk-import success box → `bg-success` / `text-success-foreground` / `border-success-foreground`; "Rejected rows" warning box + per-row reason text → `bg-pending` / `text-pending-foreground` / `border-pending-foreground`.
- **StreamingWorklist** — "Mark linked" ghost button color → `text-success-foreground hover:text-success-foreground/80` (color-only swap on the existing `variant="ghost"`, per ticket — not a new cva variant).

### Kept (data-viz / taxonomy, per the ticket keep-list)
- Report-type severity palette (`ArtistReportCard` / `ShowReportCard`) — amber is one color in a red/orange/amber category palette, not a success/pending state.
- **Yes/No** (CollectionManagement) and **On/Off** (PipelineVenues) boolean displays.
- Approval-rate **gauge**, the 4-tile stats grid (Approved/Rejected/Pending), the OK/Error pass-fail pairs, and the gauge-derived auto-approve advisory (`PipelineVenues`).
- Per-queue nav-badge palette (`adminNav.ts`) — documented as deliberately deferred to the PSY-908 cohesion decision.

5 files changed, 9 insertions(+), 9 deletions(-).

## Test plan
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors (152 pre-existing warnings, none in changed files).
- [x] `bun run test:run features/admin components/admin features/tags` — 36 files / 563 tests pass (incl. AliasListing "success + skipped summary", PendingShowCard, ShowReportCard, ArtistReportCard, StreamingWorklist).

## Manual repro
Local shared dev stack + agent-browser, signed in as admin, **light theme** (verified `documentElement` class = `light`), token colors confirmed via `getComputedStyle`:
- **StreamingWorklist** (`/admin/streaming-worklist`) — "Mark linked" button computed color `rgb(47, 93, 58)` = `#2f5d3a` (light success-foreground), visually distinct from the muted sibling buttons.
- **AliasListing bulk import** (`/admin?tab=tags` → Aliases → Bulk import) — pasted 1 valid + 1 invalid row → success box `bg-success` = `rgb(221, 232, 216)` / text `rgb(47, 93, 58)`; rejected box `bg-pending` = `rgb(240, 230, 207)`. Both render cleanly on the light theme.

**Coverage gap (not faked):** PendingShowCard (pending tokens) and the two Resolve dialogs (success token) could not be screenshotted — the dev seed has no pending shows or open reports to render them. Their token resolution is nonetheless exercised by the captured AliasListing box, which uses the identical `text-success-foreground` / `bg-success` / `bg-pending` utilities.

## Screenshots
### StreamingWorklist — "Mark linked" (success token), light theme
![StreamingWorklist Mark linked](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-c04eb424174235a182ea/01-streaming-worklist-mark-linked.png)

### AliasListing bulk import — success box + "Rejected rows" pending box, light theme
![AliasListing bulk import](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-c04eb424174235a182ea/02-alias-bulk-import-success-and-rejected.png)

## Code review
`/code-review` (xhigh, inline in worktree per the sub-agent fallback) — **clean**, no correctness findings. The diff is pure presentational token swaps, verified live (computed colors match token hex), all tests green. One out-of-scope cleanup observation: the AliasListing result boxes could eventually adopt the `StatusBanner` primitive, but that is a structural change beyond Phase A's swap-only mandate.

## Adversarial review
`/adversarial-review` (4 lenses inline per the worktree fallback) — **CLEAN**, no findings → no fixes commit.
- **Saboteur** — CLEAN: only static className literals; no input/state/timing surface.
- **Future-Maintainer** — CLEAN: token names self-document and bring these surfaces into convention with `StatusBanner`. LOW note (AliasListing boxes sit outside the primitive) is a pre-existing condition the swap-only scope preserves.
- **Security** — CLEAN: no trust boundary / injection / data-exposure touched; `s.reason` stays React-escaped JSX text.
- **Completeness** — CLEAN: all status occurrences migrated, keep-list honored, special case handled; one coverage gap disclosed above.

Panel ran against the branch diff with no prior session context.

Closes PSY-971
