### PR TITLE
PSY-978: remove Verified Attendee badge concept

### DIFF
--- a/backend/internal/api/handlers/engagement/comment.go
+++ b/backend/internal/api/handlers/engagement/comment.go
@@ -375,14 +375,14 @@ func (h *CommentHandler) CreateReplyHandler(ctx context.Context, req *CreateRepl
 // UpdateCommentRequest represents the request for updating a comment.
 //
 // `StructuredData` is field-note-only (PSY-567): when supplied AND the target
-// is a field note, ratings + verified-attendee + spoiler flag are atomically
-// replaced as a unit alongside the body. Regular comments ignore it. Omit
-// the field for a body-only edit.
+// is a field note, ratings + spoiler flag are atomically replaced as a unit
+// alongside the body. Regular comments ignore it. Omit the field for a
+// body-only edit.
 type UpdateCommentRequest struct {
 	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
 	Body      struct {
 		Body           string                             `json:"body" doc:"Updated comment body (Markdown)" example:"Updated: Great show last night!"`
-		StructuredData *contracts.FieldNoteStructuredData `json:"structured_data,omitempty" required:"false" doc:"Field-note-only: replaces ratings / verified-attendee / spoiler as a unit"`
+		StructuredData *contracts.FieldNoteStructuredData `json:"structured_data,omitempty" required:"false" doc:"Field-note-only: replaces ratings / spoiler as a unit"`
 	}
 }
 

--- a/backend/internal/api/handlers/engagement/field_note.go
+++ b/backend/internal/api/handlers/engagement/field_note.go
@@ -53,13 +53,13 @@ func NewFieldNoteHandler(writer FieldNoteWriter, reader FieldNoteReader, auditLo
 type CreateFieldNoteRequest struct {
 	ShowID string `path:"show_id" doc:"Show ID" example:"42"`
 	Body   struct {
-		Body             string  `json:"body" doc:"Field note body (Markdown)" example:"The sound was incredible tonight."`
-		ShowArtistID     *uint   `json:"show_artist_id,omitempty" required:"false" doc:"Artist ID on the show bill" example:"5"`
-		SongPosition     *int    `json:"song_position,omitempty" required:"false" doc:"Position in the setlist (1-based)" example:"3"`
-		SoundQuality     *int    `json:"sound_quality,omitempty" required:"false" doc:"Sound quality rating 1-5" example:"4"`
-		CrowdEnergy      *int    `json:"crowd_energy,omitempty" required:"false" doc:"Crowd energy rating 1-5" example:"5"`
-		NotableMoments   *string `json:"notable_moments,omitempty" required:"false" doc:"Notable moments description" example:"Surprise cover of Ziggy Stardust"`
-		SetlistSpoiler   bool    `json:"setlist_spoiler" required:"false" doc:"Whether this note contains setlist spoilers" example:"false"`
+		Body           string  `json:"body" doc:"Field note body (Markdown)" example:"The sound was incredible tonight."`
+		ShowArtistID   *uint   `json:"show_artist_id,omitempty" required:"false" doc:"Artist ID on the show bill" example:"5"`
+		SongPosition   *int    `json:"song_position,omitempty" required:"false" doc:"Position in the setlist (1-based)" example:"3"`
+		SoundQuality   *int    `json:"sound_quality,omitempty" required:"false" doc:"Sound quality rating 1-5" example:"4"`
+		CrowdEnergy    *int    `json:"crowd_energy,omitempty" required:"false" doc:"Crowd energy rating 1-5" example:"5"`
+		NotableMoments *string `json:"notable_moments,omitempty" required:"false" doc:"Notable moments description" example:"Surprise cover of Ziggy Stardust"`
+		SetlistSpoiler bool    `json:"setlist_spoiler" required:"false" doc:"Whether this note contains setlist spoilers" example:"false"`
 	}
 }
 
@@ -85,14 +85,14 @@ func (h *FieldNoteHandler) CreateFieldNoteHandler(ctx context.Context, req *Crea
 	}
 
 	serviceReq := &contracts.CreateFieldNoteRequest{
-		ShowID:           uint(showID),
-		Body:             req.Body.Body,
-		ShowArtistID:     req.Body.ShowArtistID,
-		SongPosition:     req.Body.SongPosition,
-		SoundQuality:     req.Body.SoundQuality,
-		CrowdEnergy:      req.Body.CrowdEnergy,
-		NotableMoments:   req.Body.NotableMoments,
-		SetlistSpoiler:   req.Body.SetlistSpoiler,
+		ShowID:         uint(showID),
+		Body:           req.Body.Body,
+		ShowArtistID:   req.Body.ShowArtistID,
+		SongPosition:   req.Body.SongPosition,
+		SoundQuality:   req.Body.SoundQuality,
+		CrowdEnergy:    req.Body.CrowdEnergy,
+		NotableMoments: req.Body.NotableMoments,
+		SetlistSpoiler: req.Body.SetlistSpoiler,
 	}
 
 	fieldNote, err := h.writer.CreateFieldNote(user.ID, serviceReq)

--- a/backend/internal/api/handlers/engagement/field_note.go
+++ b/backend/internal/api/handlers/engagement/field_note.go
@@ -60,7 +60,6 @@ type CreateFieldNoteRequest struct {
 		CrowdEnergy      *int    `json:"crowd_energy,omitempty" required:"false" doc:"Crowd energy rating 1-5" example:"5"`
 		NotableMoments   *string `json:"notable_moments,omitempty" required:"false" doc:"Notable moments description" example:"Surprise cover of Ziggy Stardust"`
 		SetlistSpoiler   bool    `json:"setlist_spoiler" required:"false" doc:"Whether this note contains setlist spoilers" example:"false"`
-		VerifiedAttendee bool    `json:"verified_attendee" required:"false" doc:"Self-claim that the author attended this show (snapshot at post time, PSY-568)" example:"true"`
 	}
 }
 
@@ -94,7 +93,6 @@ func (h *FieldNoteHandler) CreateFieldNoteHandler(ctx context.Context, req *Crea
 		CrowdEnergy:      req.Body.CrowdEnergy,
 		NotableMoments:   req.Body.NotableMoments,
 		SetlistSpoiler:   req.Body.SetlistSpoiler,
-		VerifiedAttendee: req.Body.VerifiedAttendee,
 	}
 
 	fieldNote, err := h.writer.CreateFieldNote(user.ID, serviceReq)

--- a/backend/internal/api/handlers/engagement/field_note_test.go
+++ b/backend/internal/api/handlers/engagement/field_note_test.go
@@ -23,7 +23,7 @@ func testFieldNoteHandler() *FieldNoteHandler {
 
 func makeFieldNoteResponse(id uint, showID uint, userID uint) *contracts.CommentResponse {
 	sd := contracts.FieldNoteStructuredData{
-		IsVerifiedAttendee: true,
+		SetlistSpoiler: true,
 	}
 	sdBytes, _ := json.Marshal(sd)
 	raw := json.RawMessage(sdBytes)

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -24,8 +24,8 @@ type CreateCommentRequest struct {
 // `StructuredData` is optional and only meaningful when the target comment is
 // a field note (PSY-567). When supplied AND the target is a field note, it
 // REPLACES the existing structured_data row atomically with the body update —
-// ratings, verified-attendee, spoiler are edited as a single unit, never
-// merged with stored values. On a regular comment the field is ignored.
+// ratings, spoiler are edited as a single unit, never merged with stored
+// values. On a regular comment the field is ignored.
 // On a field-note edit it is optional: nil leaves the existing structured_data
 // untouched (body-only edit still works).
 type UpdateCommentRequest struct {
@@ -43,12 +43,6 @@ type CreateFieldNoteRequest struct {
 	CrowdEnergy    *int    `json:"crowd_energy,omitempty"`
 	NotableMoments *string `json:"notable_moments,omitempty"`
 	SetlistSpoiler bool    `json:"setlist_spoiler"`
-	// VerifiedAttendee captures the author's self-claim "I attended this
-	// show" at post time (PSY-568). Snapshot semantics — toggling Going
-	// after posting does NOT flip an existing field-note's badge. The
-	// frontend pre-fills the checkbox from the user's current Going RSVP
-	// but the checkbox value sent here is authoritative.
-	VerifiedAttendee bool `json:"verified_attendee"`
 }
 
 // FieldNoteStructuredData represents the JSONB structured data stored with field note comments.
@@ -57,9 +51,8 @@ type FieldNoteStructuredData struct {
 	SongPosition       *int    `json:"song_position,omitempty"`
 	SoundQuality       *int    `json:"sound_quality,omitempty"`
 	CrowdEnergy        *int    `json:"crowd_energy,omitempty"`
-	NotableMoments     *string `json:"notable_moments,omitempty"`
-	SetlistSpoiler     bool    `json:"setlist_spoiler"`
-	IsVerifiedAttendee bool    `json:"is_verified_attendee"`
+	NotableMoments *string `json:"notable_moments,omitempty"`
+	SetlistSpoiler bool    `json:"setlist_spoiler"`
 }
 
 // CommentListFilters defines filtering and sorting options for listing comments.

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -47,10 +47,10 @@ type CreateFieldNoteRequest struct {
 
 // FieldNoteStructuredData represents the JSONB structured data stored with field note comments.
 type FieldNoteStructuredData struct {
-	ShowArtistID       *uint   `json:"show_artist_id,omitempty"`
-	SongPosition       *int    `json:"song_position,omitempty"`
-	SoundQuality       *int    `json:"sound_quality,omitempty"`
-	CrowdEnergy        *int    `json:"crowd_energy,omitempty"`
+	ShowArtistID   *uint   `json:"show_artist_id,omitempty"`
+	SongPosition   *int    `json:"song_position,omitempty"`
+	SoundQuality   *int    `json:"sound_quality,omitempty"`
+	CrowdEnergy    *int    `json:"crowd_energy,omitempty"`
 	NotableMoments *string `json:"notable_moments,omitempty"`
 	SetlistSpoiler bool    `json:"setlist_spoiler"`
 }

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -615,9 +615,9 @@ func (s *CommentService) GetThread(rootID uint) ([]*contracts.CommentResponse, e
 //
 // Field notes (PSY-567) carry an additional time-bounded gate: the author can
 // edit only within FieldNoteEditWindow of created_at, and may supply a
-// `structured_data` payload to atomically replace ratings / verified-attendee
-// / spoiler flag alongside the body change. Out-of-window edits return an
-// "edit window expired" error mapped to 403 at the handler.
+// `structured_data` payload to atomically replace ratings / spoiler flag
+// alongside the body change. Out-of-window edits return an "edit window
+// expired" error mapped to 403 at the handler.
 func (s *CommentService) UpdateComment(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error) {
 	if s.db == nil {
 		return nil, errors.New("database not initialized")
@@ -978,21 +978,14 @@ func (s *CommentService) CreateFieldNote(userID uint, req *contracts.CreateField
 		}
 	}
 
-	// Verified-attendee is a self-claim captured at post time (PSY-568).
-	// The frontend pre-fills the checkbox from the user's current Going RSVP
-	// but the value sent here is authoritative. Snapshot semantics: toggling
-	// Going after posting does NOT flip an existing field-note's badge.
-	// Posting is NEVER blocked by attendance status — the flag is opt-in.
-
 	// Build structured data
 	structuredData := contracts.FieldNoteStructuredData{
-		ShowArtistID:       req.ShowArtistID,
-		SongPosition:       req.SongPosition,
-		SoundQuality:       req.SoundQuality,
-		CrowdEnergy:        req.CrowdEnergy,
-		NotableMoments:     req.NotableMoments,
-		SetlistSpoiler:     req.SetlistSpoiler,
-		IsVerifiedAttendee: req.VerifiedAttendee,
+		ShowArtistID:   req.ShowArtistID,
+		SongPosition:   req.SongPosition,
+		SoundQuality:   req.SoundQuality,
+		CrowdEnergy:    req.CrowdEnergy,
+		NotableMoments: req.NotableMoments,
+		SetlistSpoiler: req.SetlistSpoiler,
 	}
 	sdJSON, err := json.Marshal(structuredData)
 	if err != nil {

--- a/backend/internal/services/engagement/field_note_test.go
+++ b/backend/internal/services/engagement/field_note_test.go
@@ -257,18 +257,6 @@ func (suite *FieldNoteIntegrationTestSuite) addArtistToShow(showID, artistID uin
 	suite.Require().NoError(err)
 }
 
-func (suite *FieldNoteIntegrationTestSuite) markGoing(userID, showID uint, createdAt time.Time) {
-	bookmark := &engagementm.UserBookmark{
-		UserID:     userID,
-		EntityType: engagementm.BookmarkEntityShow,
-		EntityID:   showID,
-		Action:     engagementm.BookmarkActionGoing,
-		CreatedAt:  createdAt,
-	}
-	err := suite.db.Create(bookmark).Error
-	suite.Require().NoError(err)
-}
-
 // insertFieldNote creates a field note directly in the DB, bypassing rate limiting.
 func (suite *FieldNoteIntegrationTestSuite) insertFieldNote(userID, showID uint, body string, sd *contracts.FieldNoteStructuredData) *engagementm.Comment {
 	svc := suite.commentService
@@ -368,7 +356,6 @@ func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_MinimalFields() 
 	suite.Nil(sd.CrowdEnergy)
 	suite.Nil(sd.NotableMoments)
 	suite.False(sd.SetlistSpoiler)
-	suite.False(sd.IsVerifiedAttendee)
 }
 
 func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_MarkdownRendered() {
@@ -485,138 +472,6 @@ func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_ValidSoundQualit
 		suite.Require().NoError(err, "sound_quality=%d should be valid", val)
 		suite.NotZero(fieldNote.ID)
 	}
-}
-
-// =============================================================================
-// Group 3: Verified Attendee Self-Claim (PSY-568)
-// =============================================================================
-// Verified-attendee is a user-supplied self-claim captured at post time.
-// Snapshot semantics: toggling Going after posting does NOT flip the badge.
-// Posting is NEVER blocked by attendance status — the flag is opt-in.
-
-func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_VerifiedAttendeeTrue() {
-	user := suite.createTestUser()
-	showID := suite.createPastShow("Self Claim Show", 5)
-
-	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
-		ShowID:           showID,
-		Body:             "I was there.",
-		VerifiedAttendee: true,
-	})
-	suite.Require().NoError(err)
-
-	var sd contracts.FieldNoteStructuredData
-	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
-	suite.Require().NoError(err)
-	suite.True(sd.IsVerifiedAttendee, "verified_attendee=true should be persisted")
-}
-
-func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_VerifiedAttendeeFalse() {
-	user := suite.createTestUser()
-	showID := suite.createPastShow("Skipped Show", 5)
-
-	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
-		ShowID:           showID,
-		Body:             "Heard about this one second-hand.",
-		VerifiedAttendee: false,
-	})
-	suite.Require().NoError(err)
-
-	var sd contracts.FieldNoteStructuredData
-	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
-	suite.Require().NoError(err)
-	suite.False(sd.IsVerifiedAttendee, "verified_attendee=false should be persisted")
-}
-
-func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_VerifiedAttendeeRoundTrips() {
-	user := suite.createTestUser()
-	artistID := suite.createTestArtist("Round Trip Artist")
-	showID := suite.createPastShow("Round Trip Show", 3)
-	suite.addArtistToShow(showID, artistID, 0)
-
-	soundQuality := 5
-	crowdEnergy := 4
-	songPosition := 7
-	notableMoments := "Best encore in years"
-
-	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
-		ShowID:           showID,
-		Body:             "All-fields round-trip with verified_attendee=true.",
-		ShowArtistID:     &artistID,
-		SongPosition:     &songPosition,
-		SoundQuality:     &soundQuality,
-		CrowdEnergy:      &crowdEnergy,
-		NotableMoments:   &notableMoments,
-		SetlistSpoiler:   true,
-		VerifiedAttendee: true,
-	})
-	suite.Require().NoError(err)
-
-	// Re-fetch from DB to confirm persistence (not just the create-response shape).
-	var stored engagementm.Comment
-	err = suite.db.First(&stored, fieldNote.ID).Error
-	suite.Require().NoError(err)
-	suite.Require().NotNil(stored.StructuredData)
-
-	var sd contracts.FieldNoteStructuredData
-	err = json.Unmarshal(*stored.StructuredData, &sd)
-	suite.Require().NoError(err)
-	suite.Equal(&artistID, sd.ShowArtistID)
-	suite.Equal(&songPosition, sd.SongPosition)
-	suite.Equal(&soundQuality, sd.SoundQuality)
-	suite.Equal(&crowdEnergy, sd.CrowdEnergy)
-	suite.Equal(&notableMoments, sd.NotableMoments)
-	suite.True(sd.SetlistSpoiler)
-	suite.True(sd.IsVerifiedAttendee, "verified_attendee should round-trip through JSONB")
-}
-
-func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_PostingNeverBlocked_NoGoing() {
-	// Self-claim, NOT a gate: a user with no Going RSVP can still post —
-	// with or without the verified-attendee flag.
-	user := suite.createTestUser()
-	showID := suite.createPastShow("No Gate Show", 4)
-
-	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
-		ShowID:           showID,
-		Body:             "Posting works without any Going record.",
-		VerifiedAttendee: true, // user self-claims even though no RSVP
-	})
-	suite.Require().NoError(err)
-	suite.NotZero(fieldNote.ID)
-
-	var sd contracts.FieldNoteStructuredData
-	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
-	suite.Require().NoError(err)
-	suite.True(sd.IsVerifiedAttendee, "self-claim is honored independently of Going RSVP")
-}
-
-func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_SnapshotSemantics_BookmarkIgnored() {
-	// Flipping a Going RSVP on the user does NOT change the stored
-	// verified-attendee value on a previously-posted field note. The DB
-	// row is the snapshot; this test asserts the value persists exactly
-	// as supplied at post time, regardless of subsequent bookmark state.
-	user := suite.createTestUser()
-	showID := suite.createPastShow("Snapshot Show", 6)
-
-	// Post WITHOUT Going RSVP, claim attended=false
-	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
-		ShowID:           showID,
-		Body:             "Not claiming attendance.",
-		VerifiedAttendee: false,
-	})
-	suite.Require().NoError(err)
-
-	// Now mark Going AFTER posting
-	suite.markGoing(user.ID, showID, time.Now())
-
-	// Re-fetch the field note: the flag should still be false (snapshot)
-	var stored engagementm.Comment
-	err = suite.db.First(&stored, fieldNote.ID).Error
-	suite.Require().NoError(err)
-	var sd contracts.FieldNoteStructuredData
-	err = json.Unmarshal(*stored.StructuredData, &sd)
-	suite.Require().NoError(err)
-	suite.False(sd.IsVerifiedAttendee, "snapshot semantics: post-hoc Going RSVP must not flip the badge")
 }
 
 // =============================================================================
