### PR TITLE
PSY-982: scope tag facet counts to the active city filter on /shows

### DIFF
--- a/backend/internal/api/handlers/catalog/tag.go
+++ b/backend/internal/api/handlers/catalog/tag.go
@@ -46,6 +46,11 @@ type ListTagsRequest struct {
 	// than the global cross-entity total. The /tags browse page omits this
 	// param to keep the global count.
 	EntityType string `query:"entity_type" required:"false" doc:"Scope usage_count to a single entity type (artist, release, label, show, venue, festival)"`
+	// Cities scopes the show facet count to the active /shows city filter
+	// (PSY-982). Pipe-delimited "City,ST|City,ST" pairs, same wire format as
+	// /shows/upcoming. Honoured only when entity_type=show so the facet count
+	// matches the city-filtered shows list and no chip dead-ends at 0 results.
+	Cities string `query:"cities" required:"false" doc:"Scope show facet counts to these cities (entity_type=show only). Pipe-delimited 'Phoenix,AZ|Mesa,AZ'."`
 }
 
 type ListTagsResponse struct {
@@ -65,7 +70,12 @@ func (h *TagHandler) ListTagsHandler(ctx context.Context, req *ListTagsRequest) 
 		return nil, huma.Error422UnprocessableEntity("Invalid entity_type")
 	}
 
-	tags, total, err := h.tagService.ListTags(req.Category, req.Search, parentID, req.Sort, req.Limit, req.Offset, req.EntityType)
+	// cities is only meaningful for the show facet (PSY-982); for any other
+	// entity_type the service ignores it, but parsing it unconditionally keeps
+	// the handler simple and the validation in one place (the service).
+	cities := parseCityStateFilters(req.Cities)
+
+	tags, total, err := h.tagService.ListTags(req.Category, req.Search, parentID, req.Sort, req.Limit, req.Offset, req.EntityType, cities)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to list tags")
 	}

--- a/backend/internal/api/handlers/catalog/tag_filter.go
+++ b/backend/internal/api/handlers/catalog/tag_filter.go
@@ -1,8 +1,15 @@
 package catalog
 
 import (
+	"strings"
+
 	"psychic-homily-backend/internal/services/catalog"
+	"psychic-homily-backend/internal/services/contracts"
 )
+
+// maxCityFilters caps how many (city, state) pairs a single browse/facet
+// request may carry — mirrors the same cap GetUpcomingShowsHandler applies.
+const maxCityFilters = 10
 
 // parseTagFilter normalizes the `tags=` and `tag_match=` query params used
 // by the multi-tag browse filter (PSY-309). It splits on commas, trims
