### PR TITLE
PSY-975: enrich env-not-found error + fix dry-run show count label

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -13,17 +13,16 @@ Extract structured entity data from screenshots and import into Psychic Homily u
 By default, commands use whichever environment is set as default in `~/.psychic-homily/config.json`.
 
 **Shorthand:**
-- `/ingest dev ...` — targets local dev (`--env local`)
-- `/ingest stage ...` — targets staging (`--env staging`)
-- `/ingest prod ...` — targets production (`--env production`)
+- `/ingest dev ...` — targets local dev
+- `/ingest stage ...` — targets staging
+- `/ingest prod ...` — targets production
 - `/ingest ...` — uses default environment
 
-**Full form also works:**
-- `/ingest --env production ...`
-- `/ingest --env local ...`
-- `/ingest --env staging ...`
+**Full form also works:** `/ingest --env <name> ...`, where `<name>` is a configured environment (e.g. `/ingest --env production ...`).
 
-**Parsing rule:** If the first word of the argument is `dev`, `local`, `stage`, `staging`, `prod`, or `production`, treat it as the environment and strip it from the rest of the input. When an environment is specified (by shorthand or `--env`), append `--env <name>` to ALL `ph` commands in this workflow. Map `dev` → `local`, `stage` → `staging`, `prod` → `production`.
+**Parsing rule:** If the first word of the argument is `dev`, `local`, `stage`, `staging`, `prod`, or `production`, treat it as the environment and strip it from the rest of the input. When an environment is specified (by shorthand or `--env`), append `--env <name>` to ALL `ph` commands in this workflow.
+
+**Resolve the shorthand against the actual configured environment names — do not assume them.** The CLI does an exact-name match, so a wrong name fails hard with `Environment "X" not found`. Run `config show` (below) and map the shorthand to whichever configured env matches: `dev`/`local` → the local env, `stage`/`staging` → the staging env, `prod`/`production` → the production env. As of this writing the configured names are `local`, `stage`, and `production` — note the staging env is named **`stage`, not `staging`**, so `/ingest stage` → `--env stage`. Don't hardcode a name that `config show` doesn't list.
 
 Check current default with:
 ```bash
@@ -99,6 +98,8 @@ Set the `instagram` field on artist and venue batch items when a handle is ident
 ```
 
 **Matching handles to entities**: Use context clues — handle text usually resembles the artist/venue name (underscores for spaces, abbreviations). When a handle clearly maps to an entity in the post, include it. When ambiguous, skip it.
+
+**Post-author handle ≠ artist name is common — confirm, don't guess.** A post's author handle is frequently the performing artist's own social handle under a different moniker, even when it bears no resemblance to the band name (e.g. `@mercury_tracer` is the handle for the artist *Midwife*). When the author handle doesn't obviously match the named artist, do NOT silently create a separate entity for the handle, and do NOT silently discard it — ask the user whether the handle belongs to the artist. If it does, attach it as that artist's `instagram` rather than minting a second artist/venue.
 
 ### Step 2: Build Batch JSON
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { version } from "../package.json";
-import { readConfig, resolveEnvironment } from "./lib/config";
+import { readConfig, resolveEnvironment, suggestEnvironment } from "./lib/config";
 import { APIError } from "./lib/api";
 import * as display from "./lib/display";
 import { runInit } from "./commands/init";
