### PR TITLE
PSY-999: fix ph CLI show-dedup timezone window + drop phantom Shows count

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -185,6 +185,25 @@ bun run src/entry.ts submit artist --confirm '[{"name": "Missing Artist"}]'
 bun run src/entry.ts submit release --confirm '[{"title": "Album", "artists": [{"name": "Missing Artist"}]}]'
 ```
 
+## Troubleshooting & gotchas
+
+- **`event_date` is stored as a timestamp, not a bare date.** A date-only `event_date` (`YYYY-MM-DD`) is normalized to **20:00 venue-local time → UTC** (timezone from the venue's state; PSY-985/986). So `2026-07-17` at a CA venue is stored as `2026-07-18T03:00:00Z`. This is expected — don't "correct" it.
+
+- **A `422 SHOW_CREATE_FAILED` when (re-)submitting a show usually means the show already exists.** The backend enforces a unique `(artist, venue, event_date)` key. If a confirmed run already created the show, re-running hits that constraint. Before assuming a real failure, verify existence (see below). *(The CLI's client-side dedup pre-check was timezone-corrected so legitimate re-runs now report `DUPLICATE (ID: …) — skipping` cleanly instead of erroring — but older shells/builds may still surface the 422.)*
+
+- **Verify whether a show exists by date, not by the artist's "Shows" count.** `search artist` / `/artists/search` does **not** populate an upcoming-show count, so it is *not* evidence an artist has no shows. To check real shows, query the date window or the per-artist endpoint:
+  ```bash
+  # Shows on a given UTC day (note the venue-local→UTC shift: an evening show on
+  # 7/17 local lands in the 7/18 UTC window)
+  curl -s "$URL/shows?from_date=2026-07-18T00:00:00Z&to_date=2026-07-18T23:59:59Z" -H "Authorization: Bearer $TOKEN"
+  # All upcoming shows for an artist (authoritative count)
+  curl -s "$URL/artists/<id>/shows?time_filter=upcoming&limit=50" -H "Authorization: Bearer $TOKEN"
+  ```
+
+- **`search show "<query>"` matches by city only** (not title/artist/venue), and is unreliable for existence checks — prefer the date-window query above.
+
+- **Festival-named tour stops are festivals, not venues.** When a tour flyer lists a stop like "Mosswood Meltdown" or "Desert Fox Festival", create a `festival` entity (with the touring act on the bill) rather than a venue/show. A festival's own **pre-party/aftershow** at a real venue *is* a separate titled `show` (use the `title` field, e.g. "Mosswood Meltdown Pre-Party").
+
 ## Individual Commands Reference
 
 ```bash

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -63,7 +63,6 @@ async function searchArtists(client: APIClient, query: string): Promise<void> {
       slug: string;
       city?: string;
       state?: string;
-      show_count?: number;
     }>;
     count: number;
   }>("/artists/search", { q: query });
@@ -73,14 +72,16 @@ async function searchArtists(client: APIClient, query: string): Promise<void> {
     return;
   }
 
+  // NOTE: /artists/search does not populate an upcoming-show count, so we do not
+  // render a "Shows" column here — it was always 0 and misled callers into
+  // thinking an artist had no shows. Use `/artists/{id}/shows` for real counts.
   display.table([
-    ["ID", "Name", "Slug", "City", "Shows"],
+    ["ID", "Name", "Slug", "City"],
     ...result.artists.map((a) => [
       String(a.id),
       a.name,
       a.slug,
       a.city ? `${a.city}, ${a.state || ""}`.trim() : dim("—"),
-      String(a.show_count ?? 0),
     ]),
   ]);
 }