@@ -11,4 +18,32 @@ import (
 // including "all" or empty — means AND.
 func parseTagFilter(tags, match string) catalog.TagFilter {
 	return catalog.ParseTagFilter(tags, match)
+}
+
+// parseCityStateFilters turns the pipe-delimited "City,ST|City,ST" query
+// param into typed filters, using the same wire format as the /shows handler
+// (PSY-982 reuses it for the city-scoped tag facet). Malformed pairs (not
+// exactly city,state, or blank after trimming) are skipped. The list is
+// capped at maxCityFilters. Empty input ⇒ nil (no filter).
+func parseCityStateFilters(raw string) []contracts.CityStateFilter {
+	if raw == "" {
+		return nil
+	}
+	var filters []contracts.CityStateFilter
+	for _, pair := range strings.Split(raw, "|") {
+		parts := strings.Split(pair, ",")
+		if len(parts) != 2 {
+			continue
+		}
+		city := strings.TrimSpace(parts[0])
+		state := strings.TrimSpace(parts[1])
+		if city == "" || state == "" {
+			continue
+		}
+		filters = append(filters, contracts.CityStateFilter{City: city, State: state})
+		if len(filters) >= maxCityFilters {
+			break
+		}
+	}
+	return filters
 }

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -3224,7 +3224,7 @@ type MockTagService struct {
 	CreateTagFn                func(string, *string, *uint, string, bool, *uint) (*catalogm.Tag, error)
 	GetTagFn                   func(uint) (*catalogm.Tag, error)
 	GetTagBySlugFn             func(string) (*catalogm.Tag, error)
-	ListTagsFn                 func(string, string, *uint, string, int, int, string) ([]catalogm.Tag, int64, error)
+	ListTagsFn                 func(string, string, *uint, string, int, int, string, []contracts.CityStateFilter) ([]catalogm.Tag, int64, error)
 	UpdateTagFn                func(uint, *string, *string, *uint, *string, *bool) (*catalogm.Tag, error)
 	DeleteTagFn                func(uint) error
 	AddTagToEntityFn           func(uint, string, string, uint, uint, string) (*catalogm.EntityTag, error)
@@ -3272,9 +3272,9 @@ func (m *MockTagService) GetTagBySlug(slug string) (*catalogm.Tag, error) {
 	}
 	return nil, nil
 }
-func (m *MockTagService) ListTags(category string, search string, parentID *uint, sort string, limit int, offset int, entityType string) ([]catalogm.Tag, int64, error) {
+func (m *MockTagService) ListTags(category string, search string, parentID *uint, sort string, limit int, offset int, entityType string, cities []contracts.CityStateFilter) ([]catalogm.Tag, int64, error) {
 	if m.ListTagsFn != nil {
-		return m.ListTagsFn(category, search, parentID, sort, limit, offset, entityType)
+		return m.ListTagsFn(category, search, parentID, sort, limit, offset, entityType, cities)
 	}
 	return nil, 0, nil
 }

--- a/backend/internal/services/catalog/tag_filter.go
+++ b/backend/internal/services/catalog/tag_filter.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/contracts"
 
 	"gorm.io/gorm"
 )
@@ -153,6 +154,62 @@ func CountTransitiveArtistTagUsage(
 		Select("entity_tags.tag_id AS tag_id, COUNT(DISTINCT "+junctionTable+"."+containerIDColumn+") AS count").
 		Joins("JOIN entity_tags ON entity_tags.entity_type = ? AND entity_tags.entity_id = "+junctionTable+"."+artistIDColumn, catalogm.TagEntityArtist).
 		Where("entity_tags.tag_id IN ?", tagIDs).
+		Group("entity_tags.tag_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.TagID] = r.Count
+	}
+	return out, nil
+}
+
+// CountTransitiveArtistTagUsageInShowCities is the city-scoped variant of
+// CountTransitiveArtistTagUsage for the `show` entity type (PSY-982).
+//
+// It counts only shows whose denormalized `(city, state)` matches one of the
+// provided pairs — mirroring exactly the predicate `GetUpcomingShows` uses for
+// its multi-city filter (it filters on `shows.city`/`shows.state`, NOT a join
+// through `show_venues → venues`). Using the same predicate as the list query
+// is load-bearing: the `/shows` facet count and the `/shows` result set must be
+// derived from one filter so a non-zero facet can never dead-end at "0 shows".
+//
+// `cities` is the active city filter (empty → caller should use the unscoped
+// CountTransitiveArtistTagUsage instead). Counts are transitive: a show matches
+// a tag when any billed artist carries it, joined through `show_artists` and
+// `entity_tags` scoped to `entity_type='artist'`. Tags with zero matches are
+// absent from the returned map (callers treat missing keys as zero).
+func CountTransitiveArtistTagUsageInShowCities(
+	db *gorm.DB,
+	tagIDs []uint,
+	cities []contracts.CityStateFilter,
+) (map[uint]int64, error) {
+	out := make(map[uint]int64)
+	if len(tagIDs) == 0 || len(cities) == 0 {
+		return out, nil
+	}
+	type row struct {
+		TagID uint
+		Count int64
+	}
+	// Build the (city = ? AND state = ?) OR … predicate the same way
+	// GetUpcomingShows does, so the facet count stays consistent with the list.
+	cityCond := db
+	for i, cs := range cities {
+		if i == 0 {
+			cityCond = cityCond.Where("(shows.city = ? AND shows.state = ?)", cs.City, cs.State)
+		} else {
+			cityCond = cityCond.Or("(shows.city = ? AND shows.state = ?)", cs.City, cs.State)
+		}
+	}
+	var rows []row
+	err := db.Table("show_artists").
+		Select("entity_tags.tag_id AS tag_id, COUNT(DISTINCT show_artists.show_id) AS count").
+		Joins("JOIN entity_tags ON entity_tags.entity_type = ? AND entity_tags.entity_id = show_artists.artist_id", catalogm.TagEntityArtist).
+		Joins("JOIN shows ON shows.id = show_artists.show_id").
+		Where("entity_tags.tag_id IN ?", tagIDs).
+		Where(cityCond).
 		Group("entity_tags.tag_id").
 		Scan(&rows).Error
 	if err != nil {

--- a/backend/internal/services/catalog/tag_filter_integration_test.go
+++ b/backend/internal/services/catalog/tag_filter_integration_test.go
@@ -652,7 +652,7 @@ func (s *TagFilterIntegrationTestSuite) TestListTags_ShowEntityType_Transitive()
 	// Direct show-level tag: legacy/possible admin action. Must be ignored.
 	s.tag("show", sD, "shoegaze")
 
-	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow)
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow, nil)
 	s.Require().NoError(err)
 	counts := map[string]int{}
 	for _, t := range tags {
@@ -679,7 +679,7 @@ func (s *TagFilterIntegrationTestSuite) TestListTags_ShowEntityType_MultipleArti
 	s.tag("artist", a2, "shoegaze")
 	s.tag("artist", a3, "shoegaze")
 
-	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow)
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow, nil)
 	s.Require().NoError(err)
 	var shoegazeCount int
 	for _, t := range tags {
@@ -688,6 +688,93 @@ func (s *TagFilterIntegrationTestSuite) TestListTags_ShowEntityType_MultipleArti
 		}
 	}
 	s.Equal(1, shoegazeCount, "show with 3 shoegaze artists should count once")