@@ -199,9 +199,18 @@ async function resolveEnvOrExit(
 
   if (!resolved) {
     const envName = envOverride || config.default_environment || "(not set)";
-    display.error(
-      `Environment "${envName}" not found. Run "ph init" to configure one.`,
-    );
+    const configured = Object.keys(config.environments);
+    if (configured.length === 0) {
+      display.error(
+        `Environment "${envName}" not found. Run "ph init" to configure one.`,
+      );
+    } else {
+      const suggestion = suggestEnvironment(envName, configured);
+      const hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
+      display.error(
+        `Environment "${envName}" not found.${hint} Configured: ${configured.join(", ")}.`,
+      );
+    }
     process.exit(1);
   }
 

--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -347,7 +347,10 @@ export async function submitShows(
   // 5. Submit if confirmed
   if (!confirm) {
     display.info(`Dry run: ${creatablePlans.length} show${creatablePlans.length !== 1 ? "s" : ""} would be created. Use --confirm to submit.`);
-    return { plans, created: 0, failed: 0, skipped: creatablePlans.length + duplicateCount };
+    // Report would-be-creates under `created` so the batch summary mirrors the
+    // confirmed-run accounting and the other entity types (artists/venues/...);
+    // only genuinely existing (duplicate) or invalid shows count as skipped.
+    return { plans, created: creatablePlans.length, failed: 0, skipped: invalidCount + duplicateCount };
   }
 
   let created = 0;

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -47,6 +47,60 @@ export function resolveEnvironment(
   return { name, env };
 }
 
+/**
+ * Suggest the configured environment name closest to a mistyped one, for
+ * "did you mean" error hints. Prefers a substring match in either direction
+ * (catches `staging`↔`stage`, `prod`↔`production`), then falls back to the
+ * nearest name by edit distance within a small threshold. Returns null when
+ * nothing is close enough to suggest.
+ */
+export function suggestEnvironment(
+  input: string,
+  configured: string[],
+): string | null {
+  const target = input.toLowerCase();
+
+  const substringMatch = configured.find((name) => {
+    const lower = name.toLowerCase();
+    return lower.includes(target) || target.includes(lower);
+  });
+  if (substringMatch) return substringMatch;
+
+  let best: string | null = null;
+  let bestDistance = Infinity;
+  for (const name of configured) {
+    const distance = levenshtein(target, name.toLowerCase());
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = name;
+    }
+  }
+  // The threshold must be >= 3: the motivating case is `staging` -> `stage`,
+  // which is distance 3 (drop "ing", substitute to "e") and is NOT a substring
+  // match ("staging" does not contain "stage"). The substring branch above only
+  // covers prefix/suffix cases like `prod` -> `production`. Keep it at 3 so the
+  // tail typos still get a hint without suggesting wildly different names.
+  return best !== null && bestDistance <= 3 ? best : null;
+}
+
+/** Levenshtein edit distance between two strings (single-row DP). */
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 0; i < a.length; i++) {
+    const curr = [i + 1];
+    for (let j = 0; j < b.length; j++) {
+      const cost = a[i] === b[j] ? 0 : 1;
+      curr.push(Math.min(prev[j + 1] + 1, curr[j] + 1, prev[j] + cost));
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
 /** Get the config file path (for display purposes). */
 export function getConfigPath(): string {
   return getConfigFile();

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -49,20 +49,26 @@ export function resolveEnvironment(
 
 /**
  * Suggest the configured environment name closest to a mistyped one, for
- * "did you mean" error hints. Prefers a substring match in either direction
- * (catches `staging`↔`stage`, `prod`↔`production`), then falls back to the
- * nearest name by edit distance within a small threshold. Returns null when
- * nothing is close enough to suggest.
+ * "did you mean" error hints. First tries a substring match where one name
+ * contains the other (catches cases like `prod` -> `production`), then falls
+ * back to the nearest name by edit distance — which is what catches cases like
+ * `staging` -> `stage` (distance 3) that are NOT substrings of each other.
+ * Returns null for empty input or when nothing is close enough.
  */
 export function suggestEnvironment(
   input: string,
   configured: string[],
 ): string | null {
   const target = input.toLowerCase();
+  // Guard empty input: every string contains "", so the substring check below
+  // would otherwise spuriously "match" the first configured name.
+  if (!target) return null;
 
   const substringMatch = configured.find((name) => {
     const lower = name.toLowerCase();
-    return lower.includes(target) || target.includes(lower);
+    // Skip empty configured names — "".includes/target.includes("") would
+    // spuriously match every input (only reachable via a hand-edited config).
+    return lower !== "" && (lower.includes(target) || target.includes(lower));
   });
   if (substringMatch) return substringMatch;
 

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { readConfig, writeConfig, resolveEnvironment } from "../src/lib/config";
+import {
+  readConfig,
+  writeConfig,
+  resolveEnvironment,
+  suggestEnvironment,
+} from "../src/lib/config";
 import { join } from "path";
 import { tmpdir } from "os";
 import { mkdtemp, rm } from "fs/promises";
@@ -104,5 +109,36 @@ describe("config", () => {
 
     const result = resolveEnvironment(config, "staging");
     expect(result).toBeNull();
+  });
+
+  describe("suggestEnvironment", () => {
+    const configured = ["local", "stage", "production"];
+
+    test("suggests stage for staging (edit distance 3, not a substring)", () => {
+      // The PSY-975 motivating case. "staging" does NOT contain "stage"
+      // (s-t-a-g-i-n-g), so this is caught by the edit-distance fallback at
+      // distance 3 (drop "ing", substitute to "e") — which is why the
+      // threshold is 3, not 2.
+      expect(suggestEnvironment("staging", configured)).toBe("stage");
+    });
+
+    test("suggests the substring match for prod -> production", () => {
+      // "production" starts with "prod", so this hits the substring branch.
+      expect(suggestEnvironment("prod", configured)).toBe("production");
+    });
+
+    test("suggests the nearest name by edit distance for a small typo", () => {
+      // "stge" contains no configured name as a substring, so this exercises
+      // the Levenshtein fallback (distance 1) rather than the substring branch.
+      expect(suggestEnvironment("stge", configured)).toBe("stage");
+    });
+
+    test("returns null when nothing is close enough", () => {
+      expect(suggestEnvironment("xyzzy", configured)).toBeNull();
+    });
+
+    test("returns null for an empty configured list", () => {
+      expect(suggestEnvironment("stage", [])).toBeNull();
+    });
   });
 });

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -140,5 +140,17 @@ describe("config", () => {
     test("returns null for an empty configured list", () => {
       expect(suggestEnvironment("stage", [])).toBeNull();
     });
+
+    test("returns null for empty input (does not spuriously match)", () => {
+      // Every string contains "", so without the guard the substring check
+      // would return the first configured name for empty input.
+      expect(suggestEnvironment("", configured)).toBeNull();
+    });
+
+    test("ignores an empty-string configured name", () => {
+      // A hand-edited config with a "" env key must not become the suggestion
+      // (target.includes("") is always true).
+      expect(suggestEnvironment("stage", ["", "stage"])).toBe("stage");
+    });
   });
 });

--- a/cli/test/show.test.ts
+++ b/cli/test/show.test.ts
@@ -331,9 +331,8 @@ describe("addArtistsToShow", () => {
       (c) => c.method === "PUT" && /\/shows\/668$/.test(c.url),
     );
     expect(putCalls).toHaveLength(1);
-    const newArtist = putCalls[0].body.artists.find(
-      (a: { id: number }) => a.id === 50,
-    );
+    const putBody = putCalls[0].body as { artists: { id: number }[] };
+    const newArtist = putBody.artists.find((a) => a.id === 50);
     expect(newArtist).toMatchObject({ id: 50, is_headliner: true });
   });
 