@@ -761,11 +616,10 @@ func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_Structured
 	ce := 5
 	moments := "Epic guitar solo"
 	suite.insertFieldNote(user.ID, showID, "Note with SD", &contracts.FieldNoteStructuredData{
-		SoundQuality:       &sq,
-		CrowdEnergy:        &ce,
-		NotableMoments:     &moments,
-		SetlistSpoiler:     true,
-		IsVerifiedAttendee: true,
+		SoundQuality:   &sq,
+		CrowdEnergy:    &ce,
+		NotableMoments: &moments,
+		SetlistSpoiler: true,
 	})
 
 	result, err := suite.commentService.ListFieldNotesForShow(showID, 20, 0)
@@ -781,7 +635,6 @@ func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_Structured
 	suite.Require().NotNil(sd.NotableMoments)
 	suite.Equal(moments, *sd.NotableMoments)
 	suite.True(sd.SetlistSpoiler)
-	suite.True(sd.IsVerifiedAttendee)
 }
 
 // =============================================================================
@@ -887,16 +740,15 @@ func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_OutOfWindow_403(
 
 func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_StructuredDataReplaced() {
 	// PSY-567 AC: edit must allow updating structured fields (ratings,
-	// verified-attendee, spoiler) as a unit, not body-only.
+	// spoiler) as a unit, not body-only.
 	user := suite.createTestUser()
 	showID := suite.createPastShow("SD Edit", 2)
 	sq := 3
 	ce := 3
 	note := suite.insertFieldNote(user.ID, showID, "first take", &contracts.FieldNoteStructuredData{
-		SoundQuality:       &sq,
-		CrowdEnergy:        &ce,
-		SetlistSpoiler:     false,
-		IsVerifiedAttendee: false,
+		SoundQuality:   &sq,
+		CrowdEnergy:    &ce,
+		SetlistSpoiler: false,
 	})
 
 	newSQ := 5
@@ -904,10 +756,9 @@ func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_StructuredDataRe
 	updated, err := suite.commentService.UpdateComment(user.ID, note.ID, &contracts.UpdateCommentRequest{
 		Body: "revised take",
 		StructuredData: &contracts.FieldNoteStructuredData{
-			SoundQuality:       &newSQ,
-			CrowdEnergy:        &newCE,
-			SetlistSpoiler:     true,
-			IsVerifiedAttendee: true,
+			SoundQuality:   &newSQ,
+			CrowdEnergy:    &newCE,
+			SetlistSpoiler: true,
 		},
 	})
 	suite.Require().NoError(err)
@@ -919,7 +770,6 @@ func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_StructuredDataRe
 	suite.Equal(&newSQ, sd.SoundQuality)
 	suite.Equal(&newCE, sd.CrowdEnergy)
 	suite.True(sd.SetlistSpoiler)
-	suite.True(sd.IsVerifiedAttendee)
 }
 
 func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_StructuredDataInvalidRange() {

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -86,7 +86,6 @@ function makeFieldNote(overrides: Partial<Comment> = {}): Comment {
       crowd_energy: 5,
       notable_moments: 'Played 3 new songs',
       setlist_spoiler: false,
-      is_verified_attendee: true,
     },
     ...overrides,
   }
@@ -111,29 +110,6 @@ describe('FieldNoteCard', () => {
     expect(screen.getByText('TestUser')).toBeInTheDocument()
   })
 
-  it('shows verified attendee badge', () => {
-    render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
-
-    expect(screen.getByTestId('verified-badge')).toBeInTheDocument()
-    expect(screen.getByText('Verified Attendee')).toBeInTheDocument()
-  })
-
-  it('does not show verified badge when not verified', () => {
-    render(
-      <FieldNoteCard
-        comment={makeFieldNote({
-          structured_data: {
-            setlist_spoiler: false,
-            is_verified_attendee: false,
-          },
-        })}
-        showId={10}
-      />
-    )
-
-    expect(screen.queryByTestId('verified-badge')).not.toBeInTheDocument()
-  })
-
   it('displays sound quality and crowd energy ratings', () => {
     render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
 
@@ -147,9 +123,7 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: false,
-            is_verified_attendee: false,
-          },
+            setlist_spoiler: false,          },
         })}
         showId={10}
       />
