### PR TITLE
PSY-972: migrate settings/forms status greens to tokens

### DIFF
--- a/frontend/components/forms/AIFormFiller.tsx
+++ b/frontend/components/forms/AIFormFiller.tsx
@@ -429,7 +429,7 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
                           variant={artist.matched_id ? 'default' : 'secondary'}
                           className={`text-xs ${
                             !artist.matched_id && artist.suggestions?.length
-                              ? 'border-amber-500 text-amber-700 dark:text-amber-400'
+                              ? 'border-pending-foreground text-pending-foreground'
                               : ''
                           }`}
                         >
@@ -452,14 +452,14 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
                             key={`suggestion-${i}`}
                             className="ml-4 flex items-center gap-1.5 flex-wrap text-xs"
                           >
-                            <span className="text-amber-600 dark:text-amber-400">
+                            <span className="text-pending-foreground">
                               Did you mean:
                             </span>
                             {artist.suggestions.map(s => (
                               <button
                                 key={s.id}
                                 type="button"
-                                className="rounded-md border border-amber-400 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-xs hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+                                className="rounded-md border border-pending-foreground bg-pending text-pending-foreground px-2 py-0.5 text-xs hover:bg-pending/70 transition-colors"
                                 onClick={() => acceptArtistSuggestion(i, s)}
                               >
                                 {s.name}
@@ -492,7 +492,7 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
                         className={`text-xs ${
                           !extractionResult.venue.matched_id &&
                           extractionResult.venue.suggestions?.length
-                            ? 'border-amber-500 text-amber-700 dark:text-amber-400'
+                            ? 'border-pending-foreground text-pending-foreground'
                             : ''
                         }`}
                       >
@@ -510,14 +510,14 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
                       extractionResult.venue.suggestions &&
                       extractionResult.venue.suggestions.length > 0 && (
                         <div className="ml-4 flex items-center gap-1.5 flex-wrap text-xs">
-                          <span className="text-amber-600 dark:text-amber-400">
+                          <span className="text-pending-foreground">
                             Did you mean:
                           </span>
                           {extractionResult.venue.suggestions.map(s => (
                             <button
                               key={s.id}
                               type="button"
-                              className="rounded-md border border-amber-400 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-xs hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+                              className="rounded-md border border-pending-foreground bg-pending text-pending-foreground px-2 py-0.5 text-xs hover:bg-pending/70 transition-colors"
                               onClick={() => acceptVenueSuggestion(s)}
                             >
                               {s.name}
@@ -588,7 +588,7 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
 
               {/* Warnings */}
               {warnings.length > 0 && (
-                <div className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                <div className="text-xs text-pending-foreground mt-2">
                   {warnings.map((warning, i) => (
                     <div key={i}>{warning}</div>
                   ))}

--- a/frontend/components/forms/ArtistEditForm.tsx
+++ b/frontend/components/forms/ArtistEditForm.tsx
@@ -168,9 +168,9 @@ export function ArtistEditForm({
         </DialogHeader>
 
         {showSuccess && (
-          <Alert className="mb-4 border-green-500 bg-green-50 dark:bg-green-950">
-            <CheckCircle2 className="h-4 w-4 text-green-600" />
-            <AlertDescription className="text-green-600">
+          <Alert className="mb-4 border-success-foreground bg-success">
+            <CheckCircle2 className="h-4 w-4 text-success-foreground" />
+            <AlertDescription className="text-success-foreground">
               Artist updated successfully!
             </AlertDescription>
           </Alert>

--- a/frontend/components/forms/VenueEditForm.tsx
+++ b/frontend/components/forms/VenueEditForm.tsx
@@ -158,9 +158,9 @@ export function VenueEditForm({
         </DialogHeader>
 
         {showSuccess && (
-          <Alert className="mb-4 border-green-500 bg-green-50 dark:bg-green-950">
-            <CheckCircle2 className="h-4 w-4 text-green-600" />
-            <AlertDescription className="text-green-600">
+          <Alert className="mb-4 border-success-foreground bg-success">
+            <CheckCircle2 className="h-4 w-4 text-success-foreground" />
+            <AlertDescription className="text-success-foreground">
               Venue updated successfully!
             </AlertDescription>
           </Alert>

--- a/frontend/components/settings/SettingsPanel.tsx
+++ b/frontend/components/settings/SettingsPanel.tsx
@@ -140,12 +140,12 @@ export function SettingsPanel() {
               </div>
               
               {isEmailVerified ? (
-                <Badge variant="secondary" className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-0">
+                <Badge variant="secondary" className="bg-success text-success-foreground border-0">
                   <CheckCircle2 className="mr-1 h-3 w-3" />
                   Verified
                 </Badge>
               ) : (
-                <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 dark:text-amber-400 border-0">
+                <Badge variant="secondary" className="bg-pending text-pending-foreground border-0">
                   <AlertCircle className="mr-1 h-3 w-3" />
                   Not Verified
                 </Badge>
@@ -154,9 +154,9 @@ export function SettingsPanel() {
 
             {/* Verification Action */}
             {!isEmailVerified && (
-              <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4">
+              <div className="rounded-lg border border-pending-foreground bg-pending p-4">
                 <div className="flex items-start gap-3">
-                  <AlertCircle className="h-5 w-5 text-amber-500 mt-0.5 shrink-0" />
+                  <AlertCircle className="h-5 w-5 text-pending-foreground mt-0.5 shrink-0" />
                   <div className="flex-1 space-y-3">
                     <div>
                       <p className="text-sm font-medium text-foreground">
@@ -168,7 +168,7 @@ export function SettingsPanel() {
                     </div>
 
                     {emailSent && sendVerificationEmail.isSuccess ? (
-                      <div className="flex items-center gap-2 rounded-md bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400">
+                      <div className="flex items-center gap-2 rounded-md bg-success p-3 text-sm text-success-foreground">
                         <CheckCircle2 className="h-4 w-4" />
                         <span>Verification email sent! Check your inbox.</span>
                       </div>
@@ -203,9 +203,9 @@ export function SettingsPanel() {
 
             {/* Verified Success State */}
             {isEmailVerified && !user?.is_admin && (
-              <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
+              <div className="rounded-lg border border-success-foreground bg-success p-4">
                 <div className="flex items-center gap-3">
-                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                  <CheckCircle2 className="h-5 w-5 text-success-foreground" />
                   <div>
                     <p className="text-sm font-medium text-foreground">
                       Your email is verified
@@ -298,7 +298,7 @@ export function SettingsPanel() {
             )}
 
             {exportData.isSuccess && (
-              <div className="flex items-center gap-2 rounded-md bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400">
+              <div className="flex items-center gap-2 rounded-md bg-success p-3 text-sm text-success-foreground">
                 <CheckCircle2 className="h-4 w-4" />
                 <span>Data exported successfully! Check your downloads folder.</span>
               </div>
@@ -348,7 +348,7 @@ export function SettingsPanel() {
                           className="shrink-0"
                         >
                           {tokenCopied ? (
-                            <Check className="h-4 w-4 text-emerald-500" />
+                            <Check className="h-4 w-4 text-success-foreground" />
                           ) : (
                             <Copy className="h-4 w-4" />
                           )}

--- a/frontend/components/settings/api-token-management.tsx
+++ b/frontend/components/settings/api-token-management.tsx
@@ -56,11 +56,11 @@ function TokenRow({ token, onRevoke, isRevoking }: {
               Expired
             </Badge>
           ) : isExpiringSoon ? (
-            <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 dark:text-amber-400 border-0 text-xs">
+            <Badge variant="secondary" className="bg-pending text-pending-foreground border-0 text-xs">
               Expiring soon
             </Badge>
           ) : (
-            <Badge variant="secondary" className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-0 text-xs">
+            <Badge variant="secondary" className="bg-success text-success-foreground border-0 text-xs">
               Active
             </Badge>
           )}
@@ -217,18 +217,18 @@ export function APITokenManagement() {
                       className="shrink-0"
                     >
                       {tokenCopied ? (
-                        <Check className="h-4 w-4 text-emerald-500" />
+                        <Check className="h-4 w-4 text-success-foreground" />
                       ) : (
                         <Copy className="h-4 w-4" />
                       )}
                     </Button>
                   </div>
-                  <div className="flex items-center gap-2 rounded-md bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400">
+                  <div className="flex items-center gap-2 rounded-md bg-pending p-3 text-sm text-pending-foreground">
                     <AlertCircle className="h-4 w-4 shrink-0" />
                     <span>Store this token securely. It cannot be retrieved after you close this dialog.</span>
                   </div>
                   {tokenCopied && (
-                    <div className="flex items-center gap-2 rounded-md bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400">
+                    <div className="flex items-center gap-2 rounded-md bg-success p-3 text-sm text-success-foreground">
                       <CheckCircle2 className="h-4 w-4" />
                       <span>Token copied to clipboard!</span>
                     </div>

--- a/frontend/components/settings/change-password.tsx
+++ b/frontend/components/settings/change-password.tsx
@@ -101,7 +101,7 @@ export function ChangePassword() {
         >
           {/* Success message */}
           {successMessage && (
-            <div className="flex items-center gap-2 rounded-md bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400">
+            <div className="flex items-center gap-2 rounded-md bg-success p-3 text-sm text-success-foreground">
               <CheckCircle2 className="h-4 w-4 shrink-0" />
               <span>{successMessage}</span>
             </div>
@@ -232,7 +232,7 @@ export function ChangePassword() {
                 )}
                 {/* Password match indicator */}
                 {confirmPasswordValue && field.state.meta.errors.length === 0 && (
-                  <p className={`text-xs ${passwordsMatch ? 'text-green-600 dark:text-green-500' : 'text-muted-foreground'}`}>
+                  <p className={`text-xs ${passwordsMatch ? 'text-success-foreground' : 'text-muted-foreground'}`}>
                     {passwordsMatch ? 'Passwords match' : 'Passwords do not match'}
                   </p>
                 )}

--- a/frontend/components/settings/delete-account-dialog.tsx
+++ b/frontend/components/settings/delete-account-dialog.tsx
@@ -171,9 +171,9 @@ export function DeleteAccountDialog({
                     </ul>
                   </div>
 
-                  <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4">
+                  <div className="rounded-lg border border-pending-foreground bg-pending p-4">
                     <div className="flex items-start gap-3">
-                      <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+                      <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-pending-foreground" />
                       <div className="space-y-1 text-sm">
                         <p className="font-medium text-foreground">
                           30-Day Grace Period
@@ -226,7 +226,7 @@ export function DeleteAccountDialog({
             <div className="space-y-4 py-4">
               {/* OAuth-only user notice */}
               {!hasPassword && (
-                <div className="rounded-md bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400">
+                <div className="rounded-md bg-pending p-3 text-sm text-pending-foreground">
                   OAuth accounts require email confirmation for deletion. This
                   feature is coming soon. Please contact support to delete your
                   account.
@@ -341,14 +341,14 @@ export function DeleteAccountDialog({
         {step === 'success' && (
           <>
             <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
+              <DialogTitle className="flex items-center gap-2 text-success-foreground">
                 <CheckCircle2 className="h-5 w-5" />
                 Account Scheduled for Deletion
               </DialogTitle>
             </DialogHeader>
 
             <div className="space-y-4 py-4">
-              <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
+              <div className="rounded-lg border border-success-foreground bg-success p-4">
                 <p className="text-sm text-foreground">
                   Your account has been deactivated and will be permanently
                   deleted on{' '}

--- a/frontend/components/settings/passkey-management.tsx
+++ b/frontend/components/settings/passkey-management.tsx
@@ -174,7 +174,7 @@ export function PasskeyManagement() {
                         <span>Last used {formatDate(credential.last_used_at)}</span>
                       )}
                       {credential.backup_state && (
-                        <span className="text-green-600 dark:text-green-500">Synced</span>
+                        <span className="text-success-foreground">Synced</span>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

PSY-967 Phase B — Settings/Forms. Migrates dark-mode-tuned raw Tailwind `green-*` / `amber-*` / `emerald-*` status colors onto the theme-aware `success` / `pending` semantic tokens (PSY-965) across the settings + forms cluster. The raw greens/ambers were dark-mode-only and rendered muddy/low-contrast on the light newsprint theme; the tokens carry distinct light + dark values and read cleanly on both.

Token mapping (canonical reference: `frontend/components/shared/StatusBanner.tsx`):
- **success** (saved / valid / confirmed) → `bg-success` / `text-success-foreground` / `border-success-foreground`
- **pending** (warning / awaiting / soft-error) → `bg-pending` / `text-pending-foreground` / `border-pending-foreground`

className swaps only — no logic, control flow, or copy changes. 35 swaps across 8 files.

### Files changed
- `components/settings/api-token-management.tsx` — Active badge → success; Expiring-soon badge → pending; copied-check icon → success; "store securely" warning → pending; "token copied" → success.
- `components/settings/change-password.tsx` — success message banner → success; "Passwords match" indicator → success (false branch `text-muted-foreground` unchanged).
- `components/settings/delete-account-dialog.tsx` — 30-day-grace + OAuth-notice warnings → pending; success-step title + card → success.
- `components/settings/passkey-management.tsx` — "Synced" indicator → success.
- `components/settings/SettingsPanel.tsx` — Verified/Not-Verified badges → success/pending; email-verification-required card → pending; verification-sent + verified-email + data-exported + copied-check → success.
- `components/forms/AIFormFiller.tsx` — fuzzy-match (unmatched-with-suggestions) badges, "Did you mean:" labels, suggestion chips, and warnings → pending.
- `components/forms/ArtistEditForm.tsx` / `VenueEditForm.tsx` — "updated successfully!" Alert → success.

### Keep-list honored
- `components/ui/password-strength-meter.tsx` renders a red→amber→green strength **gradient** (data-viz scale, not status) — left untouched. `change-password.tsx`'s own status messages were migrated; the meter component was not. See screenshot 06 (gradient + green requirement checks intact above the migrated "Passwords match").
- No vote/diff, chart, gauge, or colorblind-palette colors live in these files.

## Test plan
- [x] `bun run typecheck` — pass (`tsc --noEmit`, no errors).
- [x] `bun run lint` — pass (0 errors; only pre-existing warnings, none on changed lines).
- [x] `bun run test:run components/settings` — 197/197 pass (10 files).
- [x] `bun run test:run components/forms` — 138/138 pass (10 files, incl. ArtistEditForm/VenueEditForm "shows the success alert").
- [x] Verified every introduced class (`bg-success`, `text-success-foreground`, `border-success-foreground`, `bg-pending`, `text-pending-foreground`, `border-pending-foreground`, `hover:bg-pending/70`) maps to a registered `@theme` token in `app/globals.css`.

## Manual repro
Shared dev backend (:8080) + dispatch stack (`--mode=shared`). Signed in as admin, **light theme**, navigated `/profile` → Settings tab. Confirmed migrated tokens render via DOM computed color:
- "Passwords match" → `rgb(47, 93, 58)` = `--success-foreground` (light).
- "Venue updated successfully!" banner → `bg` `rgb(221, 232, 216)` = `--success` (light).

Reverted the venue website edit used to trigger the save back to its original value (shared backend hygiene).

### Coverage gaps (not faked)
- `ArtistEditForm` has no live render site in app code (barrel-export only), so its success banner couldn't be screenshotted in-app. Its identical sibling `VenueEditForm` is captured live (screenshot 07), and the `ArtistEditForm` success-alert test passes.
- `delete-account-dialog` success step + `api-token-management` "store securely" pending banner not screenshotted (would require destructive/extra flows); covered by the identical token vocabulary + passing component tests.

## Screenshots
Light theme.

| Surface | Image |
| --- | --- |
| Profile overview | ![profile](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-482dd5cdd795d095b5b6/01-profile-full.png) |
| Settings tab (full) | ![settings](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-482dd5cdd795d095b5b6/02-settings-tab-full.png) |
| Verified badge (success token) | ![verified](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-482dd5cdd795d095b5b6/03-verified-badge-light.png) |
| API token "Active" badge (success token) | ![active](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-482dd5cdd795d095b5b6/04-api-token-active-badge-light.png) |
| CLI token generated | ![cli](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-482dd5cdd795d095b5b6/05-cli-token-generated-light.png) |
| Password strength meter KEPT + "Passwords match" migrated | ![meter](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-482dd5cdd795d095b5b6/06-password-meter-and-match-light.png) |
| VenueEditForm success banner (success token) | ![venue-success](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-482dd5cdd795d095b5b6/07-venue-edit-success-light.png) |

## Code review
`/code-review` — clean (run inline; dispatched sub-agent has no Agent tool, per repo fallback convention). Diff is 35 className swaps, zero logic. Verified: every token class maps to a `@theme` registration; the only conditionals touched (`passwordsMatch` ternary, badge-variant logic) preserve their conditions exactly; no removed guards; no hardcoded-color or hue remnants (broad re-grep clean); no redundant `dark:` variants on the new theme-aware tokens. No findings.

## Adversarial review
`/adversarial-review` — CLEAN (4 lenses run inline; no Agent tool in worktree, per convention). No findings, so no fixes commit.
- **Saboteur**: only conditional touched preserves its branches; CSS class strings can't throw; `hover:bg-pending/70` degrades gracefully and resolves (hex token).
- **Future-Maintainer**: swaps follow the canonical StatusBanner vocabulary used across 8+ components; full-opacity tokens on the formerly-subtle cards match StatusBanner and render soft (the token values are pastels).
- **Security**: presentational only — no trust boundaries, authz, injection, secrets, or data exposure.
- **Completeness**: all acceptance criteria met; meter gradient verified kept; coverage gaps disclosed above, not faked.

Closes PSY-972