+}
+
+// seedShowInCity creates an approved upcoming show with denormalized
+// (city, state) set — the columns GetUpcomingShows filters on (PSY-982).
+func (s *TagFilterIntegrationTestSuite) seedShowInCity(title, city, state string) uint {
+	show := &catalogm.Show{
+		Title:       title,
+		EventDate:   time.Now().Add(24 * time.Hour).UTC(),
+		Status:      catalogm.ShowStatusApproved,
+		SubmittedBy: &s.user.ID,
+		City:        &city,
+		State:       &state,
+	}
+	s.Require().NoError(s.db.Create(show).Error)
+	return show.ID
+}
+
+// TestListTags_ShowEntityType_CityScoped is the core PSY-982 regression: the
+// `/tags?entity_type=show&cities=…` facet count must reflect ONLY shows in the
+// active city filter, transitively via billed artists. Without the city filter
+// the count is global; with it the count shrinks to the city — and crucially a
+// tag present only in another city must report 0 so the chip can be disabled
+// rather than dead-ending at "0 shows".
+func (s *TagFilterIntegrationTestSuite) TestListTags_ShowEntityType_CityScoped() {
+	// 2 shoegaze shows in Phoenix, 1 shoegaze show in Tucson, 1 post-punk show
+	// in Phoenix. The shoegaze artist plays all three shoegaze shows.
+	phxA := s.seedShowInCity("PHX-SG-A", "Phoenix", "AZ")
+	phxB := s.seedShowInCity("PHX-SG-B", "Phoenix", "AZ")
+	tucC := s.seedShowInCity("TUC-SG-C", "Tucson", "AZ")
+	phxPP := s.seedShowInCity("PHX-PP", "Phoenix", "AZ")
+
+	sgArtist := s.seedArtist("CityScopeSG")
+	ppArtist := s.seedArtist("CityScopePP")
+	s.addArtistToShow(phxA, sgArtist, 0)
+	s.addArtistToShow(phxB, sgArtist, 0)
+	s.addArtistToShow(tucC, sgArtist, 0)
+	s.addArtistToShow(phxPP, ppArtist, 0)
+	s.tag("artist", sgArtist, "shoegaze")
+	s.tag("artist", ppArtist, "post-punk")
+
+	// Global (no city filter): shoegaze=3 (2 PHX + 1 TUC), post-punk=1.
+	global, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow, nil)
+	s.Require().NoError(err)
+	globalCounts := map[string]int{}
+	for _, t := range global {
+		globalCounts[t.Slug] = t.UsageCount
+	}
+	s.Equal(3, globalCounts["shoegaze"], "global shoegaze across all cities")
+	s.Equal(1, globalCounts["post-punk"], "global post-punk across all cities")
+
+	// Phoenix-only: shoegaze=2 (PHX-A, PHX-B; Tucson excluded), post-punk=1.
+	phx := []contracts.CityStateFilter{{City: "Phoenix", State: "AZ"}}
+	phxTags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow, phx)
+	s.Require().NoError(err)
+	phxCounts := map[string]int{}
+	for _, t := range phxTags {
+		phxCounts[t.Slug] = t.UsageCount
+	}
+	s.Equal(2, phxCounts["shoegaze"], "Phoenix-scoped shoegaze excludes the Tucson show")
+	s.Equal(1, phxCounts["post-punk"], "Phoenix-scoped post-punk")
+
+	// Tucson-only: shoegaze=1, post-punk=0 (no post-punk show in Tucson →
+	// the chip would be disabled, never a dead-end).
+	tuc := []contracts.CityStateFilter{{City: "Tucson", State: "AZ"}}
+	tucTags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow, tuc)
+	s.Require().NoError(err)
+	tucCounts := map[string]int{}
+	for _, t := range tucTags {
+		tucCounts[t.Slug] = t.UsageCount
+	}
+	s.Equal(1, tucCounts["shoegaze"], "Tucson-scoped shoegaze")
+	s.Equal(0, tucCounts["post-punk"], "post-punk has no Tucson show → 0 (disabled, not dead-end)")
+
+	// Multi-city (Phoenix + Tucson) restores the union: shoegaze=3.
+	both := []contracts.CityStateFilter{
+		{City: "Phoenix", State: "AZ"},
+		{City: "Tucson", State: "AZ"},
+	}
+	bothTags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityShow, both)
+	s.Require().NoError(err)
+	var bothShoegaze int
+	for _, t := range bothTags {
+		if t.Slug == "shoegaze" {
+			bothShoegaze = t.UsageCount
+		}
+	}
+	s.Equal(3, bothShoegaze, "Phoenix+Tucson union covers all shoegaze shows")
 }
 
 // TestListTags_FestivalEntityType_Transitive mirrors the show test for
@@ -708,7 +795,7 @@ func (s *TagFilterIntegrationTestSuite) TestListTags_FestivalEntityType_Transiti
 	// Direct festival tag, should NOT count.
 	s.tag("festival", f3, "electronic")
 
