### PR TITLE
PSY-997: entity_requests HTTP endpoints (queue-create + admin decide)

### DIFF
--- a/backend/internal/api/handlers/community/entity_request.go
+++ b/backend/internal/api/handlers/community/entity_request.go
@@ -1,0 +1,318 @@
+package community
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
+)
+
+// PSY-997: HTTP endpoints for the polymorphic entity_requests moderation queue
+// (built on PSY-869's service in services/community/entityrequest.go). Mirrors
+// the polymorphic shape of entity_report.go: one user-facing create endpoint +
+// admin list/decide endpoints, with audit-log writes fire-and-forget.
+//
+// These endpoints are intentionally SEPARATE from the pending_entity_edits
+// admin endpoints (PSY-871's frontend unifies the two queues into one page;
+// the backend keeps them parallel and independently testable).
+
+// EntityRequestHandler handles entity-request queue API endpoints.
+type EntityRequestHandler struct {
+	entityRequestService contracts.EntityRequestServiceInterface
+	fulfiller            contracts.EntityRequestFulfillerInterface
+	auditLogService      contracts.AuditLogServiceInterface
+}
+
+// NewEntityRequestHandler creates a new entity-request handler. fulfiller is
+// used only on the admin decide-approve path to create the actual entity from
+// the payload; it may be nil in unit tests that don't exercise approval.
+func NewEntityRequestHandler(
+	entityRequestService contracts.EntityRequestServiceInterface,
+	fulfiller contracts.EntityRequestFulfillerInterface,
+	auditLogService contracts.AuditLogServiceInterface,
+) *EntityRequestHandler {
+	return &EntityRequestHandler{
+		entityRequestService: entityRequestService,
+		fulfiller:            fulfiller,
+		auditLogService:      auditLogService,
+	}
+}
+
+// ============================================================================
+// User: Queue an entity-creation request — POST /entity-requests
+// ============================================================================
+
+// CreateEntityRequestRequest is the Huma request for POST /entity-requests.
+//
+// Payload is the typed, per-entity_type creation payload (the shapes in
+// communitym/entity_request_payloads.go). It is carried as a raw JSON object
+// and validated against the entity_type's registered struct on the read side;
+// the handler only enforces it is present + non-empty here.
+type CreateEntityRequestRequest struct {
+	Body struct {
+		EntityType    string          `json:"entity_type" doc:"Entity type to request (artist, venue, label, release, show, festival)"`
+		Payload       json.RawMessage `json:"payload" doc:"Typed creation payload for the entity_type"`
+		SourceContext string          `json:"source_context" required:"false" doc:"How the request originated (ai_extraction, paste_mode, manual); defaults to manual"`
+		Confirmed     bool            `json:"confirmed" required:"false" doc:"FE-side confirm step (only relevant to trusted_contributor tier)"`
+	}
+}
+
+// CreateEntityRequestResponse is the Huma response for POST /entity-requests.
+type CreateEntityRequestResponse struct {
+	Body *communitym.EntityRequest
+}
+
+// CreateEntityRequestHandler handles POST /entity-requests.
+//
+// Tier policy lives in PSY-869's service (autoApproves): contributor/new_user
+// file a PENDING request (never autonomously create the entity, per
+// feedback_human_verify_ai_entity_data); admin/local_ambassador (and confirmed
+// trusted_contributor) auto-approve. The service stamps decided_by/at on
+// auto-approve. This handler is a thin validator + pass-through.
+func (h *EntityRequestHandler) CreateEntityRequestHandler(ctx context.Context, req *CreateEntityRequestRequest) (*CreateEntityRequestResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	entityType := strings.TrimSpace(req.Body.EntityType)
+	if !communitym.IsValidEntityRequestType(entityType) {
+		return nil, huma.Error422UnprocessableEntity("Invalid entity type '" + entityType + "'")
+	}
+
+	// source_context defaults to manual when omitted; any provided value must
+	// be a recognized source.
+	sourceContext := strings.TrimSpace(req.Body.SourceContext)
+	if sourceContext == "" {
+		sourceContext = communitym.EntityRequestSourceManual
+	}
+	if !communitym.IsValidEntityRequestSource(sourceContext) {
+		return nil, huma.Error422UnprocessableEntity("Invalid source context '" + sourceContext + "'")
+	}
+
+	if len(strings.TrimSpace(string(req.Body.Payload))) == 0 {
+		return nil, huma.Error422UnprocessableEntity("Payload is required")
+	}
+
+	created, err := h.entityRequestService.CreateRequest(user, entityType, req.Body.Payload, sourceContext, req.Body.Confirmed)
+	if err != nil {
+		if mapped := shared.MapEntityRequestError(err); mapped != nil {
+			return nil, mapped
+		}
+		logger.FromContext(ctx).Error("entity_request_create_failed",
+			"user_id", user.ID,
+			"entity_type", entityType,
+			"source_context", sourceContext,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to create entity request")
+	}
+
+	// Fire-and-forget audit log. Distinguish auto-approved (trusted tiers) from
+	// queued so the activity feed reads correctly.
+	if h.auditLogService != nil {
+		action := "queue_entity_request"
+		if created.DecisionState == communitym.EntityRequestStateApproved {
+			action = "auto_approve_entity_request"
+		}
+		reqID := created.ID
+		state := string(created.DecisionState)
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(user.ID, action, entityType, reqID, map[string]interface{}{
+				"request_id":     reqID,
+				"source_context": sourceContext,
+				"decision_state": state,
+			})
+		})
+	}
+
+	return &CreateEntityRequestResponse{Body: created}, nil
+}
+
+// ============================================================================
+// Admin: List entity requests — GET /admin/entity-requests
+// ============================================================================
+
+// AdminListEntityRequestsRequest is the Huma request for GET /admin/entity-requests.
+type AdminListEntityRequestsRequest struct {
+	State         string `query:"state" required:"false" doc:"Filter by decision state (pending, approved, rejected); defaults to pending"`
+	EntityType    string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, venue, label, release, show, festival)"`
+	SourceContext string `query:"source_context" required:"false" doc:"Filter by source context (ai_extraction, paste_mode, manual)"`
+	Limit         int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20, max 100)"`
+	Offset        int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
+}
+
+// AdminListEntityRequestsResponse is the Huma response for GET /admin/entity-requests.
+type AdminListEntityRequestsResponse struct {
+	Body struct {
+		Requests []communitym.EntityRequest `json:"requests"`
+		Total    int64                      `json:"total"`
+	}
+}
+
+// AdminListEntityRequestsHandler handles GET /admin/entity-requests.
+// Admin-gated via rc.Admin middleware (no inline admin check, per PSY-423).
+func (h *EntityRequestHandler) AdminListEntityRequestsHandler(ctx context.Context, req *AdminListEntityRequestsRequest) (*AdminListEntityRequestsResponse, error) {
+	if req.EntityType != "" && !communitym.IsValidEntityRequestType(req.EntityType) {
+		return nil, huma.Error422UnprocessableEntity("Invalid entity type '" + req.EntityType + "'")
+	}
+	if req.State != "" && !communitym.IsValidEntityRequestState(req.State) {
+		return nil, huma.Error422UnprocessableEntity("Invalid state '" + req.State + "'")
+	}
+	if req.SourceContext != "" && !communitym.IsValidEntityRequestSource(req.SourceContext) {
+		return nil, huma.Error422UnprocessableEntity("Invalid source context '" + req.SourceContext + "'")
+	}
+
+	requests, total, err := h.entityRequestService.ListRequests(&contracts.EntityRequestFilters{
+		EntityType:    req.EntityType,
+		State:         req.State,
+		SourceContext: req.SourceContext,
+		Limit:         req.Limit,
+		Offset:        req.Offset,
+	})
+	if err != nil {
+		logger.FromContext(ctx).Error("entity_request_list_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to list entity requests")
+	}
+
+	resp := &AdminListEntityRequestsResponse{}
+	resp.Body.Requests = requests
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
+// Admin: Decide an entity request — POST /admin/entity-requests/{id}/decide
+// ============================================================================
+
+// AdminDecideEntityRequestRequest is the Huma request for
+// POST /admin/entity-requests/{id}/decide.
+type AdminDecideEntityRequestRequest struct {
+	ID   string `path:"id" doc:"Entity request ID to decide"`
+	Body struct {
+		Decision string  `json:"decision" doc:"Decision: approved or rejected"`
+		Note     *string `json:"note" required:"false" doc:"Optional decision note (shown to the requester)"`
+	}
+}
+
+// AdminDecideEntityRequestResponse is the Huma response for the decide endpoint.
+// On approve, CreatedEntityID/CreatedEntityType report the catalog entity that
+// was created from the payload.
+type AdminDecideEntityRequestResponse struct {
+	Body struct {
+		Request           *communitym.EntityRequest `json:"request"`
+		CreatedEntityID   *uint                     `json:"created_entity_id,omitempty"`
+		CreatedEntityType *string                   `json:"created_entity_type,omitempty"`
+	}
+}
+
+// AdminDecideEntityRequestHandler handles POST /admin/entity-requests/{id}/decide.
+// Admin-gated via rc.Admin middleware (no inline admin check, per PSY-423).
+//
+// Approve flow (claim-then-fulfill): the service's atomic Decide claims the
+// pending→approved transition FIRST (so two concurrent approvals can't both
+// win and double-create the entity), then the handler fulfills the payload into
+// a real catalog entity. If fulfillment fails after the claim, the row is
+// approved-but-unfulfilled and the error is logged loudly + surfaced — the
+// admin can create the entity manually. This trades a rare orphaned-approval
+// for never double-creating an entity.
+//
+// Reject flow: marks rejected + optional note. No entity is created.
+func (h *EntityRequestHandler) AdminDecideEntityRequestHandler(ctx context.Context, req *AdminDecideEntityRequestRequest) (*AdminDecideEntityRequestResponse, error) {
+	admin := middleware.GetUserFromContext(ctx)
+
+	requestID, err := strconv.ParseUint(req.ID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	decision := strings.TrimSpace(req.Body.Decision)
+	var newState communitym.EntityRequestDecisionState
+	switch decision {
+	case string(communitym.EntityRequestStateApproved):
+		newState = communitym.EntityRequestStateApproved
+	case string(communitym.EntityRequestStateRejected):
+		newState = communitym.EntityRequestStateRejected
+	default:
+		return nil, huma.Error422UnprocessableEntity("Decision must be 'approved' or 'rejected'")
+	}
+
+	var note *string
+	if req.Body.Note != nil {
+		trimmed := strings.TrimSpace(*req.Body.Note)
+		if trimmed != "" {
+			note = &trimmed
+		}
+	}
+
+	// Claim the decision atomically before any side effect.
+	decided, err := h.entityRequestService.Decide(uint(requestID), admin.ID, newState, note)
+	if err != nil {
+		if mapped := shared.MapEntityRequestError(err); mapped != nil {
+			return nil, mapped
+		}
+		logger.FromContext(ctx).Error("entity_request_decide_failed",
+			"request_id", requestID,
+			"admin_id", admin.ID,
+			"decision", decision,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to record decision")
+	}
+
+	resp := &AdminDecideEntityRequestResponse{}
+	resp.Body.Request = decided
+
+	if newState == communitym.EntityRequestStateApproved {
+		createdID, err := h.fulfillEntity(decided)
+		if err != nil {
+			// The row is already approved (claimed). Surface the fulfillment
+			// failure so the admin knows the entity was NOT created and can act,
+			// rather than silently returning success.
+			logger.FromContext(ctx).Error("entity_request_fulfill_failed",
+				"request_id", requestID,
+				"admin_id", admin.ID,
+				"entity_type", decided.EntityType,
+				"error", err.Error(),
+			)
+			if mapped := shared.MapEntityRequestError(err); mapped != nil {
+				return nil, mapped
+			}
+			return nil, huma.Error500InternalServerError("Request approved but creating the entity failed: " + err.Error())
+		}
+		resp.Body.CreatedEntityID = &createdID
+		et := decided.EntityType
+		resp.Body.CreatedEntityType = &et
+	}
+
+	// Fire-and-forget audit log.
+	if h.auditLogService != nil {
+		action := "approve_entity_request"
+		if newState == communitym.EntityRequestStateRejected {
+			action = "reject_entity_request"
+		}
+		reqID := decided.ID
+		metadata := map[string]interface{}{
+			"request_id":   reqID,
+			"requester_id": decided.RequesterID,
+		}
+		if resp.Body.CreatedEntityID != nil {
+			metadata["created_entity_id"] = *resp.Body.CreatedEntityID
+		}
+		entityType := decided.EntityType
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(admin.ID, action, entityType, reqID, metadata)
+		})
+	}
+
+	return resp, nil
+}

--- a/backend/internal/api/handlers/community/entity_request.go
+++ b/backend/internal/api/handlers/community/entity_request.go
@@ -103,6 +103,14 @@ func (h *EntityRequestHandler) CreateEntityRequestHandler(ctx context.Context, r
 		return nil, huma.Error422UnprocessableEntity("Payload is required")
 	}
 
+	// Validate the payload decodes cleanly into its typed struct (rejects
+	// unknown fields / wrong shape / missing required fields) at the trust
+	// boundary, so a malformed contributor payload is rejected here rather than
+	// stored as junk in the queue and failing confusingly on admin approve.
+	if err := communitym.ValidateEntityRequestPayload(entityType, req.Body.Payload); err != nil {
+		return nil, huma.Error422UnprocessableEntity("Invalid payload for " + entityType + ": " + err.Error())
+	}
+
 	created, err := h.entityRequestService.CreateRequest(user, entityType, req.Body.Payload, sourceContext, req.Body.Confirmed)
 	if err != nil {
 		if mapped := shared.MapEntityRequestError(err); mapped != nil {

--- a/backend/internal/api/handlers/community/entity_request_fulfill.go
+++ b/backend/internal/api/handlers/community/entity_request_fulfill.go
@@ -1,0 +1,121 @@
+package community
+
+import (
+	apperrors "psychic-homily-backend/internal/errors"
+	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// PSY-997: fulfillment dispatcher — turns an approved entity_request's typed
+// payload into a real catalog entity via the narrow fulfiller interface.
+//
+// Per-type mapping is isolated here (the volatile part: catalog create
+// contracts evolve independently of the request payloads). Each branch decodes
+// the payload with the typed UnmarshalPayload[T] guard (fails loud on schema
+// drift) and maps the user-supplied fields onto the catalog Create*Request.
+//
+// Field-mapping note: a few payload fields have no slot on the catalog Create
+// contracts today (artist image_url + bandcamp_embed_url, venue
+// description/image_url, label image_url). They are NOT silently dropped from
+// the system — they remain on the persisted request row — but the created
+// entity does not carry them until a follow-up adds those fields to the Create
+// contracts or a post-create update. This is a known fidelity gap, not data
+// loss of the request itself.
+//
+// show + festival are deliberately unsupported: CreateShowRequest requires
+// venues + artists and CreateFestivalRequest requires series_slug, neither of
+// which the payloads carry. Approving those returns a typed
+// FulfillUnsupported error (422) so the admin creates them manually.
+func (h *EntityRequestHandler) fulfillEntity(req *communitym.EntityRequest) (uint, error) {
+	if req.Payload == nil {
+		return 0, apperrors.ErrEntityRequestEmptyPayload(req.EntityType)
+	}
+	raw := *req.Payload
+
+	switch req.EntityType {
+	case communitym.EntityRequestArtist:
+		p, err := communitym.UnmarshalPayload[communitym.ArtistRequestPayload](raw)
+		if err != nil {
+			return 0, apperrors.ErrEntityRequestPayloadInvalid(req.EntityType, err)
+		}
+		created, err := h.fulfiller.CreateArtist(&contracts.CreateArtistRequest{
+			Name:        p.Name,
+			City:        p.City,
+			State:       p.State,
+			Country:     p.Country,
+			Description: p.Description,
+		})
+		if err != nil {
+			return 0, err
+		}
+		return created.ID, nil
+
+	case communitym.EntityRequestVenue:
+		p, err := communitym.UnmarshalPayload[communitym.VenueRequestPayload](raw)
+		if err != nil {
+			return 0, apperrors.ErrEntityRequestPayloadInvalid(req.EntityType, err)
+		}
+		// Admin is approving, so create as an admin-verified venue.
+		created, err := h.fulfiller.CreateVenue(&contracts.CreateVenueRequest{
+			Name:    p.Name,
+			City:    p.City,
+			State:   p.State,
+			Address: p.Address,
+			Country: p.Country,
+			Zipcode: p.Zipcode,
+		}, true)
+		if err != nil {
+			return 0, err
+		}
+		return created.ID, nil
+
+	case communitym.EntityRequestLabel:
+		p, err := communitym.UnmarshalPayload[communitym.LabelRequestPayload](raw)
+		if err != nil {
+			return 0, apperrors.ErrEntityRequestPayloadInvalid(req.EntityType, err)
+		}
+		created, err := h.fulfiller.CreateLabel(&contracts.CreateLabelRequest{
+			Name:        p.Name,
+			City:        p.City,
+			State:       p.State,
+			Country:     p.Country,
+			FoundedYear: p.FoundedYear,
+			Description: p.Description,
+		})
+		if err != nil {
+			return 0, err
+		}
+		return created.ID, nil
+
+	case communitym.EntityRequestRelease:
+		p, err := communitym.UnmarshalPayload[communitym.ReleaseRequestPayload](raw)
+		if err != nil {
+			return 0, apperrors.ErrEntityRequestPayloadInvalid(req.EntityType, err)
+		}
+		releaseType := ""
+		if p.ReleaseType != nil {
+			releaseType = *p.ReleaseType
+		}
+		created, err := h.fulfiller.CreateRelease(&contracts.CreateReleaseRequest{
+			Title:       p.Title,
+			ReleaseType: releaseType,
+			ReleaseYear: p.ReleaseYear,
+			ReleaseDate: p.ReleaseDate,
+			CoverArtURL: p.CoverArtURL,
+			Description: p.Description,
+		})
+		if err != nil {
+			return 0, err
+		}
+		return created.ID, nil
+
+	case communitym.EntityRequestShow, communitym.EntityRequestFestival:
+		return 0, apperrors.ErrEntityRequestFulfillUnsupported(req.EntityType)
+
+	default:
+		// IsValidEntityRequestType is enforced on create, so this is
+		// defense-in-depth against a future entity_type added to the registry
+		// without a fulfillment branch.
+		return 0, apperrors.ErrEntityRequestFulfillUnsupported(req.EntityType)
+	}
+}

--- a/backend/internal/api/handlers/community/entity_request_test.go
+++ b/backend/internal/api/handlers/community/entity_request_test.go
@@ -1,0 +1,455 @@
+package community
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
+	authm "psychic-homily-backend/internal/models/auth"
+	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func erAdminCtx() context.Context {
+	return testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+}
+
+func erUserCtx() context.Context {
+	return testhelpers.CtxWithUser(&authm.User{ID: 2, IsAdmin: false, UserTier: "contributor"})
+}
+
+func artistPayload(t *testing.T, name string) json.RawMessage {
+	t.Helper()
+	raw, err := communitym.MarshalPayload(communitym.ArtistRequestPayload{Name: name})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return raw
+}
+
+func pendingRequest(id uint, entityType string) *communitym.EntityRequest {
+	raw := json.RawMessage(`{"name":"Test"}`)
+	return &communitym.EntityRequest{
+		ID:            id,
+		EntityType:    entityType,
+		Payload:       &raw,
+		RequesterID:   2,
+		SourceContext: communitym.EntityRequestSourceManual,
+		DecisionState: communitym.EntityRequestStatePending,
+	}
+}
+
+// ============================================================================
+// Tests: Queue-create — auth & validation
+// ============================================================================
+
+func TestCreateEntityRequest_NoUser(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	_, err := h.CreateEntityRequestHandler(context.Background(), req)
+	testhelpers.AssertHumaError(t, err, 401)
+}
+
+func TestCreateEntityRequest_InvalidEntityType(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "wizard"
+	req.Body.Payload = json.RawMessage(`{"name":"x"}`)
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestCreateEntityRequest_InvalidSource(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	req.Body.SourceContext = "carrier_pigeon"
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestCreateEntityRequest_EmptyPayload(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = json.RawMessage("   ")
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: Queue-create — success
+// ============================================================================
+
+// contributor tier files a PENDING request (no autonomous creation).
+func TestCreateEntityRequest_ContributorQueuesPending(t *testing.T) {
+	want := pendingRequest(7, "artist")
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+				if user.ID != 2 {
+					t.Errorf("expected requester 2, got %d", user.ID)
+				}
+				if entityType != "artist" {
+					t.Errorf("expected artist, got %s", entityType)
+				}
+				if sourceContext != communitym.EntityRequestSourceManual {
+					t.Errorf("expected default source manual, got %s", sourceContext)
+				}
+				return want, nil
+			},
+		},
+		nil,
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+
+	resp, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 7 {
+		t.Errorf("expected id 7, got %d", resp.Body.ID)
+	}
+	if resp.Body.DecisionState != communitym.EntityRequestStatePending {
+		t.Errorf("expected pending, got %s", resp.Body.DecisionState)
+	}
+}
+
+func TestCreateEntityRequest_ServiceError(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+				return nil, fmt.Errorf("db down")
+			},
+		},
+		nil,
+		nil,
+	)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+func TestCreateEntityRequest_MapsTypedError(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+				return nil, apperrors.ErrEntityRequestEmptyPayload("artist")
+			},
+		},
+		nil,
+		nil,
+	)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: Admin list
+// ============================================================================
+
+func TestAdminListEntityRequests_Success(t *testing.T) {
+	rows := []communitym.EntityRequest{*pendingRequest(1, "artist")}
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			ListRequestsFn: func(f *contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error) {
+				if f.EntityType != "artist" {
+					t.Errorf("expected entity_type filter artist, got %s", f.EntityType)
+				}
+				if f.SourceContext != communitym.EntityRequestSourcePasteMode {
+					t.Errorf("expected source paste_mode, got %s", f.SourceContext)
+				}
+				return rows, 1, nil
+			},
+		},
+		nil,
+		nil,
+	)
+
+	resp, err := h.AdminListEntityRequestsHandler(erAdminCtx(), &AdminListEntityRequestsRequest{
+		EntityType:    "artist",
+		SourceContext: communitym.EntityRequestSourcePasteMode,
+		State:         "pending",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 || len(resp.Body.Requests) != 1 {
+		t.Errorf("expected 1 request total=1, got total=%d len=%d", resp.Body.Total, len(resp.Body.Requests))
+	}
+}
+
+func TestAdminListEntityRequests_InvalidEntityType(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	_, err := h.AdminListEntityRequestsHandler(erAdminCtx(), &AdminListEntityRequestsRequest{EntityType: "wizard"})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestAdminListEntityRequests_InvalidState(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	_, err := h.AdminListEntityRequestsHandler(erAdminCtx(), &AdminListEntityRequestsRequest{State: "limbo"})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestAdminListEntityRequests_InvalidSource(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	_, err := h.AdminListEntityRequestsHandler(erAdminCtx(), &AdminListEntityRequestsRequest{SourceContext: "smoke_signal"})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestAdminListEntityRequests_ServiceError(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			ListRequestsFn: func(f *contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error) {
+				return nil, 0, fmt.Errorf("db down")
+			},
+		},
+		nil,
+		nil,
+	)
+	_, err := h.AdminListEntityRequestsHandler(erAdminCtx(), &AdminListEntityRequestsRequest{})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: Admin decide — validation
+// ============================================================================
+
+func TestAdminDecide_InvalidID(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	req := &AdminDecideEntityRequestRequest{ID: "abc"}
+	req.Body.Decision = "approved"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestAdminDecide_InvalidDecision(t *testing.T) {
+	h := NewEntityRequestHandler(nil, nil, nil)
+	req := &AdminDecideEntityRequestRequest{ID: "1"}
+	req.Body.Decision = "maybe"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: Admin decide — approve (creates entity)
+// ============================================================================
+
+func TestAdminDecide_ApproveArtist_CreatesEntity(t *testing.T) {
+	decided := pendingRequest(5, "artist")
+	decided.DecisionState = communitym.EntityRequestStateApproved
+	createCalled := false
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				if requestID != 5 || adminID != 1 {
+					t.Errorf("unexpected decide params: req=%d admin=%d", requestID, adminID)
+				}
+				if newState != communitym.EntityRequestStateApproved {
+					t.Errorf("expected approved, got %s", newState)
+				}
+				return decided, nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{
+			CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+				createCalled = true
+				if req.Name != "Test" {
+					t.Errorf("expected name Test from payload, got %s", req.Name)
+				}
+				return &contracts.ArtistDetailResponse{ID: 99}, nil
+			},
+		},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &AdminDecideEntityRequestRequest{ID: "5"}
+	req.Body.Decision = "approved"
+
+	resp, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !createCalled {
+		t.Error("expected fulfiller CreateArtist to be called on approve")
+	}
+	if resp.Body.CreatedEntityID == nil || *resp.Body.CreatedEntityID != 99 {
+		t.Errorf("expected created entity id 99, got %v", resp.Body.CreatedEntityID)
+	}
+	if resp.Body.CreatedEntityType == nil || *resp.Body.CreatedEntityType != "artist" {
+		t.Errorf("expected created entity type artist, got %v", resp.Body.CreatedEntityType)
+	}
+	if resp.Body.Request.DecisionState != communitym.EntityRequestStateApproved {
+		t.Errorf("expected request approved, got %s", resp.Body.Request.DecisionState)
+	}
+}
+
+// Approving a show is unsupported (payload lacks venues + artists) → 422.
+func TestAdminDecide_ApproveShow_Unsupported(t *testing.T) {
+	decided := pendingRequest(6, "show")
+	decided.DecisionState = communitym.EntityRequestStateApproved
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				return decided, nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &AdminDecideEntityRequestRequest{ID: "6"}
+	req.Body.Decision = "approved"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	// The row was claimed (approved) but fulfillment is unsupported → 422.
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+// Fulfillment failure after claim surfaces a 500 (entity NOT created).
+func TestAdminDecide_ApproveFulfillFails(t *testing.T) {
+	decided := pendingRequest(8, "artist")
+	decided.DecisionState = communitym.EntityRequestStateApproved
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				return decided, nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{
+			CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+				return nil, fmt.Errorf("slug collision")
+			},
+		},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &AdminDecideEntityRequestRequest{ID: "8"}
+	req.Body.Decision = "approved"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: Admin decide — reject (no entity created)
+// ============================================================================
+
+func TestAdminDecide_Reject(t *testing.T) {
+	rejected := pendingRequest(9, "artist")
+	rejected.DecisionState = communitym.EntityRequestStateRejected
+	fulfillCalled := false
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				if newState != communitym.EntityRequestStateRejected {
+					t.Errorf("expected rejected, got %s", newState)
+				}
+				if note == nil || *note != "not notable" {
+					t.Errorf("expected trimmed note 'not notable', got %v", note)
+				}
+				return rejected, nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{
+			CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+				fulfillCalled = true
+				return &contracts.ArtistDetailResponse{ID: 1}, nil
+			},
+		},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	note := "  not notable  "
+	req := &AdminDecideEntityRequestRequest{ID: "9"}
+	req.Body.Decision = "rejected"
+	req.Body.Note = &note
+
+	resp, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fulfillCalled {
+		t.Error("reject must NOT create an entity")
+	}
+	if resp.Body.CreatedEntityID != nil {
+		t.Errorf("reject must not report a created entity, got %v", resp.Body.CreatedEntityID)
+	}
+	if resp.Body.Request.DecisionState != communitym.EntityRequestStateRejected {
+		t.Errorf("expected rejected, got %s", resp.Body.Request.DecisionState)
+	}
+}
+
+// ============================================================================
+// Tests: Admin decide — error mapping
+// ============================================================================
+
+func TestAdminDecide_NotFound(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				return nil, apperrors.ErrEntityRequestNotFound(404)
+			},
+		},
+		nil,
+		nil,
+	)
+	req := &AdminDecideEntityRequestRequest{ID: "404"}
+	req.Body.Decision = "approved"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+// Re-deciding an already-resolved request → 409 conflict.
+func TestAdminDecide_AlreadyDecided(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				return nil, apperrors.ErrEntityRequestInvalidState(1, "approved")
+			},
+		},
+		nil,
+		nil,
+	)
+	req := &AdminDecideEntityRequestRequest{ID: "1"}
+	req.Body.Decision = "approved"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 409)
+}
+
+func TestAdminDecide_ServiceError(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				return nil, fmt.Errorf("db down")
+			},
+		},
+		nil,
+		nil,
+	)
+	req := &AdminDecideEntityRequestRequest{ID: "1"}
+	req.Body.Decision = "rejected"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/community/entity_request_test.go
+++ b/backend/internal/api/handlers/community/entity_request_test.go
@@ -87,6 +87,44 @@ func TestCreateEntityRequest_EmptyPayload(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 422)
 }
 