--- a/cli/test/submit-show.test.ts
+++ b/cli/test/submit-show.test.ts
@@ -437,8 +437,10 @@ describe("submitShows", () => {
     });
 
     const result = await submitShows(client, json, false); // dry-run
-    expect(result.created).toBe(0);
-    expect(result.skipped).toBe(1);
+    // Dry-run reports the would-be-created show under `created` (not `skipped`),
+    // mirroring the confirmed-run accounting and the other batch entity types.
+    expect(result.created).toBe(1);
+    expect(result.skipped).toBe(0);
     expect(postCalled).toBe(false);
   });
 

--- a/cli/test/submit-show.test.ts
+++ b/cli/test/submit-show.test.ts
@@ -512,6 +512,42 @@ describe("submitShows", () => {
     expect(result.plans[0].valid).toBe(true);
     expect(result.plans[1].valid).toBe(false);
   });
+
+  test("dry-run with a valid + invalid show: invalid counts as skipped", async () => {
+    // Exercises the dry-run branch's `skipped: invalidCount + duplicateCount`:
+    // the creatable show reports under `created` (1) and the invalid one under
+    // `skipped` (1). Reaching this branch requires creatablePlans.length > 0,
+    // so a valid+invalid mix is the discriminating case. (Pre-fix, the creatable
+    // show was reported as skipped and `created` was 0.)
+    let postCalled = false;
+    const client = createMockClient({
+      get: async () => ({ artists: [], venues: [] }),
+      post: async () => {
+        postCalled = true;
+        return { id: 1 };
+      },
+    });
+
+    const json = JSON.stringify([
+      {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "Test" }],
+        venues: [{ name: "Test Venue" }],
+      },
+      {
+        // Missing event_date, city, state -> invalid
+        artists: [{ name: "Test" }],
+        venues: [{ name: "Test Venue" }],
+      },
+    ]);
+
+    const result = await submitShows(client, json, false); // dry-run
+    expect(result.created).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(postCalled).toBe(false);
+  });
 });
 
 // -- checkShowDuplicate ------------------------------------------------------


### PR DESCRIPTION
Closes PSY-975.

## Summary
Two `ph` CLI developer-experience fixes surfaced while running the `/ingest` skill against the `stage` environment, plus the companion `/ingest` skill-prose fixes.

