### PR TITLE
PSY-980: remove Discussion section from artist pages

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -83,13 +83,6 @@ vi.mock('@/features/contributions', () => ({
   useSuggestEdit: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
-// Mock comments feature
-vi.mock('@/features/comments', () => ({
-  CommentThread: ({ entityType, entityId }: { entityType: string; entityId: number }) => (
-    <div data-testid="comment-thread">Comments for {entityType} {entityId}</div>
-  ),
-}))
-
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
   usePathname: () => '/artists/test-artist',
@@ -382,8 +375,10 @@ describe('ArtistDetail', () => {
       expect(screen.queryByTestId('tab-labels')).not.toBeInTheDocument()
       // Main-column content renders directly.
       expect(screen.getByTestId('artist-shows-list')).toBeInTheDocument()
-      expect(screen.getByTestId('comment-thread')).toBeInTheDocument()
       expect(screen.getByTestId('revision-history')).toBeInTheDocument()
+      // The community Discussion (comments) section was removed from artist
+      // pages in PSY-980 — the shared CommentThread is no longer mounted here.
+      expect(screen.queryByTestId('comment-thread')).not.toBeInTheDocument()
     })
 
     it('renders the header action linkbox as bracket links', () => {

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -52,7 +52,6 @@ import { EntityTagList, AddTagDialog } from '@/features/tags'
 import { EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner, AttributionLine, ReportEntityDialog, ContributionPrompt, useSuggestEdit } from '@/features/contributions'
 import { AsHeardOn } from '@/features/radio'
 import { EntityCollections } from '@/features/collections'
-import { CommentThread } from '@/features/comments'
 import { NotifyMeButton } from '@/features/notifications'
 import { ArtistShowsList } from './ArtistShowsList'
 import { ArtistSimilarSidebar, ArtistGraphDialog } from './RelatedArtists'
@@ -1240,8 +1239,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
             entityId={artist.id}
             isAdmin={!!isAdmin}
           />
-
-          <CommentThread entityType="artist" entityId={artist.id} />
         </div>
       </EntityDetailLayout>
 


### PR DESCRIPTION
## Summary

Artist detail pages rendered a community Discussion (comments) section via the
shared `CommentThread` component. This removes it from **artist pages only** so
random commentary doesn't color a visitor's first impression of a band or
invite drama on artist pages.

The shared `CommentThread` component is untouched and still renders on shows,
venues, releases, labels, festivals, and collections. No backend change —
existing artist comments stay in the DB, just unrendered (fully reversible).

**Files changed:**
- `frontend/features/artists/components/ArtistDetail.tsx` — removed the
  `CommentThread` import and its `<CommentThread entityType="artist" ... />`
  render.
- `frontend/features/artists/components/ArtistDetail.test.tsx` — dropped the
  now-unused `@/features/comments` mock; flipped the render assertion to assert
  the comment thread is **not** mounted (regression guard).

No dead artist-comments prefetch existed in the artist route — the route's
`prefetchEntity` seeds the artist entity itself (the standard TanStack SSR
hydration pattern), not comments; `CommentThread` lazy-loaded its own data
client-side. Nothing to remove there.

## Test plan

- [x] `cd frontend && bun run typecheck` — passes (clean)
- [x] `cd frontend && bun run test:run features/artists` — 22 files, 275 tests passed
- [x] `bunx eslint features/artists/components/ArtistDetail.tsx` — exit 0 (no unused-import introduced)

## Manual repro

Ran the per-worktree dispatch stack (`stack-up.sh --mode=shared`, auto-escalated
to isolated since :8080 was free). Against the live frontend:

- **Artist page** (`/artists/ajj`): no Discussion section — page ends at History
  with no comments UI below it. Live DOM `[data-testid="comment-thread"]` count =
  0; no "discussion"/"comment" text in visible `innerText`.
- **Venue page** (`/venues/crescent-ballroom-phoenix-az`): Discussion section
  still present ("Sign in to join the discussion." / "No comments yet."),
  confirming the shared component is intact for other entity types.

Stack torn down after repro.

## Screenshots

Artist page — no Discussion section:

![artist no comments](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-980-screenshots/artist-ajj-no-comments.png)

Venue page — Discussion section intact:

![venue has comments](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-980-screenshots/venue-crescent-has-comments.png)

## Code review

`/code-review` (run inline — dispatched sub-agent has no Agent tool) — CLEAN, no
findings. Verified: no dangling `@/features/comments` references; the dropped
test mock is safe (the SUT no longer imports the comments module); all 6 other
entity detail pages still render `CommentThread`; `artist.id` still used
elsewhere (no orphaned variable); eslint clean. No files edited.

## Adversarial review

`/adversarial-review` — CLEAN. Panel: Saboteur · Future-Maintainer · Security ·
Completeness (run inline — dispatched sub-agent has no Agent tool, expected
per project fallback). No findings:
- Saboteur — pure leaf-component removal; no state/writes/races; reversible, no
  data touched.
- Future-Maintainer — flipped test assertion carries a "why" comment citing
  PSY-980; no silent convention drift (artist is the deliberate, documented
  outlier).
- Security — UI removal reduces surface; no authz/injection/exposure change.
- Completeness — all four acceptance criteria verified against the diff + live
  repro.

No fixes required, so no separate adversarial-review commit.

Closes PSY-980