+// Payload missing the type's required field (empty name) → 422 at create time,
+// not deferred to fulfillment.
+func TestCreateEntityRequest_PayloadMissingRequiredField(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+				t.Fatal("service must NOT be called for an invalid payload")
+				return nil, nil
+			},
+		},
+		nil, nil,
+	)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = json.RawMessage(`{"name":""}`)
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+// Payload with an unknown field (schema drift) → 422 (UnmarshalPayload's
+// DisallowUnknownFields guard surfaces at the boundary).
+func TestCreateEntityRequest_PayloadUnknownField(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+				t.Fatal("service must NOT be called for an invalid payload")
+				return nil, nil
+			},
+		},
+		nil, nil,
+	)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = json.RawMessage(`{"name":"Boris","sneaky":"x"}`)
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
 // ============================================================================
 // Tests: Queue-create — success
 // ============================================================================

--- a/backend/internal/api/handlers/shared/error_mappers.go
+++ b/backend/internal/api/handlers/shared/error_mappers.go
@@ -289,6 +289,35 @@ func MapEntityReportError(err error) error {
 	return nil
 }
 
+// MapEntityRequestError converts an EntityRequestError to an appropriate Huma
+// HTTP error. Returns nil if err is not a *apperrors.EntityRequestError so the
+// caller can fall through to a 500. PSY-997.
+//
+// not-found → 404; already-decided (invalid state for a decision) → 409;
+// invalid type / source / decision / empty payload (semantic validation) → 422.
+func MapEntityRequestError(err error) error {
+	var reqErr *apperrors.EntityRequestError
+	if errors.As(err, &reqErr) {
+		switch reqErr.Code {
+		case apperrors.CodeEntityRequestNotFound:
+			return huma.Error404NotFound(reqErr.Message)
+		case apperrors.CodeEntityRequestInvalidState:
+			return huma.Error409Conflict(reqErr.Message)
+		case apperrors.CodeEntityRequestInvalidType,
+			apperrors.CodeEntityRequestInvalidSource,
+			apperrors.CodeEntityRequestEmptyPayload,
+			apperrors.CodeEntityRequestInvalidDecision,
+			apperrors.CodeEntityRequestFulfillUnsupported:
+			return huma.Error422UnprocessableEntity(reqErr.Message)
+		case apperrors.CodeEntityRequestPayloadInvalid:
+			// Stored payload corruption — server-side data fault, not the
+			// admin's input.
+			return huma.Error500InternalServerError(reqErr.Message)
+		}
+	}
+	return nil
+}
+
 // MapLeaderboardError converts a LeaderboardError to an appropriate Huma HTTP
 // error. Returns nil if err is not a *apperrors.LeaderboardError.
 //

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1552,6 +1552,85 @@ func (m *MockEntityReportService) DismissEntityReport(reportID uint, reviewerID 
 }
 
 // ============================================================================