- **Env-not-found error is no longer a dead end.** `resolveEnvOrExit` now lists the configured environments and suggests the nearest match (new `suggestEnvironment` helper in `config.ts`: substring match in either direction, then Levenshtein within distance 3). `ph --env staging …` now prints `Environment "staging" not found. Did you mean "stage"? Configured: production, local, stage.` instead of just `Run "ph init"`.
- **Dry-run batch summary no longer mislabels shows.** `submitShows` dry-run now reports would-be-created shows under `created` (was `skipped`), matching the confirmed-run accounting and the other entity types — so the summary line (`shows (N): N created`) stops contradicting the inline `N would be created` preview.
- **`/ingest` skill prose** (bundled per request): resolve env shorthand against actual `config show` names instead of a hardcoded `stage→staging` map (the env is named `stage`); and add guidance that a post-author handle not matching the artist name is often the artist's own handle (`mercury_tracer` = Midwife) — confirm rather than minting a second entity or dropping it.
- **Incidental:** fixed a pre-existing whole-project typecheck error (`test/show.test.ts:334`, `putCalls[0].body` was `unknown`) that blocked `bun run typecheck` on `main`; verified it reproduces on a clean `origin/main`.

## Deferred
- **`submit-release` + `submit-festival` dry-run** still report would-be-creates as `created: 0` (release) / omit them (festival), the same inconsistency this PR fixes for shows. Out of scope here (PSY-975 was scoped to shows). Filed **PSY-977** to bring them in line. Surfaced by the `/adversarial-review` Completeness lens.

## Adversarial review
`/adversarial-review` ran in two stages — a sustained API 529 overload initially blocked the fresh-context panel, so the lenses were run inline first; the fresh-context reviewer then recovered and ran on the final diff, returning **CLEAN**. All four findings fixed in commit `b9982b0a`:
- [MEDIUM] Future-Maintainer: `suggestEnvironment` docstring claimed the substring branch catches `staging↔stage`, contradicting the inline comment (it's edit-distance 3, not a substring) → docstring corrected.
- [LOW/MEDIUM] Saboteur: `suggestEnvironment("")` returned the first configured name (every string contains `""`) → empty-input guard + regression test.
- [LOW] Saboteur (fresh panel): an empty-string key in `config.environments` would be returned by the substring branch → skip empty configured names + regression test.
- [LOW] Future-Maintainer (fresh panel): docstring "prefix/suffix typos" was narrower than actual behavior → reworded.

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

## Heads up from `/code-review`
`/code-review` suggested tightening the Levenshtein threshold from `≤3` to `≤2`. I applied it — and the local unit test immediately caught that it **broke the motivating case** (`staging → stage` is distance 3, *not* a substring, contrary to the shared assumption). Reverted to `≤3` and documented why the threshold is load-bearing (in both the code comment and the test). Noted here because it's a good example of the threshold being intentional, not loose.

## Test plan
- [x] `cd cli && bun run typecheck` — clean. (Also fixes the pre-existing `show.test.ts:334` error; verified in-session that it reproduces on a clean `origin/main` checkout before fixing.)
- [x] `cd cli && bun test` — 368/368 passing (added 7 `suggestEnvironment` unit tests + a dry-run valid+invalid show test, and updated the show dry-run assertion).
- [x] `/code-review` — 4 reviewer agents; one threshold suggestion applied, caught as wrong by local tests, reverted + documented.
- [x] `/adversarial-review` — inline pass (panel 529-blocked) then fresh-context panel CLEAN; 4 findings fixed in separate commit `b9982b0a`.
- [x] `/psy-self-review` — 3 reviewers; one coverage gap (the dry-run `invalidCount` path was unexercised) addressed with a new test; evidence-trail and convention checks pass.
- [x] Manual repro — env error: `ph --env staging search artist x` → suggests `stage`; `--env producton` → suggests `production`; `--env qqqq` / `--env dev` → lists configured envs, no suggestion. Dry-run batch against `stage` with a fresh fake entity → summary reads `shows (1): 1 created` (was `skipped`).
- [x] No UI surface — screenshots skipped.

## Coverage gaps
- **`/ingest` skill prose is doc-only** (skills aren't unit-tested) — the env-resolution and post-author-handle guidance is advisory text, verified by reading, not by an automated test.
- **The `cli.ts` env-error branches** (empty-config → `ph init` message; suggestion vs no-suggestion) are exercised via manual repro + the `suggestEnvironment` unit tests, but not via an end-to-end empty-config CLI run; the empty-config path is a straight fallback to the prior behavior.
- **Release/festival dry-run** consistency is explicitly deferred to PSY-977, not addressed here.