-	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityFestival)
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityFestival, nil)
 	s.Require().NoError(err)
 	counts := map[string]int{}
 	for _, t := range tags {
@@ -727,7 +814,7 @@ func (s *TagFilterIntegrationTestSuite) TestListTags_ArtistEntityType_DirectCoun
 	s.tag("artist", a1, "post-punk")
 	s.tag("artist", a2, "post-punk")
 
-	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityArtist)
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, catalogm.TagEntityArtist, nil)
 	s.Require().NoError(err)
 	var ppCount int
 	for _, t := range tags {

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -130,7 +130,13 @@ func (s *TagService) GetTagBySlug(slug string) (*catalogm.Tag, error) {
 // is set so the facet on each browse page lists the most-applicable tags
 // first. entityType is validated against TagEntityTypes; an unknown value
 // returns an error.
-func (s *TagService) ListTags(category string, search string, parentID *uint, sort string, limit, offset int, entityType string) ([]catalogm.Tag, int64, error) {
+//
+// cities scopes the per-tag count to a set of (city, state) pairs (PSY-982).
+// It is honoured only for entityType=="show": when the /shows facet carries the
+// active city filter, the count reflects shows in those cities so a non-zero
+// chip can never dead-end at "0 shows". cities is ignored for every other
+// entity type (no city-scoped facet exists for them today).
+func (s *TagService) ListTags(category string, search string, parentID *uint, sort string, limit, offset int, entityType string, cities []contracts.CityStateFilter) ([]catalogm.Tag, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
 	}
@@ -179,7 +185,7 @@ func (s *TagService) ListTags(category string, search string, parentID *uint, so
 		for i, t := range tags {
 			ids[i] = t.ID
 		}
-		countByID, err := s.computeEntityTypeTagCounts(entityType, ids)
+		countByID, err := s.computeEntityTypeTagCounts(entityType, ids, cities)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to compute per-entity-type tag counts: %w", err)
 		}
@@ -208,10 +214,16 @@ func (s *TagService) ListTags(category string, search string, parentID *uint, so
 // shows" instead of the misleading "0" when 3 shows have shoegaze-tagged
 // artists on the bill).
 //
+// cities further narrows the show count to the active city filter (PSY-982).
+// It applies only to entityType=="show"; it is ignored for every other type.
+//
 // Tags absent from the relevant tables get 0 (missing from the returned map).
-func (s *TagService) computeEntityTypeTagCounts(entityType string, tagIDs []uint) (map[uint]int64, error) {
+func (s *TagService) computeEntityTypeTagCounts(entityType string, tagIDs []uint, cities []contracts.CityStateFilter) (map[uint]int64, error) {
 	switch entityType {
 	case catalogm.TagEntityShow:
+		if len(cities) > 0 {
+			return CountTransitiveArtistTagUsageInShowCities(s.db, tagIDs, cities)
+		}
 		return CountTransitiveArtistTagUsage(s.db, "show_artists", "show_id", "artist_id", tagIDs)
 	case catalogm.TagEntityFestival:
 		return CountTransitiveArtistTagUsage(s.db, "festival_artists", "festival_id", "artist_id", tagIDs)

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -227,7 +227,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_All() {
 	suite.createTag("jazz", "genre")
 	suite.createTag("1990s", "other")
 
-	tags, total, err := suite.tagService.ListTags("", "", nil, "name", 50, 0, "")
+	tags, total, err := suite.tagService.ListTags("", "", nil, "name", 50, 0, "", nil)
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(3), total)
 	suite.Assert().Len(tags, 3)
@@ -238,7 +238,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_FilterByCategory() {
 	suite.createTag("jazz", "genre")
 	suite.createTag("1990s", "other")
 
-	tags, total, err := suite.tagService.ListTags("genre", "", nil, "name", 50, 0, "")
+	tags, total, err := suite.tagService.ListTags("genre", "", nil, "name", 50, 0, "", nil)
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(2), total)
 	suite.Assert().Len(tags, 2)
@@ -249,7 +249,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_Search() {
 	suite.createTag("post-rock", "genre")
 	suite.createTag("jazz", "genre")
 
-	tags, total, err := suite.tagService.ListTags("", "post", nil, "name", 50, 0, "")
+	tags, total, err := suite.tagService.ListTags("", "post", nil, "name", 50, 0, "", nil)
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(2), total)
 	suite.Assert().Len(tags, 2)
@@ -262,7 +262,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_FilterByParent() {
 	_, err := suite.tagService.CreateTag("post-rock", nil, &parent.ID, "genre", false, nil)
 	suite.Require().NoError(err)
 
-	tags, total, err := suite.tagService.ListTags("", "", &parent.ID, "name", 50, 0, "")
+	tags, total, err := suite.tagService.ListTags("", "", &parent.ID, "name", 50, 0, "", nil)
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(1), total)
 	suite.Assert().Len(tags, 1)
@@ -304,7 +304,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_EntityTypeScopedCounts
 	suite.Assert().Equal(1, reloaded.UsageCount)
 
 	// artist scope: punk=2, rock=0
-	tags, _, err := suite.tagService.ListTags("", "", nil, "name", 50, 0, "artist")
+	tags, _, err := suite.tagService.ListTags("", "", nil, "name", 50, 0, "artist", nil)
 	suite.Require().NoError(err)
 	suite.Require().Len(tags, 2)
 	got := map[string]int{}
@@ -315,7 +315,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_EntityTypeScopedCounts
 	suite.Assert().Equal(0, got["rock"], "rock should have 0 artist applications")
 
 	// venue scope: punk=0, rock=1
-	tags, _, err = suite.tagService.ListTags("", "", nil, "name", 50, 0, "venue")
+	tags, _, err = suite.tagService.ListTags("", "", nil, "name", 50, 0, "venue", nil)
 	suite.Require().NoError(err)
 	got = map[string]int{}
 	for _, t := range tags {
@@ -325,14 +325,14 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_EntityTypeScopedCounts
 	suite.Assert().Equal(1, got["rock"], "rock should have 1 venue application")
 
 	// festival scope: both 0 (no festival tags created)
-	tags, _, err = suite.tagService.ListTags("", "", nil, "name", 50, 0, "festival")
+	tags, _, err = suite.tagService.ListTags("", "", nil, "name", 50, 0, "festival", nil)
 	suite.Require().NoError(err)
 	for _, t := range tags {
 		suite.Assert().Equal(0, t.UsageCount, "tag %q should have 0 festival applications", t.Name)
 	}
 
 	// Empty entity_type → original global count comes through
-	tags, _, err = suite.tagService.ListTags("", "", nil, "name", 50, 0, "")
+	tags, _, err = suite.tagService.ListTags("", "", nil, "name", 50, 0, "", nil)
 	suite.Require().NoError(err)
 	got = map[string]int{}
 	for _, t := range tags {
@@ -384,13 +384,13 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_EntityTypeScopedSort()
 	}
 
 	// Global usage: rock=3, punk=2 → rock first when no entity_type.
-	tags, _, err := suite.tagService.ListTags("", "", nil, "usage", 50, 0, "")
+	tags, _, err := suite.tagService.ListTags("", "", nil, "usage", 50, 0, "", nil)
 	suite.Require().NoError(err)
 	suite.Require().GreaterOrEqual(len(tags), 2)
 	suite.Assert().Equal("rock", tags[0].Name, "global usage sort should put rock first")
 
 	// Venue scope: punk=2, rock=1 → punk first.
-	tags, _, err = suite.tagService.ListTags("", "", nil, "usage", 50, 0, "venue")
+	tags, _, err = suite.tagService.ListTags("", "", nil, "usage", 50, 0, "venue", nil)
 	suite.Require().NoError(err)
 	suite.Require().GreaterOrEqual(len(tags), 2)
 	suite.Assert().Equal("punk", tags[0].Name, "venue-scoped usage sort should put punk first")
@@ -401,7 +401,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_EntityTypeScopedSort()
 // entity types so we don't paper over a frontend typo with "all zero counts".
 func (suite *TagServiceIntegrationTestSuite) TestListTags_InvalidEntityType() {
 	suite.createTag("punk", "genre")
-	_, _, err := suite.tagService.ListTags("", "", nil, "name", 50, 0, "user")
+	_, _, err := suite.tagService.ListTags("", "", nil, "name", 50, 0, "user", nil)
 	suite.Assert().Error(err)
 	suite.Assert().Contains(err.Error(), "invalid entity type")
 }
@@ -1081,7 +1081,7 @@ func (suite *TagServiceIntegrationTestSuite) TestAddTagToEntity_InlineCreate_Exi
 	suite.Assert().NotNil(et)
 
 	// Verify only one tag with that name exists
-	tags, total, err := suite.tagService.ListTags("", "ambient", nil, "name", 50, 0, "")
+	tags, total, err := suite.tagService.ListTags("", "ambient", nil, "name", 50, 0, "", nil)
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(1), total)
 	suite.Assert().Len(tags, 1)

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -283,8 +283,10 @@ type TagServiceInterface interface {
 	// ListTags returns tags with optional filters/sort. When entityType is
 	// non-empty, each returned tag's UsageCount is overridden with the count
 	// of entity_tags rows for that specific entity type (PSY-484). The
-	// persisted tags.usage_count is never mutated.
-	ListTags(category string, search string, parentID *uint, sort string, limit, offset int, entityType string) ([]catalogm.Tag, int64, error)
+	// persisted tags.usage_count is never mutated. cities scopes the count to
+	// a set of (city, state) pairs and is honoured only for entityType=="show"
+	// (PSY-982); pass nil when no city filter is active.
+	ListTags(category string, search string, parentID *uint, sort string, limit, offset int, entityType string, cities []CityStateFilter) ([]catalogm.Tag, int64, error)
 	UpdateTag(tagID uint, name *string, description *string, parentID *uint, category *string, isOfficial *bool) (*catalogm.Tag, error)
 	DeleteTag(tagID uint) error
 

--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -270,6 +270,7 @@ export function ShowList() {
           onClear={handleTagsClear}
           title="Filter shows by tag"
           entityType="show"
+          selectedCities={selectedCities}
         />
         <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
@@ -282,6 +283,7 @@ export function ShowList() {
             onClear={handleTagsClear}
             heading="Filter shows by tag"
             entityType="show"
+            selectedCities={selectedCities}
           />
         </aside>
 

--- a/frontend/features/tags/components/TagFacetPanel.test.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.test.tsx
@@ -39,15 +39,36 @@ const entityTypeOverrides: Record<string, Record<string, number>> = {
   festival: { shoegaze: 0, phoenix: 0, diy: 0 },
 }
 
+// City-scoped overrides (PSY-982): when entity_type=show AND cities are passed,
+// some tags drop to 0 because the selected city has no matching shows. shoegaze
+// keeps a non-zero count so we can assert a mix of enabled + disabled chips.
+const cityScopedShowCounts: Record<string, number> = {
+  'post-punk': 4,
+  shoegaze: 0,
+  phoenix: 0,
+  diy: 0,
+}
+
 vi.mock('../hooks', () => ({
-  useTags: (params: { category?: keyof typeof tagsByCategory; entity_type?: string }) => {
+  useTags: (params: {
+    category?: keyof typeof tagsByCategory
+    entity_type?: string
+    cities?: Array<{ city: string; state: string }>
+  }) => {
     const baseTags = params?.category ? tagsByCategory[params.category] ?? [] : []
-    const tags = params?.entity_type
-      ? baseTags.map(t => {
-          const override = entityTypeOverrides[params.entity_type ?? '']?.[t.slug]
-          return override !== undefined ? { ...t, usage_count: override } : t
-        })
-      : baseTags
+    const cityScoped =
+      params?.entity_type === 'show' && (params?.cities?.length ?? 0) > 0
+    const tags = cityScoped
+      ? baseTags.map(t => ({
+          ...t,
+          usage_count: cityScopedShowCounts[t.slug] ?? 0,
+        }))
+      : params?.entity_type
+        ? baseTags.map(t => {
+            const override = entityTypeOverrides[params.entity_type ?? '']?.[t.slug]
+            return override !== undefined ? { ...t, usage_count: override } : t
+          })
+        : baseTags
     return {
       data: { tags, total: tags.length },
       isLoading: false,
@@ -254,6 +275,99 @@ describe('TagFacetPanel', () => {
     const shoegaze = screen.getByTestId('tag-facet-chip-shoegaze')
     expect(shoegaze).toBeInTheDocument()
     expect(shoegaze).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  // PSY-982: city-scoped /shows facet. When a city is selected, zero-in-city
+  // chips are SHOWN but DISABLED (not hidden) so they can't dead-end at
+  // "0 shows", and the non-zero chips stay clickable.
+  describe('city-scoped show facet (PSY-982)', () => {
+    const cities = [{ city: 'Phoenix', state: 'AZ' }]
+
+    it('shows zero-in-city chips disabled instead of hiding them', () => {
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+          entityType="show"
+          selectedCities={cities}
+        />
+      )
+      // post-punk has shows in Phoenix → enabled.
+      const postPunk = screen.getByTestId('tag-facet-chip-post-punk')
+      expect(postPunk).toBeInTheDocument()
+      expect(postPunk).not.toBeDisabled()
+      // shoegaze / phoenix / diy have 0 Phoenix shows → present but disabled.
+      const shoegaze = screen.getByTestId('tag-facet-chip-shoegaze')
+      expect(shoegaze).toBeInTheDocument()
+      expect(shoegaze).toBeDisabled()
+      expect(screen.getByTestId('tag-facet-chip-phoenix')).toBeDisabled()
+      expect(screen.getByTestId('tag-facet-chip-diy')).toBeDisabled()
+    })
+
+    it('does not call onToggle when a disabled zero-in-city chip is clicked', async () => {
+      const user = userEvent.setup()
+      const onToggle = vi.fn()
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={onToggle}
+          onClear={() => {}}
+          entityType="show"
+          selectedCities={cities}
+        />
+      )
+      await user.click(screen.getByTestId('tag-facet-chip-shoegaze'))
+      expect(onToggle).not.toHaveBeenCalled()
+    })
+
+    it('omits the "Show all tags" expander in city-scoped mode', () => {
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+          entityType="show"
+          selectedCities={cities}
+        />
+      )
+      expect(screen.queryByTestId('tag-facet-show-all')).not.toBeInTheDocument()
+    })
+
+    it('keeps a selected zero-in-city chip interactive so it can be deselected', async () => {
+      const user = userEvent.setup()
+      const onToggle = vi.fn()
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={['shoegaze']}
+          onToggle={onToggle}
+          onClear={() => {}}
+          entityType="show"
+          selectedCities={cities}
+        />
+      )
+      const shoegaze = screen.getByTestId('tag-facet-chip-shoegaze')
+      expect(shoegaze).not.toBeDisabled()
+      await user.click(shoegaze)
+      expect(onToggle).toHaveBeenCalledWith([])
+    })
+
+    it('falls back to the global hide-behavior when no city is selected', () => {
+      // entityType=show with no cities → not city-scoped → uses the PSY-484
+      // path. With the default stub counts every show chip is non-zero, so all
+      // chips render enabled and the expander reappears only if something is
+      // hidden (nothing is here).
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+          entityType="show"
+        />
+      )
+      expect(screen.getByTestId('tag-facet-chip-post-punk')).not.toBeDisabled()
+      expect(screen.getByTestId('tag-facet-chip-shoegaze')).not.toBeDisabled()
+    })
   })
 
   // PSY-499: transitive filter info tooltip. Only rendered for show/festival

--- a/frontend/features/tags/components/TagFacetPanel.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.tsx
@@ -12,6 +12,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import type { CityState } from '@/components/filters'
 import { useTags } from '../hooks'
 import {
   TAG_CATEGORIES,
@@ -56,6 +57,17 @@ export interface TagFacetPanelProps {
    * `/tags` browse where the global count is the right signal.
    */
   entityType?: TagEntityType
+  /**
+   * Active city filter passed through to the facet count query (PSY-982).
+   * Used only by `/shows` (entityType="show"): the backend scopes each tag's
+   * count to shows in these cities so the facet matches the city-filtered
+   * shows list. While a city is selected, zero-in-city chips are shown
+   * DISABLED (greyed, non-clickable) rather than hidden — the user sees the
+   * tag exists but has no shows here, instead of it silently vanishing and
+   * instead of dead-ending at "0 shows matching <tag>". Omit for the global,
+   * city-agnostic facet (every other browse page).
+   */
+  selectedCities?: CityState[]
 }
 
 /**
@@ -77,6 +89,7 @@ export function TagFacetPanel({
   hideHeading = false,
   className,
   entityType,
+  selectedCities,
 }: TagFacetPanelProps) {
   const selectedSet = useMemo(() => new Set(selectedSlugs), [selectedSlugs])
   // When entity_type is set we hide zero-count chips — they would lie about
@@ -84,6 +97,11 @@ export function TagFacetPanel({
   // full vocabulary. Without entity_type (e.g. `/tags` browse) every chip is
   // a valid destination so we show them all.
   const [showAll, setShowAll] = useState(false)
+  // City-scoped mode (PSY-982): while a city is selected on /shows the facet
+  // counts are city-scoped, so a zero-count chip means "no shows here". We
+  // SHOW those chips DISABLED instead of hiding them — the expander is
+  // redundant in this mode, and a disabled chip can never dead-end on click.
+  const cityScoped = (selectedCities?.length ?? 0) > 0
   const handleToggle = (slug: string) => {
     if (selectedSet.has(slug)) {
       onToggle(selectedSlugs.filter(s => s !== slug))
@@ -146,12 +164,16 @@ export function TagFacetPanel({
           selectedSet={selectedSet}
           onToggle={handleToggle}
           entityType={entityType}
+          selectedCities={selectedCities}
           showAll={showAll}
+          cityScoped={cityScoped}
         />
       ))}
 
-      {/* "Show all tags" expander only matters when we're filtering chips */}
-      {entityType && (
+      {/* "Show all tags" expander only matters when we hide zero-count chips.
+          In city-scoped mode they are shown disabled instead, so the expander
+          is redundant and omitted. */}
+      {entityType && !cityScoped && (
         <div className="pt-1">
           <button
             type="button"
@@ -173,7 +195,10 @@ interface CategoryGroupProps {
   selectedSet: Set<string>
   onToggle: (slug: string) => void
   entityType?: TagEntityType
+  selectedCities?: CityState[]
   showAll: boolean
+  /** When true, zero-count chips are shown disabled instead of hidden. */
+  cityScoped: boolean
 }
 
 function CategoryGroup({
@@ -182,23 +207,31 @@ function CategoryGroup({
   selectedSet,
   onToggle,
   entityType,
+  selectedCities,
   showAll,
+  cityScoped,
 }: CategoryGroupProps) {
   const { data, isLoading } = useTags({
     category,
     sort: 'usage',
     limit,
     entity_type: entityType,
+    // Only the show facet honours cities backend-side; passing it for other
+    // entity types is harmless (the backend ignores it) but we keep it to the
+    // city-scoped case so cache keys stay clean for the global pages.
+    cities: cityScoped ? selectedCities : undefined,
   })
   const allTags = data?.tags ?? []
-  // When entity_type is set, the API returns per-entity-type counts. Hide
-  // zero-count chips by default so the surface area shrinks to *useful*
-  // filters; the user can expand to see the full vocabulary.
-  // Selected chips stay visible regardless of count so the selection
-  // controls remain reachable even when the user navigates to a different
-  // browse page where the tag has zero matches (preserves clear/toggle UX).
+  // When entity_type is set, the API returns per-entity-type counts.
+  // - Default (city-agnostic) mode: hide zero-count chips so the surface area
+  //   shrinks to *useful* filters; the user can expand to see the full vocab.
+  // - City-scoped mode (PSY-982): show every chip, but render zero-in-city
+  //   chips disabled — the user sees the tag exists with no shows here rather
+  //   than it vanishing, and a disabled chip can never dead-end on click.
+  // Selected chips stay visible regardless of count so the selection controls
+  // remain reachable (preserves clear/toggle UX across navigation).
   const visibleTags =
-    entityType && !showAll
+    entityType && !cityScoped && !showAll
       ? allTags.filter(
           tag => tag.usage_count > 0 || selectedSet.has(tag.slug),
         )
@@ -226,6 +259,13 @@ function CategoryGroup({
               tag={tag}
               selected={selectedSet.has(tag.slug)}
               onToggle={onToggle}
+              // Disable only an unselected zero-in-city chip: a selected chip
+              // must stay interactive so the user can always deselect it.
+              disabled={
+                cityScoped &&
+                tag.usage_count === 0 &&
+                !selectedSet.has(tag.slug)
+              }
             />
           ))}
         </div>
@@ -238,22 +278,29 @@ interface TagChipProps {
   tag: TagListItem
   selected: boolean
   onToggle: (slug: string) => void
+  /** Zero-match chip in city-scoped mode: shown but non-interactive. */
+  disabled?: boolean
 }
 
-function TagChip({ tag, selected, onToggle }: TagChipProps) {
+function TagChip({ tag, selected, onToggle, disabled = false }: TagChipProps) {
   const catColors = getCategoryColor(tag.category)
   return (
     <button
       type="button"
       onClick={() => onToggle(tag.slug)}
       aria-pressed={selected}
+      disabled={disabled}
+      title={disabled ? `No shows for ${tag.name} in the selected city` : undefined}
       data-testid={`tag-facet-chip-${tag.slug}`}
       className={cn(
         'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium',
-        'transition-all duration-100 select-none cursor-pointer',
+        'transition-all duration-100 select-none',
+        disabled
+          ? 'cursor-not-allowed opacity-40'
+          : 'cursor-pointer',
         selected
           ? 'bg-primary text-primary-foreground border-primary shadow-sm ring-1 ring-primary/40'
-          : `${catColors} hover:bg-muted/60`
+          : `${catColors} ${disabled ? '' : 'hover:bg-muted/60'}`
       )}
     >
       <span>{tag.name}</span>

--- a/frontend/features/tags/hooks/index.test.tsx
+++ b/frontend/features/tags/hooks/index.test.tsx
@@ -128,6 +128,43 @@ describe('useTags', () => {
     const url = mockApiRequest.mock.calls[0][0] as string
     expect(url).not.toContain('entity_type=')
   })
+
+  // PSY-982: the /shows facet forwards the active city filter so counts are
+  // city-scoped. Verify the hook serializes cities into the pipe-delimited
+  // wire format used by /shows/upcoming.
+  it('forwards cities as the pipe-delimited param', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [], total: 0 })
+
+    const { result } = renderHook(
+      () =>
+        useTags({
+          entity_type: 'show',
+          cities: [
+            { city: 'Phoenix', state: 'AZ' },
+            { city: 'Mesa', state: 'AZ' },
+          ],
+        }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    // URLSearchParams encodes the pipe/comma; assert on the decoded form.
+    expect(decodeURIComponent(url)).toContain('cities=Phoenix,AZ|Mesa,AZ')
+  })
+
+  it('omits cities when the list is empty', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useTags({ entity_type: 'show', cities: [] }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).not.toContain('cities=')
+  })
 })
 
 describe('useSearchTags', () => {

--- a/frontend/features/tags/hooks/index.ts
+++ b/frontend/features/tags/hooks/index.ts
@@ -9,6 +9,8 @@
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest, API_ENDPOINTS } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
+import { buildCitiesParam } from '@/components/filters/cityParams'
+import type { CityState } from '@/components/filters'
 import type {
   TagDetailResponse,
   TagEnrichedDetailResponse,
@@ -40,6 +42,15 @@ interface UseTagsParams {
    * omits this param to keep the global count.
    */
   entity_type?: string
+  /**
+   * Scope the show facet count to the active /shows city filter (PSY-982).
+   * Honoured by the backend only when `entity_type === 'show'`. Wired so the
+   * facet count matches the city-filtered shows list — a tag with no shows in
+   * the selected city reports 0 and its chip is disabled rather than
+   * dead-ending at "0 shows matching <tag>". Omit (or pass empty) for the
+   * global, city-agnostic count.
+   */
+  cities?: CityState[]
 }
 
 /** Fetch tags list with optional filters */
@@ -52,6 +63,9 @@ export function useTags(params?: UseTagsParams) {
   if (params?.limit) searchParams.set('limit', String(params.limit))
   if (params?.offset) searchParams.set('offset', String(params.offset))
   if (params?.entity_type) searchParams.set('entity_type', params.entity_type)
+  if (params?.cities && params.cities.length > 0) {
+    searchParams.set('cities', buildCitiesParam(params.cities))
+  }
 
   const queryString = searchParams.toString()
   const url = queryString


### PR DESCRIPTION
## Summary

On `/shows`, the "Filter shows by tag" facet computed counts across **all** shows, ignoring the active city filter. With a city selected, a tag that had shows elsewhere but none in that city dead-ended at "0 shows matching `<tag>`".

This scopes the facet count to the same city filter the shows list uses, so the facet count and the result set are always derived from one filter — a non-zero chip can never dead-end.

**Backend**
- `GET /tags` gains an optional `cities` query param (pipe-delimited `City,ST|City,ST`, same wire format as `/shows/upcoming`, capped at 10).
- When `entity_type=show` **and** `cities` are set, `ListTags` scopes the transitive per-tag count to shows in those cities via a new `CountTransitiveArtistTagUsageInShowCities`. It's transitive (a show matches a tag when any billed artist carries it) and city-filtered on `shows.city`/`shows.state`. `cities` is ignored for every other entity type.

**Frontend**
- `useTags` forwards `cities`; `ShowList` passes `selectedCities` into `TagFacetPanel` + `TagFacetSheet`.
- In city-scoped mode the panel shows zero-in-city chips **disabled** (greyed, non-clickable, with a hover explainer) instead of hiding them, and drops the now-redundant "Show all tags" expander. A selected chip stays interactive so it can always be deselected. All other browse pages (no city scope) keep the existing PSY-484 hide-behavior unchanged.

### ⚠️ Deliberate deviation from the ticket spec (please confirm)

The PSY-982 comment suggested scoping via `entity_tags → show_artists → shows → show_venues → venues` (venue city/state). I implemented the city match on the denormalized **`shows.city`/`shows.state`** columns instead, because that is **exactly** what `GetUpcomingShows` (the shows list) and `GetShowCities` (the city chips) filter on. Matching the list predicate is load-bearing: it's the only way to guarantee the facet count and the list result agree, so a non-zero chip can never dead-end. Joining through `venues` would risk divergence whenever `shows.city` ≠ `venues.city` — which would re-introduce the exact bug being fixed. Verified end-to-end (see Manual repro). If venue-city scoping was intended for a deeper reason, flag it and I'll revisit.

## Test plan

- [x] `cd backend && go build ./...`
- [x] `cd backend && go test ./internal/services/catalog/... ./internal/api/handlers/catalog/...` — pass (incl. new `TestListTags_ShowEntityType_CityScoped`: global vs Phoenix vs Tucson vs multi-city, with a zero-in-city tag)
- [x] OpenAPI diff reviewed — single additive optional `cities` query param on `GET /tags`, no response-shape change, no new route
- [x] `cd frontend && bun run typecheck`
- [x] `cd frontend && bun run test:run features/tags features/shows` — 650 pass (new `TagFacetPanel` disabled-chip tests + `useTags` cities serialization tests)

## Manual repro

Isolated fullstack dispatch stack (`stack-up.sh --mode=isolated`), seeded a city-divergent scenario: `shoegaze` (via an all-cities artist) and `desert-folk` (via a Phoenix-only artist + show).

| Selection | shoegaze | desert-folk | List ("desert-folk") |
|---|---|---|---|
| No city (global) | 12 | 1 | — |
| Phoenix | 4 | 1 (enabled) | 1 show |
| Tucson | 4 | **0 (disabled)** | 0 shows (no dead-end — chip disabled) |
| Phoenix + Tucson | 8 | 1 | — |

- Facet counts shrink to the selected city; clearing the city restores global counts.
- In Tucson, `desert-folk` renders disabled (`opacity 0.4`, `cursor: not-allowed`); clicking it is a no-op (URL unchanged) — no dead-end.
- Phoenix facet `desert-folk 1` matches the list "1 show matching desert-folk" exactly (facet/list consistency).

## Screenshots

**Phoenix selected** — both `shoegaze 4` and `desert-folk 1` enabled:
![Phoenix](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-982-screenshots/psy982-phoenix-vp.png)

**Tucson selected** — `shoegaze 4` enabled, `desert-folk 0` disabled (greyed):
![Tucson](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-982-screenshots/psy982-tucson-vp.png)

## Code review

`/code-review` (xhigh, inline — dispatched sub-agent, no Agent tool in worktree). Ran all 9 angles against the diff. No confirmed correctness findings: the GORM OR-grouping mirrors `GetUpcomingShows` (validated live), `cities: undefined` doesn't change the TanStack query-key hash (undefined keys dropped), and the native `disabled` button blocks the click (verified live). One cosmetic nit (singular "city" in the disabled-chip tooltip) left as-is.

## Adversarial review

`/adversarial-review` — **CLEAN** (inline, 4 lenses; no Agent tool in worktree). No CRITICAL/HIGH/MEDIUM.
- **Saboteur:** city/state are bound params (no injection); cities capped at 10 (no DoS); count is server-side over the full filtered set (correct under pagination); malformed `cities` degrades to global (no new dead-end).
- **Future-Maintainer:** the new count fn documents *why* it uses `shows.city` not a venue join (pre-empts a regressing "fix").
- **Security:** public read endpoint, aggregate integers only, no new data exposure or authz change.
- **Completeness:** all 6 acceptance criteria met (see Test plan + Manual repro); the spec→`shows.city` deviation is disclosed above.
- LOW (not blocking): comma-in-city-name limitation is pre-existing and shared across all city-filtered surfaces (the facet inherits it identically to the list, so they degrade together — no new divergence).

Reviewers ran against the branch diff with no prior session context.

Closes PSY-982