+// Mock: EntityRequestFulfillerInterface
+// ============================================================================
+
+type MockEntityRequestFulfiller struct {
+	CreateArtistFn  func(*contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error)
+	CreateVenueFn   func(*contracts.CreateVenueRequest, bool) (*contracts.VenueDetailResponse, error)
+	CreateLabelFn   func(*contracts.CreateLabelRequest) (*contracts.LabelDetailResponse, error)
+	CreateReleaseFn func(*contracts.CreateReleaseRequest) (*contracts.ReleaseDetailResponse, error)
+}
+
+func (m *MockEntityRequestFulfiller) CreateArtist(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+	if m.CreateArtistFn != nil {
+		return m.CreateArtistFn(req)
+	}
+	return nil, nil
+}
+func (m *MockEntityRequestFulfiller) CreateVenue(req *contracts.CreateVenueRequest, isAdmin bool) (*contracts.VenueDetailResponse, error) {
+	if m.CreateVenueFn != nil {
+		return m.CreateVenueFn(req, isAdmin)
+	}
+	return nil, nil
+}
+func (m *MockEntityRequestFulfiller) CreateLabel(req *contracts.CreateLabelRequest) (*contracts.LabelDetailResponse, error) {
+	if m.CreateLabelFn != nil {
+		return m.CreateLabelFn(req)
+	}
+	return nil, nil
+}
+func (m *MockEntityRequestFulfiller) CreateRelease(req *contracts.CreateReleaseRequest) (*contracts.ReleaseDetailResponse, error) {
+	if m.CreateReleaseFn != nil {
+		return m.CreateReleaseFn(req)
+	}
+	return nil, nil
+}
+
+// ============================================================================
+// Mock: EntityRequestServiceInterface
+// ============================================================================
+
+type MockEntityRequestService struct {
+	CreateRequestFn func(*authm.User, string, []byte, string, bool) (*communitym.EntityRequest, error)
+	GetRequestFn    func(uint) (*communitym.EntityRequest, error)
+	ListPendingFn   func(string, int, int) ([]communitym.EntityRequest, int64, error)
+	ListRequestsFn  func(*contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error)
+	DecideFn        func(uint, uint, communitym.EntityRequestDecisionState, *string) (*communitym.EntityRequest, error)
+}
+
+func (m *MockEntityRequestService) CreateRequest(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+	if m.CreateRequestFn != nil {
+		return m.CreateRequestFn(user, entityType, payload, sourceContext, confirmed)
+	}
+	return nil, nil
+}
+func (m *MockEntityRequestService) GetRequest(requestID uint) (*communitym.EntityRequest, error) {
+	if m.GetRequestFn != nil {
+		return m.GetRequestFn(requestID)
+	}
+	return nil, nil
+}
+func (m *MockEntityRequestService) ListPending(entityType string, limit int, offset int) ([]communitym.EntityRequest, int64, error) {
+	if m.ListPendingFn != nil {
+		return m.ListPendingFn(entityType, limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *MockEntityRequestService) ListRequests(filters *contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error) {
+	if m.ListRequestsFn != nil {
+		return m.ListRequestsFn(filters)
+	}
+	return nil, 0, nil
+}
+func (m *MockEntityRequestService) Decide(requestID uint, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+	if m.DecideFn != nil {
+		return m.DecideFn(requestID, adminID, newState, note)
+	}
+	return nil, nil
+}
+
+// ============================================================================
 // Mock: ExploreServiceInterface
 // ============================================================================
 
@@ -4111,6 +4190,8 @@ var _ contracts.DiscoveryServiceInterface = (*MockDiscoveryService)(nil)
 var _ contracts.EmailServiceInterface = (*MockEmailService)(nil)
 var _ contracts.EnrichmentServiceInterface = (*MockEnrichmentService)(nil)
 var _ contracts.EntityReportServiceInterface = (*MockEntityReportService)(nil)
+var _ contracts.EntityRequestFulfillerInterface = (*MockEntityRequestFulfiller)(nil)
+var _ contracts.EntityRequestServiceInterface = (*MockEntityRequestService)(nil)
 var _ contracts.ExploreServiceInterface = (*MockExploreService)(nil)
 var _ contracts.ExtractionServiceInterface = (*MockExtractionService)(nil)
 var _ contracts.FeaturedSlotServiceInterface = (*MockFeaturedSlotService)(nil)

--- a/backend/internal/api/routes/entity_requests.go
+++ b/backend/internal/api/routes/entity_requests.go
@@ -1,0 +1,33 @@
+package routes
+
+import (
+	"github.com/danielgtaylor/huma/v2"
+
+	communityh "psychic-homily-backend/internal/api/handlers/community"
+)
+
+// setupEntityRequestRoutes configures the polymorphic entity_requests queue
+// endpoints (PSY-997, built on PSY-869's service).
+//
+//   - User queue-create on rc.Protected (auth required; trust-tier gating is
+//     in the service — contributor/new_user file a pending request).
+//   - Admin list + decide on rc.Admin (auth + IsAdmin enforced by middleware,
+//     per PSY-423; handlers carry no inline admin check).
+//
+// These are SEPARATE from the pending_entity_edits admin endpoints — PSY-871's
+// frontend unifies the two queues into one page; the backend keeps them
+// parallel and independently testable.
+func setupEntityRequestRoutes(rc RouteContext) {
+	entityRequestHandler := communityh.NewEntityRequestHandler(
+		rc.SC.EntityRequest,
+		rc.SC.EntityRequestFulfiller,
+		rc.SC.AuditLog,
+	)
+
+	// User: file an entity-creation request (consumed by PSY-845 + PSY-853).
+	huma.Post(rc.Protected, "/entity-requests", entityRequestHandler.CreateEntityRequestHandler)
+
+	// Admin: moderation queue (consumed by PSY-871).
+	huma.Get(rc.Admin, "/admin/entity-requests", entityRequestHandler.AdminListEntityRequestsHandler)
+	huma.Post(rc.Admin, "/admin/entity-requests/{id}/decide", entityRequestHandler.AdminDecideEntityRequestHandler)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -91,6 +91,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupChartsRoutes(rc)
 	setupPendingEditRoutes(rc)
 	setupEntityReportRoutes(rc)
+	setupEntityRequestRoutes(rc)
 	setupContributeRoutes(rc)
 	setupLeaderboardRoutes(rc)
 	setupDataGapsRoutes(rc)

--- a/backend/internal/errors/entity_request.go
+++ b/backend/internal/errors/entity_request.go
@@ -19,6 +19,13 @@ const (
 	CodeEntityRequestEmptyPayload    = "ENTITY_REQUEST_EMPTY_PAYLOAD"
 	CodeEntityRequestInvalidDecision = "ENTITY_REQUEST_INVALID_DECISION"
 	CodeEntityRequestInvalidState    = "ENTITY_REQUEST_INVALID_STATE"
+	// CodeEntityRequestFulfillUnsupported: approve cannot create the entity for
+	// this entity_type because the payload lacks required associations (show ⇒
+	// venues + artists; festival ⇒ series_slug). PSY-997.
+	CodeEntityRequestFulfillUnsupported = "ENTITY_REQUEST_FULFILL_UNSUPPORTED"
+	// CodeEntityRequestPayloadInvalid: the stored payload failed to decode into
+	// its typed struct on the fulfillment path (schema drift / corruption).
+	CodeEntityRequestPayloadInvalid = "ENTITY_REQUEST_PAYLOAD_INVALID"
 )
 
 // EntityRequestError represents an entity-request error with context.
@@ -91,5 +98,24 @@ func ErrEntityRequestInvalidState(requestID uint, currentState string) *EntityRe
 		Code:      CodeEntityRequestInvalidState,
 		Message:   fmt.Sprintf("Entity request %d is %s, expected pending", requestID, currentState),
 		RequestID: requestID,
+	}
+}
+
+// ErrEntityRequestFulfillUnsupported creates an error when an approved request's
+// entity_type cannot be auto-created from its payload (show / festival). PSY-997.
+func ErrEntityRequestFulfillUnsupported(entityType string) *EntityRequestError {
+	return &EntityRequestError{
+		Code:    CodeEntityRequestFulfillUnsupported,
+		Message: fmt.Sprintf("Approving a %s request cannot auto-create the entity (its payload lacks required associations); create it manually", entityType),
+	}
+}
+
+// ErrEntityRequestPayloadInvalid creates an error when a stored payload fails to
+// decode into its typed struct on the fulfillment path. PSY-997.
+func ErrEntityRequestPayloadInvalid(entityType string, internal error) *EntityRequestError {
+	return &EntityRequestError{
+		Code:     CodeEntityRequestPayloadInvalid,
+		Message:  fmt.Sprintf("Stored %s payload is invalid and cannot be fulfilled", entityType),
+		Internal: internal,
 	}
 }

--- a/backend/internal/models/community/entity_request.go
+++ b/backend/internal/models/community/entity_request.go
@@ -53,3 +53,28 @@ type EntityRequest struct {
 
 // TableName specifies the table name for EntityRequest.
 func (EntityRequest) TableName() string { return "entity_requests" }
+
+// IsValidEntityRequestState reports whether s is a recognized decision_state.
+// Used at the admin-list trust boundary to validate the optional state filter
+// before it reaches the query. PSY-997.
+func IsValidEntityRequestState(s string) bool {
+	switch EntityRequestDecisionState(s) {
+	case EntityRequestStatePending, EntityRequestStateApproved, EntityRequestStateRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidEntityRequestSource reports whether s is a recognized source_context.
+// Mirrors the migration's CHECK constraint and the service's (unexported)
+// source-context guard; exported so the HTTP handlers can validate the
+// queue-create body + the admin-list source filter. PSY-997.
+func IsValidEntityRequestSource(s string) bool {
+	switch s {
+	case EntityRequestSourceAIExtraction, EntityRequestSourcePasteMode, EntityRequestSourceManual:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/models/community/entity_request_payloads.go
+++ b/backend/internal/models/community/entity_request_payloads.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // PSY-869: typed payload schemas for the polymorphic entity_requests table.
@@ -151,6 +152,84 @@ var payloadRegistry = map[string]EntityRequestPayload{
 func IsValidEntityRequestType(entityType string) bool {
 	_, ok := payloadRegistry[entityType]
 	return ok
+}
+
+// ValidateEntityRequestPayload checks that raw decodes cleanly into the typed
+// struct for entityType AND that the type's required field(s) are present.
+// PSY-997: called at the queue-create trust boundary so a malformed payload
+// (unknown fields, wrong shape, missing required Name/Title) is rejected with a
+// 422 at submit time instead of being stored as junk in the queue and failing
+// confusingly when an admin later approves it.
+//
+// Returns nil for a well-formed payload. The error is descriptive of the
+// decode/required-field failure (it does not wrap an EntityRequestError —
+// the caller maps it to a 422). entityType MUST be a registered type
+// (IsValidEntityRequestType) — an unknown type returns an error.
+func ValidateEntityRequestPayload(entityType string, raw json.RawMessage) error {
+	switch entityType {
+	case EntityRequestArtist:
+		p, err := UnmarshalPayload[ArtistRequestPayload](raw)
+		if err != nil {
+			return err
+		}
+		return requireField("artist", "name", p.Name)
+	case EntityRequestRelease:
+		p, err := UnmarshalPayload[ReleaseRequestPayload](raw)
+		if err != nil {
+			return err
+		}
+		return requireField("release", "title", p.Title)
+	case EntityRequestLabel:
+		p, err := UnmarshalPayload[LabelRequestPayload](raw)
+		if err != nil {
+			return err
+		}
+		return requireField("label", "name", p.Name)
+	case EntityRequestVenue:
+		p, err := UnmarshalPayload[VenueRequestPayload](raw)
+		if err != nil {
+			return err
+		}
+		if err := requireField("venue", "name", p.Name); err != nil {
+			return err
+		}
+		if err := requireField("venue", "city", p.City); err != nil {
+			return err
+		}
+		return requireField("venue", "state", p.State)
+	case EntityRequestShow:
+		p, err := UnmarshalPayload[ShowRequestPayload](raw)
+		if err != nil {
+			return err
+		}
+		if err := requireField("show", "title", p.Title); err != nil {
+			return err
+		}
+		return requireField("show", "event_date", p.EventDate)
+	case EntityRequestFestival:
+		p, err := UnmarshalPayload[FestivalRequestPayload](raw)
+		if err != nil {
+			return err
+		}
+		if err := requireField("festival", "name", p.Name); err != nil {
+			return err
+		}
+		if err := requireField("festival", "start_date", p.StartDate); err != nil {
+			return err
+		}
+		return requireField("festival", "end_date", p.EndDate)
+	default:
+		return fmt.Errorf("unsupported entity request type: %q", entityType)
+	}
+}
+
+// requireField returns an error when a required string field is empty (after
+// trimming). Keeps ValidateEntityRequestPayload's required-field checks terse.
+func requireField(entityType, field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s payload: %s is required", entityType, field)
+	}
+	return nil
 }
 
 // ValidEntityRequestTypes returns the registered entity_type discriminators.

--- a/backend/internal/models/community/entity_request_payloads_test.go
+++ b/backend/internal/models/community/entity_request_payloads_test.go
@@ -221,3 +221,36 @@ func TestIsValidEntityRequestType(t *testing.T) {
 	assert.False(t, IsValidEntityRequestType("podcast"))
 	assert.False(t, IsValidEntityRequestType(""))
 }
+
+// TestValidateEntityRequestPayload covers the PSY-997 create-time payload guard:
+// clean payloads pass; malformed shape / unknown fields / missing required
+// fields are rejected.
+func TestValidateEntityRequestPayload(t *testing.T) {
+	t.Run("valid artist", func(t *testing.T) {
+		assert.NoError(t, ValidateEntityRequestPayload(EntityRequestArtist, json.RawMessage(`{"name":"Boris"}`)))
+	})
+	t.Run("valid venue with required city+state", func(t *testing.T) {
+		assert.NoError(t, ValidateEntityRequestPayload(EntityRequestVenue, json.RawMessage(`{"name":"Trunk Space","city":"Phoenix","state":"AZ"}`)))
+	})
+	t.Run("artist missing name", func(t *testing.T) {
+		assert.Error(t, ValidateEntityRequestPayload(EntityRequestArtist, json.RawMessage(`{"name":""}`)))
+	})
+	t.Run("artist blank-only name", func(t *testing.T) {
+		assert.Error(t, ValidateEntityRequestPayload(EntityRequestArtist, json.RawMessage(`{"name":"   "}`)))
+	})
+	t.Run("unknown field rejected", func(t *testing.T) {
+		assert.Error(t, ValidateEntityRequestPayload(EntityRequestArtist, json.RawMessage(`{"name":"Boris","sneaky":1}`)))
+	})
+	t.Run("venue missing required state", func(t *testing.T) {
+		assert.Error(t, ValidateEntityRequestPayload(EntityRequestVenue, json.RawMessage(`{"name":"X","city":"Phoenix","state":""}`)))
+	})
+	t.Run("malformed json", func(t *testing.T) {
+		assert.Error(t, ValidateEntityRequestPayload(EntityRequestArtist, json.RawMessage(`{"name":`)))
+	})
+	t.Run("unsupported type", func(t *testing.T) {
+		assert.Error(t, ValidateEntityRequestPayload("podcast", json.RawMessage(`{}`)))
+	})
+	t.Run("festival requires dates", func(t *testing.T) {
+		assert.Error(t, ValidateEntityRequestPayload(EntityRequestFestival, json.RawMessage(`{"name":"Desert Daze","edition_year":2026,"start_date":"2026-01-01","end_date":""}`)))
+	})
+}

--- a/backend/internal/services/community/entityrequest_fulfiller.go
+++ b/backend/internal/services/community/entityrequest_fulfiller.go
@@ -1,0 +1,47 @@
+package community
+
+import (
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// PSY-997: EntityRequestFulfiller composes the per-entity catalog create
+// services behind the narrow contracts.EntityRequestFulfillerInterface used by
+// the decide-approve handler. It is a pure adapter — each method delegates to
+// the matching catalog service — so the handler depends on one small interface
+// instead of four fat catalog service interfaces, and fulfillment can be
+// mocked in handler tests via the generated MockEntityRequestFulfiller.
+type EntityRequestFulfiller struct {
+	artist  contracts.ArtistServiceInterface
+	venue   contracts.VenueServiceInterface
+	label   contracts.LabelServiceInterface
+	release contracts.ReleaseServiceInterface
+}
+
+// NewEntityRequestFulfiller wires the catalog create services into the adapter.
+func NewEntityRequestFulfiller(
+	artist contracts.ArtistServiceInterface,
+	venue contracts.VenueServiceInterface,
+	label contracts.LabelServiceInterface,
+	release contracts.ReleaseServiceInterface,
+) *EntityRequestFulfiller {
+	return &EntityRequestFulfiller{artist: artist, venue: venue, label: label, release: release}
+}
+
+func (f *EntityRequestFulfiller) CreateArtist(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+	return f.artist.CreateArtist(req)
+}
+
+func (f *EntityRequestFulfiller) CreateVenue(req *contracts.CreateVenueRequest, isAdmin bool) (*contracts.VenueDetailResponse, error) {
+	return f.venue.CreateVenue(req, isAdmin)
+}
+
+func (f *EntityRequestFulfiller) CreateLabel(req *contracts.CreateLabelRequest) (*contracts.LabelDetailResponse, error) {
+	return f.label.CreateLabel(req)
+}
+
+func (f *EntityRequestFulfiller) CreateRelease(req *contracts.CreateReleaseRequest) (*contracts.ReleaseDetailResponse, error) {
+	return f.release.CreateRelease(req)
+}
+
+// Compile-time assertion the adapter satisfies the fulfiller interface.
+var _ contracts.EntityRequestFulfillerInterface = (*EntityRequestFulfiller)(nil)

--- a/backend/internal/services/community/entityrequest_list.go
+++ b/backend/internal/services/community/entityrequest_list.go
@@ -1,0 +1,67 @@
+package community
+
+import (
+	"fmt"
+
+	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// PSY-997: admin-queue list query for entity_requests. Added as a SIBLING to
+// PSY-869's entityrequest.go (whose ListPending is pending-only + entity_type-
+// only) so the admin list endpoint can also filter by decision_state and
+// source_context without modifying PSY-869's owned logic.
+//
+// Defaults to decision_state='pending' (the admin's primary view) when no
+// State filter is given, matching ListPending's behavior and the index in the
+// migration (idx_entity_requests_state_type). Requester is preloaded so the
+// queue can show who filed each request; Payload is already on the row for the
+// per-type preview.
+func (s *EntityRequestService) ListRequests(filters *contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+	if filters == nil {
+		filters = &contracts.EntityRequestFilters{}
+	}
+
+	query := s.db.Model(&communitym.EntityRequest{})
+
+	// State: default to pending (the queue's primary view). The handler has
+	// already validated any non-empty value against the model enum.
+	state := filters.State
+	if state == "" {
+		state = string(communitym.EntityRequestStatePending)
+	}
+	query = query.Where("decision_state = ?", state)
+
+	if filters.EntityType != "" {
+		query = query.Where("entity_type = ?", filters.EntityType)
+	}
+	if filters.SourceContext != "" {
+		query = query.Where("source_context = ?", filters.SourceContext)
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count entity requests: %w", err)
+	}
+
+	limit := filters.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := filters.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	var reqs []communitym.EntityRequest
+	if err := query.Preload("Requester").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&reqs).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to list entity requests: %w", err)
+	}
+	return reqs, total, nil
+}

--- a/backend/internal/services/community/entityrequest_test.go
+++ b/backend/internal/services/community/entityrequest_test.go
@@ -10,6 +10,7 @@ import (
 
 	authm "psychic-homily-backend/internal/models/auth"
 	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -312,6 +313,91 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestListPending_FiltersAn
 	suite.Assert().Equal(int64(1), total)
 	suite.Require().Len(artistsOnly, 1)
 	suite.Assert().Equal(communitym.EntityRequestArtist, artistsOnly[0].EntityType)
+}
+
+// --- PSY-997: ListRequests (admin queue with state + source filters) --------
+
+// Default state (empty filter) returns pending only, mirroring ListPending,
+// and excludes approved rows.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_DefaultPendingExcludesApproved() {
+	newbie := suite.createUser("lr-newbie", tierNewUser, false)
+	admin := suite.createUser("lr-admin", tierNewUser, true)
+
+	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
+		suite.marshalArtist("LR Pending"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+	_, err = suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
+		suite.marshalArtist("LR Approved"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total, "default filter is pending-only")
+	suite.Require().Len(rows, 1)
+	suite.Assert().Equal(communitym.EntityRequestStatePending, rows[0].DecisionState)
+}
+
+// Explicit state=approved returns the approved rows.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_StateApproved() {
+	admin := suite.createUser("lr-admin2", tierNewUser, true)
+	_, err := suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
+		suite.marshalArtist("LR Approved 2"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{
+		State: string(communitym.EntityRequestStateApproved),
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Require().Len(rows, 1)
+	suite.Assert().Equal(communitym.EntityRequestStateApproved, rows[0].DecisionState)
+}
+
+// source_context filter narrows the pending queue to one origin.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_SourceContextFilter() {
+	newbie := suite.createUser("lr-src", tierNewUser, false)
+
+	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
+		suite.marshalArtist("Manual one"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+	_, err = suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
+		suite.marshalArtist("Paste one"), communitym.EntityRequestSourcePasteMode, false)
+	suite.Require().NoError(err)
+
+	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{
+		SourceContext: communitym.EntityRequestSourcePasteMode,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Require().Len(rows, 1)
+	suite.Assert().Equal(communitym.EntityRequestSourcePasteMode, rows[0].SourceContext)
+}
+
+// entity_type filter narrows by type; pagination bounds the result page while
+// total reflects the full filtered count.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_EntityTypeAndPagination() {
+	newbie := suite.createUser("lr-page", tierNewUser, false)
+
+	for i := 0; i < 3; i++ {
+		_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
+			suite.marshalArtist(fmt.Sprintf("Page artist %d", i)), communitym.EntityRequestSourceManual, false)
+		suite.Require().NoError(err)
+	}
+	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestVenue,
+		mustMarshalVenue(suite, "Page venue"), communitym.EntityRequestSourceManual, false)
+	suite.Require().NoError(err)
+
+	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{
+		EntityType: communitym.EntityRequestArtist,
+		Limit:      2,
+		Offset:     0,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(3), total, "total counts all filtered rows, not the page")
+	suite.Assert().Len(rows, 2, "page is bounded by limit")
+	for _, r := range rows {
+		suite.Assert().Equal(communitym.EntityRequestArtist, r.EntityType)
+	}
 }
 
 // strptr is a local pointer helper for the entity-request payload fixtures.

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -41,6 +41,8 @@ type ServiceContainer struct {
 	Calendar               *engagement.CalendarService
 	Collection             *community.CollectionService
 	Request                *community.RequestService
+	EntityRequest          *community.EntityRequestService
+	EntityRequestFulfiller *community.EntityRequestFulfiller
 	Tag                    *catalog.TagService
 	ArtistRelationship     *catalog.ArtistRelationshipService
 	Scene                  *catalog.SceneService
@@ -142,6 +144,14 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	radioSvc := catalog.NewRadioService(database)
 	artistRelSvc := catalog.NewArtistRelationshipService(database)
 
+	// PSY-997: entity_requests creation queue + its fulfillment adapter. The
+	// fulfiller composes the catalog create services so the admin decide-approve
+	// handler can create the entity from an approved request's payload.
+	labelSvc := catalog.NewLabelService(database)
+	releaseSvc := catalog.NewReleaseService(database)
+	entityRequestSvc := community.NewEntityRequestService(database)
+	entityRequestFulfiller := community.NewEntityRequestFulfiller(artist, venue, labelSvc, releaseSvc)
+
 	// PSY-289: wire the comment notifier into the comment service so new
 	// comments fan out notification emails fire-and-forget.
 	commentSvc := engagement.NewCommentService(database, utils.NewMarkdownRenderer())
@@ -182,6 +192,8 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Calendar:               engagement.NewCalendarService(database, savedShow),
 		Collection:             collectionSvc,
 		Request:                community.NewRequestService(database),
+		EntityRequest:          entityRequestSvc,
+		EntityRequestFulfiller: entityRequestFulfiller,
 		Tag:                    tagSvc,
 		ArtistRelationship:     artistRelSvc,
 		Scene:                  catalog.NewSceneService(database),
@@ -193,8 +205,8 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Follow:                 engagement.NewFollowService(database),
 		Festival:               catalog.NewFestivalService(database),
 		FestivalIntelligence:   catalog.NewFestivalIntelligenceService(database),
-		Label:                  catalog.NewLabelService(database),
-		Release:                catalog.NewReleaseService(database),
+		Label:                  labelSvc,
+		Release:                releaseSvc,
 		SavedShow:              savedShow,
 		Show:                   catalog.NewShowService(database),
 		ShowReport:             adminsvc.NewShowReportService(database),

--- a/backend/internal/services/contracts/entity_request.go
+++ b/backend/internal/services/contracts/entity_request.go
@@ -1,0 +1,73 @@
+package contracts
+
+import (
+	authm "psychic-homily-backend/internal/models/auth"
+	communitym "psychic-homily-backend/internal/models/community"
+)
+
+// ──────────────────────────────────────────────
+// Entity Request Service Interface (PSY-997)
+// ──────────────────────────────────────────────
+
+// EntityRequestServiceInterface defines the contract for the polymorphic
+// entity-creation moderation queue (PSY-869's service). The HTTP handlers
+// (PSY-997) depend on this interface so they can be unit-tested with the
+// generated mock instead of a live DB.
+//
+// CreateRequest / GetRequest / ListPending / Decide mirror the PSY-869
+// service in services/community/entityrequest.go EXACTLY (that file is owned
+// by PSY-869 and is not modified here). ListRequests is the admin-list query
+// added by PSY-997 (sibling file entityrequest_list.go) — ListPending alone
+// can't satisfy the state + source_context filtering the admin queue needs.
+type EntityRequestServiceInterface interface {
+	// CreateRequest persists a typed entity-creation request, applying
+	// trust-tier gating to decide whether it auto-approves or queues.
+	CreateRequest(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error)
+
+	// GetRequest retrieves a request by ID (requester + decider preloaded);
+	// returns (nil, nil) when not found.
+	GetRequest(requestID uint) (*communitym.EntityRequest, error)
+
+	// ListPending returns pending requests filtered by entity_type only.
+	// PSY-869's original queue query. PSY-997's admin list uses ListRequests.
+	ListPending(entityType string, limit, offset int) ([]communitym.EntityRequest, int64, error)
+
+	// ListRequests returns requests for the admin queue, filterable by
+	// entity_type + decision_state + source_context, paginated newest-first.
+	ListRequests(filters *EntityRequestFilters) ([]communitym.EntityRequest, int64, error)
+
+	// Decide records an admin's moderation decision atomically (the conditional
+	// UPDATE guards against concurrent decisions). Marks approved/rejected +
+	// decided_by/at + optional note. Creating the actual entity from the
+	// payload is the HANDLER's responsibility (PSY-997), not the service's.
+	Decide(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error)
+}
+
+// EntityRequestFilters holds the admin-queue list filters. Empty string for a
+// field means "no filter on that dimension". The handler validates State and
+// SourceContext against the model's allowed enums before calling.
+type EntityRequestFilters struct {
+	EntityType    string // "artist", "venue", ... ; "" = all types
+	State         string // "pending", "approved", "rejected"; "" = pending (default)
+	SourceContext string // "ai_extraction", "paste_mode", "manual"; "" = all sources
+	Limit         int
+	Offset        int
+}
+
+// EntityRequestFulfiller creates the actual catalog entity from an approved
+// request's payload. It is intentionally narrow — only the create methods the
+// approve path needs — so the decide handler doesn't depend on the full
+// catalog service interfaces. The concrete implementation lives in the service
+// container, composing the per-entity catalog services.
+//
+// Show and festival are deliberately absent: their catalog create contracts
+// require associations (show ⇒ venues + artists; festival ⇒ series_slug) that
+// the entity_request payloads do not carry. Fulfilling those types needs an
+// association-resolution step that is out of scope for PSY-997; the decide
+// handler returns a typed "fulfillment unsupported" error for them.
+type EntityRequestFulfillerInterface interface {
+	CreateArtist(req *CreateArtistRequest) (*ArtistDetailResponse, error)
+	CreateVenue(req *CreateVenueRequest, isAdmin bool) (*VenueDetailResponse, error)
+	CreateLabel(req *CreateLabelRequest) (*LabelDetailResponse, error)
+	CreateRelease(req *CreateReleaseRequest) (*ReleaseDetailResponse, error)
+}


### PR DESCRIPTION
## Summary

Wires thin HTTP handlers onto PSY-869's polymorphic `entity_requests` service. Carves out the shared HTTP slice that three queue-for-review consumers (PSY-845, PSY-853, PSY-871) were blocked on, so they don't collide on duplicate route/handler registration. **Backend only.** PSY-869's service logic is untouched.

Three endpoints:

- **`POST /entity-requests`** (`rc.Protected`) — user queue-create. Trust-tier gating lives in PSY-869's service (`contributor`/`new_user` file a PENDING request, never autonomously create the entity per `feedback_human_verify_ai_entity_data`; admin/local_ambassador/confirmed-trusted auto-approve). Thin validator + pass-through; returns the created row.
- **`GET /admin/entity-requests`** (`rc.Admin`) — moderation queue, filterable by `entity_type` + `state` + `source_context`, paginated, defaults to pending.
- **`POST /admin/entity-requests/{id}/decide`** (`rc.Admin`) — wires the service's atomic `Decide` (claim-then-fulfill). Approve marks approved + `decided_by`/`at` + note, then creates the catalog entity from the typed payload. Reject marks rejected + note. Audit-log fire-and-forget on both paths.

### Key design decisions

- **Admin list filtering**: `ListPending` (PSY-869) is entity_type + pending only. The AC needs `state` + `source_context` too. Rather than modify PSY-869's owned `entityrequest.go`, added a **sibling** `ListRequests(filters)` in `entityrequest_list.go`.
- **Approve-creates-entity** is isolated in `entity_request_fulfill.go` behind a narrow `EntityRequestFulfillerInterface` composing the catalog create services. `artist`/`venue`/`label`/`release` map cleanly. **`show` + `festival` are deliberately unsupported** — their catalog create contracts require associations the payloads don't carry (show ⇒ venues + artists; festival ⇒ `series_slug`) — and return a typed **422 `FulfillUnsupported`** so an admin creates them manually. (The real consumers PSY-845/853 queue artist/release/label.) A few nullable payload fields (artist `image_url`/`bandcamp_embed_url`, venue `description`/`image_url`, label `image_url`) have no slot on the Create contracts yet — documented fidelity gap, not request data loss.
- **`pending_entity_edits` admin endpoints untouched** — the two queues stay parallel; PSY-871's frontend unifies them.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/api/handlers/...` — all packages ok
- [x] `cd backend && go test ./internal/services/community/...` — ok (testcontainers Postgres)
- [x] `cd backend && go test ./internal/models/community/...` — ok
- [x] `bash scripts/check_entity_request_payloads.sh` — payload registry / CHECK parity ok
- [x] `/code-review` — no findings
- [x] `/adversarial-review` — 1 MEDIUM, fixed in a separate commit

## Manual repro

The handler + service integration tests ARE the manual repro (PSY-592 pattern). No browser, no migration (backend-only).

Handler tests (`internal/api/handlers/community/entity_request_test.go`, mocked):
- `TestCreateEntityRequest_ContributorQueuesPending` — contributor → service returns a PENDING row; handler returns it (no autonomous create).
- `TestCreateEntityRequest_{NoUser,InvalidEntityType,InvalidSource,EmptyPayload,PayloadMissingRequiredField,PayloadUnknownField}` — 401/422 validation at the boundary; service NOT called for invalid payloads.
- `TestAdminListEntityRequests_Success` — `entity_type` + `source_context` + `state` filters reach the service; `{InvalidEntityType,InvalidState,InvalidSource}` → 422.
- `TestAdminDecide_ApproveArtist_CreatesEntity` — approve calls `Decide` (approved) THEN the fulfiller's `CreateArtist`; response carries `created_entity_id` + `created_entity_type=artist`.
- `TestAdminDecide_ApproveShow_Unsupported` — approving a show → 422 (payload can't be fulfilled).
- `TestAdminDecide_ApproveFulfillFails` — fulfillment error after the atomic claim → 500 (entity NOT created).
- `TestAdminDecide_Reject` — reject does NOT call the fulfiller; no `created_entity_id`; note trimmed.
- `TestAdminDecide_{InvalidID,InvalidDecision,NotFound,AlreadyDecided,ServiceError}` — 400/422/404/409/500.

Service tests (`internal/services/community/entityrequest_test.go`, real Postgres):
- `TestListRequests_DefaultPendingExcludesApproved` / `_StateApproved` / `_SourceContextFilter` / `_EntityTypeAndPagination` — `ListRequests` filter + pagination semantics (total = full filtered count, page bounded by limit).

Model tests (`internal/models/community/entity_request_payloads_test.go`):
- `TestValidateEntityRequestPayload` — clean / missing-required / blank-only / unknown-field / malformed-json / unsupported-type / festival-requires-dates.

## Code review

`/code-review` (xhigh, inline as a dispatched sub-agent): ran the 9 angles against the commit diff. No correctness, reuse, simplification, efficiency, or altitude findings survived verification. Probed and refuted: nil-user deref on admin handlers (rc.Admin middleware guarantees user; matches `pending_edit.go` convention), Decide→fulfill payload availability (GetRequest preloads payload), pointer-to-local aliasing (fresh locals).

## Adversarial review

`/adversarial-review` — verdict CONCERNS; 1 finding addressed in commit `46cd38d0`. Panel run inline (dispatched sub-agent, no Agent tool): Saboteur · Future-Maintainer · Security · Completeness, no prior session context, against the branch diff.

- **[MEDIUM] Queue-create deferred payload validity to fulfillment** → fixed in `46cd38d0`: added `community.ValidateEntityRequestPayload` (decode into typed struct via `UnmarshalPayload[T]`'s `DisallowUnknownFields` + required-field check) at the create trust boundary → 422, so malformed contributor payloads are rejected at submit instead of sitting as junk in the queue.
- **Held up well**: admin gating (`HumaAdminMiddleware` enforces auth + `IsAdmin`); no mass-assignment of `decision_state`/`decided_by` (envelope set by service); atomic claim-then-fulfill prevents duplicate-entity on retry; GORM parameterized queries (no injection); enum filters validated before query.
- **Disclosed (by design, not a defect)**: approving a `show`/`festival` returns 422 (payloads can't satisfy the catalog create contracts) — future ticket can add association-resolution.

Closes PSY-997
