### PR TITLE
PSY-976: stop Codecov upload flakes from blocking merges (fail_ci_if_error: false)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,12 @@ jobs:
           files: backend/coverage.out
           flags: backend
           disable_search: true
-          fail_ci_if_error: true
+          # PSY-976: don't let a flaky Codecov *upload* block merges. The
+          # action's GPG uploader-key import fails intermittently (upstream
+          # codecov/codecov-action#1876) — a transient upload error must not
+          # fail an otherwise-green job. `go test` above still gates real
+          # test failures; this only relaxes the post-test upload step.
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # PSY-772: backend lint gate.
@@ -239,7 +244,10 @@ jobs:
           files: coverage/lcov.info
           flags: frontend
           disable_search: true
-          fail_ci_if_error: true
+          # PSY-976: see backend upload above — a flaky Codecov upload
+          # (codecov/codecov-action#1876) must not fail an otherwise-green
+          # job. `bun run test:coverage` still gates real test failures.
+          fail_ci_if_error: false
           working-directory: ./frontend
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## What

Flip `fail_ci_if_error: true` → `false` on both Codecov upload steps in `.github/workflows/ci.yml` (backend + frontend coverage uploads).

## Why

`codecov/codecov-action@v5` imports a GPG "Codecov Uploader Verification Key" before uploading, and that import **flakes intermittently** (`gpg: no valid OpenPGP data found` → `No public key`), surfacing as a "required dependencies are missing" / exit-1 on the *upload* step. With `fail_ci_if_error: true`, a transient third-party upload error becomes a merge-blocking failure on PRs whose tests actually passed.

This is a known, still-open upstream bug — [codecov/codecov-action#1876 — "Random fails due to uploader verification key import failing"](https://github.com/codecov/codecov-action/issues/1876) (Sept 2025, no maintainer fix). Retry is a dice-roll (observed re-failing on retry).

**Observed (2026-06-06):** PR #987 went red on `Backend Tests` + `Frontend Unit Tests` — both the Codecov *upload* step (#1876), tests themselves green. (#987's `E2E Smoke` red was a separate Docker Hub registry timeout, out of scope here.)

## Scope

- CI-config only; no app code.
- Test jobs (`go test`, `bun run test:coverage`) **still gate real test failures** — this only relaxes the post-test *upload* step. Codecov's PR comment/status stays advisory.
- Out of scope: the E2E Docker-registry flake; prior codecov upload-path fixes (PSY-852 #819 / PSY-863 #840).

## Verification

- `git diff` = exactly the two flag flips + `why` comments.
- `ci.yml` parses clean (YAML).
- `/simplify` N/A — 2-line config flip, nothing to simplify; no app tests apply.

Closes PSY-976

🤖 Generated with [Claude Code](https://claude.com/claude-code)
