### PR TITLE
PSY-845: AddItemsPicker plain-text match + Pick + queue review

### DIFF
--- a/frontend/features/collections/components/AddItemsPicker.test.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import React from 'react'
-import { render, screen, act } from '@testing-library/react'
+import { screen, act, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+// Use the providers-wrapped render: the local queue-for-review mutation
+// (useQueueEntityRequest) calls useMutation, which needs a QueryClient in
+// context. renderWithProviders supplies one (re-exported here as `render`).
+import { render } from '@/test/utils'
 
 import {
   AddItemsPicker,
@@ -49,9 +53,58 @@ let mockSearchResult: MockedEntitySearchResult = {
   searchError: false,
 }
 
+// Per-line plain-text search (PSY-845). Tests drive results by raw query
+// string via mockFetchEntitySearch; the default returns empty groups (→
+// zero results → queue-for-review path). flattenEntitySearchResults keeps the
+// real flatten order so the candidate-count branching is exercised honestly.
+type SearchGroups = {
+  artists: unknown[]
+  venues: unknown[]
+  shows: unknown[]
+  releases: unknown[]
+  labels: unknown[]
+  festivals: unknown[]
+  tags: unknown[]
+}
+const EMPTY_GROUPS: SearchGroups = {
+  artists: [],
+  venues: [],
+  shows: [],
+  releases: [],
+  labels: [],
+  festivals: [],
+  tags: [],
+}
+let mockFetchEntitySearch = vi.fn(
+  async (_query: string): Promise<{ results: SearchGroups; allFailed: boolean }> => ({
+    results: EMPTY_GROUPS,
+    allFailed: false,
+  })
+)
+
 vi.mock('@/lib/hooks/common/useEntitySearch', () => ({
   useEntitySearch: () => mockSearchResult,
   ENTITY_SEARCH_UNAVAILABLE_MESSAGE: 'Search is temporarily unavailable. Try again in a moment.',
+  fetchEntitySearch: (query: string) => mockFetchEntitySearch(query),
+  flattenEntitySearchResults: (results: SearchGroups) => [
+    ...results.artists,
+    ...results.shows,
+    ...results.venues,
+    ...results.releases,
+    ...results.labels,
+    ...results.festivals,
+  ],
+}))
+
+// Queue-for-review POST (useQueueEntityRequest → apiRequest). Tests inspect
+// mockApiRequest calls to assert the entity_request body; mockApiRequest can
+// be made to reject to exercise the queue_failed → Retry path.
+const mockApiRequest = vi.fn(async (..._args: unknown[]) => ({}))
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    COLLECTIONS: { ENTITY_REQUESTS: 'http://test/entity-requests' },
+  },
 }))
 
 // Resolve mutation — most tests don't fire it; the few that do can override
@@ -101,7 +154,18 @@ vi.mock('@/components/ui/input', () => ({
 }))
 
 vi.mock('@/components/ui/badge', () => ({
-  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  // Forward data-testid (drop the non-DOM `variant` prop) so PSY-845's queued
+  // chip (add-items-picker-paste-row-queued) is queryable — a children-only
+  // mock would silently drop the testid while still rendering the label.
+  Badge: ({
+    children,
+    variant: _variant,
+    ...props
+  }: {
+    children: React.ReactNode
+    variant?: string
+    [key: string]: unknown
+  }) => <span {...(props as Record<string, unknown>)}>{children}</span>,
 }))
 
 let activeTabValue = 'search'