@@ -170,9 +144,7 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: true,
-            is_verified_attendee: false,
-          },
+            setlist_spoiler: true,          },
         })}
         showId={10}
       />
@@ -190,9 +162,7 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: true,
-            is_verified_attendee: false,
-          },
+            setlist_spoiler: true,          },
         })}
         showId={10}
       />
@@ -211,7 +181,6 @@ describe('FieldNoteCard', () => {
           structured_data: {
             show_artist_id: 42,
             setlist_spoiler: false,
-            is_verified_attendee: true,
           },
         })}
         showId={10}
@@ -232,9 +201,7 @@ describe('FieldNoteCard', () => {
         comment={makeFieldNote({
           structured_data: {
             song_position: 7,
-            setlist_spoiler: false,
-            is_verified_attendee: false,
-          },
+            setlist_spoiler: false,          },
         })}
         showId={10}
       />
@@ -279,9 +246,7 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: true,
-            is_verified_attendee: false,
-            notable_moments: 'Secret setlist info',
+            setlist_spoiler: true,            notable_moments: 'Secret setlist info',
           },
         })}
         showId={10}
@@ -585,13 +550,10 @@ describe('FieldNoteCard', () => {
       expect(textarea.value).toBe('My original take')
       // The read-only body view is replaced while editing.
       expect(screen.queryByTestId('field-note-body')).not.toBeInTheDocument()
-      // PSY-567: structured-data inputs are present so ratings / verified-
-      // attendee / spoiler can be edited as a unit.
+      // PSY-567: structured-data inputs are present so ratings / spoiler
+      // can be edited as a unit.
       expect(screen.getByTestId('sound-quality-rating')).toBeInTheDocument()
       expect(screen.getByTestId('crowd-energy-rating')).toBeInTheDocument()
-      expect(
-        screen.getByTestId('verified-attendee-checkbox')
-      ).toBeInTheDocument()
       expect(
         screen.getByTestId('setlist-spoiler-checkbox')
       ).toBeInTheDocument()
@@ -630,7 +592,6 @@ describe('FieldNoteCard', () => {
           crowd_energy: 5,
           notable_moments: 'Played 3 new songs',
           setlist_spoiler: false,
-          is_verified_attendee: true,
         },
       })
     })

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -123,7 +123,8 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: false,          },
+            setlist_spoiler: false,
+          },
         })}
         showId={10}
       />
