### PR TITLE
PSY-962: Create-drawer polish — overview strip, drag-reorder, chip status tokens

### DIFF
--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -510,7 +510,7 @@ export function AICollectionFiller({
           )}
 
           {warnings.length > 0 && (
-            <div className="text-xs text-amber-600 dark:text-amber-400 space-y-0.5">
+            <div className="text-xs text-pending-foreground space-y-0.5">
               {warnings.map((warning, i) => (
                 <div key={i}>{warning}</div>
               ))}
@@ -558,7 +558,7 @@ function ExtractedRow({
             {item.matched_artist_id && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-success text-success-foreground"
               >
                 <CheckCircle2 className="h-3 w-3 mr-0.5" />
                 MATCH
@@ -567,7 +567,7 @@ function ExtractedRow({
             {hasSuggestions && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-pending text-pending-foreground"
               >
                 <AlertTriangle className="h-3 w-3 mr-0.5" />
                 PICK
@@ -576,7 +576,7 @@ function ExtractedRow({
             {isNew && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive/10 text-destructive"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive text-destructive-foreground"
               >
                 <AlertCircle className="h-3 w-3 mr-0.5" />
                 NEW
@@ -610,14 +610,14 @@ function ExtractedRow({
 
       {hasSuggestions && (
         <div className="ml-0 mt-1.5 flex items-center gap-1.5 flex-wrap text-xs">
-          <span className="text-amber-600 dark:text-amber-400">
+          <span className="text-pending-foreground">
             Did you mean:
           </span>
           {item.artist_suggestions!.map(s => (
             <button
               key={s.id}
               type="button"
-              className="rounded-md border border-amber-400 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-xs hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+              className="rounded-md border border-border bg-secondary text-secondary-foreground px-2 py-0.5 text-xs hover:bg-secondary/80 transition-colors"
               onClick={() => onAcceptSuggestion(s)}
               data-testid="ai-collection-filler-row-pick"
             >

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -558,7 +558,7 @@ function ExtractedRow({
             {item.matched_artist_id && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-success text-success-foreground"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-success text-success-foreground motion-safe:animate-in motion-safe:fade-in"
               >
                 <CheckCircle2 className="h-3 w-3 mr-0.5" />
                 MATCH
@@ -567,16 +567,21 @@ function ExtractedRow({
             {hasSuggestions && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-pending text-pending-foreground"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-pending text-pending-foreground motion-safe:animate-in motion-safe:fade-in"
               >
                 <AlertTriangle className="h-3 w-3 mr-0.5" />
                 PICK
               </Badge>
             )}
+            {/* NEW uses the SOFT destructive tint (bg-destructive/10), not the
+                solid bg-destructive action token MATCH/PICK-style: "will be
+                created" is an advisory outcome, not an error/failure. The DS has
+                no soft destructive *surface* token, so this uses /10; success +
+                pending ARE soft surface tokens, so MATCH/PICK apply them directly. */}
             {isNew && (
               <Badge
                 variant="secondary"
-                className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive text-destructive-foreground"
+                className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive/10 text-destructive motion-safe:animate-in motion-safe:fade-in"
               >
                 <AlertCircle className="h-3 w-3 mr-0.5" />
                 NEW

--- a/frontend/features/collections/components/AddItemsPicker.test.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.test.tsx
@@ -587,4 +587,60 @@ describe('AddItemsPicker', () => {
     expect(mockResolveMutate).not.toHaveBeenCalled()
     expect(screen.getByText(/canonical PH paths/i)).toBeInTheDocument()
   })
+
+  // ── PSY-962: overview strip + drag-reorder ──
+  // Full drag interaction is exercised by @dnd-kit itself + manual repro;
+  // these cover the strip render, count/plural, overflow cap, and the
+  // reorder-affordance gating (handle only when there's >1 item to reorder).
+  const staged = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      entityType: 'artist' as const,
+      entityId: i + 1,
+      name: `Artist ${i + 1}`,
+      subtitle: null,
+    }))
+
+  it('renders the overview strip with item count + reorder hint (>1 item)', () => {
+    render(
+      <AddItemsPicker stagedItems={staged(3)} onStagedItemsChange={vi.fn()} />
+    )
+    const strip = screen.getByTestId('add-items-picker-overview-strip')
+    expect(strip).toHaveTextContent('3 items')
+    expect(strip).toHaveTextContent('drag to reorder')
+  })
+
+  it('overview strip: singular "item" + no reorder hint for a single item', () => {
+    render(
+      <AddItemsPicker stagedItems={staged(1)} onStagedItemsChange={vi.fn()} />
+    )
+    const strip = screen.getByTestId('add-items-picker-overview-strip')
+    expect(strip).toHaveTextContent('1 item')
+    expect(strip).not.toHaveTextContent('drag to reorder')
+  })
+
+  it('overview strip caps its preview and shows a +N overflow chip', () => {
+    render(
+      <AddItemsPicker stagedItems={staged(30)} onStagedItemsChange={vi.fn()} />
+    )
+    // 24 shown + 6 overflow.
+    expect(
+      screen.getByTestId('add-items-picker-overview-strip')
+    ).toHaveTextContent('+6')
+  })
+
+  it('renders a drag handle per row when reorderable (>1 staged item)', () => {
+    render(
+      <AddItemsPicker stagedItems={staged(3)} onStagedItemsChange={vi.fn()} />
+    )
+    expect(screen.getAllByTestId('staged-row-drag-handle')).toHaveLength(3)
+  })
+
+  it('hides the drag handle for a single staged item (nothing to reorder)', () => {
+    render(
+      <AddItemsPicker stagedItems={staged(1)} onStagedItemsChange={vi.fn()} />
+    )
+    expect(
+      screen.queryByTestId('staged-row-drag-handle')
+    ).not.toBeInTheDocument()
+  })
 })

--- a/frontend/features/collections/components/AddItemsPicker.test.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.test.tsx
@@ -3,7 +3,11 @@ import React from 'react'
 import { render, screen, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { AddItemsPicker, parsePasteLine } from './AddItemsPicker'
+import {
+  AddItemsPicker,
+  parsePasteLine,
+  reorderStagedItems,
+} from './AddItemsPicker'
 
 // ──────────────────────────────────────────────
 // Mocks
@@ -642,5 +646,39 @@ describe('AddItemsPicker', () => {
     expect(
       screen.queryByTestId('staged-row-drag-handle')
     ).not.toBeInTheDocument()
+  })
+})
+
+// PSY-962 adversarial-review: the reorder CONTRACT (preserve all items, no
+// dupes/drops, correct order) is the ticket's load-bearing behavior — unit it
+// directly via the pure helper rather than driving @dnd-kit.
+describe('reorderStagedItems', () => {
+  const mk = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      entityType: 'artist' as const,
+      entityId: i + 1,
+      name: `Artist ${i + 1}`,
+      subtitle: null,
+    }))
+
+  it('moves the active item to the over position, preserving every item', () => {
+    const next = reorderStagedItems(mk(3), 'artist-1', 'artist-3')
+    expect(next).not.toBeNull()
+    expect(next!.map((s) => s.entityId)).toEqual([2, 3, 1])
+    expect(next).toHaveLength(3)
+    expect(new Set(next!.map((s) => s.entityId))).toEqual(new Set([1, 2, 3]))
+  })
+
+  it('returns null (no-op) when there is no drop target', () => {
+    expect(reorderStagedItems(mk(3), 'artist-1', null)).toBeNull()
+  })
+
+  it('returns null (no-op) when an item is dropped on itself', () => {
+    expect(reorderStagedItems(mk(3), 'artist-2', 'artist-2')).toBeNull()
+  })
+
+  it('returns null (no-op) for an id not in the list', () => {
+    expect(reorderStagedItems(mk(3), 'artist-9', 'artist-1')).toBeNull()
+    expect(reorderStagedItems(mk(3), 'artist-1', 'artist-9')).toBeNull()
   })
 })

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -24,7 +24,14 @@
  * extraction via Claude Haiku.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react'
 import { useDebounce } from 'use-debounce'
 import {
   Plus,
@@ -35,6 +42,7 @@ import {
   Library,
   Loader2,
   Info,
+  GripVertical,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -56,6 +64,25 @@ import { useResolveCollectionItems } from '../hooks'
 import { getEntityTypeLabel, type CollectionEntityType } from '../types'
 import { cn } from '@/lib/utils'
 import { AICollectionFiller } from './AICollectionFiller'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { ENTITY_ICONS } from './collectionDetailShared'
 
 // ──────────────────────────────────────────────
 // Types
@@ -391,6 +418,33 @@ export function AddItemsPicker({
     )
   }
 
+  // ─── Reorder (PSY-962) ───
+  // Drag-to-reorder the staged list; the overview strip mirrors this order.
+  // Sensors mirror the collections drag-drop primitive (PSY-348): pointer 8px,
+  // touch long-press, keyboard arrow-key fallback.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 8 },
+    }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+  const stagedIds = useMemo(
+    () => stagedItems.map((s) => `${s.entityType}-${s.entityId}`),
+    [stagedItems]
+  )
+  const handleReorder = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const oldIndex = stagedIds.indexOf(String(active.id))
+      const newIndex = stagedIds.indexOf(String(over.id))
+      if (oldIndex === -1 || newIndex === -1) return
+      onStagedItemsChange(arrayMove(stagedItems, oldIndex, newIndex))
+    },
+    [stagedIds, stagedItems, onStagedItemsChange]
+  )
+
   // ─── Render ───
 
   const stagedCount = stagedItems.length
@@ -463,25 +517,39 @@ export function AddItemsPicker({
         )}
       </Tabs>
 
-      {/* Staged list */}
+      {/* Staged list (PSY-962: overview strip + drag-reorderable detail list) */}
       {stagedCount > 0 && (
-        <div className="mt-3 border-t border-border/50 pt-3">
-          <div
-            className={cn(
-              'space-y-0.5',
-              stagedCount > STAGED_LIST_MAX_VISIBLE && 'max-h-[420px] overflow-y-auto'
-            )}
-            data-testid="add-items-picker-staged-list"
+        <div className="mt-3 border-t border-border/50 pt-3 space-y-2">
+          <StagedOverviewStrip items={stagedItems} />
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleReorder}
           >
-            {stagedItems.map((item, index) => (
-              <StagedRow
-                key={`${item.entityType}-${item.entityId}`}
-                index={index}
-                item={item}
-                onRemove={() => unstageItem(item.entityType, item.entityId)}
-              />
-            ))}
-          </div>
+            <SortableContext
+              items={stagedIds}
+              strategy={verticalListSortingStrategy}
+            >
+              <div
+                className={cn(
+                  'space-y-0.5',
+                  stagedCount > STAGED_LIST_MAX_VISIBLE &&
+                    'max-h-[420px] overflow-y-auto'
+                )}
+                data-testid="add-items-picker-staged-list"
+              >
+                {stagedItems.map((item, index) => (
+                  <StagedRow
+                    key={`${item.entityType}-${item.entityId}`}
+                    index={index}
+                    item={item}
+                    canReorder={stagedCount > 1}
+                    onRemove={() => unstageItem(item.entityType, item.entityId)}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
         </div>
       )}
     </div>
@@ -831,20 +899,102 @@ function PastePreviewRow({
   )
 }
 
+/**
+ * PSY-962: at-a-glance overview strip above the staged list — item count + a
+ * capped row of entity-type icon chips. The numbered list below stays the
+ * detail + drag-reorder surface; this strip mirrors its order. Icon-only +
+ * monochrome by design (color is reserved for the AI status chips). Enter
+ * animation is gated on `motion-safe` so it honors prefers-reduced-motion.
+ */
+const STRIP_PREVIEW_CAP = 24
+function StagedOverviewStrip({ items }: { items: StagedCollectionItem[] }) {
+  const shown = items.slice(0, STRIP_PREVIEW_CAP)
+  const overflow = items.length - shown.length
+  return (
+    <div className="space-y-1.5" data-testid="add-items-picker-overview-strip">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-mono text-muted-foreground">
+          {items.length} {items.length === 1 ? 'item' : 'items'}
+        </span>
+        {items.length > 1 && (
+          <span className="text-[10px] font-mono text-muted-foreground">
+            ⇅ drag to reorder
+          </span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {shown.map((item) => {
+          const Icon = ENTITY_ICONS[item.entityType] ?? Library
+          return (
+            <span
+              key={`${item.entityType}-${item.entityId}`}
+              className="flex h-7 w-7 items-center justify-center rounded border border-border bg-secondary text-secondary-foreground motion-safe:animate-in motion-safe:fade-in"
+              title={`${item.name} — ${getEntityTypeLabel(item.entityType)}`}
+            >
+              <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            </span>
+          )
+        })}
+        {overflow > 0 && (
+          <span className="flex h-7 items-center rounded border border-border bg-muted px-2 text-[10px] font-mono text-muted-foreground">
+            +{overflow}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function StagedRow({
   index,
   item,
+  canReorder,
   onRemove,
 }: {
   index: number
   item: StagedCollectionItem
+  canReorder: boolean
   onRemove: () => void
 }) {
+  // useSortable returns no-op refs/listeners when reorder is disabled (single
+  // item), keeping hook order stable across renders.
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: `${item.entityType}-${item.entityId}`,
+    disabled: !canReorder,
+  })
+  const sortableStyle: CSSProperties = canReorder
+    ? {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.6 : undefined,
+      }
+    : {}
   return (
     <div
-      className="flex items-center gap-3 rounded-md px-2 py-1.5 border border-border/40"
+      ref={canReorder ? setNodeRef : undefined}
+      style={sortableStyle}
+      className="flex items-center gap-2 rounded-md px-2 py-1.5 border border-border/40 bg-popover motion-safe:animate-in motion-safe:fade-in"
       data-testid="add-items-picker-staged-row"
     >
+      {canReorder && (
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="touch-none cursor-grab active:cursor-grabbing flex h-6 w-4 shrink-0 items-center justify-center text-muted-foreground hover:text-foreground rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`Drag to reorder ${item.name}. Use space to lift, arrow keys to move.`}
+          data-testid="staged-row-drag-handle"
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </button>
+      )}
       <span className="text-xs font-mono text-muted-foreground w-6 shrink-0 text-right">
         {String(index + 1).padStart(2, '0')}
       </span>

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -115,6 +115,24 @@ export interface StagedCollectionItem {
 const stagedKey = (s: { entityType: string; entityId: number }): string =>
   `${s.entityType}-${s.entityId}`
 
+/**
+ * Pure reorder behind the drag-end handler — exported so the reorder contract
+ * (preserve every item, no dupes, correct new order) is unit-testable without
+ * driving @dnd-kit. Returns the reordered array, or null for a no-op (no drop
+ * target, dropped on itself, or an id not in the list).
+ */
+export function reorderStagedItems(
+  items: StagedCollectionItem[],
+  activeId: string,
+  overId: string | null
+): StagedCollectionItem[] | null {
+  if (!overId || activeId === overId) return null
+  const oldIndex = items.findIndex((s) => stagedKey(s) === activeId)
+  const newIndex = items.findIndex((s) => stagedKey(s) === overId)
+  if (oldIndex === -1 || newIndex === -1) return null
+  return arrayMove(items, oldIndex, newIndex)
+}
+
 interface ExistingItemKey {
   entity_type: string
   entity_id: number
@@ -430,7 +448,12 @@ export function AddItemsPicker({
   // ─── Reorder (PSY-962) ───
   // Drag-to-reorder the staged list; the overview strip mirrors this order.
   // Sensors mirror the collections drag-drop primitive (PSY-348): pointer 8px,
-  // touch long-press, keyboard arrow-key fallback.
+  // touch long-press, and KeyboardSensor for keyboard reorder (focus the drag
+  // handle → Space to lift → arrow keys to move → Space to drop). Unlike
+  // CollectionItemCard (the heavier detail-page surface), this transient
+  // staging list intentionally omits the separate up/down arrow BUTTONS — the
+  // locked PSY-962 design is a drag-handle-only row; all three input modalities
+  // (pointer/touch/keyboard) can still reorder via the sensors above.
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, {
@@ -445,13 +468,14 @@ export function AddItemsPicker({
   const handleReorder = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
-      if (!over || active.id === over.id) return
-      const oldIndex = stagedIds.indexOf(String(active.id))
-      const newIndex = stagedIds.indexOf(String(over.id))
-      if (oldIndex === -1 || newIndex === -1) return
-      onStagedItemsChange(arrayMove(stagedItems, oldIndex, newIndex))
+      const next = reorderStagedItems(
+        stagedItems,
+        String(active.id),
+        over ? String(over.id) : null
+      )
+      if (next) onStagedItemsChange(next)
     },
-    [stagedIds, stagedItems, onStagedItemsChange]
+    [stagedItems, onStagedItemsChange]
   )
 
   // ─── Render ───
@@ -873,7 +897,7 @@ function PastePreviewRow({
         <>
           <Badge
             variant="secondary"
-            className="text-[10px] px-1.5 py-0 shrink-0 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+            className="text-[10px] px-1.5 py-0 shrink-0 bg-success text-success-foreground motion-safe:animate-in motion-safe:fade-in"
           >
             <Check className="h-3 w-3 mr-0.5" />
             MATCH
@@ -898,7 +922,7 @@ function PastePreviewRow({
       {row.status === 'unresolved' && (
         <Badge
           variant="secondary"
-          className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive/10 text-destructive"
+          className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive/10 text-destructive motion-safe:animate-in motion-safe:fade-in"
         >
           <AlertCircle className="h-3 w-3 mr-0.5" />
           NO MATCH
@@ -915,6 +939,9 @@ function PastePreviewRow({
  * monochrome by design (color is reserved for the AI status chips). Enter
  * animation is gated on `motion-safe` so it honors prefers-reduced-motion.
  */
+/** Overview-strip preview cap — render at most this many entity-type icon
+ *  chips, then a "+N" overflow chip. ~2 wrapped rows of 28px chips at the
+ *  drawer's min width; the numbered list below stays the complete view. */
 const STRIP_PREVIEW_CAP = 24
 function StagedOverviewStrip({ items }: { items: StagedCollectionItem[] }) {
   const shown = items.slice(0, STRIP_PREVIEW_CAP)
@@ -931,7 +958,9 @@ function StagedOverviewStrip({ items }: { items: StagedCollectionItem[] }) {
           </span>
         )}
       </div>
-      <div className="flex flex-wrap gap-1.5">
+      {/* Decorative: icons duplicate the numbered list below, which is the
+          accessible source of truth (full names + type badges). */}
+      <div className="flex flex-wrap gap-1.5" aria-hidden="true">
         {shown.map((item) => {
           const Icon = ENTITY_ICONS[item.entityType] ?? Library
           return (

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -106,6 +106,15 @@ export interface StagedCollectionItem {
   subtitle: string | null
 }
 
+/**
+ * Stable identity for a staged item — used as BOTH the React key and the
+ * @dnd-kit sortable id. These MUST agree character-for-character (the
+ * SortableContext `items` list vs each row's `useSortable` id) or drag-reorder
+ * silently no-ops. Single-source it so the call sites can't drift (PSY-962).
+ */
+const stagedKey = (s: { entityType: string; entityId: number }): string =>
+  `${s.entityType}-${s.entityId}`
+
 interface ExistingItemKey {
   entity_type: string
   entity_id: number
@@ -430,7 +439,7 @@ export function AddItemsPicker({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
   const stagedIds = useMemo(
-    () => stagedItems.map((s) => `${s.entityType}-${s.entityId}`),
+    () => stagedItems.map(stagedKey),
     [stagedItems]
   )
   const handleReorder = useCallback(
@@ -540,7 +549,7 @@ export function AddItemsPicker({
               >
                 {stagedItems.map((item, index) => (
                   <StagedRow
-                    key={`${item.entityType}-${item.entityId}`}
+                    key={stagedKey(item)}
                     index={index}
                     item={item}
                     canReorder={stagedCount > 1}
@@ -927,7 +936,7 @@ function StagedOverviewStrip({ items }: { items: StagedCollectionItem[] }) {
           const Icon = ENTITY_ICONS[item.entityType] ?? Library
           return (
             <span
-              key={`${item.entityType}-${item.entityId}`}
+              key={stagedKey(item)}
               className="flex h-7 w-7 items-center justify-center rounded border border-border bg-secondary text-secondary-foreground motion-safe:animate-in motion-safe:fade-in"
               title={`${item.name} — ${getEntityTypeLabel(item.entityType)}`}
             >
@@ -966,7 +975,7 @@ function StagedRow({
     transition,
     isDragging,
   } = useSortable({
-    id: `${item.entityType}-${item.entityId}`,
+    id: stagedKey(item),
     disabled: !canReorder,
   })
   const sortableStyle: CSSProperties = canReorder


### PR DESCRIPTION
## What

Create-drawer polish layer (the original PSY-829 drawer scope), design-first off the locked Figma:

- **Overview strip** above the staged-items list — item count + a capped row of entity-type icon chips (reuses the shared `ENTITY_ICONS`) with a `+N` overflow chip. Icon-only/monochrome by design; the numbered list below stays the detail surface.
- **Drag-to-reorder** on the staged list via `@dnd-kit/sortable` (`verticalListSortingStrategy`), mirroring the collections drag-drop primitive (PSY-348): PointerSensor 8px / TouchSensor long-press / KeyboardSensor arrow-keys. Drag handle renders only when there's >1 item.
- **AI per-row chips → DS status tokens** (continues PSY-973): MATCH→`success`, PICK→`pending`, NEW→soft `bg-destructive/10`; suggestion buttons, "Did you mean", and extraction warnings all migrated off raw emerald/amber. Paste-tab MATCH chip migrated too for in-drawer consistency.
- **Animations** on add + state-resolution, all gated on `motion-safe:` (honors `prefers-reduced-motion`, CSS-only).

Design locked in Figma (Product Designs file, `Collections` page): https://www.figma.com/design/XakQQ0nYGqnt77PrHKO9IE/Psychic-Homily-Product-Designs?node-id=408-341 — long-form decisions on the PSY-962 Linear comment.

## Scope / deferred

- **Out of scope (deferred):** 200-item windowing (`@tanstack/react-virtual` + `@dnd-kit` coordination) → **PSY-994**. The strip caps at 24 + `+N` and the list keeps the existing `max-h` scroll in the interim.
- **Design-only here:** will-create + ambiguous chip *actions* are designed in Figma but implemented in **PSY-853** (this PR ships the visual language + the states that exist today).
- **Chunk-safety:** `AddItemsPicker`'s only consumers are already lazy (`CreateCollectionForm` via `dynamic()` in the drawer; `CollectionItemsList` via `dynamic()` per PSY-951, already carrying `@dnd-kit`), so adding `@dnd-kit` here does not repollute the global shared chunk.

## /simplify
Extracted `stagedKey()` so the React key + `@dnd-kit` sortable id are single-sourced (they must agree character-for-character). Skipped (premature per all 4 lenses): extracting a shared dnd sensors/sortable hook vs `CollectionItemsList` — 2 divergent call sites (persist-via-mutation+grid vs local-state+list).

## Adversarial review
`/adversarial-review` — 2 rounds; round-1 BLOCK (2 HIGH) → fixed → round-2 confirmed resolved. Findings + fixes in commit `869ce1b8`:
- [HIGH] NEW chip on the loud `bg-destructive` action token → soft `bg-destructive/10` (consistent with `success`/`pending` peers + sibling NO-MATCH badge).
- [HIGH] reorder contract untested → extracted pure `reorderStagedItems()` + 4 unit tests (preserves all items, no dupes/drops; no-op guards).
- [MEDIUM] paste-tab chips left on raw emerald / un-animated → migrated + `motion-safe` fade.
- [MEDIUM] chip-treatment asymmetry undocumented → rationale comment (NEW is soft because it's advisory, and the DS has no soft-destructive *surface* token).
- [LOW] `STRIP_PREVIEW_CAP` undocumented → comment; icon chips invisible to AT → `aria-hidden` (numbered list is the accessible source).
- **Rejected (with counter-argument):** (a) adding up/down arrow buttons — reorder works for pointer/touch/keyboard via the sensors; arrow buttons are an extra detail-page affordance and the locked design is drag-handle-only (clarified the comment + documented the divergence); (b) conditional-mount of `DndContext` — `@dnd-kit` is statically imported (no bundle savings) and conditional mount would remount the list at the 1→2 boundary, re-firing animations; (c) "Extraction complete" header on `text-primary` — out of chip-migration scope, already a DS token.

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

## Verification
- `tsc --noEmit` clean
- **42** AddItemsPicker + AICollectionFiller tests pass (incl. 5 strip + 4 reorder-contract tests); full collections suite (303) green
- `eslint` 0 errors (1 pre-existing `<img>` warning, untouched)
- **Manual drag repro pending** (worktree has no running dev stack) — recommended before merge: verify pointer/touch/keyboard reorder + the strip mirroring order in the live drawer.

Closes PSY-962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
