### PR TITLE
PSY-973: migrate collections/feature status greens to tokens

### DIFF
--- a/frontend/components/contributor/ContributorProfilePreview.tsx
+++ b/frontend/components/contributor/ContributorProfilePreview.tsx
@@ -115,7 +115,7 @@ export function ContributorProfilePreview() {
                   Joined {formatDate(profile.joined_at)}
                 </span>
                 {!isPublic && (
-                  <span className="text-amber-600 dark:text-amber-400">
+                  <span className="text-pending-foreground">
                     Profile is private
                   </span>
                 )}

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -517,7 +517,7 @@ export function AddToCollectionButton({
             </span>
           </span>
           {added && !isConfirming && (
-            <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400 shrink-0">
+            <span className="flex items-center gap-1 text-xs text-success-foreground shrink-0">
               <Check className="h-3.5 w-3.5" />
               Added
             </span>

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -919,9 +919,9 @@ function DiscoveryCandidateCard({
 }) {
   const confidenceClass =
     candidate.confidence === 'high'
-      ? 'text-green-600 dark:text-green-400'
+      ? 'text-success-foreground'
       : candidate.confidence === 'medium'
-        ? 'text-amber-600 dark:text-amber-400'
+        ? 'text-pending-foreground'
         : 'text-muted-foreground'
   const facts = [
     candidate.location,

--- a/frontend/features/artists/components/RelatedArtists.tsx
+++ b/frontend/features/artists/components/RelatedArtists.tsx
@@ -1004,7 +1004,7 @@ function SuggestSimilarArtist({ centerArtistId, centerArtistSlug, onClose }: Sug
       )}
 
       {success && (
-        <p className="mt-2 text-xs text-green-400">Relationship created with your upvote!</p>
+        <p className="mt-2 text-xs text-success-foreground">Relationship created with your upvote!</p>
       )}
     </div>
   )

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -833,7 +833,7 @@ function CreateCollectionForm({
 
       {bulkAddRejectedCount > 0 && (
         <p
-          className="text-sm text-amber-600 dark:text-amber-400"
+          className="text-sm text-pending-foreground"
           data-testid="collection-create-bulk-rejected"
         >
           Collection created, but {bulkAddRejectedCount}{' '}

--- a/frontend/features/collections/components/collectionDetailShared.tsx
+++ b/frontend/features/collections/components/collectionDetailShared.tsx
@@ -81,7 +81,7 @@ export function MutationFeedback({
   const Icon = variant === 'success' ? Check : AlertCircle
   const tone =
     variant === 'success'
-      ? 'text-green-600 dark:text-green-400'
+      ? 'text-success-foreground'
       : 'text-destructive'
   return (
     <div

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -144,7 +144,7 @@ export function CommentCard({
         {comment.visibility === 'pending_review' && isOwner && (
           <Badge
             variant="outline"
-            className="text-[10px] px-1.5 py-0 gap-1 border-amber-700/50 text-amber-500"
+            className="text-[10px] px-1.5 py-0 gap-1 border-pending-foreground text-pending-foreground"
             data-testid="pending-review-badge"
           >
             <Clock className="h-2.5 w-2.5" />

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -181,7 +181,7 @@ export function FieldNoteCard({
         {isVerified && (
           <Badge
             variant="secondary"
-            className="text-[10px] px-1.5 py-0 bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+            className="text-[10px] px-1.5 py-0 bg-success text-success-foreground"
             data-testid="verified-badge"
           >
             <CheckCircle className="h-3 w-3 mr-0.5" />
@@ -201,7 +201,7 @@ export function FieldNoteCard({
         {comment.visibility === 'pending_review' && isOwner && (
           <Badge
             variant="outline"
-            className="text-[10px] px-1.5 py-0 gap-1 border-amber-700/50 text-amber-500"
+            className="text-[10px] px-1.5 py-0 gap-1 border-pending-foreground text-pending-foreground"
             data-testid="pending-review-badge"
           >
             <Clock className="h-2.5 w-2.5" />

--- a/frontend/features/contributions/components/MyPendingEditsList.tsx
+++ b/frontend/features/contributions/components/MyPendingEditsList.tsx
@@ -82,7 +82,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
       return (
         <Badge
           variant="secondary"
-          className="bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800"
+          className="bg-pending text-pending-foreground border-pending-foreground"
         >
           <Clock className="h-3 w-3 mr-1" />
           Pending
@@ -92,7 +92,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
       return (
         <Badge
           variant="secondary"
-          className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800"
+          className="bg-success text-success-foreground border-success-foreground"
         >
           <CheckCircle2 className="h-3 w-3 mr-1" />
           Approved

--- a/frontend/features/notifications/components/FilterForm.tsx
+++ b/frontend/features/notifications/components/FilterForm.tsx
@@ -529,7 +529,7 @@ export function FilterForm({ open, onOpenChange, filter }: FilterFormProps) {
           </div>
 
           {!hasCriteria && name.trim().length > 0 && (
-            <p className="text-xs text-amber-600 dark:text-amber-400">
+            <p className="text-xs text-pending-foreground">
               Add at least one criteria (artist, venue, label, tag, or price) to create this filter.
             </p>
           )}

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -368,10 +368,10 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
 
                   {/* Fulfillment info */}
                   {request.status === 'fulfilled' && (
-                    <div className="mt-4 rounded-lg border border-green-500/20 bg-green-500/5 p-3">
+                    <div className="mt-4 rounded-lg border border-success-foreground bg-success p-3">
                       <div className="flex items-center gap-2 text-sm">
-                        <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
-                        <span className="font-medium text-green-700 dark:text-green-400">
+                        <CheckCircle className="h-4 w-4 text-success-foreground" />
+                        <span className="font-medium text-success-foreground">
                           Fulfilled
                         </span>
                       </div>


### PR DESCRIPTION
## Summary

PSY-967 **Phase C** — migrate the Collections / Contributor / Community (+ a few
misc feature-status) surfaces off raw `green-*` / `amber-*` / `emerald-*` Tailwind
colors onto the theme-aware `--success` / `--pending` semantic tokens (PSY-965),
mirroring `components/shared/StatusBanner.tsx`. These were dark-mode-only colors
that rendered as muddy / low-contrast on the light newsprint theme.

**className swaps only — zero logic changes.** This was the highest-risk phase
because several target files also carry vote / diff / colorblind-audited colors
that had to stay untouched.

### Migrated (status / feedback only)

| File | Site | Token |
| --- | --- | --- |
| `components/shared/AddToCollectionButton.tsx` | "Added" confirmation | `text-success-foreground` |
| `features/collections/components/collectionDetailShared.tsx` | `MutationFeedback` success tone | `text-success-foreground` |
| `features/collections/components/CollectionList.tsx` | bulk-add partial-success | `text-pending-foreground` |
| `components/contributor/ContributorProfilePreview.tsx` | "Profile is private" | `text-pending-foreground` |
| `features/artists/components/ArtistDetail.tsx` | discovery confidence (high / medium) | `text-success-foreground` / `text-pending-foreground` |
| `features/artists/components/RelatedArtists.tsx` | "Relationship created" success | `text-success-foreground` |
| `features/notifications/components/FilterForm.tsx` | criteria validation warning | `text-pending-foreground` |
| `features/comments/components/FieldNoteCard.tsx` | "Verified Attendee" / "Pending review" | `bg-success text-success-foreground` / `border-pending-foreground text-pending-foreground` |
| `features/comments/components/CommentCard.tsx` | "Pending review" | `border-pending-foreground text-pending-foreground` |
| `features/contributions/components/MyPendingEditsList.tsx` | Pending / Approved badges | pending chrome / success chrome |
| `features/requests/components/RequestDetail.tsx` | Fulfilled panel (border + icon + text) | `border-success-foreground bg-success` + `text-success-foreground` |

### Deliberately KEPT untouched (NOT status colors)

- **RelatedArtists**: relationship-type badges (`:42-43`, colorblind-audited PSY-362/363) and the upvote button (`:839`, vote color).
- **MyPendingEditsList**: the `rejected` rose badge (`:105`), the rejection-reason rose panel (`:190-196`), and the diff old/new red/green value pair (`:238`/`:242`).
- **RequestDetail**: vote buttons + `vote_score` color (`:256-284`).

Each occurrence in every target file was re-grepped and classified before swapping.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors (152 pre-existing warnings, none in touched files).
- [x] `bun run test:run features/comments` — 168 pass.
- [x] `bun run test:run features/requests features/contributions features/collections features/notifications` — 694 pass.
- [x] `bun run test:run features/artists` — 275 pass.
- [x] `bun run test:run components/contributor components/shared` — 619 pass.

No test asserted on the old raw color classes, so nothing needed updating.

## Manual repro

Shared dev stack (`stack-up.sh --mode=shared`), signed in as admin, **light theme** (verified `documentElement` had no `dark` class). Exercised on the live app:

1. **AddToCollectionButton** — added an artist to a fresh collection → green "Added" confirmation renders via `text-success-foreground`.
2. **FieldNoteCard** — posted a field note with "I attended this show" checked → "Verified Attendee" badge renders with the pale-green success fill + dark-green text (`bg-success text-success-foreground`). Live `className` confirmed via `eval`. (Test note cleaned up / deleted afterward — shared backend left clean.)
3. **MyPendingEditsList** (`/submissions`) — two "Approved" badges render with the success chrome (`bg-success text-success-foreground border-success-foreground`).
4. **Kept-colors verification** — expanded a pending-edit's "field changes": the diff old-value (red strikethrough) → new-value (green) pair still renders with raw `bg-red-500` / `bg-green-500`, confirming the diff colors were NOT migrated.

### Coverage gaps (not faked)

The shared dev backend's seed had no rows for these states, so they were verified by
code inspection + tests only (not screenshotted): `RequestDetail` Fulfilled panel
(no fulfilled request seeded), `MyPendingEditsList` Pending/Rejected badges (only
Approved present), the `collectionDetailShared` / `CollectionList` / `FilterForm` /
`ContributorProfilePreview` / `RelatedArtists` / `ArtistDetail`-confidence /
`CommentCard` states. All are pure className swaps verified against the rendered
token vocabulary.

## Screenshots

**"Added" confirmation (success token):**
![Added confirmation](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2688705543f4bf4af707/01-add-to-collection-added-success.png)

**"Verified Attendee" badge (success chrome):**
![Verified Attendee](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2688705543f4bf4af707/02-field-note-verified-attendee-success.png)

**"Approved" pending-edit badges (success chrome):**
![Approved badges](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2688705543f4bf4af707/03-pending-edits-approved-badge-success.png)

**Diff colors KEPT untouched (raw red/green next to migrated Approved badge):**
![Diff colors kept](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-2688705543f4bf4af707/04-diff-colors-kept-untouched.png)

## Code review

`/code-review` (xhigh, run inline — dispatched sub-agent has no Agent tool, expected per `pattern_subagent_inline_code_review.md`): **0 findings.** All 16 changes are presentational className swaps; no logic / signatures / test-ids changed; dark-mode coverage preserved via the CSS-var tokens; `tailwind-merge` correctly resolves the `Badge variant="secondary"` base-vs-override conflicts (confirmed live via `eval` + screenshots).

## Adversarial review

`/adversarial-review` — **CLEAN** (run inline, 4 lenses). No findings → no fix commit.
- **Saboteur**: verified dark-mode values exist for every token (`globals.css:165-168`) and that the badge base-variant `bg-secondary`/`text-secondary-foreground` is correctly overridden (live `eval`).
- **Future-Maintainer**: tokens are strictly more intent-revealing than raw colors; rose `rejected` asymmetry is intentional + documented (no rejected token in scope).
- **Security**: no attack surface (pure CSS class strings).
- **Completeness**: all 11 mandated sites migrated; all 6 documented keeps (vote/diff/colorblind) confirmed untouched; no status site missed, no vote/diff color accidentally migrated.

Panel ran with no prior session context against the branch diff.

Closes PSY-973