@@ -144,7 +145,8 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: true,          },
+            setlist_spoiler: true,
+          },
         })}
         showId={10}
       />
@@ -162,7 +164,8 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: true,          },
+            setlist_spoiler: true,
+          },
         })}
         showId={10}
       />
@@ -201,7 +204,8 @@ describe('FieldNoteCard', () => {
         comment={makeFieldNote({
           structured_data: {
             song_position: 7,
-            setlist_spoiler: false,          },
+            setlist_spoiler: false,
+          },
         })}
         showId={10}
       />
@@ -246,7 +250,8 @@ describe('FieldNoteCard', () => {
       <FieldNoteCard
         comment={makeFieldNote({
           structured_data: {
-            setlist_spoiler: true,            notable_moments: 'Secret setlist info',
+            setlist_spoiler: true,
+            notable_moments: 'Secret setlist info',
           },
         })}
         showId={10}

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { MessageSquare, Star, CheckCircle, Eye, EyeOff, Flag, Clock, Pencil, Trash2, History } from 'lucide-react'
+import { MessageSquare, Star, Eye, EyeOff, Flag, Clock, Pencil, Trash2, History } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
@@ -98,7 +98,6 @@ export function FieldNoteCard({
 
   const sd = comment.structured_data
   const isSpoiler = sd?.setlist_spoiler === true
-  const isVerified = sd?.is_verified_attendee === true
 
   // Find artist name from show_artist_id
   const artistName = sd?.show_artist_id
@@ -116,10 +115,10 @@ export function FieldNoteCard({
   // PUT/DELETE /comments/{id} endpoints operate on the row regardless of
   // kind, so field-note edits go through the same useUpdateComment hook
   // and inherit the comment_edits history (admin-visible via PSY-297).
-  // PSY-567: structured fields (ratings, verified-attendee, spoiler,
-  // notable moments, artist set, song position) are now editable as a
-  // unit — the FieldNoteForm carries the same fields as creation and
-  // the backend replaces structured_data atomically with the body.
+  // PSY-567: structured fields (ratings, spoiler, notable moments, artist
+  // set, song position) are now editable as a unit — the FieldNoteForm
+  // carries the same fields as creation and the backend replaces
+  // structured_data atomically with the body.
   const handleEdit = (input: CreateFieldNoteInput) => {
     const structuredData: FieldNoteStructuredData = {
       show_artist_id: input.show_artist_id ?? null,
@@ -128,7 +127,6 @@ export function FieldNoteCard({
       crowd_energy: input.crowd_energy ?? null,
       notable_moments: input.notable_moments ?? null,
       setlist_spoiler: input.setlist_spoiler ?? false,
-      is_verified_attendee: input.verified_attendee ?? false,
     }
     updateMutation.mutate(
       {
@@ -178,16 +176,6 @@ export function FieldNoteCard({
           className="font-medium text-foreground hover:underline"
           testId={comment.author_username ? 'field-note-author-link' : 'field-note-author-name'}
         />
-        {isVerified && (
-          <Badge
-            variant="secondary"
-            className="text-[10px] px-1.5 py-0 bg-success text-success-foreground"
-            data-testid="verified-badge"
-          >
-            <CheckCircle className="h-3 w-3 mr-0.5" />
-            Verified Attendee
-          </Badge>
-        )}
         <span className="text-muted-foreground">
           {formatRelativeTime(comment.created_at)}
         </span>
@@ -246,10 +234,10 @@ export function FieldNoteCard({
       {/* Body — with spoiler handling. PSY-590: edit mode replaces the
           rendered body with an edit form.
           PSY-567: the ROOT field-note edits via FieldNoteForm so structured
-          fields (sound / crowd / notable / artist / position / spoiler /
-          verified-attendee) are editable as a unit. Replies under a field
-          note are regular comments (kind="comment", no structured data) and
-          continue to edit body-only via CommentForm. */}
+          fields (sound / crowd / notable / artist / position / spoiler) are
+          editable as a unit. Replies under a field note are regular comments
+          (kind="comment", no structured data) and continue to edit body-only
+          via CommentForm. */}
       {isEditing && isFieldNote ? (
         <div className="mt-2">
           <FieldNoteForm
@@ -267,7 +255,6 @@ export function FieldNoteCard({
               setlist_spoiler: sd?.setlist_spoiler ?? false,
               show_artist_id: sd?.show_artist_id ?? null,
               song_position: sd?.song_position ?? null,
-              verified_attendee: sd?.is_verified_attendee ?? false,
             }}
           />
         </div>

--- a/frontend/features/comments/components/FieldNoteForm.test.tsx
+++ b/frontend/features/comments/components/FieldNoteForm.test.tsx
@@ -266,7 +266,7 @@ describe('FieldNoteForm', () => {
     )
   })
 
-  it('does not include optional fields when empty (PSY-568: verified_attendee is always sent as the explicit user choice)', () => {
+  it('does not include optional fields when empty', () => {
     const handleSubmit = vi.fn()
     render(<FieldNoteForm onSubmit={handleSubmit} />)
 
@@ -276,91 +276,10 @@ describe('FieldNoteForm', () => {
     fireEvent.click(screen.getByTestId('field-note-submit'))
 
     const call = handleSubmit.mock.calls[0][0]
-    // PSY-568: verified_attendee is always included so the backend stores
-    // the explicit user choice. Default is false (unchecked) when there is
-    // no Going RSVP, matching the server-side default.
-    expect(call).toEqual({ body: 'Simple note', verified_attendee: false })
+    expect(call).toEqual({ body: 'Simple note' })
     expect(call).not.toHaveProperty('sound_quality')
     expect(call).not.toHaveProperty('crowd_energy')
     expect(call).not.toHaveProperty('notable_moments')
     expect(call).not.toHaveProperty('setlist_spoiler')
-  })
-
-  // PSY-568: Self-claim verified-attendee checkbox.
-  describe('PSY-568 verified-attendee checkbox', () => {
-    it('renders the "I attended this show" checkbox', () => {
-      render(<FieldNoteForm onSubmit={vi.fn()} />)
-
-      const checkbox = screen.getByTestId('verified-attendee-checkbox')
-      expect(checkbox).toBeInTheDocument()
-      expect(screen.getByText('I attended this show')).toBeInTheDocument()
-    })
-
-    it('checkbox is unchecked by default when defaultVerifiedAttendee is false (no Going RSVP)', () => {
-      render(<FieldNoteForm onSubmit={vi.fn()} />)
-
-      const checkbox = screen.getByTestId('verified-attendee-checkbox')
-      expect(checkbox).toHaveAttribute('aria-checked', 'false')
-    })
-
-    it('checkbox is pre-checked when defaultVerifiedAttendee is true (user has Going set)', () => {
-      render(<FieldNoteForm onSubmit={vi.fn()} defaultVerifiedAttendee />)
-
-      const checkbox = screen.getByTestId('verified-attendee-checkbox')
-      expect(checkbox).toHaveAttribute('aria-checked', 'true')
-    })
-
-    it('sends verified_attendee=true when the user checks the box', async () => {
-      const user = userEvent.setup()
-      const handleSubmit = vi.fn()
-      render(<FieldNoteForm onSubmit={handleSubmit} />)
-
-      fireEvent.change(screen.getByTestId('field-note-textarea'), {
-        target: { value: 'I was there.' },
-      })
-      await user.click(screen.getByTestId('verified-attendee-checkbox'))
-      fireEvent.click(screen.getByTestId('field-note-submit'))
-
-      expect(handleSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: 'I was there.',
-          verified_attendee: true,
-        })
-      )
-    })
-
-    it('sends verified_attendee=false when the user unchecks a pre-checked box (override)', async () => {
-      const user = userEvent.setup()
-      const handleSubmit = vi.fn()
-      render(<FieldNoteForm onSubmit={handleSubmit} defaultVerifiedAttendee />)
-
-      fireEvent.change(screen.getByTestId('field-note-textarea'), {
-        target: { value: 'Marked Going but couldn\'t make it.' },
-      })
-      // Box pre-checked; user unticks it.
-      await user.click(screen.getByTestId('verified-attendee-checkbox'))
-      fireEvent.click(screen.getByTestId('field-note-submit'))
-
-      expect(handleSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          verified_attendee: false,
-        })
-      )
-    })
-
-    it('re-syncs the checkbox when defaultVerifiedAttendee changes (attendance loads after mount)', () => {
-      const { rerender } = render(<FieldNoteForm onSubmit={vi.fn()} />)
-      expect(screen.getByTestId('verified-attendee-checkbox')).toHaveAttribute(
-        'aria-checked',
-        'false'
-      )
-
-      // Attendance query resolves and the parent passes defaultVerifiedAttendee=true.
-      rerender(<FieldNoteForm onSubmit={vi.fn()} defaultVerifiedAttendee />)
-      expect(screen.getByTestId('verified-attendee-checkbox')).toHaveAttribute(
-        'aria-checked',
-        'true'
-      )
-    })
   })
 })

--- a/frontend/features/comments/components/FieldNoteForm.tsx
+++ b/frontend/features/comments/components/FieldNoteForm.tsx
@@ -34,15 +34,6 @@ interface FieldNoteFormProps {
    */
   resetSignal?: number
   /**
-   * PSY-568: pre-checks the "I attended this show" checkbox when the
-   * current user has Going set on this show. The checkbox value sent on
-   * submit is authoritative — the user can uncheck it (e.g. they were
-   * marked Going but couldn't actually make it). Snapshot semantics:
-   * toggling Going after posting does NOT flip the badge on existing
-   * notes.
-   */
-  defaultVerifiedAttendee?: boolean
-  /**
    * PSY-567: optional initial values for edit mode. When supplied, all
    * fields pre-populate from the existing note. resetSignal still works
    * but resets back to these initial values (not blank). Mode visibility
@@ -57,7 +48,6 @@ interface FieldNoteFormProps {
     setlist_spoiler?: boolean
     show_artist_id?: number | null
     song_position?: number | null
-    verified_attendee?: boolean
   }
   /**
    * PSY-567: submit-button label override. Defaults to "Post Field Note"
@@ -120,7 +110,6 @@ export function FieldNoteForm({
   disabledMessage,
   errorMessage,
   resetSignal,
-  defaultVerifiedAttendee = false,
   initialValues,
   submitLabel,
   onCancel,
@@ -140,30 +129,9 @@ export function FieldNoteForm({
   const [songPosition, setSongPosition] = useState(
     initialValues?.song_position != null ? String(initialValues.song_position) : ''
   )
-  // PSY-568: self-claim "I attended this show". Initial state mirrors the
-  // user's current Going RSVP; falls back to false. Re-syncs when the
-  // default changes (e.g. attendance loads after the form mounts).
-  // PSY-567: in edit mode, the stored value takes precedence over the
-  // Going-RSVP default — the user's prior self-claim is what they're
-  // editing.
-  const [verifiedAttendee, setVerifiedAttendee] = useState(
-    initialValues?.verified_attendee ?? defaultVerifiedAttendee
-  )
-  useEffect(() => {
-    // PSY-567: only re-sync from Going status on the CREATE path. Editing
-    // an existing note must not silently overwrite the prior self-claim
-    // when attendance data loads after the form mounts.
-    if (initialValues) return
-    setVerifiedAttendee(defaultVerifiedAttendee)
-  }, [defaultVerifiedAttendee, initialValues])
 
   // PSY-608: parent bumps resetSignal from mutation onSuccess. Mirrors the
   // CommentForm pattern so a 4xx response keeps the user's draft intact.
-  // PSY-568: also resets the verified-attendee checkbox to the current
-  // default. defaultVerifiedAttendee is intentionally OMITTED from the
-  // dep array — its own useEffect above handles re-sync when Going status
-  // changes, and including it here would wipe the user's draft on every
-  // attendance refetch.
   // PSY-567: in edit mode, reset returns to initialValues (not blank) so
   // a save-then-reopen cycle shows the freshly-saved state.
   useEffect(() => {
@@ -180,7 +148,6 @@ export function FieldNoteForm({
           ? String(initialValues.song_position)
           : ''
       )
-      setVerifiedAttendee(initialValues.verified_attendee ?? false)
       return
     }
     setBody('')
@@ -190,7 +157,6 @@ export function FieldNoteForm({
     setSetlistSpoiler(false)
     setShowArtistId(undefined)
     setSongPosition('')
-    setVerifiedAttendee(defaultVerifiedAttendee)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetSignal])
 
@@ -209,9 +175,6 @@ export function FieldNoteForm({
     if (songPosition && parseInt(songPosition, 10) > 0) {
       input.song_position = parseInt(songPosition, 10)
     }
-    // PSY-568: always send the flag so the backend stores the explicit
-    // user choice (default-false on the server matches an unchecked box).
-    input.verified_attendee = verifiedAttendee
 
     onSubmit(input)
     // PSY-608: reset is parent-driven via resetSignal (mirrors CommentForm).
@@ -260,24 +223,6 @@ export function FieldNoteForm({
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Optional Details
         </p>
-
-        {/* PSY-568: self-claim "I attended this show". Pre-checked when the
-            user has Going set; user can override (snapshot at post time). */}
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="verified-attendee"
-            checked={verifiedAttendee}
-            onCheckedChange={(checked) => setVerifiedAttendee(checked === true)}
-            disabled={isPending}
-            data-testid="verified-attendee-checkbox"
-          />
-          <Label
-            htmlFor="verified-attendee"
-            className="text-sm text-foreground cursor-pointer"
-          >
-            I attended this show
-          </Label>
-        </div>
 
         {/* Star ratings */}
         <StarRating

--- a/frontend/features/comments/components/FieldNotesSection.test.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.test.tsx
@@ -8,18 +8,6 @@ import type { Comment } from '../types'
 const mockUseFieldNotes = vi.fn()
 const mockUseCreateFieldNote = vi.fn()
 const mockUseAuthContext = vi.fn()
-// PSY-568: FieldNotesSection now reads attendance to pre-check the
-// "I attended this show" checkbox. Default to "no Going RSVP" for tests
-// that don't care; PSY-568-specific tests override per case.
-type MockAttendance = {
-  show_id?: number
-  going_count?: number
-  interested_count?: number
-  user_status?: string
-}
-const mockUseShowAttendance = vi.fn(
-  (_showId: number) => ({ data: undefined as MockAttendance | undefined })
-)
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 
@@ -44,11 +32,6 @@ vi.mock('../hooks', async () => {
 
 vi.mock('@/lib/context/AuthContext', () => ({
   useAuthContext: () => mockUseAuthContext(),
-}))
-
-// PSY-568: stub the shows hooks barrel — only useShowAttendance is consumed.
-vi.mock('@/features/shows/hooks', () => ({
-  useShowAttendance: (showId: number) => mockUseShowAttendance(showId),
 }))
 
 vi.mock('@/features/contributions', () => ({
@@ -76,9 +59,6 @@ describe('FieldNotesSection', () => {
       mutate: vi.fn(),
       isPending: false,
     })
-    // PSY-568: default to no attendance data (user not Going). Tests that
-    // exercise the pre-checked checkbox override this per case.
-    mockUseShowAttendance.mockReturnValue({ data: undefined })
   })
 
   describe('past show (field notes available)', () => {
@@ -169,7 +149,6 @@ describe('FieldNotesSection', () => {
               updated_at: '2026-04-01T00:00:00Z',
               structured_data: {
                 setlist_spoiler: false,
-                is_verified_attendee: false,
               },
             },
           ],
@@ -219,7 +198,6 @@ describe('FieldNotesSection', () => {
                 sound_quality: 4,
                 crowd_energy: 5,
                 setlist_spoiler: false,
-                is_verified_attendee: true,
               },
             },
           ],
@@ -235,7 +213,6 @@ describe('FieldNotesSection', () => {
 
       expect(screen.getByTestId('field-note-card')).toBeInTheDocument()
       expect(screen.getByText('TestUser')).toBeInTheDocument()
-      expect(screen.getByTestId('verified-badge')).toBeInTheDocument()
     })
 
     it('renders loading skeleton', () => {
@@ -337,7 +314,6 @@ describe('FieldNotesSection', () => {
         updated_at: '2026-04-29T18:00:00Z',
         structured_data: {
           setlist_spoiler: false,
-          is_verified_attendee: false,
         },
         ...overrides,
       }
@@ -455,80 +431,4 @@ describe('FieldNotesSection', () => {
     })
   })
 
-  // PSY-568: self-claim verified-attendee. Default state of the checkbox
-  // mirrors the user's current Going RSVP, but the checkbox value is
-  // authoritative (snapshot at post time).
-  describe('verified-attendee default state (PSY-568)', () => {
-    it('checkbox is unchecked by default when user has no Going RSVP', () => {
-      mockUseAuthContext.mockReturnValue({
-        isAuthenticated: true,
-        user: { id: '1', email: 'u@example.com' },
-      })
-      mockUseFieldNotes.mockReturnValue({
-        data: { comments: [], total: 0, has_more: false },
-        isLoading: false,
-      })
-      // No attendance data — user is not Going.
-      mockUseShowAttendance.mockReturnValue({ data: undefined })
-
-      render(
-        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
-      )
-
-      const checkbox = screen.getByTestId('verified-attendee-checkbox')
-      expect(checkbox).toHaveAttribute('aria-checked', 'false')
-    })
-
-    it('checkbox is unchecked when user is only Interested (not Going)', () => {
-      mockUseAuthContext.mockReturnValue({
-        isAuthenticated: true,
-        user: { id: '1', email: 'u@example.com' },
-      })
-      mockUseFieldNotes.mockReturnValue({
-        data: { comments: [], total: 0, has_more: false },
-        isLoading: false,
-      })
-      mockUseShowAttendance.mockReturnValue({
-        data: {
-          show_id: 1,
-          going_count: 0,
-          interested_count: 1,
-          user_status: 'interested',
-        },
-      })
-
-      render(
-        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
-      )
-
-      const checkbox = screen.getByTestId('verified-attendee-checkbox')
-      expect(checkbox).toHaveAttribute('aria-checked', 'false')
-    })
-
-    it('checkbox is pre-checked when user has Going set on this show', () => {
-      mockUseAuthContext.mockReturnValue({
-        isAuthenticated: true,
-        user: { id: '1', email: 'u@example.com' },
-      })
-      mockUseFieldNotes.mockReturnValue({
-        data: { comments: [], total: 0, has_more: false },
-        isLoading: false,
-      })
-      mockUseShowAttendance.mockReturnValue({
-        data: {
-          show_id: 1,
-          going_count: 1,
-          interested_count: 0,
-          user_status: 'going',
-        },
-      })
-
-      render(
-        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
-      )
-
-      const checkbox = screen.getByTestId('verified-attendee-checkbox')
-      expect(checkbox).toHaveAttribute('aria-checked', 'true')
-    })
-  })
 })

--- a/frontend/features/comments/components/FieldNotesSection.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import { ClipboardList } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useShowAttendance } from '@/features/shows/hooks'
 import { StatusBanner } from '@/components/shared'
 import {
   useFieldNotes,
@@ -43,12 +42,6 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
   const { isAuthenticated } = useAuthContext()
   const { data, isLoading } = useFieldNotes(showId)
   const createMutation = useCreateFieldNote()
-  // PSY-568: drives the default state of the "I attended this show" checkbox.
-  // Reuses the same hook AttendanceButton uses, so no extra request when the
-  // user is also rendering a Going button on the same page (TanStack Query
-  // dedupes via the shared queryKey).
-  const { data: attendance } = useShowAttendance(isAuthenticated ? showId : 0)
-  const isGoing = attendance?.user_status === 'going'
   // PSY-513: track the author's pending-review field note so we can render
   // it optimistically alongside the public list (which filters out
   // pending_review). De-duped once the canonical row appears post-approval.
@@ -118,7 +111,6 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
                   createMutation.error
                 )}
                 resetSignal={submitGeneration}
-                defaultVerifiedAttendee={isGoing}
               />
             </div>
           ) : (

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -236,9 +236,9 @@ export function useUpdateComment() {
       entityType: string
       entityId: number
       // PSY-567: field-note edits send the full structured-data block so
-      // ratings / verified-attendee / spoiler are replaced atomically with
-      // the body. Backend ignores this for non-field-note comments, so the
-      // same hook stays usable from CommentCard. Undefined => body-only edit.
+      // ratings / spoiler are replaced atomically with the body. Backend
+      // ignores this for non-field-note comments, so the same hook stays
+      // usable from CommentCard. Undefined => body-only edit.
       structuredData?: FieldNoteStructuredData | null
     }) =>
       apiRequest<Comment>(commentEndpoints.UPDATE(commentId), {

--- a/frontend/features/comments/types.ts
+++ b/frontend/features/comments/types.ts
@@ -84,7 +84,6 @@ export interface FieldNoteStructuredData {
   crowd_energy?: number | null
   notable_moments?: string | null
   setlist_spoiler: boolean
-  is_verified_attendee: boolean
 }
 
 export interface CreateFieldNoteInput {
@@ -95,11 +94,6 @@ export interface CreateFieldNoteInput {
   crowd_energy?: number
   notable_moments?: string
   setlist_spoiler?: boolean
-  // PSY-568: self-claim "I attended this show" captured at post time.
-  // Snapshot semantics — toggling Going after posting does NOT flip the
-  // badge on existing notes. Frontend pre-fills the checkbox from the
-  // user's current Going RSVP but the value sent here is authoritative.
-  verified_attendee?: boolean
 }
 
 // PSY-567: time-bounded edit / delete window for a field note's author.


### PR DESCRIPTION
## Summary

Removes the "Verified Attendee" badge concept entirely. Field-note
attendance was a self-claimed, unverifiable checkbox ("I attended this
show") that rendered an authoritative-looking green "Verified Attendee"
badge — anyone could check the box, so the badge was misleading. This
drops the checkbox, the badge, and the field from both contracts.

**No DB migration.** The flag lived only in the `structured_data` JSONB
column (no dedicated column); existing rows' `is_verified_attendee` key
is simply ignored going forward — Go's `json.Unmarshal` drops the
unknown key, and the slimmed struct re-marshals without it on any edit.

Frontend: removed the checkbox from `FieldNoteForm`, the badge from
`FieldNoteCard`, the RSVP-driven `defaultVerifiedAttendee` plumbing
(`FieldNotesSection` no longer fetches `useShowAttendance` — that fetch
existed solely to pre-check the box), and `is_verified_attendee` /
`verified_attendee` from the comments types. The RSVP feature itself
(`AttendanceButton`, `useShowAttendance`) is untouched.

Backend: removed `verified_attendee` from the request contract and
`is_verified_attendee` from the `FieldNoteStructuredData`
response/JSONB shape.

14 files changed (4 backend non-test, 2 backend test, 4 frontend
non-test, 4 frontend test).

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test -count=1 ./internal/api/handlers/engagement/... ./internal/services/engagement/...` — pass (contracts pkg has no test files)
- [x] OpenAPI spec diff verified EXACTLY the removed fields: generated the reflection-derived spec from `main` and from this branch and diffed — the only changes are (1) `verified_attendee` request property removed, (2) `is_verified_attendee` response property removed from `FieldNoteStructuredData`, (3) `is_verified_attendee` dropped from that schema's `required` array, (4) the tied `structured_data` doc-text update. No unintended schema drift.
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:run features/comments` — 157 tests pass (11 files)
- [x] `gofmt -l` on all six touched backend files — clean (after adversarial-review fix)

## Manual repro

Brought up the isolated dispatch stack (`stack-up.sh --mode=isolated`;
fullstack diff → isolated), backdated a seed show to the past so field
notes are enabled, logged in as `e2e-user@test.local`, and:

- **Form:** the field-note form's "Optional Details" section shows Sound
  Quality, Crowd Energy, Notable Moments, Artist Set, Song #, and
  "Contains setlist spoilers" — and NO "I attended this show" checkbox
  (DOM assert: `verified-attendee-checkbox` absent, no "attended this
  show" label).
- **Card:** posted a field note; it renders by the author with NO
  "Verified Attendee" badge (DOM assert: 0 `verified-badge` nodes, no
  "Verified Attendee" text). Persisted `structured_data` =
  `{"setlist_spoiler": false}` — no `is_verified_attendee` key.
- **Contract boundary:** POSTing the legacy `verified_attendee: true`
  field now returns 422 `unexpected property` at `body.verified_attendee`
  (the field is genuinely gone from the schema); a clean body posts
  fine. Stack torn down after.

## Screenshots

![Field-note form — no "I attended this show" checkbox](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-015d439bf669abb0cba7/01-field-note-form-no-checkbox.png)

![Rendered field note — no "Verified Attendee" badge](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-015d439bf669abb0cba7/02-field-note-card-no-badge.png)

## Code review

`/code-review` — 1 finding addressed in commit `7f32d87b`.
- [LOW] 5 malformed inline-brace / trailing-whitespace lines in
  `FieldNoteCard.test.tsx` left by the bulk `is_verified_attendee`
  removal → fixed (formatting only; tests + typecheck green).
No correctness bugs surfaced — the change is a symmetric removal across
all sites.

## Adversarial review

`/adversarial-review` — 1 finding addressed in commit `b0f2e448`.
- [HIGH] gofmt non-compliance: removing the longest struct field left the
  struct + composite-literal columns over-aligned in
  `contracts/comment.go` and `field_note.go`, which `gofmt -l` (Go CI
  gate) would reject → fixed via `gofmt -w`; all six touched backend
  files now gofmt-clean, build + tests still green.
Panel: Saboteur (CLEAN — stale-JSONB and contract-tightening paths
safe) · Future-Maintainer (the gofmt finding) · Security (CLEAN — net
positive: removes a spoofable self-claim, no new surface) ·
Completeness (CLEAN — all ACs met). Lenses run inline (dispatched
sub-agent has no Agent tool) against the branch diff.

Closes PSY-978