@@ -156,6 +220,20 @@ vi.mock('@/components/shared', () => ({
 vi.mock('./AICollectionFiller', () => ({
   AICollectionFiller: () => <div data-testid="ai-collection-filler-stub" />,
 }))
+
+// Paste the whole textarea value in ONE operation. The component debounces in
+// production; the test mocks useDebounce to pass-through, so char-by-char
+// `user.type` would re-run usePastePreview's effect on EVERY keystroke and
+// spawn a stale async search worker per char (a test-only artifact). A single
+// paste runs the effect once — exactly the production code path after debounce.
+async function pasteInto(
+  user: ReturnType<typeof userEvent.setup>,
+  text: string
+) {
+  const ta = screen.getByTestId('add-items-picker-paste-textarea')
+  await user.click(ta)
+  await user.paste(text)
+}
 
 // ──────────────────────────────────────────────
 // parsePasteLine — pure function tests
@@ -242,6 +320,12 @@ describe('AddItemsPicker', () => {
     activeTabValue = 'search'
     mockResolveMutate.mockClear()
     mockResolveSuccessHandler = null
+    mockApiRequest.mockClear()
+    mockApiRequest.mockResolvedValue({})
+    mockFetchEntitySearch = vi.fn(async () => ({
+      results: EMPTY_GROUPS,
+      allFailed: false,
+    }))
     mockSearchResult = {
       data: {
         artists: [],
@@ -578,18 +662,190 @@ describe('AddItemsPicker', () => {
     expect(screen.queryByText('Older Artist')).not.toBeInTheDocument()
   })
 
-  it('Paste mode: shows the unresolved-help copy when only plain text is pasted', async () => {
+  // ── PSY-845: plain-text auto-match / ambiguous Pick / queue-for-review ──
+
+  it('Paste mode: plain-text line never hits the URL resolver', async () => {
     const user = userEvent.setup()
     render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
     await user.click(screen.getByTestId('tab-paste'))
-    await user.type(
-      screen.getByTestId('add-items-picker-paste-textarea'),
-      'Mount Eerie - A Crow'
-    )
-
-    // Resolver should NOT be called when there are zero URL entries.
+    await pasteInto(user, 'Mount Eerie')
+    // URL resolver is only for canonical-path lines — plain text routes to
+    // the per-line entity search (fetchEntitySearch), not the resolver.
     expect(mockResolveMutate).not.toHaveBeenCalled()
-    expect(screen.getByText(/canonical PH paths/i)).toBeInTheDocument()
+    await waitFor(() => expect(mockFetchEntitySearch).toHaveBeenCalled())
+  })
+
+  it('Paste mode: a single search result ⇒ MATCH with a stageable [Add]', async () => {
+    const onStaged = vi.fn()
+    mockFetchEntitySearch = vi.fn(async () => ({
+      results: {
+        ...EMPTY_GROUPS,
+        artists: [
+          {
+            id: 7,
+            slug: 'mount-eerie',
+            name: 'Mount Eerie',
+            subtitle: 'Anacortes, WA',
+            entityType: 'artist',
+            href: '/artists/mount-eerie',
+          },
+        ],
+      },
+      allFailed: false,
+    }))
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={onStaged} />)
+    await user.click(screen.getByTestId('tab-paste'))
+    await pasteInto(user, 'Mount Eerie')
+
+    // MATCH chip renders once the per-line search resolves. (The name also
+    // appears in the textarea value, so scope the name assertion to the row.)
+    expect(await screen.findByText('MATCH')).toBeInTheDocument()
+    const row = screen.getByTestId('add-items-picker-paste-row')
+    expect(within(row).getByText('Mount Eerie')).toBeInTheDocument()
+
+    const addBtn = screen
+      .getAllByRole('button', { name: /add/i })
+      .find((b) => b.textContent?.trim().toLowerCase() === 'add')!
+    await user.click(addBtn)
+
+    const last = onStaged.mock.calls.at(-1)?.[0]
+    expect(last).toHaveLength(1)
+    expect(last?.[0]).toMatchObject({ entityType: 'artist', entityId: 7 })
+  })
+
+  it('Paste mode: 2+ results ⇒ AMBIGUOUS with an inline [Pick] that promotes to MATCH', async () => {
+    const onStaged = vi.fn()
+    mockFetchEntitySearch = vi.fn(async () => ({
+      results: {
+        ...EMPTY_GROUPS,
+        artists: [
+          {
+            id: 1,
+            slug: 'nirvana',
+            name: 'Nirvana (Seattle)',
+            subtitle: 'Seattle, WA',
+            entityType: 'artist',
+            href: '/artists/nirvana',
+          },
+          {
+            id: 2,
+            slug: 'nirvana-uk',
+            name: 'Nirvana (UK)',
+            subtitle: 'London, UK',
+            entityType: 'artist',
+            href: '/artists/nirvana-uk',
+          },
+        ],
+      },
+      allFailed: false,
+    }))
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={onStaged} />)
+    await user.click(screen.getByTestId('tab-paste'))
+    await pasteInto(user, 'Nirvana')
+
+    // PICK chip + the candidate dropdown render.
+    expect(await screen.findByText('PICK')).toBeInTheDocument()
+    const pickRow = screen.getByTestId('add-items-picker-paste-row-pick')
+    expect(pickRow).toHaveTextContent('Did you mean:')
+
+    // Pick the second candidate → row promotes to MATCH, then stage it.
+    await user.click(
+      within(pickRow).getByRole('button', { name: /Nirvana \(UK\)/i })
+    )
+    expect(await screen.findByText('MATCH')).toBeInTheDocument()
+
+    const addBtn = screen
+      .getAllByRole('button', { name: /add/i })
+      .find((b) => b.textContent?.trim().toLowerCase() === 'add')!
+    await user.click(addBtn)
+    const last = onStaged.mock.calls.at(-1)?.[0]
+    expect(last?.[0]).toMatchObject({ entityType: 'artist', entityId: 2 })
+  })
+
+  it('Paste mode: caps the AMBIGUOUS Pick dropdown at 5 candidates', async () => {
+    mockFetchEntitySearch = vi.fn(async () => ({
+      results: {
+        ...EMPTY_GROUPS,
+        artists: Array.from({ length: 8 }, (_, i) => ({
+          id: i + 1,
+          slug: `dup-${i}`,
+          name: `Dup ${i}`,
+          subtitle: null,
+          entityType: 'artist',
+          href: `/artists/dup-${i}`,
+        })),
+      },
+      allFailed: false,
+    }))
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await user.click(screen.getByTestId('tab-paste'))
+    await pasteInto(user, 'Dup')
+
+    const pickRow = await screen.findByTestId('add-items-picker-paste-row-pick')
+    // 5 candidate buttons max (the "Did you mean:" label is a span, not a button).
+    expect(within(pickRow).getAllByRole('button')).toHaveLength(5)
+  })
+
+  it('Paste mode: zero results ⇒ queue-for-review (POSTs an entity_request)', async () => {
+    // Default mockFetchEntitySearch returns empty groups → zero results.
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await user.click(screen.getByTestId('tab-paste'))
+    await pasteInto(user, 'Totally Unknown Artist')
+
+    // The queued affordance renders and the POST fired with the line as the
+    // artist payload + paste_mode source.
+    expect(
+      await screen.findByTestId('add-items-picker-paste-row-queued')
+    ).toHaveTextContent('FOR REVIEW')
+    await waitFor(() => expect(mockApiRequest).toHaveBeenCalled())
+    const [, opts] = mockApiRequest.mock.calls.at(-1)!
+    const body = JSON.parse((opts as { body: string }).body)
+    expect(body).toMatchObject({
+      entity_type: 'artist',
+      source_context: 'paste_mode',
+      payload: { name: 'Totally Unknown Artist' },
+    })
+  })
+
+  it('Paste mode: a failed queue POST shows a Retry that re-fires the request', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('boom'))
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await user.click(screen.getByTestId('tab-paste'))
+    await pasteInto(user, 'Flaky Network Artist')
+
+    // First POST rejects → Retry button surfaces.
+    const retry = await screen.findByTestId(
+      'add-items-picker-paste-row-retry-queue'
+    )
+    mockApiRequest.mockClear()
+    mockApiRequest.mockResolvedValue({})
+    await user.click(retry)
+
+    // Retry re-fires the POST and the row settles to FOR REVIEW.
+    await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1))
+    expect(
+      await screen.findByTestId('add-items-picker-paste-row-queued')
+    ).toHaveTextContent('FOR REVIEW')
+  })
+
+  it('Paste mode: a per-line search outage ⇒ NO MATCH (not queued)', async () => {
+    mockFetchEntitySearch = vi.fn(async () => {
+      throw new Error('search down')
+    })
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await user.click(screen.getByTestId('tab-paste'))
+    await pasteInto(user, 'Some Artist')
+
+    // A transient search failure is NOT a confirmed zero-result: mark
+    // unresolved (retryable) and do NOT file a queue request.
+    expect(await screen.findByText('NO MATCH')).toBeInTheDocument()
+    expect(mockApiRequest).not.toHaveBeenCalled()
   })
 
   // ── PSY-962: overview strip + drag-reorder ──

--- a/frontend/features/collections/components/AddItemsPicker.test.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.test.tsx
@@ -848,6 +848,28 @@ describe('AddItemsPicker', () => {
     expect(mockApiRequest).not.toHaveBeenCalled()
   })
 
+  it('Paste mode: queues EACH zero-result line independently (no last-write-wins)', async () => {
+    // Guards the multi-junk-line case: usePastePreview reuses ONE
+    // queueMutation instance across the bounded worker pool. Each per-call
+    // mutate() must fire its own onSuccess targeting its own row index —
+    // a last-write-wins bug would queue only one line / one POST.
+    const user = userEvent.setup()
+    render(<AddItemsPicker stagedItems={[]} onStagedItemsChange={vi.fn()} />)
+    await user.click(screen.getByTestId('tab-paste'))
+    await pasteInto(user, 'JunkOne\nJunkTwo\nJunkThree')
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByTestId('add-items-picker-paste-row-queued')
+      ).toHaveLength(3)
+    )
+    expect(mockApiRequest).toHaveBeenCalledTimes(3)
+    const names = mockApiRequest.mock.calls
+      .map((c) => JSON.parse((c[1] as { body: string }).body).payload.name)
+      .sort()
+    expect(names).toEqual(['JunkOne', 'JunkThree', 'JunkTwo'])
+  })
+
   // ── PSY-962: overview strip + drag-reorder ──
   // Full drag interaction is exercised by @dnd-kit itself + manual repro;
   // these cover the strip render, count/plural, overflow cap, and the

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -449,11 +449,15 @@ function usePastePreview(pasteText: string): {
   // File a queue-for-review request for a zero-result plain-text line.
   // Extracted so the initial pass AND retryQueue share one code path. Each
   // call is an independent POST (see queueEntityRequest) so concurrent
-  // zero-result lines each get their own request + row update.
+  // zero-result lines each get their own request + row update. Returns the
+  // settle promise so the bounded worker pool can AWAIT it — that keeps a
+  // 200-junk-line paste from firing 200 simultaneous POSTs (the same
+  // "don't hammer the backend" bound the search side gets). retryQueue, a
+  // single user-triggered call, ignores the return (fire-and-forget).
   const fileQueueRequest = useCallback(
-    (generation: number, index: number, raw: string) => {
+    (generation: number, index: number, raw: string): Promise<void> => {
       updateRow(generation, index, { status: 'queuing' })
-      queueEntityRequest(raw).then(
+      return queueEntityRequest(raw).then(
         () => updateRow(generation, index, { status: 'queued' }),
         () => updateRow(generation, index, { status: 'queue_failed' })
       )
@@ -573,8 +577,11 @@ function usePastePreview(pasteText: string): {
                 .map(toPreviewItem),
             })
           } else {
-            // Zero results ⇒ queue for admin review.
-            fileQueueRequest(generation, entry.index, entry.raw)
+            // Zero results ⇒ queue for admin review. Await the POST so it
+            // counts against the concurrency budget — without this, a paste
+            // of N all-junk lines would fire N POSTs at once (the search
+            // bound would be moot for the queue side).
+            await fileQueueRequest(generation, entry.index, entry.raw)
           }
         }
       )

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -36,7 +36,6 @@ import {
   type CSSProperties,
 } from 'react'
 import { useDebounce } from 'use-debounce'
-import { useMutation } from '@tanstack/react-query'
 import {
   Plus,
   Search,
@@ -256,35 +255,39 @@ export function parsePasteLine(line: string): ParsedPasteLine {
 // ──────────────────────────────────────────────
 
 /**
- * LOCAL queue-create mutation (PSY-845). Posts an `entity_request` to
- * PSY-997's `POST /entity-requests` so a plain-text line with ZERO matches
- * becomes an admin-reviewable artist-creation request rather than being
- * silently dropped.
+ * LOCAL queue-create call (PSY-845). Posts an `entity_request` to PSY-997's
+ * `POST /entity-requests` so a plain-text line with ZERO matches becomes an
+ * admin-reviewable artist-creation request rather than being silently dropped.
  *
  * Deliberately LOCAL (not a shared exported hook): PSY-853 posts to the same
  * endpoint from AICollectionFiller in parallel. Keeping each consumer's
- * mutation local avoids a cross-PR file collision; a future ticket dedups the
- * two into one shared `useCreateEntityRequest` hook. The small duplication is
- * intentional (see coordination note on PSY-845).
+ * queue-create local avoids a cross-PR file collision; a future ticket dedups
+ * the two into one shared hook. The small duplication is intentional (see
+ * coordination note on PSY-845).
  *
- * Entity type is `artist`: a bare plain-text line in a music collection
- * picker is overwhelmingly an artist name, and `artist` is the only
- * entity_request payload whose sole required field is `name` (releases need a
- * title, shows need an event_date, venues need city+state, etc.) — so the
- * line text is sufficient to file a well-formed request. The admin reviewing
- * the queue retypes/reclassifies if it was actually a release or venue.
+ * A plain async function, NOT a `useMutation` hook: a single paste can queue
+ * several zero-result lines CONCURRENTLY (the bounded worker pool), and one
+ * shared `useMutation` observer only tracks the latest in-flight mutation —
+ * rapid successive `.mutate()` calls drop earlier per-call callbacks, so only
+ * the last line would end up queued. Per-call `apiRequest` has no such shared
+ * state; usePastePreview owns the per-row status, so the hook's
+ * data/isPending/error were unused anyway.
+ *
+ * Entity type is `artist`: a bare plain-text line in a music collection picker
+ * is overwhelmingly an artist name, and `artist` is the only entity_request
+ * payload whose sole required field is `name` (releases need a title, shows an
+ * event_date, venues city+state, etc.) — so the line text is sufficient to
+ * file a well-formed request. The admin reviewing the queue retypes /
+ * reclassifies if it was actually a release or venue.
  */
-function useQueueEntityRequest() {
-  return useMutation({
-    mutationFn: (name: string) =>
-      apiRequest(API_ENDPOINTS.COLLECTIONS.ENTITY_REQUESTS, {
-        method: 'POST',
-        body: JSON.stringify({
-          entity_type: 'artist',
-          payload: { name },
-          source_context: 'paste_mode',
-        }),
-      }),
+function queueEntityRequest(name: string): Promise<unknown> {
+  return apiRequest(API_ENDPOINTS.COLLECTIONS.ENTITY_REQUESTS, {
+    method: 'POST',
+    body: JSON.stringify({
+      entity_type: 'artist',
+      payload: { name },
+      source_context: 'paste_mode',
+    }),
   })
 }
 
@@ -425,7 +428,6 @@ function usePastePreview(pasteText: string): {
 } {
   const [debouncedPaste] = useDebounce(pasteText, 400)
   const resolveMutation = useResolveCollectionItems()
-  const queueMutation = useQueueEntityRequest()
   const [previewRows, setPreviewRows] = useState<PreviewRow[]>([])
   const generationRef = useRef(0)
 
@@ -445,16 +447,18 @@ function usePastePreview(pasteText: string): {
   )
 
   // File a queue-for-review request for a zero-result plain-text line.
-  // Extracted so the initial pass AND retryQueue share one code path.
+  // Extracted so the initial pass AND retryQueue share one code path. Each
+  // call is an independent POST (see queueEntityRequest) so concurrent
+  // zero-result lines each get their own request + row update.
   const fileQueueRequest = useCallback(
     (generation: number, index: number, raw: string) => {
       updateRow(generation, index, { status: 'queuing' })
-      queueMutation.mutate(raw, {
-        onSuccess: () => updateRow(generation, index, { status: 'queued' }),
-        onError: () => updateRow(generation, index, { status: 'queue_failed' }),
-      })
+      queueEntityRequest(raw).then(
+        () => updateRow(generation, index, { status: 'queued' }),
+        () => updateRow(generation, index, { status: 'queue_failed' })
+      )
     },
-    [queueMutation, updateRow]
+    [updateRow]
   )
 
   useEffect(() => {

--- a/frontend/features/collections/components/AddItemsPicker.tsx
+++ b/frontend/features/collections/components/AddItemsPicker.tsx
@@ -15,10 +15,13 @@
  *     Clicking [Add] STAGES the row (not commit). Parent commits the
  *     staged list via its own submit affordance.
  *   - "Paste URLs" — textarea accepting canonical PH paths
- *     (`https://psychichomily.com/artists/<slug>` or `/artists/<slug>`).
- *     Lines are parsed client-side and resolved via a single backend
- *     round-trip (useResolveCollectionItems). Plain-text lines fall to
- *     UNRESOLVED for V1 — plain-text auto-match is a follow-up.
+ *     (`https://psychichomily.com/artists/<slug>` or `/artists/<slug>`)
+ *     AND free plain-text lines (PSY-845). URL lines are parsed client-side
+ *     and resolved via a single backend round-trip (useResolveCollectionItems).
+ *     Plain-text lines auto-search the entity endpoints (bounded to 5 in
+ *     flight): exactly one result ⇒ MATCH (stageable); 2+ ⇒ AMBIGUOUS with an
+ *     inline [Pick] dropdown (≤5); zero ⇒ queue-for-review (POSTs an
+ *     entity_request for an admin to approve). See usePastePreview.
  *
  * AI mode (third tab) mounts AICollectionFiller for paste-an-article
  * extraction via Claude Haiku.
@@ -33,16 +36,19 @@ import {
   type CSSProperties,
 } from 'react'
 import { useDebounce } from 'use-debounce'
+import { useMutation } from '@tanstack/react-query'
 import {
   Plus,
   Search,
   X,
   Check,
   AlertCircle,
+  AlertTriangle,
   Library,
   Loader2,
   Info,
   GripVertical,
+  Inbox,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -57,11 +63,14 @@ import {
 import { InlineErrorBanner } from '@/components/shared'
 import {
   useEntitySearch,
+  fetchEntitySearch,
+  flattenEntitySearchResults,
   ENTITY_SEARCH_UNAVAILABLE_MESSAGE,
   type EntitySearchResult,
 } from '@/lib/hooks/common/useEntitySearch'
 import { useResolveCollectionItems } from '../hooks'
 import { getEntityTypeLabel, type CollectionEntityType } from '../types'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { AICollectionFiller } from './AICollectionFiller'
 import {
@@ -143,13 +152,57 @@ interface ParsedPasteLine {
   url: { entityType: CollectionEntityType; slug: string } | null
 }
 
-type PreviewStatus = 'matched' | 'unresolved' | 'loading'
+/**
+ * Preview-row lifecycle states (PSY-845).
+ *
+ * URL lines (canonical PH paths) resolve through the batch
+ * `useResolveCollectionItems` round-trip and only ever land on
+ * `loading` → `matched` | `unresolved`.
+ *
+ * Plain-text lines auto-search the entity endpoints per line and land on:
+ *   - `searching`     — search in flight
+ *   - `matched`       — exactly ONE result across all types ⇒ stageable
+ *   - `ambiguous`     — 2+ candidates ⇒ inline [Pick] dropdown (≤5)
+ *   - `queuing`       — zero results ⇒ entity_request POST in flight
+ *   - `queued`        — zero results ⇒ request filed for admin review
+ *   - `queue_failed`  — zero results ⇒ the request POST errored (retryable)
+ */
+type PreviewStatus =
+  | 'matched'
+  | 'unresolved'
+  | 'loading'
+  | 'searching'
+  | 'ambiguous'
+  | 'queuing'
+  | 'queued'
+  | 'queue_failed'
+
+/** A candidate offered for an AMBIGUOUS plain-text line's [Pick] dropdown. */
+interface PreviewCandidate {
+  entityType: CollectionEntityType
+  entityId: number
+  name: string
+  subtitle: string | null
+}
 
 interface PreviewRow {
   raw: string
   status: PreviewStatus
+  /** The resolved/picked entity for `matched` rows; null otherwise. */
   item: StagedCollectionItem | null
+  /**
+   * AMBIGUOUS candidates (≤5) when `status === 'ambiguous'`. The user picks
+   * one via the inline dropdown, which promotes the row to `matched`.
+   */
+  candidates?: PreviewCandidate[]
 }
+
+/** Max candidates surfaced in an AMBIGUOUS line's [Pick] dropdown. */
+const MAX_PICK_CANDIDATES = 5
+
+/** Bounded in-flight plain-text searches — don't hammer the backend on a
+ *  200-line paste. (PSY-845 locked decision.) */
+const PLAINTEXT_SEARCH_CONCURRENCY = 5
 
 // ──────────────────────────────────────────────
 // URL parsing
@@ -196,6 +249,43 @@ export function parsePasteLine(line: string): ParsedPasteLine {
   const entityType = URL_PATH_TO_ENTITY_TYPE[match[1].toLowerCase()]
   const slug = match[2].toLowerCase()
   return { raw: trimmed, url: { entityType, slug } }
+}
+
+// ──────────────────────────────────────────────
+// Queue-for-review (PSY-845 + PSY-997)
+// ──────────────────────────────────────────────
+
+/**
+ * LOCAL queue-create mutation (PSY-845). Posts an `entity_request` to
+ * PSY-997's `POST /entity-requests` so a plain-text line with ZERO matches
+ * becomes an admin-reviewable artist-creation request rather than being
+ * silently dropped.
+ *
+ * Deliberately LOCAL (not a shared exported hook): PSY-853 posts to the same
+ * endpoint from AICollectionFiller in parallel. Keeping each consumer's
+ * mutation local avoids a cross-PR file collision; a future ticket dedups the
+ * two into one shared `useCreateEntityRequest` hook. The small duplication is
+ * intentional (see coordination note on PSY-845).
+ *
+ * Entity type is `artist`: a bare plain-text line in a music collection
+ * picker is overwhelmingly an artist name, and `artist` is the only
+ * entity_request payload whose sole required field is `name` (releases need a
+ * title, shows need an event_date, venues need city+state, etc.) — so the
+ * line text is sufficient to file a well-formed request. The admin reviewing
+ * the queue retypes/reclassifies if it was actually a release or venue.
+ */
+function useQueueEntityRequest() {
+  return useMutation({
+    mutationFn: (name: string) =>
+      apiRequest(API_ENDPOINTS.COLLECTIONS.ENTITY_REQUESTS, {
+        method: 'POST',
+        body: JSON.stringify({
+          entity_type: 'artist',
+          payload: { name },
+          source_context: 'paste_mode',
+        }),
+      }),
+  })
 }
 
 // ──────────────────────────────────────────────
@@ -270,6 +360,259 @@ function AiTabInfoTooltip() {
   )
 }
 
+// ──────────────────────────────────────────────
+// Paste-mode resolution hook (PSY-823 URL resolve + PSY-845 plain-text)
+// ──────────────────────────────────────────────
+
+/**
+ * Resolve a `name` from a plain-text search hit into the preview-row item
+ * shape. Mirrors the resolved-item mapping the URL path uses.
+ */
+function toPreviewItem(r: EntitySearchResult): StagedCollectionItem {
+  return {
+    entityType: r.entityType as CollectionEntityType,
+    entityId: r.id,
+    name: r.name,
+    subtitle: r.subtitle ?? null,
+  }
+}
+
+/**
+ * Run `task` over `items` with at most `limit` in flight at once (PSY-845).
+ * A bounded worker pool: `limit` workers each pull the next index off a
+ * shared cursor until the list is drained. Keeps a 200-line paste from
+ * firing 200 simultaneous searches at the backend.
+ */
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<void>
+): Promise<void> {
+  let cursor = 0
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor++
+      await task(items[index], index)
+    }
+  }
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    () => worker()
+  )
+  await Promise.all(workers)
+}
+
+/**
+ * Owns the Paste-mode preview lifecycle: parses the textarea, batch-resolves
+ * canonical PH URL lines (PSY-823), and auto-searches plain-text lines with
+ * bounded parallelism (PSY-845). Returns the ordered preview rows plus the
+ * row-level actions (pick a candidate for an AMBIGUOUS line; retry a failed
+ * queue POST).
+ *
+ * Isolated as a hook so the component body stays declarative and the volatile
+ * concurrency / dual-resolution machinery lives behind one narrow interface
+ * (Code Complete: information hiding + isolate-likely-to-change).
+ *
+ * Stale-response guard: each debounced change bumps `generationRef`; every
+ * async continuation (URL resolve onSuccess, per-line search, queue POST)
+ * checks its captured generation before committing, so an older paste's
+ * in-flight responses can never overwrite a newer paste's preview.
+ */
+function usePastePreview(pasteText: string): {
+  previewRows: PreviewRow[]
+  pickCandidate: (rowIndex: number, candidate: PreviewCandidate) => void
+  retryQueue: (rowIndex: number) => void
+} {
+  const [debouncedPaste] = useDebounce(pasteText, 400)
+  const resolveMutation = useResolveCollectionItems()
+  const queueMutation = useQueueEntityRequest()
+  const [previewRows, setPreviewRows] = useState<PreviewRow[]>([])
+  const generationRef = useRef(0)
+
+  // Commit a single row's update IFF the captured generation is still current.
+  // Used by every async continuation so a stale paste can't clobber the list.
+  const updateRow = useCallback(
+    (generation: number, index: number, next: Partial<PreviewRow>) => {
+      setPreviewRows((rows) => {
+        if (generationRef.current !== generation) return rows
+        if (index < 0 || index >= rows.length) return rows
+        const copy = rows.slice()
+        copy[index] = { ...copy[index], ...next }
+        return copy
+      })
+    },
+    []
+  )
+
+  // File a queue-for-review request for a zero-result plain-text line.
+  // Extracted so the initial pass AND retryQueue share one code path.
+  const fileQueueRequest = useCallback(
+    (generation: number, index: number, raw: string) => {
+      updateRow(generation, index, { status: 'queuing' })
+      queueMutation.mutate(raw, {
+        onSuccess: () => updateRow(generation, index, { status: 'queued' }),
+        onError: () => updateRow(generation, index, { status: 'queue_failed' }),
+      })
+    },
+    [queueMutation, updateRow]
+  )
+
+  useEffect(() => {
+    const lines = debouncedPaste
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+    if (lines.length === 0) {
+      generationRef.current += 1 // invalidate any in-flight continuations
+      setPreviewRows([])
+      return
+    }
+
+    generationRef.current += 1
+    const generation = generationRef.current
+
+    const parsed = lines.map((l) => parsePasteLine(l))
+
+    // Initial states: URL lines → loading (batch resolve); plain-text → searching.
+    setPreviewRows(
+      parsed.map((p) => ({
+        raw: p.raw,
+        status: p.url ? 'loading' : 'searching',
+        item: null,
+      }))
+    )
+
+    // ── URL lines: one batch round-trip (PSY-823 path, unchanged semantics) ──
+    const urlEntries = parsed
+      .map((p, i) => ({ parsed: p, index: i }))
+      .filter((e) => e.parsed.url !== null)
+
+    if (urlEntries.length > 0) {
+      resolveMutation.mutate(
+        urlEntries.map((e) => ({
+          entity_type: e.parsed.url!.entityType,
+          slug: e.parsed.url!.slug,
+        })),
+        {
+          onSuccess: (data) => {
+            const resolvedBySlug = new Map<string, StagedCollectionItem>()
+            for (const r of data.resolved) {
+              resolvedBySlug.set(`${r.entity_type}:${r.slug}`, {
+                entityType: r.entity_type as CollectionEntityType,
+                entityId: r.entity_id,
+                name: r.name,
+                subtitle: r.subtitle ?? null,
+              })
+            }
+            for (const e of urlEntries) {
+              const key = `${e.parsed.url!.entityType}:${e.parsed.url!.slug}`
+              const match = resolvedBySlug.get(key)
+              updateRow(
+                generation,
+                e.index,
+                match
+                  ? { status: 'matched', item: match }
+                  : { status: 'unresolved', item: null }
+              )
+            }
+          },
+          onError: () => {
+            // Network/server error — mark URL rows unresolved so the user
+            // can retry by editing the paste.
+            for (const e of urlEntries) {
+              updateRow(generation, e.index, { status: 'unresolved', item: null })
+            }
+          },
+        }
+      )
+    }
+
+    // ── Plain-text lines: per-line auto-search, bounded to 5 in flight ──
+    const plaintextEntries = parsed
+      .map((p, i) => ({ raw: p.raw, index: i }))
+      .filter((e) => parsed[e.index].url === null)
+
+    if (plaintextEntries.length > 0) {
+      void runWithConcurrency(
+        plaintextEntries,
+        PLAINTEXT_SEARCH_CONCURRENCY,
+        async (entry) => {
+          // Bail early if a newer paste superseded this one.
+          if (generationRef.current !== generation) return
+          let candidates: EntitySearchResult[]
+          try {
+            const { results } = await fetchEntitySearch(entry.raw)
+            candidates = flattenEntitySearchResults(results)
+          } catch {
+            // Search outage for this line — mark unresolved (retryable by
+            // editing the paste). Don't queue: a transient failure isn't a
+            // confirmed zero-result.
+            updateRow(generation, entry.index, {
+              status: 'unresolved',
+              item: null,
+            })
+            return
+          }
+          if (generationRef.current !== generation) return
+
+          if (candidates.length === 1) {
+            updateRow(generation, entry.index, {
+              status: 'matched',
+              item: toPreviewItem(candidates[0]),
+            })
+          } else if (candidates.length > 1) {
+            updateRow(generation, entry.index, {
+              status: 'ambiguous',
+              item: null,
+              candidates: candidates
+                .slice(0, MAX_PICK_CANDIDATES)
+                .map(toPreviewItem),
+            })
+          } else {
+            // Zero results ⇒ queue for admin review.
+            fileQueueRequest(generation, entry.index, entry.raw)
+          }
+        }
+      )
+    }
+    // Only re-resolve when the debounced paste text changes. alreadyStaged is
+    // computed at render time off the current stagedItems prop (PastePreviewRow),
+    // so staged/existing changes don't need to re-fire resolution.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedPaste])
+
+  // Promote an AMBIGUOUS row to MATCH with the user's chosen candidate.
+  const pickCandidate = useCallback(
+    (rowIndex: number, candidate: PreviewCandidate) => {
+      setPreviewRows((rows) => {
+        if (rowIndex < 0 || rowIndex >= rows.length) return rows
+        const copy = rows.slice()
+        copy[rowIndex] = {
+          ...copy[rowIndex],
+          status: 'matched',
+          item: candidate,
+          candidates: undefined,
+        }
+        return copy
+      })
+    },
+    []
+  )
+
+  // Retry a failed queue POST for a zero-result line (against the CURRENT
+  // generation so it survives the row-bounds check).
+  const retryQueue = useCallback(
+    (rowIndex: number) => {
+      const row = previewRows[rowIndex]
+      if (!row || row.status !== 'queue_failed') return
+      fileQueueRequest(generationRef.current, rowIndex, row.raw)
+    },
+    [previewRows, fileQueueRequest]
+  )
+
+  return { previewRows, pickCandidate, retryQueue }
+}
+
 export function AddItemsPicker({
   existingItems = [],
   stagedItems,
@@ -290,131 +633,18 @@ export function AddItemsPicker({
     enabled: tab === 'search',
   })
 
-  // ─── Paste mode state ───
+  // ─── Paste mode state (resolution lives in usePastePreview) ───
   const [pasteText, setPasteText] = useState('')
-  const [debouncedPaste] = useDebounce(pasteText, 400)
-  const resolveMutation = useResolveCollectionItems()
-  const [previewRows, setPreviewRows] = useState<PreviewRow[]>([])
-  // Stale-response guard: each resolve fire bumps this counter; the
-  // onSuccess handler only commits its result when its captured token
-  // matches the latest. Protects against out-of-order responses when the
-  // user types fast enough that the older request resolves AFTER a newer
-  // one — without this, an earlier response would overwrite the newer
-  // preview state.
-  const resolveGenerationRef = useRef(0)
-
-  // Resolve paste textarea contents whenever the debounced value changes.
-  // Only URL lines hit the backend; plain-text lines fall through as
-  // UNRESOLVED until the plain-text auto-match follow-up ships.
-  useEffect(() => {
-    const lines = debouncedPaste
-      .split('\n')
-      .map((l) => l.trim())
-      .filter((l) => l.length > 0)
-    if (lines.length === 0) {
-      setPreviewRows([])
-      return
-    }
-
-    const parsed = lines.map((l) => parsePasteLine(l))
-    const urlEntries = parsed
-      .filter((p) => p.url !== null)
-      .map((p) => ({ entity_type: p.url!.entityType, slug: p.url!.slug }))
-
-    if (urlEntries.length === 0) {
-      // Nothing to resolve; mark all rows as unresolved.
-      setPreviewRows(
-        parsed.map((p) => ({
-          raw: p.raw,
-          status: 'unresolved',
-          item: null,
-        }))
-      )
-      return
-    }
-
-    // Show "loading" rows for the URL lines while the request is in flight,
-    // unresolved for the rest, so the UI doesn't flicker on every keystroke.
-    setPreviewRows(
-      parsed.map((p) => ({
-        raw: p.raw,
-        status: p.url ? 'loading' : 'unresolved',
-        item: null,
-      }))
-    )
-
-    // Bump the generation; only this fire's onSuccess will commit. Older
-    // in-flight requests' onSuccess will see a stale token and bail.
-    resolveGenerationRef.current += 1
-    const myGeneration = resolveGenerationRef.current
-
-    resolveMutation.mutate(urlEntries, {
-      onSuccess: (data) => {
-        if (resolveGenerationRef.current !== myGeneration) return
-        const resolvedBySlug = new Map<string, StagedCollectionItem>()
-        for (const r of data.resolved) {
-          const key = `${r.entity_type}:${r.slug}`
-          resolvedBySlug.set(key, {
-            entityType: r.entity_type as CollectionEntityType,
-            entityId: r.entity_id,
-            name: r.name,
-            subtitle: r.subtitle ?? null,
-          })
-        }
-
-        setPreviewRows(
-          parsed.map((p) => {
-            if (!p.url) {
-              return { raw: p.raw, status: 'unresolved', item: null }
-            }
-            const key = `${p.url.entityType}:${p.url.slug}`
-            const match = resolvedBySlug.get(key)
-            if (!match) {
-              return { raw: p.raw, status: 'unresolved', item: null }
-            }
-            return {
-              raw: p.raw,
-              status: 'matched',
-              item: match,
-            }
-          })
-        )
-      },
-      onError: () => {
-        if (resolveGenerationRef.current !== myGeneration) return
-        // Network/server error — mark URL rows as unresolved so the user
-        // can retry. (We could surface an explicit error banner, but
-        // unresolved + the InlineErrorBanner below the textarea is enough
-        // signal for V1.)
-        setPreviewRows(
-          parsed.map((p) => ({
-            raw: p.raw,
-            status: 'unresolved',
-            item: null,
-          }))
-        )
-      },
-    })
-    // We intentionally only re-resolve when the debounced paste text
-    // changes. The alreadyStaged flag is computed at render time off the
-    // current stagedItems prop — see PastePreviewRow — so existingItems
-    // / stagedItems changes don't need to re-fire the resolver.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedPaste])
+  const { previewRows, pickCandidate, retryQueue } = usePastePreview(pasteText)
 
   // Flattened search results for the active query. Mirrors the existing
-  // AddItemsSection shape so users get a familiar list.
-  const searchRows: EntitySearchResult[] = useMemo(() => {
-    if (!searchResults) return []
-    return [
-      ...searchResults.artists,
-      ...searchResults.shows,
-      ...searchResults.venues,
-      ...searchResults.releases,
-      ...searchResults.labels,
-      ...searchResults.festivals,
-    ]
-  }, [searchResults])
+  // AddItemsSection shape so users get a familiar list. The flatten order
+  // is single-sourced in flattenEntitySearchResults so the interactive
+  // search list and the plain-text auto-match (usePastePreview) agree.
+  const searchRows: EntitySearchResult[] = useMemo(
+    () => (searchResults ? flattenEntitySearchResults(searchResults) : []),
+    [searchResults]
+  )
 
   // ─── Staging helpers ───
   // Single-call updates only — multiple successive onStagedItemsChange
@@ -533,6 +763,8 @@ export function AddItemsPicker({
             stagedItems={stagedItems}
             onStage={stageItem}
             onStageBatch={stageBatch}
+            onPick={pickCandidate}
+            onRetryQueue={retryQueue}
           />
         )}
 
@@ -739,6 +971,8 @@ function PasteModePane({
   stagedItems,
   onStage,
   onStageBatch,
+  onPick,
+  onRetryQueue,
 }: {
   text: string
   onTextChange: (v: string) => void
@@ -747,10 +981,25 @@ function PasteModePane({
   stagedItems: StagedCollectionItem[]
   onStage: (item: StagedCollectionItem) => void
   onStageBatch: (items: StagedCollectionItem[]) => void
+  onPick: (rowIndex: number, candidate: PreviewCandidate) => void
+  onRetryQueue: (rowIndex: number) => void
 }) {
   const matchedCount = previewRows.filter((r) => r.status === 'matched').length
   const unresolvedCount = previewRows.filter((r) => r.status === 'unresolved').length
-  const loadingCount = previewRows.filter((r) => r.status === 'loading').length
+  // In-flight rows (URL batch resolve + plain-text per-line search) share one
+  // "resolving" tally — both are transient, both end at a terminal state.
+  const loadingCount = previewRows.filter(
+    (r) => r.status === 'loading' || r.status === 'searching'
+  ).length
+  const ambiguousCount = previewRows.filter((r) => r.status === 'ambiguous').length
+  // Queued + queuing + queue_failed all count toward "for review" — the line
+  // had no match and is (or will be) an admin-reviewable request.
+  const queuedCount = previewRows.filter(
+    (r) =>
+      r.status === 'queued' ||
+      r.status === 'queuing' ||
+      r.status === 'queue_failed'
+  ).length
 
   // "Add all" affordance: stages every matched row at once. Bypasses the
   // per-row [Add] button so the canon-list use case (200 URLs pasted) is
@@ -785,10 +1034,10 @@ function PasteModePane({
         value={text}
         onChange={(e) => onTextChange(e.target.value)}
         placeholder={
-          'One item per line:\n' +
+          'One item per line — a PH link or just a name:\n' +
           'https://psychichomily.com/artists/kendrick-lamar\n' +
           '/releases/to-pimp-a-butterfly\n' +
-          '/artists/frank-ocean'
+          'Frank Ocean'
         }
         rows={6}
         className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-xs focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
@@ -800,12 +1049,18 @@ function PasteModePane({
           className="flex flex-wrap items-center justify-between gap-2"
           data-testid="add-items-picker-paste-summary"
         >
+          {/* Counts joined with " · " via a parts array so adding a status to
+              the tally doesn't grow the brittle pairwise-separator chain. */}
           <p className="text-xs text-muted-foreground">
-            {matchedCount > 0 && `${matchedCount} matched`}
-            {matchedCount > 0 && (loadingCount > 0 || unresolvedCount > 0) && ' · '}
-            {loadingCount > 0 && `${loadingCount} resolving`}
-            {loadingCount > 0 && unresolvedCount > 0 && ' · '}
-            {unresolvedCount > 0 && `${unresolvedCount} unresolved`}
+            {[
+              matchedCount > 0 && `${matchedCount} matched`,
+              loadingCount > 0 && `${loadingCount} resolving`,
+              ambiguousCount > 0 && `${ambiguousCount} need a pick`,
+              queuedCount > 0 && `${queuedCount} for review`,
+              unresolvedCount > 0 && `${unresolvedCount} unresolved`,
+            ]
+              .filter(Boolean)
+              .join(' · ')}
           </p>
           {addAllEligible > 0 && (
             <Button
@@ -833,17 +1088,26 @@ function PasteModePane({
                   : false
               }
               onAdd={() => row.item && onStage(row.item)}
+              onPick={(candidate) => onPick(index, candidate)}
+              onRetryQueue={() => onRetryQueue(index)}
             />
           ))}
         </div>
       )}
 
+      {previewRows.length > 0 && queuedCount > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Lines with no match are filed as creation requests for an admin to
+          review — they won&apos;t appear in your collection until approved.
+        </p>
+      )}
+
       {previewRows.length > 0 && unresolvedCount > 0 && (
         <p className="text-xs text-muted-foreground">
-          Unresolved lines must be canonical PH paths like{' '}
-          <code className="px-1 rounded bg-muted">/artists/&lt;slug&gt;</code>.
-          For an article URL or pasted prose, switch to the AI tab. Free-text
-          auto-match in this paste-URL field is a follow-up.
+          Unresolved lines are a canonical PH path that didn&apos;t match
+          (e.g. <code className="px-1 rounded bg-muted">/artists/&lt;slug&gt;</code>),
+          or search was momentarily unavailable. Re-paste to retry, or switch
+          to the AI tab for an article URL or pasted prose.
         </p>
       )}
     </div>
@@ -854,79 +1118,150 @@ function PastePreviewRow({
   row,
   alreadyStaged,
   onAdd,
+  onPick,
+  onRetryQueue,
 }: {
   row: PreviewRow
   alreadyStaged: boolean
   onAdd: () => void
+  onPick: (candidate: PreviewCandidate) => void
+  onRetryQueue: () => void
 }) {
+  const candidates = row.candidates ?? []
   return (
     <div
-      className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
+      className="rounded-md p-2 hover:bg-muted/50"
       data-testid="add-items-picker-paste-row"
     >
-      <div className="h-7 w-7 shrink-0 rounded bg-muted/50 flex items-center justify-center">
-        <Library className="h-3.5 w-3.5 text-muted-foreground/60" />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium truncate">
-            {row.item?.name ?? row.raw}
-          </span>
-          {row.item && (
-            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
-              {getEntityTypeLabel(row.item.entityType)}
-            </Badge>
+      <div className="flex items-center gap-3">
+        <div className="h-7 w-7 shrink-0 rounded bg-muted/50 flex items-center justify-center">
+          <Library className="h-3.5 w-3.5 text-muted-foreground/60" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium truncate">
+              {row.item?.name ?? row.raw}
+            </span>
+            {row.item && (
+              <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+                {getEntityTypeLabel(row.item.entityType)}
+              </Badge>
+            )}
+          </div>
+          {row.item?.subtitle && (
+            <p className="text-xs text-muted-foreground truncate">
+              {row.item.subtitle}
+            </p>
+          )}
+          {!row.item && (
+            <p className="text-xs text-muted-foreground truncate font-mono">
+              {row.raw}
+            </p>
           )}
         </div>
-        {row.item?.subtitle && (
-          <p className="text-xs text-muted-foreground truncate">
-            {row.item.subtitle}
-          </p>
+
+        {(row.status === 'loading' || row.status === 'searching') && (
+          <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
         )}
-        {!row.item && (
-          <p className="text-xs text-muted-foreground truncate font-mono">
-            {row.raw}
-          </p>
+        {row.status === 'matched' && (
+          <>
+            <Badge
+              variant="secondary"
+              className="text-[10px] px-1.5 py-0 shrink-0 bg-success text-success-foreground motion-safe:animate-in motion-safe:fade-in"
+            >
+              <Check className="h-3 w-3 mr-0.5" />
+              MATCH
+            </Badge>
+            {alreadyStaged ? (
+              <Badge variant="secondary" className="text-xs shrink-0">
+                Added
+              </Badge>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 shrink-0"
+                onClick={onAdd}
+              >
+                <Plus className="h-3.5 w-3.5 mr-1" />
+                Add
+              </Button>
+            )}
+          </>
+        )}
+        {row.status === 'ambiguous' && (
+          // PICK uses the soft pending surface token, mirroring AICollectionFiller's
+          // "did you mean" suggestion chips — an ambiguous match is a prompt for a
+          // decision, not an error.
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 shrink-0 bg-pending text-pending-foreground motion-safe:animate-in motion-safe:fade-in"
+          >
+            <AlertTriangle className="h-3 w-3 mr-0.5" />
+            PICK
+          </Badge>
+        )}
+        {row.status === 'queuing' && (
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+            <Loader2 className="h-3 w-3 mr-0.5 animate-spin" />
+            Queuing…
+          </Badge>
+        )}
+        {row.status === 'queued' && (
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 shrink-0 bg-pending text-pending-foreground motion-safe:animate-in motion-safe:fade-in"
+            data-testid="add-items-picker-paste-row-queued"
+          >
+            <Inbox className="h-3 w-3 mr-0.5" />
+            FOR REVIEW
+          </Badge>
+        )}
+        {row.status === 'queue_failed' && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 shrink-0 text-destructive"
+            onClick={onRetryQueue}
+            data-testid="add-items-picker-paste-row-retry-queue"
+          >
+            <AlertCircle className="h-3.5 w-3.5 mr-1" />
+            Retry
+          </Button>
+        )}
+        {row.status === 'unresolved' && (
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive/10 text-destructive motion-safe:animate-in motion-safe:fade-in"
+          >
+            <AlertCircle className="h-3 w-3 mr-0.5" />
+            NO MATCH
+          </Badge>
         )}
       </div>
 
-      {row.status === 'loading' && (
-        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
-      )}
-      {row.status === 'matched' && (
-        <>
-          <Badge
-            variant="secondary"
-            className="text-[10px] px-1.5 py-0 shrink-0 bg-success text-success-foreground motion-safe:animate-in motion-safe:fade-in"
-          >
-            <Check className="h-3 w-3 mr-0.5" />
-            MATCH
-          </Badge>
-          {alreadyStaged ? (
-            <Badge variant="secondary" className="text-xs shrink-0">
-              Added
-            </Badge>
-          ) : (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 shrink-0"
-              onClick={onAdd}
-            >
-              <Plus className="h-3.5 w-3.5 mr-1" />
-              Add
-            </Button>
-          )}
-        </>
-      )}
-      {row.status === 'unresolved' && (
-        <Badge
-          variant="secondary"
-          className="text-[10px] px-1.5 py-0 shrink-0 bg-destructive/10 text-destructive motion-safe:animate-in motion-safe:fade-in"
+      {/* AMBIGUOUS: inline [Pick] candidate dropdown (≤5). Picking promotes the
+          row to MATCH. Mirrors AICollectionFiller's "did you mean" chip row. */}
+      {row.status === 'ambiguous' && candidates.length > 0 && (
+        <div
+          className="ml-10 mt-1.5 flex items-center gap-1.5 flex-wrap text-xs"
+          data-testid="add-items-picker-paste-row-pick"
         >
-          <AlertCircle className="h-3 w-3 mr-0.5" />
-          NO MATCH
-        </Badge>
+          <span className="text-pending-foreground">Did you mean:</span>
+          {candidates.map((candidate) => (
+            <button
+              key={`${candidate.entityType}-${candidate.entityId}`}
+              type="button"
+              className="rounded-md border border-pending-foreground/20 bg-pending px-2 py-0.5 text-xs text-pending-foreground hover:bg-pending/80 transition-colors"
+              onClick={() => onPick(candidate)}
+            >
+              {candidate.name}
+              <span className="ml-1 opacity-70">
+                {getEntityTypeLabel(candidate.entityType)}
+              </span>
+            </button>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -271,6 +271,10 @@ export const API_ENDPOINTS = {
     // PSY-823: paste-URL preview helper. Maps (entity_type, slug) pairs to
     // entity_ids + display metadata.
     RESOLVE_ITEMS: `${API_BASE_URL}/collections/resolve-items`,
+    // PSY-997: queue an entity-creation request for admin moderation. Used by
+    // PSY-845 (AddItemsPicker plain-text queue-for-review) + PSY-853
+    // (AICollectionFiller). Auth-gated (rc.Protected).
+    ENTITY_REQUESTS: `${API_BASE_URL}/entity-requests`,
     ITEM: (slug: string, itemId: number) =>
       `${API_BASE_URL}/collections/${slug}/items/${itemId}`,
     UPDATE_ITEM: (slug: string, itemId: number) =>

--- a/frontend/lib/hooks/common/useEntitySearch.ts
+++ b/frontend/lib/hooks/common/useEntitySearch.ts
@@ -257,7 +257,15 @@ function settledValue<T>(settled: PromiseSettledResult<T>, fallback: T): T {
   return settled.status === 'fulfilled' ? settled.value : fallback
 }
 
-async function fetchEntitySearch(query: string): Promise<FetchEntitySearchResult> {
+/**
+ * One-shot entity search across all types. Exported (PSY-845) so per-line
+ * callers like AddItemsPicker's plain-text auto-match can fan out a search
+ * for each pasted line WITHOUT the `useEntitySearch` hook's single-query +
+ * debounce machinery (a hook can't be called once per line). The
+ * `useEntitySearch` hook is still the canonical surface for an interactive
+ * single search box; this is the underlying query for batch/per-line use.
+ */
+export async function fetchEntitySearch(query: string): Promise<FetchEntitySearchResult> {
   const encoded = encodeURIComponent(query)
 
   // Fire all requests in parallel via allSettled so we can tally rejections
@@ -313,6 +321,27 @@ async function fetchEntitySearch(query: string): Promise<FetchEntitySearchResult
     },
     allFailed,
   }
+}
+
+/**
+ * Flatten grouped search results into a single ordered list (PSY-845).
+ * Order mirrors AddItemsPicker's existing `searchRows` memo so the per-line
+ * auto-match and the interactive search list agree on candidate ordering.
+ * Tags are intentionally EXCLUDED — they are not a collectible entity type
+ * (CollectionEntityType has no `tag`), so a plain-text line must never
+ * auto-match to a tag.
+ */
+export function flattenEntitySearchResults(
+  results: EntitySearchResults
+): EntitySearchResult[] {
+  return [
+    ...results.artists,
+    ...results.shows,
+    ...results.venues,
+    ...results.releases,
+    ...results.labels,
+    ...results.festivals,
+  ]
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

PSY-823's AddItemsPicker Paste mode only handled canonical PH URL paths; every plain-text line was flagged NO MATCH. This implements the locked Figma "Paste Mixed" (state 03) behavior: plain-text lines now auto-search the entity endpoints and render MATCH / AMBIGUOUS(Pick) / queue-for-review.

- **Plain-text auto-match** — each non-URL line auto-searches the entity endpoints, debounced + bounded to **5 in flight** (a bounded worker pool, so a 200-line paste doesn't fan out 200 simultaneous requests).
- **Single result ⇒ MATCH** with a stageable `[Add]`.
- **2+ candidates ⇒ AMBIGUOUS** with an inline `[Pick]` dropdown (≤5 candidates, mirrors AICollectionFiller's "did you mean" chips) that promotes the picked entity to MATCH.
- **Zero results ⇒ queue-for-review** — POSTs an `entity_request` (`entity_type: artist`, `source_context: paste_mode`) to PSY-997's `POST /entity-requests` for an admin to approve; the row shows a `FOR REVIEW` chip. A transient per-line search outage marks the row NO MATCH (retryable) rather than queuing, so a flaky backend doesn't seed false negatives. Failed POSTs show a `Retry`.
- **URL-path lines keep their existing batch-resolve behavior** unchanged.

Resolution is isolated in a new `usePastePreview` hook (bounded worker pool + a per-generation stale-response guard across URL resolve, per-line search, and queue POST). The queue-create is a **local** `queueEntityRequest()` (not a shared exported hook) — small intentional duplication with PSY-853's parallel AICollectionFiller path, per the coordination note; a future ticket dedups into a shared hook.

**Files changed**
- `frontend/features/collections/components/AddItemsPicker.tsx` — the feature (usePastePreview hook, new preview states, Pick dropdown, queue affordances).
- `frontend/features/collections/components/AddItemsPicker.test.tsx` — new cases for MATCH / AMBIGUOUS+Pick / queue / queue-retry / search-outage / concurrent-queue.
- `frontend/lib/hooks/common/useEntitySearch.ts` — export `fetchEntitySearch` + `flattenEntitySearchResults` for per-line reuse (tags excluded — not a collectible type).
- `frontend/lib/api.ts` — add `COLLECTIONS.ENTITY_REQUESTS` endpoint.

## Test plan
- [x] `cd frontend && bun run typecheck` — clean.
- [x] `bun run test:run features/collections/components/AddItemsPicker` — 38 passed (added MATCH / AMBIGUOUS+Pick / queue / retry / search-outage / concurrent-queue cases).
- [x] `bun run test:run features/collections` — 377 passed (no regression).
- [x] `bun run test:run lib/hooks/common/useEntitySearch` — 20 passed.
- [x] `bunx eslint` on changed files — 0 errors.
- [x] `/code-review` (xhigh) — found + fixed 1 confirmed bug (see below).
- [x] `/adversarial-review` (4 lenses, inline) — found + fixed 1 MEDIUM (see below).

## Manual repro
Shared dev stack (auto-escalated to isolated), signed in as `e2e-user@test.local`, Create Collection drawer → Paste URLs tab. Pasted a mix:
```
Sundressed                  → AMBIGUOUS (PICK): artist + 4 same-named shows
the                         → AMBIGUOUS (PICK): 5 capped candidates
Zxqwerty Nonexistent Band   → FOR REVIEW (queued)
/artists/ajj                → MATCH (URL path)
```
Observed states matched exactly (summary "1 matched · 2 need a pick · 1 for review"). Verified the queue POST landed in the DB: `SELECT ... FROM entity_requests WHERE source_context='paste_mode'` → `artist | Zxqwerty Nonexistent Band | paste_mode | pending`. Clicked a Pick candidate → row promoted PICK → MATCH and the summary updated to "2 matched · 1 need a pick · 1 for review". Stack torn down.

## Screenshots
| State | |
|---|---|
| Mixed paste (textarea + summary + first PICK row) | ![mixed](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-388c1d05ccf0eb6276d3/01-paste-mixed-states.png) |
| Both PICK rows + FOR REVIEW help copy | ![pick](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-388c1d05ccf0eb6276d3/02-queue-and-match-rows.png) |
| MATCH + FOR REVIEW + MATCH rows | ![match](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-388c1d05ccf0eb6276d3/03-match-and-forreview.png) |
| Pick promoted to MATCH ("the" → The Maine, summary "2 matched") | ![promoted](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-388c1d05ccf0eb6276d3/04-pick-promoted-to-match.png) |

## Code review
`/code-review` (xhigh, inline) — **1 confirmed correctness bug**, fixed in `ad4dca18`:
- **[HIGH] Last-write-wins on concurrent queue POSTs** — the queue path used one shared `useMutation` instance for N concurrent zero-result lines. TanStack Query's mutation observer only tracks the latest in-flight mutation, so rapid successive `.mutate()` calls dropped earlier per-call callbacks — only the last junk line ended up queued. Fix: replaced the local `useQueueEntityRequest` hook with a plain async `queueEntityRequest()` (per-call `apiRequest`); added a regression test (3 junk lines → 3 FOR REVIEW rows + 3 POSTs).

## Adversarial review
`/adversarial-review` (4 lenses — Saboteur · Future-Maintainer · Security · Completeness — run inline, no prior session context) — **1 MEDIUM addressed** in `026c47a2`:
- **[MEDIUM] Concurrency bound didn't cover the queue POSTs** — the 5-in-flight limit bounded SEARCHES only; a 200-junk-line paste would still fire ~200 POSTs near-simultaneously (the exact "don't hammer the backend" case the semaphore exists to prevent). Fix: `fileQueueRequest` returns its settle promise and the bounded worker `await`s it, so each queue POST counts against the same budget. (`retryQueue`, a single user click, stays fire-and-forget.)
- **Deferred (disclosed):** duplicate identical junk lines in one paste each file a separate `entity_request` (no cross-row dedup; backend has no unique constraint). Realistic only on accidental dupes; admin review handles it. Cross-row dedup state across the concurrent worker pool isn't worth the complexity now.
- **Held up well:** stale-generation guard (verified via the existing out-of-order resolver test + new per-line cases); auth-gated POST with parameterized backend storage (no injection); tag results correctly excluded from candidates (no invalid-cast crash).

Closes PSY-845
