### PR TITLE
PSY-996: render show-notification event_date in the venue timezone

### DIFF
--- a/backend/internal/services/engagement/reminder.go
+++ b/backend/internal/services/engagement/reminder.go
@@ -15,6 +15,7 @@ import (
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/services/shared"
+	"psychic-homily-backend/internal/utils"
 )
 
 // Default reminder check interval (30 minutes)
@@ -28,6 +29,7 @@ type reminderRow struct {
 	ShowTitle string
 	ShowSlug  string
 	EventDate time.Time
+	State     *string // show state — fallback for venue-local rendering (PSY-996)
 }
 
 // ReminderService sends email reminders for saved shows ~24h before the event
@@ -108,7 +110,8 @@ func (s *ReminderService) runReminderCycle() {
 			u.email,
 			s.title AS show_title,
 			COALESCE(s.slug, CAST(s.id AS TEXT)) AS show_slug,
-			s.event_date
+			s.event_date,
+			s.state
 		FROM user_bookmarks ub
 		JOIN shows s ON s.id = ub.entity_id
 		JOIN users u ON u.id = ub.user_id
@@ -136,8 +139,13 @@ func (s *ReminderService) runReminderCycle() {
 
 	s.logger.Info("found shows to send reminders for", "count", len(rows))
 
-	// Collect venue names for each show
-	venueCache := make(map[uint][]string)
+	// Collect venue names + the first venue's timezone for each show.
+	type venueInfo struct {
+		names    []string
+		timezone *string
+		state    string
+	}
+	venueCache := make(map[uint]venueInfo)
 
 	sentCount := 0
 	errorCount := 0
@@ -145,14 +153,36 @@ func (s *ReminderService) runReminderCycle() {
 	for _, row := range rows {
 		// Fetch venues if not cached
 		if _, ok := venueCache[row.ShowID]; !ok {
-			var venueNames []string
+			type vRow struct {
+				Name     string
+				Timezone *string
+				State    string
+			}
+			var vRows []vRow
 			s.db.Raw(`
-				SELECT v.name FROM venues v
+				SELECT v.name, v.timezone, v.state FROM venues v
 				JOIN show_venues sv ON sv.venue_id = v.id
 				WHERE sv.show_id = ?
-			`, row.ShowID).Scan(&venueNames)
-			venueCache[row.ShowID] = venueNames
+			`, row.ShowID).Scan(&vRows)
+			info := venueInfo{}
+			for i, v := range vRows {
+				info.names = append(info.names, v.Name)
+				if i == 0 {
+					info.timezone = v.Timezone
+					info.state = v.State
+				}
+			}
+			venueCache[row.ShowID] = info
 		}
+		info := venueCache[row.ShowID]
+
+		// Render the event time in the venue's local zone (PSY-996): prefer the
+		// first venue's timezone, fall back to the venue/show state.
+		locState := info.state
+		if locState == "" && row.State != nil {
+			locState = *row.State
+		}
+		localizedEvent := row.EventDate.In(utils.EventLocation(info.timezone, locState))
 
 		showURL := fmt.Sprintf("%s/shows/%s", s.frontendURL, row.ShowSlug)
 		unsubscribeURL := GenerateUnsubscribeURL(s.frontendURL, row.UserID, s.jwtSecret)
@@ -162,8 +192,8 @@ func (s *ReminderService) runReminderCycle() {
 			row.ShowTitle,
 			showURL,
 			unsubscribeURL,
-			row.EventDate,
-			venueCache[row.ShowID],
+			localizedEvent,
+			info.names,
 		)
 		if err != nil {
 			s.logger.Error("failed to send show reminder email",

--- a/backend/internal/services/notification/discord.go
+++ b/backend/internal/services/notification/discord.go
@@ -19,32 +19,16 @@ import (
 	"psychic-homily-backend/internal/utils"
 )
 
-// eventLocation resolves the IANA location for rendering a show's event time in
-// the venue's local zone: prefer an explicit venue timezone (PSY-985), fall back
-// to the US state->tz map, then UTC. Notifications previously formatted the raw
-// UTC instant, so an evening US show (e.g. 8 PM Central, stored as 01:00Z the
-// next day) rendered as "1:00 AM" on the wrong date. (PSY-996)
-func eventLocation(timezone *string, stateFallback string) *time.Location {
-	tz := ""
-	if timezone != nil {
-		tz = *timezone
-	}
-	if tz == "" {
-		tz = utils.GetTimezoneForState(stateFallback)
-	}
-	if loc, err := time.LoadLocation(tz); err == nil {
-		return loc
-	}
-	return time.UTC
-}
-
 // showResponseLocation resolves the event-time location for a ShowResponse from
-// its first venue's timezone, falling back to the show's state.
+// its first venue's timezone, falling back to the show's state. Show
+// notifications previously formatted the raw UTC instant, so an evening US show
+// (e.g. 8 PM Central, stored as 01:00Z the next day) rendered as "1:00 AM" on
+// the wrong date. (PSY-996)
 func showResponseLocation(show *contracts.ShowResponse) *time.Location {
 	if len(show.Venues) > 0 {
-		return eventLocation(show.Venues[0].Timezone, show.Venues[0].State)
+		return utils.EventLocation(show.Venues[0].Timezone, show.Venues[0].State)
 	}
-	return eventLocation(nil, derefString(show.State))
+	return utils.EventLocation(nil, derefString(show.State))
 }
 
 // derefString returns the pointed-to string, or "" when nil.
@@ -269,7 +253,7 @@ func (s *DiscordService) NotifyShowReport(report *communitym.ShowReport, reporte
 	eventDate := "Unknown Date"
 	if report.Show.ID != 0 {
 		showTitle = report.Show.Title
-		eventDate = report.Show.EventDate.In(eventLocation(nil, derefString(report.Show.State))).Format("Jan 2, 2006")
+		eventDate = report.Show.EventDate.In(utils.EventLocation(nil, derefString(report.Show.State))).Format("Jan 2, 2006")
 	}
 
 	fields := []DiscordEmbedField{

--- a/backend/internal/services/notification/discord.go
+++ b/backend/internal/services/notification/discord.go
@@ -19,6 +19,42 @@ import (
 	"psychic-homily-backend/internal/utils"
 )
 
+// eventLocation resolves the IANA location for rendering a show's event time in
+// the venue's local zone: prefer an explicit venue timezone (PSY-985), fall back
+// to the US state->tz map, then UTC. Notifications previously formatted the raw
+// UTC instant, so an evening US show (e.g. 8 PM Central, stored as 01:00Z the
+// next day) rendered as "1:00 AM" on the wrong date. (PSY-996)
+func eventLocation(timezone *string, stateFallback string) *time.Location {
+	tz := ""
+	if timezone != nil {
+		tz = *timezone
+	}
+	if tz == "" {
+		tz = utils.GetTimezoneForState(stateFallback)
+	}
+	if loc, err := time.LoadLocation(tz); err == nil {
+		return loc
+	}
+	return time.UTC
+}
+
+// showResponseLocation resolves the event-time location for a ShowResponse from
+// its first venue's timezone, falling back to the show's state.
+func showResponseLocation(show *contracts.ShowResponse) *time.Location {
+	if len(show.Venues) > 0 {
+		return eventLocation(show.Venues[0].Timezone, show.Venues[0].State)
+	}
+	return eventLocation(nil, derefString(show.State))
+}
+
+// derefString returns the pointed-to string, or "" when nil.
+func derefString(s *string) string {
+	if s != nil {
+		return *s
+	}
+	return ""
+}
+
 // Discord embed colors
 const (
 	ColorGreen  = 0x00FF00 // New user signups, show approved
@@ -126,7 +162,7 @@ func (s *DiscordService) NotifyNewShow(show *contracts.ShowResponse, submitterEm
 
 	embed := DiscordEmbed{
 		Title:       fmt.Sprintf("New Show: %s", show.Title),
-		Description: fmt.Sprintf("Event Date: %s", show.EventDate.Format("Jan 2, 2006 3:04 PM")),
+		Description: fmt.Sprintf("Event Date: %s", show.EventDate.In(showResponseLocation(show)).Format("Jan 2, 2006 3:04 PM")),
 		Color:       ColorBlue,
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
 		Fields:      fields,
@@ -178,7 +214,7 @@ func (s *DiscordService) NotifyShowApproved(show *contracts.ShowResponse) {
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Fields: []DiscordEmbedField{
 			{Name: "Show ID", Value: fmt.Sprintf("%d", show.ID), Inline: true},
-			{Name: "Event Date", Value: show.EventDate.Format("Jan 2, 2006"), Inline: true},
+			{Name: "Event Date", Value: show.EventDate.In(showResponseLocation(show)).Format("Jan 2, 2006"), Inline: true},
 			{Name: "Venue(s)", Value: venues, Inline: false},
 			{Name: "Actions", Value: viewLink, Inline: false},
 		},
@@ -203,7 +239,7 @@ func (s *DiscordService) NotifyShowRejected(show *contracts.ShowResponse, reason
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
 		Fields: []DiscordEmbedField{
 			{Name: "Show ID", Value: fmt.Sprintf("%d", show.ID), Inline: true},
-			{Name: "Event Date", Value: show.EventDate.Format("Jan 2, 2006"), Inline: true},
+			{Name: "Event Date", Value: show.EventDate.In(showResponseLocation(show)).Format("Jan 2, 2006"), Inline: true},
 			{Name: "Venue(s)", Value: venues, Inline: false},
 			{Name: "Actions", Value: adminLink, Inline: false},
 		},
@@ -233,7 +269,7 @@ func (s *DiscordService) NotifyShowReport(report *communitym.ShowReport, reporte
 	eventDate := "Unknown Date"
 	if report.Show.ID != 0 {
 		showTitle = report.Show.Title
-		eventDate = report.Show.EventDate.Format("Jan 2, 2006")
+		eventDate = report.Show.EventDate.In(eventLocation(nil, derefString(report.Show.State))).Format("Jan 2, 2006")
 	}
 
 	fields := []DiscordEmbedField{

--- a/backend/internal/services/notification/discord_test.go
+++ b/backend/internal/services/notification/discord_test.go
@@ -893,3 +893,43 @@ func TestNotifyBackfillCompleted_CapsAtTwentyFive(t *testing.T) {
 	assert.Contains(t, payload.Embeds[0].Fields[0].Value, "…and 5 more")
 	assert.Contains(t, payload.Embeds[0].Description, "30 show(s)")
 }
+
+// TestNotifyNewShow_RendersEventTimeInVenueTimezone is the regression for PSY-996:
+// an 8 PM Central show (stored as 01:00Z the next day) must render in venue-local
+// time, not the raw UTC instant ("Jul 10, 2026 1:00 AM").
+func TestNotifyNewShow_RendersEventTimeInVenueTimezone(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+	chicago := "America/Chicago"
+	show := &contracts.ShowResponse{
+		ID:        68,
+		Title:     "Snooper",
+		EventDate: time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC), // 8 PM CDT on Jul 9
+		Status:    "approved",
+		Venues:    []contracts.VenueResponse{{Name: "Gremlin", City: "McAllen", State: "TX", Timezone: &chicago}},
+	}
+
+	svc.NotifyNewShow(show, "submitter@test.com")
+
+	raw := waitForPayload(t, payloads)
+	payload := parseWebhookPayload(t, raw)
+	require.Len(t, payload.Embeds, 1)
+	assert.Contains(t, payload.Embeds[0].Description, "Jul 9, 2026 8:00 PM")
+	assert.NotContains(t, payload.Embeds[0].Description, "1:00 AM")
+}
+
+// TestEventLocation covers the timezone resolution: venue timezone wins, US state
+// is the fallback, and unknown input degrades to America/Phoenix (no crash).
+func TestEventLocation(t *testing.T) {
+	instant := time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC) // 8 PM CDT on Jul 9
+
+	if got := instant.In(eventLocation(nil, "TX")).Format("Jan 2, 2006 3:04 PM"); got != "Jul 9, 2026 8:00 PM" {
+		t.Errorf("TX state fallback: got %q, want %q", got, "Jul 9, 2026 8:00 PM")
+	}
+	london := "Europe/London"
+	if got := eventLocation(&london, "TX").String(); got != "Europe/London" {
+		t.Errorf("explicit venue tz should win: got %q, want Europe/London", got)
+	}
+	if got := eventLocation(nil, "").String(); got != "America/Phoenix" {
+		t.Errorf("empty fallback: got %q, want America/Phoenix", got)
+	}
+}

--- a/backend/internal/services/notification/discord_test.go
+++ b/backend/internal/services/notification/discord_test.go
@@ -905,7 +905,10 @@ func TestNotifyNewShow_RendersEventTimeInVenueTimezone(t *testing.T) {
 		Title:     "Snooper",
 		EventDate: time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC), // 8 PM CDT on Jul 9
 		Status:    "approved",
-		Venues:    []contracts.VenueResponse{{Name: "Gremlin", City: "McAllen", State: "TX", Timezone: &chicago}},
+		// State and Timezone deliberately disagree (NY=Eastern vs Chicago=Central)
+		// so the assertion proves venue.Timezone wins over the state fallback:
+		// 01:00Z is 8 PM in Chicago but 9 PM in New York.
+		Venues: []contracts.VenueResponse{{Name: "Gremlin", City: "McAllen", State: "NY", Timezone: &chicago}},
 	}
 
 	svc.NotifyNewShow(show, "submitter@test.com")
@@ -915,21 +918,4 @@ func TestNotifyNewShow_RendersEventTimeInVenueTimezone(t *testing.T) {
 	require.Len(t, payload.Embeds, 1)
 	assert.Contains(t, payload.Embeds[0].Description, "Jul 9, 2026 8:00 PM")
 	assert.NotContains(t, payload.Embeds[0].Description, "1:00 AM")
-}
-
-// TestEventLocation covers the timezone resolution: venue timezone wins, US state
-// is the fallback, and unknown input degrades to America/Phoenix (no crash).
-func TestEventLocation(t *testing.T) {
-	instant := time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC) // 8 PM CDT on Jul 9
-
-	if got := instant.In(eventLocation(nil, "TX")).Format("Jan 2, 2006 3:04 PM"); got != "Jul 9, 2026 8:00 PM" {
-		t.Errorf("TX state fallback: got %q, want %q", got, "Jul 9, 2026 8:00 PM")
-	}
-	london := "Europe/London"
-	if got := eventLocation(&london, "TX").String(); got != "Europe/London" {
-		t.Errorf("explicit venue tz should win: got %q, want Europe/London", got)
-	}
-	if got := eventLocation(nil, "").String(); got != "America/Phoenix" {
-		t.Errorf("empty fallback: got %q, want America/Phoenix", got)
-	}
 }

--- a/backend/internal/services/notification/filter_service.go
+++ b/backend/internal/services/notification/filter_service.go
@@ -22,6 +22,7 @@ import (
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/services/engagement"
 	"psychic-homily-backend/internal/services/shared"
+	"psychic-homily-backend/internal/utils"
 )
 
 // NotificationFilterService handles notification filter CRUD, matching, and delivery.
@@ -550,14 +551,35 @@ func (s *NotificationFilterService) sendFilterEmail(userID uint, filterID uint, 
 
 	// Build show info
 	showTitle := show.Title
-	// Render in the venue's local zone (PSY-996); show.State drives the fallback.
-	showDate := show.EventDate.In(eventLocation(nil, derefString(show.State))).Format("Monday, January 2, 2006")
 
-	var venueNames []string
+	// Fetch venues with timezone so the event time renders in the venue's local
+	// zone (PSY-996), preferring the first venue's timezone over the state map.
+	type venueRow struct {
+		Name     string
+		Timezone *string
+		State    string
+	}
+	var venueRows []venueRow
 	s.db.Table("show_venues").
+		Select("venues.name, venues.timezone, venues.state").
 		Joins("JOIN venues ON venues.id = show_venues.venue_id").
 		Where("show_venues.show_id = ?", show.ID).
-		Pluck("venues.name", &venueNames)
+		Scan(&venueRows)
+
+	venueNames := make([]string, 0, len(venueRows))
+	var venueTZ *string
+	venueState := derefString(show.State)
+	for i, v := range venueRows {
+		venueNames = append(venueNames, v.Name)
+		if i == 0 {
+			venueTZ = v.Timezone
+			if v.State != "" {
+				venueState = v.State
+			}
+		}
+	}
+
+	showDate := show.EventDate.In(utils.EventLocation(venueTZ, venueState)).Format("Monday, January 2, 2006")
 
 	var artistNames []string
 	s.db.Table("show_artists").

--- a/backend/internal/services/notification/filter_service.go
+++ b/backend/internal/services/notification/filter_service.go
@@ -550,7 +550,8 @@ func (s *NotificationFilterService) sendFilterEmail(userID uint, filterID uint, 
 
 	// Build show info
 	showTitle := show.Title
-	showDate := show.EventDate.Format("Monday, January 2, 2006")
+	// Render in the venue's local zone (PSY-996); show.State drives the fallback.
+	showDate := show.EventDate.In(eventLocation(nil, derefString(show.State))).Format("Monday, January 2, 2006")
 
 	var venueNames []string
 	s.db.Table("show_venues").

--- a/backend/internal/utils/timezone.go
+++ b/backend/internal/utils/timezone.go
@@ -1,6 +1,9 @@
 package utils
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 // StateTimezones maps US state abbreviations to IANA timezone names.
 var StateTimezones = map[string]string{
@@ -21,4 +24,23 @@ func GetTimezoneForState(state string) string {
 		return tz
 	}
 	return "America/Phoenix"
+}
+
+// EventLocation resolves the IANA location for rendering an event time in a
+// venue's local zone. Precedence: a valid explicit venue timezone, then the US
+// state->tz map (GetTimezoneForState, which itself defaults unknown/empty input
+// to America/Phoenix), and finally UTC only if a non-empty timezone string
+// fails to load. A malformed venue timezone falls through to the state map
+// rather than jumping straight to UTC. (PSY-996)
+func EventLocation(timezone *string, stateFallback string) *time.Location {
+	if timezone != nil && *timezone != "" {
+		if loc, err := time.LoadLocation(*timezone); err == nil {
+			return loc
+		}
+		// Malformed/unknown IANA string — fall through to the state map below.
+	}
+	if loc, err := time.LoadLocation(GetTimezoneForState(stateFallback)); err == nil {
+		return loc
+	}
+	return time.UTC
 }

--- a/backend/internal/utils/timezone_test.go
+++ b/backend/internal/utils/timezone_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -26,4 +27,31 @@ func TestGetTimezoneForState_CaseInsensitive(t *testing.T) {
 func TestGetTimezoneForState_UnknownDefaultsToPhoenix(t *testing.T) {
 	assert.Equal(t, "America/Phoenix", GetTimezoneForState("XX"))
 	assert.Equal(t, "America/Phoenix", GetTimezoneForState(""))
+}
+
+func TestEventLocation(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	// 8 PM Central on Jul 9 is stored as 01:00Z on Jul 10.
+	instant := time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC)
+
+	t.Run("explicit venue timezone wins over state", func(t *testing.T) {
+		// Venue tz = Chicago, state = NY (Eastern): must use Chicago.
+		got := instant.In(EventLocation(ptr("America/Chicago"), "NY")).Format("Jan 2, 2006 3:04 PM")
+		assert.Equal(t, "Jul 9, 2026 8:00 PM", got)
+	})
+
+	t.Run("state fallback when no venue timezone", func(t *testing.T) {
+		assert.Equal(t, "America/Chicago", EventLocation(nil, "TX").String())
+		assert.Equal(t, "America/New_York", EventLocation(ptr(""), "NY").String())
+	})
+
+	t.Run("malformed venue timezone falls through to state, not UTC", func(t *testing.T) {
+		// A bad IANA string must NOT collapse to UTC when a valid state exists.
+		assert.Equal(t, "America/Chicago", EventLocation(ptr("Mars/Olympus"), "TX").String())
+	})
+
+	t.Run("unknown state defaults to Phoenix", func(t *testing.T) {
+		assert.Equal(t, "America/Phoenix", EventLocation(nil, "").String())
+		assert.Equal(t, "America/Phoenix", EventLocation(nil, "ZZ").String())
+	})
 }


### PR DESCRIPTION
## Summary

Show notifications rendered `event_date` (a UTC instant) **without converting to the venue's timezone**, so an evening US show — e.g. 8 PM Central, stored as `01:00Z` the next day — showed as **"1:00 AM"** on the wrong date. The UI was already correct (it converts to venue-local, now via PSY-985's `venue.timezone`); these backend notification formatters weren't. Same root cause as the PSY-984 epic; surfaced on stage Discord.

Closes PSY-996

## Fix

New `utils.EventLocation(timezone *string, stateFallback string)` resolves the render zone: a valid venue timezone (PSY-985) → the US state→tz map → UTC (only if a non-empty tz string fails to load). Every notification site converts `event_date` to that zone before formatting.

Sites fixed (all 6):
- Discord **`NotifyNewShow`** (date+time — the reported one), `NotifyShowApproved`, `NotifyShowRejected`, `NotifyShowReport`.
- Filter **digest email** — its query already JOINed `venues`; now also selects `venues.timezone` and renders venue-local.
- **~24h saved-show reminder email** — surfaced by the adversarial panel as a missed 6th site (and the highest-impact one: an end-user "your show is tomorrow" email with a clock time). The reminder query now selects the show state + first venue timezone; the venue-localized time flows through (no signature change — a `time.Time` carries its location, which `Format` honors).

The 3 Discord `ShowResponse` paths + both emails use the venue's timezone; `NotifyShowReport` uses the show's state (its venue relation isn't preloaded — and it's a date-only field, so a zone only matters at a date boundary).

## Test plan

- [x] `go build ./...` + `go vet` on changed packages
- [x] `utils.EventLocation` unit test — venue tz wins; **malformed tz falls through to the state map (not UTC)**; unknown → Phoenix
- [x] Discord regression test — `State=NY` + `Timezone=Chicago` → "Jul 9, 2026 8:00 PM" (proves venue tz beats the state fallback), never "1:00 AM"
- [x] notification + engagement + utils suites green (engagement/reminder via testcontainers)

## Adversarial review

`/adversarial-review` (Saboteur · Future-Maintainer · Completeness, fresh context) ran **2 rounds, converged CLEAN**. Fixes in commit `ed67753d`:
- **[HIGH]** the ~24h reminder email was a missed 6th UTC site → fixed + verified end-to-end.
- **[MEDIUM]** a malformed venue tz skipped the state fallback → now falls through before UTC.
- **[MEDIUM]** digest email used state-only → now uses the venue's timezone.
- **[MEDIUM]** resolver moved to `utils.EventLocation` (the `notification` package imports `engagement`, so `utils` is the cycle-free home) + corrected docstring.
- **[MEDIUM]** regression test now proves venue-tz precedence (NY state vs Chicago venue tz).

## Out of scope (verified correct / noted)

- iCal `DTSTART` correctly emits a UTC-`Z` instant (calendar clients convert to the viewer's zone) — left alone.
- The backend `utils.StateTimezones` map is intentionally small; the *venue timezone* (PSY-985, backfilled by PSY-987) is the accurate source the notification paths now prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
