### PR TITLE
PSY-992: Rebuild /tags browse as a dense sortable tag directory

### DIFF
--- a/frontend/features/tags/components/TagBrowse.test.tsx
+++ b/frontend/features/tags/components/TagBrowse.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { TagListItem } from '../types'
@@ -23,22 +23,17 @@ vi.mock('next/navigation', () => ({
 }))
 
 vi.mock('next/link', () => ({
-  default: ({
-    href,
-    children,
-    ...props
-  }: {
-    href: string
-    children: React.ReactNode
-    [key: string]: unknown
-  }) => (
-    <a href={href} {...props}>
+  default: React.forwardRef<
+    HTMLAnchorElement,
+    React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }
+  >(({ href, children, ...props }, ref) => (
+    <a href={href} ref={ref} {...props}>
       {children}
     </a>
-  ),
+  )),
 }))
 
-import { TagBrowse, cloudFontSizePx } from './TagBrowse'
+import { TagBrowse } from './TagBrowse'
 
 function setUrlParams(params: Record<string, string> = {}) {
   mockSearchParamsStore = new URLSearchParams(params)
@@ -73,43 +68,75 @@ function makeTag(overrides: Partial<TagListItem> = {}): TagListItem {
   }
 }
 
+/**
+ * Helper to drive the multi-query `useTags` mock. The component issues:
+ *   1. main list query (category/search/sort/offset)
+ *   2-4. one count query per category ({genre|locale|other}, limit:1)
+ * We key the count responses off the `category` param so facet counts and the
+ * main list are independently controllable.
+ */
+function mockTags({
+  list,
+  total = list.length,
+  counts = { genre: 0, locale: 0, other: 0 },
+  isLoading = false,
+  error = null as Error | null,
+  refetch = vi.fn(),
+}: {
+  list: TagListItem[]
+  total?: number
+  counts?: { genre: number; locale: number; other: number }
+  isLoading?: boolean
+  error?: Error | null
+  refetch?: () => void
+}) {
+  mockUseTags.mockImplementation((params?: { category?: string; limit?: number }) => {
+    // Count queries are the limit:1, category-scoped calls.
+    if (params?.limit === 1 && params.category) {
+      const cat = params.category as 'genre' | 'locale' | 'other'
+      return {
+        data: { tags: [], total: counts[cat] ?? 0 },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      }
+    }
+    // Main list query.
+    return {
+      data: error ? undefined : { tags: list, total },
+      isLoading,
+      error,
+      refetch,
+    }
+  })
+}
+
 describe('TagBrowse', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     setUrlParams()
-    mockUseTags.mockReturnValue({
-      data: { tags: [], total: 0 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+    mockTags({ list: [], total: 0 })
   })
 
   // ── Loading state ──
 
   it('shows loading spinner on initial load', () => {
-    mockUseTags.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      error: null,
-      refetch: vi.fn(),
+    mockUseTags.mockImplementation((params?: { limit?: number; category?: string }) => {
+      if (params?.limit === 1 && params.category) {
+        return { data: { tags: [], total: 0 }, isLoading: false, error: null, refetch: vi.fn() }
+      }
+      return { data: undefined, isLoading: true, error: null, refetch: vi.fn() }
     })
 
     renderWithProviders(<TagBrowse />)
 
-    const spinner = document.querySelector('.animate-spin')
-    expect(spinner).toBeInTheDocument()
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
   })
 
   // ── Error state ──
 
   it('shows error message on error', () => {
-    mockUseTags.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Server error'),
-      refetch: vi.fn(),
-    })
+    mockTags({ list: [], error: new Error('Server error') })
 
     renderWithProviders(<TagBrowse />)
 
@@ -120,12 +147,7 @@ describe('TagBrowse', () => {
 
   it('shows Retry button on error', async () => {
     const mockRefetch = vi.fn()
-    mockUseTags.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Server error'),
-      refetch: mockRefetch,
-    })
+    mockTags({ list: [], error: new Error('Server error'), refetch: mockRefetch })
 
     const user = userEvent.setup()
     renderWithProviders(<TagBrowse />)
@@ -137,204 +159,242 @@ describe('TagBrowse', () => {
   // ── Empty state ──
 
   it('shows generic empty copy when no filter is active', () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [], total: 0 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+    mockTags({ list: [], total: 0 })
 
     renderWithProviders(<TagBrowse />)
 
     expect(screen.getByText('No tags found.')).toBeInTheDocument()
   })
 
-  it('shows filter-aware empty copy when a category pill is active', async () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [], total: 0 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+  it('shows filter-aware empty copy when a category facet is active', async () => {
+    mockTags({ list: [], total: 0, counts: { genre: 0, locale: 3, other: 0 } })
 
     const user = userEvent.setup()
     renderWithProviders(<TagBrowse />)
 
-    await user.click(screen.getByRole('button', { name: 'Locale' }))
+    await user.click(screen.getByTestId('facet-locale'))
 
     expect(screen.getByText('No locale tags yet.')).toBeInTheDocument()
   })
 
-  // ── Tag rendering (grid) ──
+  // ── Dense table rendering ──
 
-  it('renders tag cards as links in grid view (default)', () => {
-    const tags = [
-      makeTag({ id: 1, name: 'rock', slug: 'rock' }),
-      makeTag({ id: 2, name: 'punk', slug: 'punk', category: 'other' }),
-    ]
-    mockUseTags.mockReturnValue({
-      data: { tags, total: 2 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+  it('renders a directory table with Tag / Category / Uses column headers', () => {
+    mockTags({ list: [makeTag()], total: 1 })
 
     renderWithProviders(<TagBrowse />)
 
-    const rockLink = screen.getByRole('link', { name: /rock/ })
-    expect(rockLink).toHaveAttribute('href', '/tags/rock')
-
-    const punkLink = screen.getByRole('link', { name: /punk/ })
-    expect(punkLink).toHaveAttribute('href', '/tags/punk')
-
-    // Default view is grid — tag cloud must not be rendered.
-    expect(screen.queryByTestId('tag-cloud')).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Tag' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: 'Category' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Uses' })).toBeInTheDocument()
   })
 
-  it('renders usage count on tag cards', () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [makeTag({ usage_count: 42 })], total: 1 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
+  it('renders each tag as a row link to its detail page', () => {
+    mockTags({
+      list: [
+        makeTag({ id: 1, name: 'rock', slug: 'rock' }),
+        makeTag({ id: 2, name: 'punk', slug: 'punk', category: 'other' }),
+      ],
+      total: 2,
     })
 
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByText('42 uses')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /rock/ })).toHaveAttribute(
+      'href',
+      '/tags/rock'
+    )
+    expect(screen.getByRole('link', { name: /punk/ })).toHaveAttribute(
+      'href',
+      '/tags/punk'
+    )
   })
 
-  it('renders singular usage count', () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [makeTag({ usage_count: 1 })], total: 1 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+  it('renders the category as a tinted text label (not a pill)', () => {
+    mockTags({ list: [makeTag({ category: 'genre' })], total: 1 })
 
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByText('1 use')).toBeInTheDocument()
+    const rows = screen.getAllByRole('row')
+    // Header row + 1 data row.
+    const dataRow = rows[1]
+    const label = within(dataRow).getByText('Genre')
+    // chart-6 = denim genre tint, no bg/border pill classes.
+    expect(label.className).toContain('text-chart-6')
+    expect(label.className).not.toContain('rounded-full')
   })
 
-  it('renders Official badge on official tags', () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [makeTag({ is_official: true })], total: 1 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+  it('renders the usage count in a right-aligned cell', () => {
+    mockTags({ list: [makeTag({ usage_count: 142 })], total: 1 })
 
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByText('Official')).toBeInTheDocument()
+    const cell = screen.getByText('142')
+    expect(cell).toHaveClass('text-right')
+    expect(cell).toHaveClass('tabular-nums')
+  })
+
+  it('renders Official indicator on official tags', () => {
+    mockTags({ list: [makeTag({ is_official: true })], total: 1 })
+
+    renderWithProviders(<TagBrowse />)
+
+    // Dense rows use the compact icon-only indicator (aria-label, no visible text).
+    expect(screen.getByRole('img', { name: 'Official tag' })).toBeInTheDocument()
   })
 
   it('renders total count', () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [makeTag()], total: 15 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+    mockTags({ list: [makeTag()], total: 15 })
 
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByText('15 tags found')).toBeInTheDocument()
+    expect(screen.getByText('15 tags')).toBeInTheDocument()
   })
 
   it('renders singular total count', () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [makeTag()], total: 1 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+    mockTags({ list: [makeTag()], total: 1 })
 
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByText('1 tag found')).toBeInTheDocument()
+    expect(screen.getByText('1 tag')).toBeInTheDocument()
   })
 
-  // ── Category filter tabs ──
+  // ── Category facet chips with counts ──
 
-  it('renders all category filter buttons plus "All"', () => {
+  it('renders All + per-category facet chips', () => {
+    mockTags({ list: [makeTag()], total: 1, counts: { genre: 18, locale: 4, other: 2 } })
+
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByText('All')).toBeInTheDocument()
-    expect(screen.getByText('Genre')).toBeInTheDocument()
-    expect(screen.getByText('Locale')).toBeInTheDocument()
-    expect(screen.getByText('Other')).toBeInTheDocument()
+    expect(screen.getByTestId('facet-all')).toBeInTheDocument()
+    expect(screen.getByTestId('facet-genre')).toBeInTheDocument()
+    expect(screen.getByTestId('facet-locale')).toBeInTheDocument()
+    expect(screen.getByTestId('facet-other')).toBeInTheDocument()
   })
 
-  it('calls useTags with category when a category button is clicked', async () => {
+  it('shows live per-category counts (and All = sum) on the facet chips', () => {
+    mockTags({ list: [makeTag()], total: 24, counts: { genre: 18, locale: 4, other: 2 } })
+
+    renderWithProviders(<TagBrowse />)
+
+    expect(within(screen.getByTestId('facet-all')).getByText('24')).toBeInTheDocument()
+    expect(within(screen.getByTestId('facet-genre')).getByText('18')).toBeInTheDocument()
+    expect(within(screen.getByTestId('facet-locale')).getByText('4')).toBeInTheDocument()
+    expect(within(screen.getByTestId('facet-other')).getByText('2')).toBeInTheDocument()
+  })
+
+  it('disables a facet chip with zero results', () => {
+    mockTags({ list: [makeTag()], total: 22, counts: { genre: 18, locale: 4, other: 0 } })
+
+    renderWithProviders(<TagBrowse />)
+
+    expect(screen.getByTestId('facet-other')).toBeDisabled()
+    expect(screen.getByTestId('facet-genre')).not.toBeDisabled()
+  })
+
+  it('calls useTags with category when a facet chip is clicked', async () => {
+    mockTags({ list: [makeTag()], total: 18, counts: { genre: 18, locale: 4, other: 2 } })
+
     const user = userEvent.setup()
     renderWithProviders(<TagBrowse />)
 
-    await user.click(screen.getByText('Genre'))
+    await user.click(screen.getByTestId('facet-genre'))
 
-    const lastCall = mockUseTags.mock.calls[mockUseTags.mock.calls.length - 1]
-    expect(lastCall[0]).toEqual(
+    const listCalls = mockUseTags.mock.calls.filter(
+      c => (c[0] as { limit?: number })?.limit !== 1
+    )
+    expect(listCalls[listCalls.length - 1][0]).toEqual(
       expect.objectContaining({ category: 'genre' })
     )
   })
 
   // ── Search ──
 
-  it('renders search input', () => {
+  it('renders an autofocused search input', () => {
+    mockTags({ list: [], total: 0 })
+
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByPlaceholderText('Search tags...')).toBeInTheDocument()
+    const input = screen.getByPlaceholderText('Search tags...')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveFocus()
   })
 
-  // ── Sort dropdown ──
+  // ── Sort segmented control ──
 
-  it('renders all sort options', () => {
+  it('renders the three sort options as a segmented control', () => {
+    mockTags({ list: [makeTag()], total: 1 })
+
     renderWithProviders(<TagBrowse />)
 
-    const select = screen.getByLabelText('Sort tags') as HTMLSelectElement
-    const values = Array.from(select.options).map(o => o.value)
-    expect(values).toEqual(['popularity', 'alphabetical', 'newest'])
+    expect(screen.getByTestId('sort-popularity')).toBeInTheDocument()
+    expect(screen.getByTestId('sort-alphabetical')).toBeInTheDocument()
+    expect(screen.getByTestId('sort-newest')).toBeInTheDocument()
+  })
+
+  it('marks popularity as the default checked sort', () => {
+    mockTags({ list: [makeTag()], total: 1 })
+
+    renderWithProviders(<TagBrowse />)
+
+    expect(screen.getByTestId('sort-popularity')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('sort-alphabetical')).toHaveAttribute('aria-checked', 'false')
   })
 
   it('defaults to popularity sort → calls useTags with backend sort "usage"', () => {
+    mockTags({ list: [makeTag()], total: 1 })
+
     renderWithProviders(<TagBrowse />)
 
-    const lastCall = mockUseTags.mock.calls[mockUseTags.mock.calls.length - 1]
-    expect(lastCall[0]).toEqual(
+    const listCalls = mockUseTags.mock.calls.filter(
+      c => (c[0] as { limit?: number })?.limit !== 1
+    )
+    expect(listCalls[listCalls.length - 1][0]).toEqual(
       expect.objectContaining({ sort: 'usage' })
     )
   })
 
-  it('reflects URL sort param ?sort=alphabetical in the select and in the useTags call', () => {
+  it('reflects URL ?sort=alphabetical in the control and the useTags call', () => {
     setUrlParams({ sort: 'alphabetical' })
+    mockTags({ list: [makeTag()], total: 1 })
 
     renderWithProviders(<TagBrowse />)
 
-    const select = screen.getByLabelText('Sort tags') as HTMLSelectElement
-    expect(select.value).toBe('alphabetical')
+    expect(screen.getByTestId('sort-alphabetical')).toHaveAttribute('aria-checked', 'true')
 
-    const lastCall = mockUseTags.mock.calls[mockUseTags.mock.calls.length - 1]
-    expect(lastCall[0]).toEqual(expect.objectContaining({ sort: 'name' }))
+    const listCalls = mockUseTags.mock.calls.filter(
+      c => (c[0] as { limit?: number })?.limit !== 1
+    )
+    expect(listCalls[listCalls.length - 1][0]).toEqual(
+      expect.objectContaining({ sort: 'name' })
+    )
   })
 
-  it('reflects URL sort param ?sort=newest and maps to backend "created"', () => {
+  it('reflects URL ?sort=newest and maps to backend "created"', () => {
     setUrlParams({ sort: 'newest' })
+    mockTags({ list: [makeTag()], total: 1 })
 
     renderWithProviders(<TagBrowse />)
 
-    const select = screen.getByLabelText('Sort tags') as HTMLSelectElement
-    expect(select.value).toBe('newest')
+    expect(screen.getByTestId('sort-newest')).toHaveAttribute('aria-checked', 'true')
 
-    const lastCall = mockUseTags.mock.calls[mockUseTags.mock.calls.length - 1]
-    expect(lastCall[0]).toEqual(expect.objectContaining({ sort: 'created' }))
+    const listCalls = mockUseTags.mock.calls.filter(
+      c => (c[0] as { limit?: number })?.limit !== 1
+    )
+    expect(listCalls[listCalls.length - 1][0]).toEqual(
+      expect.objectContaining({ sort: 'created' })
+    )
   })
 
-  it('selecting a non-default sort pushes it into the URL via router.replace', async () => {
+  it('selecting a non-default sort pushes it into the URL', async () => {
+    mockTags({ list: [makeTag()], total: 1 })
+
     const user = userEvent.setup()
     renderWithProviders(<TagBrowse />)
 
-    await user.selectOptions(screen.getByLabelText('Sort tags'), 'alphabetical')
+    await user.click(screen.getByTestId('sort-alphabetical'))
 
     expect(mockReplace).toHaveBeenCalled()
     const call = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
@@ -343,109 +403,62 @@ describe('TagBrowse', () => {
 
   it('selecting the default sort strips ?sort from the URL', async () => {
     setUrlParams({ sort: 'alphabetical' })
+    mockTags({ list: [makeTag()], total: 1 })
+
     const user = userEvent.setup()
     renderWithProviders(<TagBrowse />)
 
-    await user.selectOptions(screen.getByLabelText('Sort tags'), 'popularity')
+    await user.click(screen.getByTestId('sort-popularity'))
 
     const call = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
     expect(call[0]).toBe('/tags')
   })
 
-  // ── View toggle (grid / cloud) ──
+  // ── Keyboard nav (↑/↓ between rows; Enter is native on the anchor) ──
 
-  it('renders the view toggle with grid selected by default', () => {
-    renderWithProviders(<TagBrowse />)
-
-    const grid = screen.getByTestId('view-grid')
-    const cloud = screen.getByTestId('view-cloud')
-
-    expect(grid).toHaveAttribute('aria-checked', 'true')
-    expect(cloud).toHaveAttribute('aria-checked', 'false')
-  })
-
-  it('clicking the cloud button pushes ?view=cloud into the URL', async () => {
-    const user = userEvent.setup()
-    renderWithProviders(<TagBrowse />)
-
-    await user.click(screen.getByTestId('view-cloud'))
-
-    const call = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
-    expect(call[0]).toBe('/tags?view=cloud')
-  })
-
-  it('clicking back to grid strips ?view from the URL', async () => {
-    setUrlParams({ view: 'cloud' })
-    const user = userEvent.setup()
-    renderWithProviders(<TagBrowse />)
-
-    await user.click(screen.getByTestId('view-grid'))
-
-    const call = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
-    expect(call[0]).toBe('/tags')
-  })
-
-  it('toggling cloud view with a non-default sort already in the URL preserves both params', async () => {
-    // Simulate an incoming URL of /tags?sort=newest, then user clicks Cloud.
-    setUrlParams({ sort: 'newest' })
-    const user = userEvent.setup()
-    renderWithProviders(<TagBrowse />)
-
-    await user.click(screen.getByTestId('view-cloud'))
-
-    const call = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]
-    const url = new URL(call[0], 'http://t')
-    expect(url.pathname).toBe('/tags')
-    expect(url.searchParams.get('sort')).toBe('newest')
-    expect(url.searchParams.get('view')).toBe('cloud')
-  })
-
-  // ── Cloud view rendering & log-scale font sizing ──
-
-  it('renders cloud view when ?view=cloud with usage-count-driven font sizes', () => {
-    setUrlParams({ view: 'cloud' })
-    const tags = [
-      makeTag({ id: 1, name: 'tiny', slug: 'tiny', usage_count: 1 }),
-      makeTag({ id: 2, name: 'medium', slug: 'medium', usage_count: 25 }),
-      makeTag({ id: 3, name: 'huge', slug: 'huge', usage_count: 500 }),
-    ]
-    mockUseTags.mockReturnValue({
-      data: { tags, total: 3 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
+  it('moves row focus with ArrowDown / ArrowUp', async () => {
+    mockTags({
+      list: [
+        makeTag({ id: 1, name: 'rock', slug: 'rock' }),
+        makeTag({ id: 2, name: 'punk', slug: 'punk' }),
+        makeTag({ id: 3, name: 'jazz', slug: 'jazz' }),
+      ],
+      total: 3,
     })
 
+    const user = userEvent.setup()
     renderWithProviders(<TagBrowse />)
 
-    expect(screen.getByTestId('tag-cloud')).toBeInTheDocument()
+    const rock = screen.getByRole('link', { name: /rock/ })
+    const punk = screen.getByRole('link', { name: /punk/ })
 
-    const tiny = screen.getByTestId('tag-cloud-item-tiny')
-    const medium = screen.getByTestId('tag-cloud-item-medium')
-    const huge = screen.getByTestId('tag-cloud-item-huge')
+    rock.focus()
+    expect(rock).toHaveFocus()
 
-    const sizePx = (el: HTMLElement) =>
-      parseFloat((el as HTMLElement).style.fontSize.replace('px', ''))
+    await user.keyboard('{ArrowDown}')
+    expect(punk).toHaveFocus()
 
-    expect(sizePx(tiny)).toBeLessThan(sizePx(medium))
-    expect(sizePx(medium)).toBeLessThan(sizePx(huge))
+    await user.keyboard('{ArrowUp}')
+    expect(rock).toHaveFocus()
   })
 
-  it('cloudFontSizePx uses a log scale (compressed relative to linear)', () => {
-    const minU = 1
-    const maxU = 1000
-    const mid = Math.sqrt(minU * maxU) // geometric mid ≈ 31
-    const size = cloudFontSizePx(mid, minU, maxU)
-    // With log scaling, the geometric mean lands near the midpoint of the
-    // font-size range (≈21.5px), not near the low end (≈13px) as linear
-    // scaling would give. Assert it's comfortably above halfway-low.
-    expect(size).toBeGreaterThan(19)
-    expect(size).toBeLessThan(24)
-  })
+  it('ArrowUp on the first row stays on the first row', async () => {
+    mockTags({
+      list: [
+        makeTag({ id: 1, name: 'rock', slug: 'rock' }),
+        makeTag({ id: 2, name: 'punk', slug: 'punk' }),
+      ],
+      total: 2,
+    })
 
-  it('cloudFontSizePx clamps min and max to the configured range', () => {
-    expect(cloudFontSizePx(1, 1, 1000)).toBeCloseTo(13, 0)
-    expect(cloudFontSizePx(1000, 1, 1000)).toBeCloseTo(30, 0)
+    const user = userEvent.setup()
+    renderWithProviders(<TagBrowse />)
+
+    const rock = screen.getByRole('link', { name: /rock/ })
+    rock.focus()
+
+    await user.keyboard('{ArrowUp}')
+    expect(rock).toHaveFocus()
   })
 
   // ── Pagination ──
@@ -454,30 +467,21 @@ describe('TagBrowse', () => {
     const tags = Array.from({ length: 50 }, (_, i) =>
       makeTag({ id: i + 1, name: `tag-${i}`, slug: `tag-${i}` })
     )
-    mockUseTags.mockReturnValue({
-      data: { tags, total: 100 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+    mockTags({ list: tags, total: 100 })
 
     renderWithProviders(<TagBrowse />)
 
     expect(screen.getByText('Next')).toBeInTheDocument()
     expect(screen.getByText('Previous')).toBeInTheDocument()
     expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+    expect(screen.getByText('Showing 1–50 of 100')).toBeInTheDocument()
   })
 
   it('Previous button is disabled on first page', () => {
     const tags = Array.from({ length: 50 }, (_, i) =>
       makeTag({ id: i + 1, name: `tag-${i}`, slug: `tag-${i}` })
     )
-    mockUseTags.mockReturnValue({
-      data: { tags, total: 100 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+    mockTags({ list: tags, total: 100 })
 
     renderWithProviders(<TagBrowse />)
 
@@ -485,12 +489,7 @@ describe('TagBrowse', () => {
   })
 
   it('does not show pagination when all results fit on one page', () => {
-    mockUseTags.mockReturnValue({
-      data: { tags: [makeTag()], total: 1 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    })
+    mockTags({ list: [makeTag()], total: 1 })
 
     renderWithProviders(<TagBrowse />)
 

--- a/frontend/features/tags/components/TagBrowse.test.tsx
+++ b/frontend/features/tags/components/TagBrowse.test.tsx
@@ -22,16 +22,18 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => mockSearchParamsStore,
 }))
 
-vi.mock('next/link', () => ({
-  default: React.forwardRef<
+vi.mock('next/link', () => {
+  const MockLink = React.forwardRef<
     HTMLAnchorElement,
     React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }
   >(({ href, children, ...props }, ref) => (
     <a href={href} ref={ref} {...props}>
       {children}
     </a>
-  )),
-}))
+  ))
+  MockLink.displayName = 'MockLink'
+  return { default: MockLink }
+})
 
 import { TagBrowse } from './TagBrowse'
 

--- a/frontend/features/tags/components/TagBrowse.tsx
+++ b/frontend/features/tags/components/TagBrowse.tsx
@@ -373,9 +373,14 @@ function TagDirectoryTable({ tags }: { tags: TagListItem[] }) {
 }
 
 /**
- * Category as a tinted TEXT label (not a pill). Reuses getCategoryColor's
- * token mapping but drops the bg/border classes so only the foreground tint
- * lands: genre = chart-6 (denim), locale = chart-8 (teal), other = muted.
+ * Category as a tinted TEXT label (not a pill). Derives the foreground tint
+ * from `getCategoryColor` — the single source of truth for the genre→chart-6 /
+ * locale→chart-8 / other→muted mapping — by keeping only its `text-*` token and
+ * dropping the bg/border classes. Deriving (rather than re-hardcoding the map)
+ * keeps the two surfaces from drifting. Contract: `getCategoryColor` must return
+ * exactly one `text-*` token; if that ever stops holding, this falls back to
+ * `text-muted-foreground` (and TagBrowse.test.tsx asserts the genre tint, so a
+ * regression surfaces in CI rather than silently).
  */
 function categoryTextTint(category: string): string {
   const text = getCategoryColor(category)

--- a/frontend/features/tags/components/TagBrowse.tsx
+++ b/frontend/features/tags/components/TagBrowse.tsx
@@ -1,58 +1,59 @@
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useEffect, useRef, useState, useTransition } from 'react'
+import type { KeyboardEvent } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Search, Hash, Loader2, LayoutGrid, Cloud } from 'lucide-react'
+import { Search, Hash, Loader2 } from 'lucide-react'
 import { useDebounce } from 'use-debounce'
 import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { DenseTable } from '@/components/shared'
 import { useTags } from '../hooks'
 import {
   TAG_CATEGORIES,
   TAG_SORT_OPTIONS,
   DEFAULT_TAG_SORT,
-  DEFAULT_TAG_VIEW,
   getCategoryColor,
   getCategoryLabel,
 } from '../types'
-import type { TagListItem, TagSortOption, TagView } from '../types'
+import type { TagListItem, TagSortOption } from '../types'
 import { TagOfficialIndicator } from './TagOfficialIndicator'
 
 const PAGE_SIZE = 50
 const SEARCH_DEBOUNCE_MS = 300
-
-// Cloud view: font-size interpolates on a log scale so a long usage_count
-// tail (a handful of mega-tags + many small ones) stays readable instead of
-// being dominated by one giant word.
-const CLOUD_MIN_PX = 13
-const CLOUD_MAX_PX = 30
 
 function toSort(value: string | null): TagSortOption {
   const match = TAG_SORT_OPTIONS.find(o => o.value === value)
   return match?.value ?? DEFAULT_TAG_SORT
 }
 
-function toView(value: string | null): TagView {
-  return value === 'cloud' ? 'cloud' : 'grid'
-}
-
 function sortToBackend(sort: TagSortOption): string {
   return TAG_SORT_OPTIONS.find(o => o.value === sort)?.backend ?? 'usage'
 }
 
-export function cloudFontSizePx(
-  usageCount: number,
-  minUsage: number,
-  maxUsage: number
-): number {
-  if (maxUsage <= minUsage) return (CLOUD_MIN_PX + CLOUD_MAX_PX) / 2
-  const lo = Math.log(Math.max(1, minUsage) + 1)
-  const hi = Math.log(Math.max(1, maxUsage) + 1)
-  const v = Math.log(Math.max(1, usageCount) + 1)
-  const t = (v - lo) / (hi - lo)
-  return CLOUD_MIN_PX + t * (CLOUD_MAX_PX - CLOUD_MIN_PX)
+/**
+ * Per-category total counts for the facet chips, scoped to the active search
+ * term but NOT to the selected category — each chip reports how many tags
+ * that facet would surface, so a chip can be disabled when it has none.
+ * One `useTags({category, limit:1})` per category (3 categories ⇒ 3 bounded
+ * requests, same approach as TagFacetPanel). `all` is the cross-category sum.
+ */
+function useCategoryCounts(search: string | undefined): {
+  counts: Record<string, number>
+  all: number
+} {
+  const genre = useTags({ category: 'genre', search, limit: 1 })
+  const locale = useTags({ category: 'locale', search, limit: 1 })
+  const other = useTags({ category: 'other', search, limit: 1 })
+
+  const counts: Record<string, number> = {
+    genre: genre.data?.total ?? 0,
+    locale: locale.data?.total ?? 0,
+    other: other.data?.total ?? 0,
+  }
+  return { counts, all: counts.genre + counts.locale + counts.other }
 }
 
 export function TagBrowse() {
@@ -61,12 +62,18 @@ export function TagBrowse() {
   const [isPending, startTransition] = useTransition()
 
   const sort = toSort(searchParams.get('sort'))
-  const view = toView(searchParams.get('view'))
 
   const [category, setCategory] = useState('')
   const [searchInput, setSearchInput] = useState('')
   const [debouncedSearch] = useDebounce(searchInput.trim(), SEARCH_DEBOUNCE_MS)
   const [offset, setOffset] = useState(0)
+
+  // Autofocus the search box on mount so a returning visitor can type-to-filter
+  // immediately (acceptance criterion + Figma 412:7 placeholder copy).
+  const searchRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    searchRef.current?.focus()
+  }, [])
 
   const { data, isLoading, error, refetch } = useTags({
     category: category || undefined,
@@ -76,19 +83,20 @@ export function TagBrowse() {
     sort: sortToBackend(sort),
   })
 
+  const { counts, all: allCount } = useCategoryCounts(debouncedSearch || undefined)
+
   const tags = data?.tags ?? []
   const total = data?.total ?? 0
   const hasMore = offset + PAGE_SIZE < total
+  const pageStart = total === 0 ? 0 : offset + 1
+  const pageEnd = Math.min(offset + PAGE_SIZE, total)
 
-  const updateParams = (patch: Partial<{ sort: TagSortOption; view: TagView }>) => {
+  const updateSort = (nextSort: TagSortOption) => {
     const next = new URLSearchParams(searchParams.toString())
-    const nextSort = patch.sort ?? sort
-    const nextView = patch.view ?? view
     if (nextSort === DEFAULT_TAG_SORT) next.delete('sort')
     else next.set('sort', nextSort)
-    if (nextView === DEFAULT_TAG_VIEW) next.delete('view')
-    else next.set('view', nextView)
     const qs = next.toString()
+    setOffset(0)
     startTransition(() => {
       router.replace(qs ? `/tags?${qs}` : '/tags', { scroll: false })
     })
@@ -116,17 +124,14 @@ export function TagBrowse() {
       ? `No ${getCategoryLabel(category).toLowerCase()} tags yet.`
       : 'No tags found.'
 
-  const usageValues = tags.map(t => t.usage_count)
-  const minUsage = usageValues.length ? Math.min(...usageValues) : 0
-  const maxUsage = usageValues.length ? Math.max(...usageValues) : 0
-
   return (
     <section className="w-full max-w-6xl" aria-busy={isPending}>
-      {/* Search + controls */}
-      <div className="mb-6 flex flex-wrap items-center gap-3">
-        <div className="relative w-full max-w-md">
+      {/* Search + sort controls */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative min-w-0 flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
+            ref={searchRef}
             type="search"
             value={searchInput}
             onChange={e => {
@@ -139,90 +144,56 @@ export function TagBrowse() {
           />
         </div>
 
-        <label className="sr-only" htmlFor="tag-sort">
-          Sort tags
-        </label>
-        <select
-          id="tag-sort"
-          value={sort}
-          onChange={e => updateParams({ sort: toSort(e.target.value) })}
-          className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          aria-label="Sort tags"
-        >
-          {TAG_SORT_OPTIONS.map(opt => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-
         <div
           className="inline-flex items-center rounded-lg border border-border/50 bg-muted/30 p-0.5"
           role="radiogroup"
-          aria-label="Tag layout"
+          aria-label="Sort tags"
         >
-          {(
-            [
-              { value: 'grid' as const, label: 'Grid', Icon: LayoutGrid },
-              { value: 'cloud' as const, label: 'Cloud', Icon: Cloud },
-            ]
-          ).map(({ value, label, Icon }) => (
+          {TAG_SORT_OPTIONS.map(opt => (
             <button
-              key={value}
+              key={opt.value}
               type="button"
               role="radio"
-              aria-checked={view === value}
-              onClick={() => updateParams({ view: value })}
-              data-testid={`view-${value}`}
+              aria-checked={sort === opt.value}
+              onClick={() => updateSort(opt.value)}
+              data-testid={`sort-${opt.value}`}
               className={cn(
-                'flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-100',
-                view === value
+                'rounded-md px-2.5 py-1 text-xs font-medium transition-colors duration-100',
+                sort === opt.value
                   ? 'bg-background text-foreground shadow-sm'
                   : 'text-muted-foreground hover:text-foreground'
               )}
             >
-              <Icon className="h-3.5 w-3.5" />
-              {label}
+              {opt.label}
             </button>
           ))}
         </div>
       </div>
 
-      {/* Category filter tabs */}
-      <div className="flex items-center gap-1.5 flex-wrap mb-6">
-        <button
+      {/* Category facet chips + result range */}
+      <div className="mb-4 flex flex-wrap items-center gap-1.5">
+        <FacetChip
+          label="All"
+          count={allCount}
+          active={!category}
           onClick={() => handleCategoryChange('')}
-          className={cn(
-            'rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
-            !category
-              ? 'bg-foreground text-background'
-              : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
-          )}
-        >
-          All
-        </button>
+        />
         {TAG_CATEGORIES.map(cat => (
-          <button
+          <FacetChip
             key={cat}
+            label={getCategoryLabel(cat)}
+            count={counts[cat] ?? 0}
+            active={category === cat}
+            categoryTint={getCategoryColor(cat)}
             onClick={() => handleCategoryChange(cat)}
-            className={cn(
-              'rounded-full px-3 py-1.5 text-xs font-medium transition-colors border',
-              category === cat
-                ? getCategoryColor(cat)
-                : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground border-transparent'
-            )}
-          >
-            {getCategoryLabel(cat)}
-          </button>
+          />
         ))}
+        {total > 0 && (
+          <p className="ml-auto text-sm text-muted-foreground">
+            {total} {total === 1 ? 'tag' : 'tags'}
+          </p>
+        )}
       </div>
-
-      {/* Results count */}
-      {total > 0 && (
-        <p className="text-sm text-muted-foreground mb-4">
-          {total} {total === 1 ? 'tag' : 'tags'} found
-        </p>
-      )}
 
       {/* Loading state */}
       {isLoading && !data && (
@@ -231,13 +202,14 @@ export function TagBrowse() {
         </div>
       )}
 
-      {/* Tag list */}
+      {/* Tag directory table */}
       {!isLoading && tags.length === 0 ? (
         <div className="text-center py-12 text-muted-foreground">
           {debouncedSearch ? (
             <>
               <p>
-                No tags match <span className="font-medium">&ldquo;{debouncedSearch}&rdquo;</span>.
+                No tags match{' '}
+                <span className="font-medium">&ldquo;{debouncedSearch}&rdquo;</span>.
               </p>
               <p className="text-sm mt-2">Try a different search term.</p>
             </>
@@ -245,50 +217,38 @@ export function TagBrowse() {
             <p>{emptyStateMessage}</p>
           )}
         </div>
-      ) : view === 'cloud' ? (
-        <div
-          className="flex flex-wrap items-center gap-x-3 gap-y-2 leading-tight"
-          data-testid="tag-cloud"
-        >
-          {tags.map(tag => (
-            <TagCloudItem
-              key={tag.id}
-              tag={tag}
-              fontSizePx={cloudFontSizePx(tag.usage_count, minUsage, maxUsage)}
-            />
-          ))}
-        </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {tags.map((tag: TagListItem) => (
-            <TagCard key={tag.id} tag={tag} />
-          ))}
-        </div>
+        tags.length > 0 && <TagDirectoryTable tags={tags} />
       )}
 
       {/* Pagination */}
       {(offset > 0 || hasMore) && (
-        <div className="flex items-center justify-center gap-3 mt-8">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={offset === 0}
-            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-          >
-            Previous
-          </Button>
-          <span className="text-sm text-muted-foreground">
-            Page {Math.floor(offset / PAGE_SIZE) + 1} of{' '}
-            {Math.ceil(total / PAGE_SIZE)}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={!hasMore}
-            onClick={() => setOffset(offset + PAGE_SIZE)}
-          >
-            Next
-          </Button>
+        <div className="mt-8 flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            Showing {pageStart}–{pageEnd} of {total}
+          </p>
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              Page {Math.floor(offset / PAGE_SIZE) + 1} of{' '}
+              {Math.ceil(total / PAGE_SIZE)}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasMore}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Next
+            </Button>
+          </div>
         </div>
       )}
     </section>
@@ -296,69 +256,130 @@ export function TagBrowse() {
 }
 
 // ──────────────────────────────────────────────
-// Tag Card (grid view)
+// Facet chip (All / Genre / Locale / Other)
 // ──────────────────────────────────────────────
 
-function TagCard({ tag }: { tag: TagListItem }) {
+function FacetChip({
+  label,
+  count,
+  active,
+  categoryTint,
+  onClick,
+}: {
+  label: string
+  count: number
+  active: boolean
+  /** Category tint classes (from getCategoryColor) applied when active. */
+  categoryTint?: string
+  onClick: () => void
+}) {
+  // Zero-result facets are disabled — clicking them would only show an empty
+  // table. An active chip stays interactive so the user can always deselect.
+  const disabled = count === 0 && !active
   return (
-    <Link
-      href={`/tags/${tag.slug}`}
-      className="group flex items-start gap-3 rounded-lg border border-border/50 bg-card p-4 hover:border-border hover:bg-muted/30 transition-colors"
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      data-testid={`facet-${label.toLowerCase()}`}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+        active
+          ? categoryTint
+            ? categoryTint
+            : 'border-foreground bg-foreground text-background'
+          : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted/70 hover:text-foreground',
+        disabled && 'cursor-not-allowed opacity-40 hover:bg-muted/40 hover:text-muted-foreground'
+      )}
     >
-      <div className="mt-0.5">
-        <Hash className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-1">
-          <span className="font-medium text-sm group-hover:text-foreground truncate">
-            {tag.name}
-          </span>
-          {tag.is_official && (
-            <TagOfficialIndicator size="md" tagName={tag.name} />
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          <span
-            className={cn(
-              'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium',
-              getCategoryColor(tag.category)
-            )}
-          >
-            {getCategoryLabel(tag.category)}
-          </span>
-          <span className="text-xs text-muted-foreground">
-            {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
-          </span>
-        </div>
-      </div>
-    </Link>
+      <span>{label}</span>
+      <span className="tabular-nums opacity-70">{count}</span>
+    </button>
   )
 }
 
 // ──────────────────────────────────────────────
-// Tag Cloud Item (cloud view)
+// Tag directory table (dense, sortable, zebra-striped)
 // ──────────────────────────────────────────────
 
-function TagCloudItem({
-  tag,
-  fontSizePx,
-}: {
-  tag: TagListItem
-  fontSizePx: number
-}) {
+function TagDirectoryTable({ tags }: { tags: TagListItem[] }) {
+  // Keyboard nav: ↑/↓ move focus between row links; Enter is native on the
+  // anchor. Refs index by row order so arrow keys can shift focus.
+  const rowRefs = useRef<(HTMLAnchorElement | null)[]>([])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTableSectionElement>) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+    const current = rowRefs.current.findIndex(el => el === document.activeElement)
+    if (current === -1) return
+    e.preventDefault()
+    const nextIndex =
+      e.key === 'ArrowDown'
+        ? Math.min(current + 1, tags.length - 1)
+        : Math.max(current - 1, 0)
+    rowRefs.current[nextIndex]?.focus()
+  }
+
   return (
-    <Link
-      href={`/tags/${tag.slug}`}
-      data-testid={`tag-cloud-item-${tag.slug}`}
-      style={{ fontSize: `${fontSizePx}px` }}
-      className={cn(
-        'inline-flex items-center gap-1 rounded-md px-2 py-0.5',
-        'text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors'
-      )}
-      title={`${tag.name} (${tag.usage_count} ${tag.usage_count === 1 ? 'use' : 'uses'})`}
-    >
-      <span>{tag.name}</span>
-      {tag.is_official && <TagOfficialIndicator size="sm" tagName={tag.name} />}
-    </Link>
+    <DenseTable variant="alternating">
+      <thead>
+        <tr>
+          <th scope="col">Tag</th>
+          <th scope="col">Category</th>
+          <th scope="col" className="text-right">
+            Uses
+          </th>
+        </tr>
+      </thead>
+      <tbody onKeyDown={handleKeyDown}>
+        {tags.map((tag, i) => (
+          <tr
+            key={tag.id}
+            className="cursor-pointer transition-colors hover:bg-muted/40"
+          >
+            <td>
+              <Link
+                ref={el => {
+                  rowRefs.current[i] = el
+                }}
+                href={`/tags/${tag.slug}`}
+                className="group inline-flex items-center gap-2 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Hash
+                  className="h-3.5 w-3.5 shrink-0 text-muted-foreground group-hover:text-foreground transition-colors"
+                  aria-hidden
+                />
+                <span className="font-medium text-foreground group-hover:underline">
+                  {tag.name}
+                </span>
+                {tag.is_official && (
+                  <TagOfficialIndicator size="sm" tagName={tag.name} />
+                )}
+              </Link>
+            </td>
+            <td>
+              <span className={cn('text-xs font-medium', categoryTextTint(tag.category))}>
+                {getCategoryLabel(tag.category)}
+              </span>
+            </td>
+            <td className="text-right tabular-nums text-muted-foreground">
+              {tag.usage_count}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </DenseTable>
   )
+}
+
+/**
+ * Category as a tinted TEXT label (not a pill). Reuses getCategoryColor's
+ * token mapping but drops the bg/border classes so only the foreground tint
+ * lands: genre = chart-6 (denim), locale = chart-8 (teal), other = muted.
+ */
+function categoryTextTint(category: string): string {
+  const text = getCategoryColor(category)
+    .split(' ')
+    .find(c => c.startsWith('text-'))
+  return text ?? 'text-muted-foreground'
 }

--- a/frontend/features/tags/index.ts
+++ b/frontend/features/tags/index.ts
@@ -25,12 +25,11 @@ export {
   TAG_ENTITY_TYPES,
   TAG_SORT_OPTIONS,
   DEFAULT_TAG_SORT,
-  DEFAULT_TAG_VIEW,
   getCategoryColor,
   getCategoryLabel,
 } from './types'
 
-export type { TagSortOption, TagView } from './types'
+export type { TagSortOption } from './types'
 
 export {
   useTags,

--- a/frontend/features/tags/types.test.ts
+++ b/frontend/features/tags/types.test.ts
@@ -3,7 +3,6 @@ import {
   TAG_CATEGORIES,
   TAG_SORT_OPTIONS,
   DEFAULT_TAG_SORT,
-  DEFAULT_TAG_VIEW,
   TAG_ENTITY_TYPES,
   LOW_QUALITY_REASON_LABELS,
   LOW_QUALITY_SIGNAL_CHIPS,
@@ -26,9 +25,8 @@ describe('tag constants', () => {
     ])
   })
 
-  it('defaults sort to popularity and view to grid', () => {
+  it('defaults sort to popularity', () => {
     expect(DEFAULT_TAG_SORT).toBe('popularity')
-    expect(DEFAULT_TAG_VIEW).toBe('grid')
   })
 
   it('lists the polymorphic tag entity types (collection included)', () => {

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -17,9 +17,6 @@ export const TAG_SORT_OPTIONS: { value: TagSortOption; label: string; backend: s
 
 export const DEFAULT_TAG_SORT: TagSortOption = 'popularity'
 
-export type TagView = 'grid' | 'cloud'
-export const DEFAULT_TAG_VIEW: TagView = 'grid'
-
 export const TAG_ENTITY_TYPES = [
   // PSY-354: collection joined the polymorphic tag corpus. Order matches
   // backend `models.TagEntityTypes`.


### PR DESCRIPTION
## Summary

Rebuilds `/tags` browse as a dense, sortable directory table (Tag · Category · Uses), replacing the 3-column card grid **and** the tag-cloud view per the approved Figma reference (node `412:7`, PSY-979).

- **Dense table** built on the shared `DenseTable` primitive (`alternating`/zebra variant): right-aligned `tabular-nums` usage counts, uppercase muted column headers, a bottom-bordered (sticky-style) header row, ~44px rows. Left cell is the tag name with a `#` glyph; official tags get the compact `TagOfficialIndicator`.
- **Category** renders as a tinted **text** label (not a pill) via `getCategoryColor` — genre = chart-6 (denim), locale = chart-8 (teal), other = muted. The tint is derived from the canonical `getCategoryColor` map so the two surfaces can't drift.
- **Facet chips** (All / Genre / Locale / Other) now show **live per-category counts**; zero-result facets are **disabled**. Counts respect the active search term via one bounded count query per category (same approach as `TagFacetPanel`; categories are backend-constrained to the three, so the `All` sum is exhaustive).
- **Search** autofocuses on mount and keeps the existing debounced server search; **sort** (Popularity / A–Z / Newest) and the existing offset pager are unchanged in behavior.
- **Keyboard nav**: ↑/↓ move row focus, Enter opens (native on the row anchor).
- **Removed**: card grid, tag cloud, grid/cloud toggle, `cloudFontSizePx`, the `?view=cloud` param, and the now-unused `TagView` / `DEFAULT_TAG_VIEW` types (plus their barrel exports and tests). Verified no dangling references remain.

No backend change (uses the existing `useTags` hook).

## Test plan

- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:run features/tags` — 265 passed (13 files); `TagBrowse.test.tsx` rewritten to drop cloud/grid assertions and add table-structure, tinted-text-category, right-aligned-uses, live-facet-count, **disabled zero-result facet**, sort segmented-control, and **keyboard ↑/↓** assertions. `types.test.ts` updated to drop the removed `DEFAULT_TAG_VIEW` export.

## Manual repro

Ran the per-worktree dispatch stack (isolated mode), seeded 24 representative tags (Genre 18 / Locale 4 / Other 2), and exercised `/tags` in a real browser (Chrome DevTools MCP):

- Dense zebra table renders with `#` + tag name, tinted category text, right-aligned uses — matches Figma 412:7.
- Search box is autofocused on load; typing `rock` filters to 4 genre rows.
- While filtered to `rock`: facet chips updated to **All 4 / Genre 4 / Locale 0 (disabled) / Other 0 (disabled)** — confirms live counts respect search AND zero-result facets disable.
- Sort: clicking **A–Z** sets `?sort=alphabetical` and reorders all 24 tags alphabetically; clicking back to **Popularity** strips the param.
- Keyboard: focus first row → ArrowDown moves to next row → ArrowUp moves back → Enter navigates to the tag detail page (`/tags/diy`).
- Verified light **and** dark mode (DS tokens track the cascade automatically).

## Screenshots

**Light mode**
![light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-992-screenshots/psy-992-light.png)

**Dark mode**
![dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-992-screenshots/psy-992-dark.png)

**Search filter with disabled zero-result facets** (search `rock` → Locale 0 / Other 0 disabled)
![search-disabled-facet](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-992-screenshots/psy-992-search-disabled-facet.png)

## Code review

`/code-review` (xhigh, 9 lenses, inline — no Agent tool in worktree). No CONFIRMED/PLAUSIBLE correctness bugs.
- Keyboard-nav stale-ref scenario analyzed → benign (unmounted rows' ref callbacks null out their slots; `findIndex(activeElement)` returns -1 → early return).
- All removed symbols (`cloudFontSizePx`, `TagCard`, `TagCloudItem`, `tag-cloud`/`view-*` testids, `TagView`, `DEFAULT_TAG_VIEW`) grep-confirmed fully scrubbed; no other consumers.
- Reuses `DenseTable` + `getCategoryColor` (no reinvention); 3 bounded count queries mirror the established `TagFacetPanel` pattern.

## Adversarial review

`/adversarial-review` — CONCERNS, 1 finding addressed in commit `2a486ba0`.
- [MEDIUM] (Future-Maintainer) `categoryTextTint` parses a `text-*` token out of `getCategoryColor`'s className string → documented the contract dependency (one `text-*` token; test-covered fallback). Kept derivation over a re-hardcoded map to avoid drift.
- [REFUTED] (Saboteur) "`All` count could diverge from the true total" → backend `tag_service.IsValidTagCategory` constrains every tag to genre/locale/other, so the client-side sum is exhaustive.
- Security: public browse, no new inputs / injection surface. Completeness: all acceptance criteria verified in-browser.

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

Closes PSY-992

