### PR TITLE
PSY-974: add accent/success/pending variants + apply at sites

### DIFF
--- a/frontend/components/ui/badge.test.tsx
+++ b/frontend/components/ui/badge.test.tsx
@@ -23,6 +23,14 @@ describe('Badge', () => {
     expect(screen.getByText('Danger')).toHaveClass('bg-destructive')
   })
 
+  it('applies the accent variant classes', () => {
+    render(<Badge variant="accent">Accent</Badge>)
+    const badge = screen.getByText('Accent')
+    expect(badge).toHaveClass('bg-primary/10')
+    expect(badge).toHaveClass('text-primary')
+    expect(badge).toHaveClass('border-primary/20')
+  })
+
   it('exposes a badgeVariants helper that reflects the variant', () => {
     expect(badgeVariants({ variant: 'secondary' })).toContain('bg-secondary')
     expect(badgeVariants({ variant: 'outline' })).toContain('text-foreground')

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -14,6 +14,7 @@ const badgeVariants = cva(
           'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
           'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+        accent: 'border-primary/20 bg-primary/10 text-primary',
         outline: 'text-foreground',
       },
     },

--- a/frontend/components/ui/button.test.tsx
+++ b/frontend/components/ui/button.test.tsx
@@ -48,6 +48,20 @@ describe('Button', () => {
     expect(link).toHaveClass('inline-flex')
   })
 
+  it('applies the success variant classes', () => {
+    render(<Button variant="success">Publish</Button>)
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('bg-success')
+    expect(button).toHaveClass('text-success-foreground')
+  })
+
+  it('applies the pending variant classes', () => {
+    render(<Button variant="pending">Unpublish</Button>)
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('bg-pending')
+    expect(button).toHaveClass('text-pending-foreground')
+  })
+
   it('exposes a buttonVariants helper that reflects variant/size', () => {
     const cls = buttonVariants({ variant: 'outline', size: 'lg' })
     expect(cls).toContain('border')

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -16,6 +16,10 @@ const buttonVariants = cva(
           "border bg-background hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        success:
+          "bg-success text-success-foreground hover:bg-success/90",
+        pending:
+          "bg-pending text-pending-foreground hover:bg-pending/90",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -617,7 +617,7 @@ function ExtractedRow({
             <button
               key={s.id}
               type="button"
-              className="rounded-md border border-pending bg-pending px-2 py-0.5 text-xs text-pending-foreground hover:bg-pending/80 transition-colors"
+              className="rounded-md border border-pending-foreground/20 bg-pending px-2 py-0.5 text-xs text-pending-foreground hover:bg-pending/80 transition-colors"
               onClick={() => onAcceptSuggestion(s)}
               data-testid="ai-collection-filler-row-pick"
             >

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -510,7 +510,7 @@ export function AICollectionFiller({
           )}
 
           {warnings.length > 0 && (
-            <div className="text-xs text-amber-600 dark:text-amber-400 space-y-0.5">
+            <div className="text-xs text-pending-foreground space-y-0.5">
               {warnings.map((warning, i) => (
                 <div key={i}>{warning}</div>
               ))}
@@ -558,7 +558,7 @@ function ExtractedRow({
             {item.matched_artist_id && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-success text-success-foreground"
               >
                 <CheckCircle2 className="h-3 w-3 mr-0.5" />
                 MATCH
@@ -567,7 +567,7 @@ function ExtractedRow({
             {hasSuggestions && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-pending text-pending-foreground"
               >
                 <AlertTriangle className="h-3 w-3 mr-0.5" />
                 PICK
@@ -610,14 +610,14 @@ function ExtractedRow({
 
       {hasSuggestions && (
         <div className="ml-0 mt-1.5 flex items-center gap-1.5 flex-wrap text-xs">
-          <span className="text-amber-600 dark:text-amber-400">
+          <span className="text-pending-foreground">
             Did you mean:
           </span>
           {item.artist_suggestions!.map(s => (
             <button
               key={s.id}
               type="button"
-              className="rounded-md border border-amber-400 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-xs hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+              className="rounded-md border border-pending bg-pending px-2 py-0.5 text-xs text-pending-foreground hover:bg-pending/80 transition-colors"
               onClick={() => onAcceptSuggestion(s)}
               data-testid="ai-collection-filler-row-pick"
             >

--- a/frontend/features/radio/components/RadioPlayRow.tsx
+++ b/frontend/features/radio/components/RadioPlayRow.tsx
@@ -165,7 +165,7 @@ export function RadioPlayRow({ play, showPosition = true }: RadioPlayRowProps) {
         {/* Badges */}
         <div className="flex items-center gap-1.5 shrink-0">
           {play.is_new && (
-            <Badge className="bg-green-500/15 text-green-400 border-green-500/20 text-[10px] px-1.5 py-0">
+            <Badge variant="accent" className="text-[10px] px-1.5 py-0">
               NEW
             </Badge>
           )}

--- a/frontend/features/shows/components/PublishShowDialog.tsx
+++ b/frontend/features/shows/components/PublishShowDialog.tsx
@@ -48,7 +48,7 @@ export function PublishShowDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Globe className="h-5 w-5 text-emerald-500" />
+            <Globe className="h-5 w-5 text-success-foreground" />
             Publish Show
           </DialogTitle>
           <DialogDescription>
@@ -57,7 +57,7 @@ export function PublishShowDialog({
         </DialogHeader>
 
         {hasUnverifiedVenue && (
-          <div className="rounded-md bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400 flex items-start gap-2">
+          <div className="rounded-md bg-pending p-3 text-sm text-pending-foreground flex items-start gap-2">
             <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
             <span>
               This show has an unverified venue. It will be set to
@@ -82,8 +82,7 @@ export function PublishShowDialog({
             Cancel
           </Button>
           <Button
-            variant="secondary"
-            className="bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400"
+            variant="success"
             onClick={handlePublish}
             disabled={publishMutation.isPending}
           >

--- a/frontend/features/shows/components/UnpublishShowDialog.tsx
+++ b/frontend/features/shows/components/UnpublishShowDialog.tsx
@@ -45,7 +45,7 @@ export function UnpublishShowDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <EyeOff className="h-5 w-5 text-amber-500" />
+            <EyeOff className="h-5 w-5 text-pending-foreground" />
             Unpublish Show
           </DialogTitle>
           <DialogDescription>
@@ -70,8 +70,7 @@ export function UnpublishShowDialog({
             Cancel
           </Button>
           <Button
-            variant="secondary"
-            className="bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-400"
+            variant="pending"
             onClick={handleUnpublish}
             disabled={unpublishMutation.isPending}
           >


### PR DESCRIPTION
## Summary

PSY-967 **Phase D** — adds the code-side cva variants matching the new Figma DS variants (Badge `accent`, Button `success`/`pending`, shipped + published in PSY-646), then applies them at the sites that hardcoded raw green/amber status colors. Frontend-only; no logic changes.

**cva variants added** (semantic tokens already exist in `globals.css` for both themes, PSY-965):

- `components/ui/badge.tsx` — `accent`: `border-primary/20 bg-primary/10 text-primary` (soft primary tint; visible border, unlike the solid-fill sibling variants)
- `components/ui/button.tsx`:
  - `success`: `bg-success text-success-foreground hover:bg-success/90`
  - `pending`: `bg-pending text-pending-foreground hover:bg-pending/90`

**Sites migrated** (no raw green/amber left in any of these files):

- `features/radio/components/RadioPlayRow.tsx` — "NEW" badge → `<Badge variant="accent">`
- `features/shows/components/PublishShowDialog.tsx` — publish button → `variant="success"`; Globe icon → `text-success-foreground`; unverified-venue warning block → `bg-pending` / `text-pending-foreground`
- `features/shows/components/UnpublishShowDialog.tsx` — unpublish button → `variant="pending"`; EyeOff icon → `text-pending-foreground`
- `features/collections/components/AICollectionFiller.tsx` — MATCH badge → success tokens; PICK badge + warnings + "Did you mean" label/pick-chips → pending tokens

**Out of scope (intentionally untouched):** `getRotationStatusColor` (radio rotation-status categorical color map — data-viz, not status semantics) and the `bg-destructive/10 text-destructive` NEW chip (already token-based). The migration replaces the old explicit `dark:` utility classes with theme-aware tokens (`--success`/`--pending` redefine under `.dark`), so dark mode is preserved via a single source of truth rather than lost.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (only pre-existing warnings, none in touched files)
- [x] `bun run test:run features/radio features/shows features/collections components/ui` — 1016 passed (92 files)
- [x] Added unit assertions for each new variant (`badge.test.tsx` accent; `button.test.tsx` success + pending)

## Manual repro

Per-worktree shared dispatch stack (`stack-up.sh --mode=shared`, frontend on :65300 → shared dev backend :8080), logged in as `asdf@admin.com`, **light theme**. For states with no seeded data, temporarily flipped a DB row, screenshotted, then **reverted** (verified: `radio_plays.id=1 is_new=f`, `shows 473/474 status=approved`):

- **Radio NEW accent badge** — `/radio/kexp/the-morning-show/2026-04-01`; temporarily set one play's `is_new=true`. Confirmed computed classes `border-primary/20 bg-primary/10 text-primary`.
- **Unpublish pending button** — Library → Submissions → "Make private" on a published show. EyeOff icon + button render with pending tokens.
- **Publish success button** — temporarily set show 473 → `private`, then "Publish show". Globe icon + button render with success tokens.

**Coverage gap (disclosed, not faked):** the AICollectionFiller pending states (PICK badge, "Did you mean" pick-chips, warnings) are only reachable after a successful AI extraction that produces fuzzy-but-not-exact artist matches. The dispatch stack has **no `ANTHROPIC_API_KEY`** (the AI route returns "AI service not configured"), so this surface could not be exercised live. Its pending-token changes are covered by: the no-raw-amber grep, typecheck/lint, and the identical `bg-pending`/`text-pending-foreground` token family visually verified in the Publish/Unpublish dialogs.

## Screenshots

### Radio "NEW" accent badge (light theme)
![radio new badge](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-88679b94ccb9d7367175/02-radio-new-badge-accent-playlist.png)

### Publish dialog — `variant="success"` button + success-foreground Globe icon (light theme)
![publish success](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-88679b94ccb9d7367175/04-publish-dialog-success-button.png)

### Unpublish dialog — `variant="pending"` button + pending-foreground EyeOff icon (light theme)
![unpublish pending](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-88679b94ccb9d7367175/03-unpublish-dialog-pending-button.png)

## Code review

`/code-review` (xhigh, inline — dispatched sub-agent, no Agent tool) — **1 finding, fixed in a separate commit** (`d9c7e8c2`):

- [LOW/MEDIUM] AICollectionFiller "Did you mean" pick-chip set `border-pending` == `bg-pending`, making the border invisible against its own fill (the original chip had a distinct `border-amber-400` over `bg-amber-50`). → Fixed with `border-pending-foreground/20` for a subtle pending-tinted edge, mirroring the `accent` badge's `border-primary/20` pattern.

## Adversarial review

`/adversarial-review` — **CLEAN**, no findings (ran inline; dispatched sub-agent has no Agent tool). Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers probed token resolution in both themes, removed-behavior (dropped `dark:` classes correctly subsumed by theme-aware tokens), the dropped `variant="secondary"`, icon-as-foreground-token semantics, naming/drift, and completeness against the ticket. All held up; the one real issue was already caught + fixed by `/code-review`.

Closes PSY-974