--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -283,12 +283,17 @@ export async function submitShows(
     const resolvedArtistIds = artists.filter((a) => a.id !== undefined).map((a) => a.id!);
     const resolvedArtistNames = artists.map((a) => a.name);
 
+    // Match buildShowPayload's timezone source so the dedup window aligns with
+    // how event_date will be stored (venue-local evening → UTC).
+    const venueState = venues[0]?.state || show.venues[0]?.state || show.state;
+
     const duplicate = await checkShowDuplicate(
       client,
       show.event_date,
       resolvedVenueIds,
       resolvedArtistIds,
       resolvedArtistNames,
+      venueState,
     );
 
     plans.push({

--- a/cli/src/lib/duplicates.ts
+++ b/cli/src/lib/duplicates.ts
@@ -1,5 +1,6 @@
 import type { APIClient } from "./api";
 import type { EntityType } from "./types";
+import { getTimezoneForState, localTimeToUTC } from "./timezone";
 
 export type MatchResult = "exact" | "fuzzy" | "none";
 export type ActionType = "create" | "update" | "skip";
@@ -680,10 +681,39 @@ function extractCalendarDate(dateStr: string): string {
 }
 
 /**
+ * Compute the UTC query window that covers a show's local calendar day.
+ *
+ * Shows are stored with their event_date normalized to the venue's local
+ * evening time converted to UTC (see `normalizeDate` in submit-show.ts) — e.g.
+ * 2026-07-17 at a California (PDT) venue is stored as 2026-07-18T03:00:00Z.
+ * A naive `${date}T00:00:00Z`..`${date}T23:59:59Z` window therefore queries the
+ * wrong UTC day for every US timezone (20:00 local always crosses into the next
+ * UTC day), never matches the stored row, and lets a re-run miss the duplicate —
+ * the backend then rejects the re-insert with a confusing 422 SHOW_CREATE_FAILED.
+ *
+ * Deriving the window from venue-local 00:00..23:59 (converted to UTC) keeps the
+ * dedup check aligned with how the show was actually stored. The default
+ * (America/Phoenix) mirrors `normalizeDate`'s fallback.
+ */
+export function showDedupWindow(
+  eventDate: string,
+  state?: string,
+): { fromDate: string; toDate: string } {
+  const calendarDate = extractCalendarDate(eventDate);
+  const timezone = state ? getTimezoneForState(state) : "America/Phoenix";
+  return {
+    fromDate: localTimeToUTC(calendarDate, "00:00", timezone),
+    toDate: localTimeToUTC(calendarDate, "23:59", timezone),
+  };
+}
+
+/**
  * Check if a show is a duplicate by searching for existing shows on the same
  * date with the same venue and at least one overlapping artist.
  *
  * Requires at least one resolved venue ID and one resolved artist ID/name to check.
+ * `state` (the venue/show state) is used to align the query window with the
+ * venue-timezone normalization applied when the show is created.
  */
 export async function checkShowDuplicate(
   client: APIClient,
@@ -691,6 +721,7 @@ export async function checkShowDuplicate(
   resolvedVenueIds: number[],
   resolvedArtistIds: number[],
   resolvedArtistNames: string[],
+  state?: string,
 ): Promise<ShowDuplicateResult> {
   const noMatch: ShowDuplicateResult = { isDuplicate: false };
 
@@ -700,13 +731,10 @@ export async function checkShowDuplicate(
   // Need at least one artist identifier to compare
   if (resolvedArtistIds.length === 0 && resolvedArtistNames.length === 0) return noMatch;
 
-  const calendarDate = extractCalendarDate(eventDate);
-
   try {
-    // Query shows on the same day using from_date and to_date
-    // Set to_date to the next day to get all shows on calendarDate
-    const fromDate = `${calendarDate}T00:00:00Z`;
-    const toDate = `${calendarDate}T23:59:59Z`;
+    // Query shows across the venue-local calendar day (converted to UTC) so the
+    // window matches how event_date is stored. See showDedupWindow.
+    const { fromDate, toDate } = showDedupWindow(eventDate, state);
 
     const result = await client.get<ShowResponseForDedup[]>("/shows", {
       from_date: fromDate,

--- a/cli/test/duplicates.test.ts
+++ b/cli/test/duplicates.test.ts
@@ -5,7 +5,46 @@ import {
   compareFields,
   classifyAction,
   classifyMatch,
+  showDedupWindow,
 } from "../src/lib/duplicates";
+
+describe("showDedupWindow", () => {
+  // Regression guard: shows are stored at venue-local 20:00 → UTC, which for
+  // every US timezone lands on the NEXT UTC day. The dedup window must follow
+  // the same venue-local day so a re-run can see the row it already created
+  // (otherwise the backend rejects the re-insert with a 422 SHOW_CREATE_FAILED).
+  test("CA (PDT) window covers a show stored as 20:00 local → UTC", () => {
+    const { fromDate, toDate } = showDedupWindow("2026-07-17", "CA");
+    const from = new Date(fromDate).getTime();
+    const to = new Date(toDate).getTime();
+    // normalizeDate("2026-07-17","CA") = 2026-07-18T03:00:00Z — must be inside.
+    const stored = new Date("2026-07-18T03:00:00Z").getTime();
+    expect(stored).toBeGreaterThanOrEqual(from);
+    expect(stored).toBeLessThanOrEqual(to);
+  });
+
+  test("window does not bleed into the adjacent local day", () => {
+    const { toDate } = showDedupWindow("2026-07-17", "CA");
+    // Next local day's evening show (2026-07-18 20:00 PDT = 2026-07-19T03:00Z).
+    const nextDay = new Date("2026-07-19T03:00:00Z").getTime();
+    expect(nextDay).toBeGreaterThan(new Date(toDate).getTime());
+  });
+
+  test("from_date stays on the input calendar day for US timezones", () => {
+    // The mixed-batch dedup test keys its mock on from_date.includes(date),
+    // so 00:00 local must not roll back past midnight UTC.
+    expect(showDedupWindow("2026-04-15", "NY").fromDate).toContain("2026-04-15");
+    expect(showDedupWindow("2026-04-15", "CA").fromDate).toContain("2026-04-15");
+  });
+
+  test("defaults to Arizona time when no state is given", () => {
+    const { fromDate } = showDedupWindow("2026-07-17");
+    // America/Phoenix is UTC-7 year-round → 00:00 local = 07:00Z.
+    expect(new Date(fromDate).getTime()).toBe(
+      new Date("2026-07-17T07:00:00Z").getTime(),
+    );
+  });
+});
 
 describe("normalizeForComparison", () => {
   test("lowercases text", () => {


### PR DESCRIPTION
## What

Fixes two `ph` ingest-CLI footguns around verifying whether a show already exists (surfaced while ingesting the Snooper + BIG|BRAVE tours/festivals to stage).

### 1. Show dedup window ignored venue-timezone normalization → 422 on re-run
`normalizeDate` stores a date-only `event_date` as **20:00 venue-local → UTC** (PSY-985/986). For every US timezone that lands on the *next* UTC day (e.g. `2026-07-17` at a CA venue → `2026-07-18T03:00:00Z`). But `checkShowDuplicate` queried `<date>T00:00:00Z`..`<date>T23:59:59Z`, which never overlaps the stored row — so re-running an already-created show missed the duplicate and hit the backend's unique `(artist_id, venue_id, event_date)` constraint as a generic **422 SHOW_CREATE_FAILED**.

Fix: new pure `showDedupWindow(eventDate, state)` builds the window from venue-local `00:00`..`23:59` → UTC (reuses `getTimezoneForState` + `localTimeToUTC`, defaults to `America/Phoenix` like `normalizeDate`). `checkShowDuplicate` takes `state`; `submitShows` passes `venueState` (same source as `buildShowPayload`, so the `batch` path is covered too).

### 2. `search artist` showed a phantom `Shows: 0`
`/artists/search` (→ `SearchArtists`) never populates a show count; the CLI rendered a "Shows" column from it (and read the wrong field name `show_count`), so it always printed `0` — which nearly led to the wrong conclusion that a 35-show tour wasn't on stage. Removed the column. Real counts come from `/artists/{id}/shows?time_filter=upcoming`.

## Test plan
- [x] `bun test` — 372 pass, 0 fail (added `showDedupWindow` regression tests)
- [x] `bunx tsc --noEmit` clean
- [x] Manual repro on **stage**: re-running the already-created "Mosswood Meltdown Pre-Party" batch now reports `DUPLICATE (ID: 83) — skipping` instead of a 422

## Notes
- `event_date` storing as evening-local→UTC is intentional (timezone foundation work) and is **not** changed here — only the dedup window and the search display.
- Docs updated alongside: `.claude/skills/ingest/SKILL.md` Troubleshooting section.

Closes PSY-999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
