### PR TITLE
PSY-970: badge Space Mono Bold + button Semi Bold labels

### DIFF
--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -3,8 +3,13 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
+// PSY-970: badge labels use Space Mono Bold to match the PSY-646 Figma design
+// system (Figma badge uses Space Mono; the code badge previously inherited the
+// default sans font). `font-mono` maps to --font-space-mono (see globals.css
+// @theme); Space Mono ships a real Bold (700) weight so `font-bold` is genuine,
+// not synthetic. App-wide legibility reconciliation — every badge is now mono+bold.
 const badgeVariants = cva(
-  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -4,6 +4,12 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+// PSY-970: button labels use Semi Bold to match the PSY-646 Figma design
+// system. NOTE: free Satoshi (the body font) ships no native Semibold (600), so
+// `font-semibold` synthetic-bolds the 500 weight (see globals.css @theme note) —
+// this is the intended DS approximation for buttons, deliberately diverging from
+// that note's "use font-medium for editorial weight" guidance, which targets
+// prose, not interactive controls.
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {


### PR DESCRIPTION
## Summary

App-wide code match to the PSY-646 Figma design system's label-legibility decision (PSY-970). Bumps the two shared cva primitives to bolder/heavier label weights so on-screen labels match the published Figma:

- **Badge** → **Space Mono Bold**. Base cva `font-medium` → `font-mono font-bold`. This is a deliberate Figma reconciliation: the Figma badge uses Space Mono, but the **code badge previously inherited the default sans (Satoshi) font** — so every badge now becomes monospace + bold. `font-mono` maps to `--font-mono` → `--font-space-mono` (`app/globals.css` `@theme`; the font is loaded in `app/layout.tsx`). Space Mono ships a real Bold (700) weight, so the bolding is genuine, not synthetic. `text-xs` (12px) is kept — matches Figma's 12px.
- **Button** → **Semi Bold**. Base cva `font-medium` → `font-semibold`.

Touches **only the base cva string** in each file — the `variants` objects are untouched (that's PSY-974 / #995's territory; the two PRs edit different parts of the same `cva()` call and coexist cleanly).

Files changed:
- `frontend/components/ui/badge.tsx` — base cva `font-medium` → `font-mono font-bold` + explanatory comment.
- `frontend/components/ui/button.tsx` — base cva `font-medium` → `font-semibold` + explanatory comment (see Adversarial review).

## Test plan

- [x] `bun run typecheck` — pass.
- [x] `bun run lint` — 0 errors (151 pre-existing warnings, none in the touched files).
- [x] `bun run test:run components/ui` — 121 pass (incl. badge + button).
- [x] `bun run test:run features/artists features/tags` — 541 pass. No test asserts the old `font-medium`/font class on Badge/Button, so no assertions needed updating. (The only `font-medium` test assertion in the repo is `EntityCardTitle.test.tsx`, an unrelated heading component.)

## Manual repro

Ran the shared-mode dispatch stack against the dev backend on :8080, signed in as admin, on the **light theme**. Verified the computed styles at runtime via the browser:
- A secondary Badge ("Compilation" on a release detail page) renders **`font-family: "Space Mono"`, `font-weight: 700`**.
- Status badges ("Active" on the labels list) render **Space Mono, weight 700**.
- Buttons render **weight 600** (semibold).

## Screenshots

Light theme.

**1. Release detail — "Compilation" badge in Space Mono Bold**

![release detail badge](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-4cfbab79e638f7a5a934/01-release-detail-badge-mono-bold.png)

**2. Labels list — dense "Active" status badges (Space Mono Bold) + density-toggle buttons (semibold)**

![labels list badges and buttons](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-4cfbab79e638f7a5a934/02-labels-list-badges-buttons.png)

**3. Discussion "Post" button — semibold**

![post button semibold](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-4cfbab79e638f7a5a934/03-buttons-comments-semibold.png)

## Code review

`/code-review` (inline, sub-agent fallback per repo convention) — **no findings**. The diff is two semantic class swaps in shared cva base strings; verified at the right altitude (one base string each, app-wide), no caller breakage (per-instance `className` overrides still win via tailwind-merge), `font-mono`/`font-bold` are distinct utility groups so neither cancels the other.

## Adversarial review

`/adversarial-review` (inline, sub-agent fallback) — **CONCERNS, 1 finding addressed** in commit `e2f53a4d`.
- [MEDIUM] Future-Maintainer: button's new `font-semibold` silently contradicts the `globals.css` `@theme` note ("Satoshi has no native Semibold; use `font-medium` for editorial weight"). → Fixed: added a comment on the button cva clarifying that the synthetic-bold is the intended DS approximation for interactive controls and that the note targets prose, not controls.
- [LOW, not changed] Saboteur: `SceneDetail.tsx:85` passes a per-instance `font-normal` override (a deliberate pre-existing opt-out of the editorial weight); that badge will now render Space Mono Regular while others are Bold. Intentional per-instance override — left as-is (out of scope; not a regression).
- Saboteur also probed monospace-glyph-width truncation across all `<Badge>` usages: **no** badge has a fixed/`max-w`/`truncate` width constraint, so no layout breakage. Confirmed at runtime.

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

Closes PSY-970
