### PR TITLE
PSY-853: tier-gated create/queue on AICollectionFiller NEW rows

### DIFF
--- a/frontend/features/collections/components/AICollectionFiller.test.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.test.tsx
@@ -550,6 +550,32 @@ describe('AICollectionFiller', () => {
     expect(chip).toHaveTextContent('Requested')
   })
 
+  it('a failed entity-request shows an inline error and keeps the button', async () => {
+    mockUser = { is_admin: false, user_tier: 'contributor' }
+    // 403 (or any non-ok) → the mutationFn throws; the row surfaces it inline.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'Admin access required' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    await user.click(screen.getByTestId('ai-collection-filler-row-request'))
+
+    const err = await screen.findByTestId(
+      'ai-collection-filler-row-request-error'
+    )
+    expect(err).toHaveTextContent('Admin access required')
+    // No chip; the create/queue button remains so the user can retry.
+    expect(
+      screen.queryByTestId('ai-collection-filler-row-request-chip')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('ai-collection-filler-row-request')
+    ).toBeInTheDocument()
+  })
+
   it('matched-row [Add] still works when a tier user is present (no regress)', async () => {
     mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
     mockExtractResult = {

--- a/frontend/features/collections/components/AICollectionFiller.test.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.test.tsx
@@ -576,6 +576,23 @@ describe('AICollectionFiller', () => {
     ).toBeInTheDocument()
   })
 
+  it('does not double-file when the create button is clicked twice fast', async () => {
+    mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
+    // Never-resolving fetch keeps the request in flight so a second click
+    // would double-file if the in-flight guard were missing.
+    const fetchMock = vi.fn().mockReturnValue(new Promise(() => {}))
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    const btn = screen.getByTestId('ai-collection-filler-row-request')
+    await user.click(btn)
+    // Button is now disabled (in flight) — a second click must be a no-op.
+    await user.click(btn)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('matched-row [Add] still works when a tier user is present (no regress)', async () => {
     mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
     mockExtractResult = {

--- a/frontend/features/collections/components/AICollectionFiller.test.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { AICollectionFiller } from './AICollectionFiller'
+import type { AICollectionFillerProps } from './AICollectionFiller'
 import type { ExtractedCollectionData } from '@/lib/types/extraction'
 
 // ──────────────────────────────────────────────
@@ -33,6 +35,12 @@ vi.mock('../hooks', () => ({
   }),
 }))
 
+// Tier-gated affordances read user.is_admin + user.user_tier from auth context.
+let mockUser: { is_admin?: boolean; user_tier?: string } | null = null
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ user: mockUser }),
+}))
+
 vi.mock('@/components/ui/button', () => ({
   Button: ({
     children,
@@ -52,7 +60,15 @@ vi.mock('@/components/ui/button', () => ({
 }))
 
 vi.mock('@/components/ui/badge', () => ({
-  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  // Forward arbitrary props (incl. data-testid) so chip testids survive the
+  // mock — the real Badge spreads props onto its root element too.
+  Badge: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode
+    [key: string]: unknown
+  }) => <span {...(props as Record<string, unknown>)}>{children}</span>,
 }))
 
 vi.mock('@/components/shared', () => ({
@@ -69,16 +85,36 @@ vi.mock('@/components/shared', () => ({
 // Component
 // ──────────────────────────────────────────────
 
+// Wrap renders in a QueryClientProvider — the component now always mounts a
+// local useMutation (queue-create), which needs a QueryClient even in tests
+// where the queue path isn't exercised.
+function renderFiller(props: AICollectionFillerProps) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AICollectionFiller {...props} />
+    </QueryClientProvider>
+  )
+}
+
 describe('AICollectionFiller', () => {
   beforeEach(() => {
     mockExtractResult = { data: undefined, warnings: undefined }
     mockExtractIsPending = false
     mockExtractError = null
     mockExtractCalls = []
+    mockUser = null
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('renders textarea + image drop zone + disabled extract button', () => {
-    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
     expect(screen.getByTestId('ai-collection-filler-textarea')).toBeInTheDocument()
     expect(screen.getByTestId('ai-collection-filler-file-input')).toBeInTheDocument()
     expect(screen.getByTestId('ai-collection-filler-extract')).toBeDisabled()
@@ -86,7 +122,7 @@ describe('AICollectionFiller', () => {
 
   it('enables Extract once text is typed', async () => {
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
     await user.type(
       screen.getByTestId('ai-collection-filler-textarea'),
       '1. Kendrick Lamar — TPAB'
@@ -95,7 +131,7 @@ describe('AICollectionFiller', () => {
   })
 
   it('file input accepts HEIC + HEIF for iOS Safari paste', () => {
-    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
     const input = screen.getByTestId('ai-collection-filler-file-input') as HTMLInputElement
     expect(input.getAttribute('accept')).toContain('image/heic')
     expect(input.getAttribute('accept')).toContain('image/heif')
@@ -133,7 +169,7 @@ describe('AICollectionFiller', () => {
       },
     }
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
     await user.type(
       screen.getByTestId('ai-collection-filler-textarea'),
       'list goes here'
@@ -162,7 +198,7 @@ describe('AICollectionFiller', () => {
     }
     const onStage = vi.fn()
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={onStage} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: onStage, alreadyStaged: () => false })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
 
@@ -214,7 +250,7 @@ describe('AICollectionFiller', () => {
     }
     const onStage = vi.fn()
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={onStage} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: onStage, alreadyStaged: () => false })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
 
@@ -243,7 +279,7 @@ describe('AICollectionFiller', () => {
       },
     }
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
 
@@ -270,7 +306,7 @@ describe('AICollectionFiller', () => {
       },
     }
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
 
@@ -308,7 +344,7 @@ describe('AICollectionFiller', () => {
     }
     const onStage = vi.fn()
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={onStage} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: onStage, alreadyStaged: () => false })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
 
@@ -334,12 +370,10 @@ describe('AICollectionFiller', () => {
       },
     }
     const user = userEvent.setup()
-    render(
-      <AICollectionFiller
-        onStageItems={vi.fn()}
-        alreadyStaged={(t, id) => t === 'artist' && id === 42}
-      />
-    )
+    renderFiller({
+      onStageItems: vi.fn(),
+      alreadyStaged: (t, id) => t === 'artist' && id === 42,
+    })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
 
@@ -350,10 +384,200 @@ describe('AICollectionFiller', () => {
   it('surfaces a hook error via InlineErrorBanner', async () => {
     mockExtractError = new Error('AI service temporarily unavailable.')
     const user = userEvent.setup()
-    render(<AICollectionFiller onStageItems={vi.fn()} alreadyStaged={() => false} />)
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
 
     const banner = screen.getByTestId('ai-collection-filler-error')
     expect(banner).toHaveTextContent(/temporarily unavailable/i)
+  })
+
+  // ────────────────────────────────────────────────────────────
+  // PSY-853: tier-gated create / queue actions on unmatched (NEW) rows
+  // ────────────────────────────────────────────────────────────
+
+  // One unmatched (NEW) row — no match, no suggestions — so the tier-gated
+  // create/queue affordance is the only action on the row.
+  const ONE_UNMATCHED_ROW: ExtractedCollectionData = {
+    items: [{ artist_name: 'Some Made Up Band', release_title: 'Nowhere Album' }],
+  }
+
+  /** Stub global.fetch with a single JSON response for the entity-request POST. */
+  function stubFetch(decisionState: 'approved' | 'pending', ok = true) {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok,
+      json: async () => ({ id: 7, decision_state: decisionState }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  async function extractOneUnmatchedRow(user: ReturnType<typeof userEvent.setup>) {
+    mockExtractResult = { data: ONE_UNMATCHED_ROW }
+    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+  }
+
+  it('admin sees [Create + Add] on an unmatched row (no Queue button)', async () => {
+    mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    const btn = screen.getByTestId('ai-collection-filler-row-request')
+    expect(btn).toHaveTextContent('Create + Add')
+    expect(btn).not.toHaveTextContent('Queue for review')
+  })
+
+  it('local_ambassador sees [Create + Add] (auto-approve tier, not admin)', async () => {
+    mockUser = { is_admin: false, user_tier: 'local_ambassador' }
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    expect(
+      screen.getByTestId('ai-collection-filler-row-request')
+    ).toHaveTextContent('Create + Add')
+  })
+
+  it('contributor sees [Queue for review] (never an inline create)', async () => {
+    mockUser = { is_admin: false, user_tier: 'contributor' }
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    const btn = screen.getByTestId('ai-collection-filler-row-request')
+    expect(btn).toHaveTextContent('Queue for review')
+    expect(btn).not.toHaveTextContent('Create + Add')
+  })
+
+  it('new_user sees [Queue for review]', async () => {
+    mockUser = { is_admin: false, user_tier: 'new_user' }
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    expect(
+      screen.getByTestId('ai-collection-filler-row-request')
+    ).toHaveTextContent('Queue for review')
+  })
+
+  it('anonymous / unknown tier sees NO create or queue action', async () => {
+    mockUser = null
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    expect(
+      screen.queryByTestId('ai-collection-filler-row-request')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('ai-collection-filler-row-confirm')
+    ).not.toBeInTheDocument()
+  })
+
+  it('trusted_contributor requires inline [Confirm] before filing', async () => {
+    mockUser = { is_admin: false, user_tier: 'trusted_contributor' }
+    const fetchMock = stubFetch('approved')
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    // First click reveals Confirm/Cancel — it does NOT file the request.
+    await user.click(screen.getByTestId('ai-collection-filler-row-request'))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId('ai-collection-filler-row-confirm')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('ai-collection-filler-row-cancel')
+    ).toBeInTheDocument()
+
+    // Cancel backs out without filing.
+    await user.click(screen.getByTestId('ai-collection-filler-row-cancel'))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId('ai-collection-filler-row-request')
+    ).toBeInTheDocument()
+
+    // Re-open and Confirm files a confirmed request.
+    await user.click(screen.getByTestId('ai-collection-filler-row-request'))
+    await user.click(screen.getByTestId('ai-collection-filler-row-confirm'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/entity-requests')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.confirmed).toBe(true)
+    expect(body.entity_type).toBe('artist')
+    expect(body.source_context).toBe('ai_extraction')
+    expect(body.payload).toEqual({ name: 'Some Made Up Band' })
+  })
+
+  it('queue path POSTs an entity_request and shows a "Queued" chip', async () => {
+    mockUser = { is_admin: false, user_tier: 'contributor' }
+    const fetchMock = stubFetch('pending')
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    // Sanity: the unmatched row rendered before we act on it.
+    expect(screen.getByText('Some Made Up Band')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('ai-collection-filler-row-request'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/entity-requests')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.confirmed).toBe(false)
+    expect(body.source_context).toBe('ai_extraction')
+
+    // Pending decision_state → "Queued" chip; create/queue button replaced.
+    const chip = await screen.findByTestId(
+      'ai-collection-filler-row-request-chip'
+    )
+    expect(chip).toHaveTextContent('Queued')
+    expect(
+      screen.queryByTestId('ai-collection-filler-row-request')
+    ).not.toBeInTheDocument()
+  })
+
+  it('auto-approved (admin) request shows a "Requested" chip', async () => {
+    mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
+    stubFetch('approved')
+    const user = userEvent.setup()
+    await extractOneUnmatchedRow(user)
+
+    await user.click(screen.getByTestId('ai-collection-filler-row-request'))
+
+    const chip = await screen.findByTestId(
+      'ai-collection-filler-row-request-chip'
+    )
+    expect(chip).toHaveTextContent('Requested')
+  })
+
+  it('matched-row [Add] still works when a tier user is present (no regress)', async () => {
+    mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
+    mockExtractResult = {
+      data: {
+        items: [
+          {
+            artist_name: 'Kendrick Lamar',
+            release_title: 'To Pimp a Butterfly',
+            matched_artist_id: 42,
+            matched_artist_name: 'Kendrick Lamar',
+          },
+        ],
+      },
+    }
+    const onStage = vi.fn()
+    const user = userEvent.setup()
+    renderFiller({ onStageItems: onStage, alreadyStaged: () => false })
+    await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
+    await user.click(screen.getByTestId('ai-collection-filler-extract'))
+
+    await user.click(screen.getByTestId('ai-collection-filler-row-add'))
+    expect(onStage).toHaveBeenCalledTimes(1)
+    expect(onStage.mock.calls[0][0][0]).toEqual(
+      expect.objectContaining({ entityType: 'artist', entityId: 42 })
+    )
+    // A matched row never shows the create/queue affordance.
+    expect(
+      screen.queryByTestId('ai-collection-filler-row-request')
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -250,6 +250,12 @@ export function AICollectionFiller({
   // network). Surfaced inline on the row so the action isn't a silent no-op;
   // the create/queue button stays so the user can retry.
   const [requestErrors, setRequestErrors] = useState<Record<string, string>>({})
+  // Rows with an entity-request currently in flight. Tracked per-row (not via
+  // the shared mutation's isPending) because the single useMutation only
+  // remembers its LATEST variables — clicking row B while row A is in flight
+  // would otherwise re-enable A's button mid-flight and let it double-file
+  // (the backend has no create-side dedup).
+  const [inFlightRows, setInFlightRows] = useState<Set<string>>(new Set())
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const { user } = useAuthContext()
@@ -475,6 +481,9 @@ export function AICollectionFiller({
   // backend's decision_state, not assumed) so the affordance can't be
   // double-fired.
   const requestRow = (rowKey: string, name: string, confirmed: boolean) => {
+    // Guard against a double-submit for the same row (the resolved/errored
+    // chip already guards a settled row; this guards the in-flight window).
+    if (inFlightRows.has(rowKey)) return
     // Clear any prior error on this row so a retry starts clean.
     setRequestErrors(prev => {
       if (!(rowKey in prev)) return prev
@@ -482,11 +491,19 @@ export function AICollectionFiller({
       delete next[rowKey]
       return next
     })
+    setInFlightRows(prev => new Set(prev).add(rowKey))
+    const clearInFlight = () =>
+      setInFlightRows(prev => {
+        const next = new Set(prev)
+        next.delete(rowKey)
+        return next
+      })
     queueRequest.mutate(
       { rowKey, entityType: 'artist', name, confirmed },
       {
         onSuccess: ({ outcome }) => {
           setRequestedRows(prev => ({ ...prev, [rowKey]: outcome }))
+          clearInFlight()
         },
         onError: (err: unknown) => {
           setRequestErrors(prev => ({
@@ -496,6 +513,7 @@ export function AICollectionFiller({
                 ? err.message
                 : 'Failed to submit. Please try again.',
           }))
+          clearInFlight()
         },
       }
     )
@@ -670,10 +688,7 @@ export function AICollectionFiller({
                     affordance={affordance}
                     requestOutcome={requestedRows[rowKey]}
                     requestError={requestErrors[rowKey]}
-                    isRequesting={
-                      queueRequest.isPending &&
-                      queueRequest.variables?.rowKey === rowKey
-                    }
+                    isRequesting={inFlightRows.has(rowKey)}
                     onAdd={() => stageItem(item)}
                     onAcceptSuggestion={s => acceptSuggestion(idx, s)}
                     onDismissSuggestions={() => dismissSuggestions(idx)}

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -25,6 +25,7 @@
  */
 
 import { useCallback, useRef, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import {
   Sparkles,
   X,
@@ -38,6 +39,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { InlineErrorBanner } from '@/components/shared'
+import { useAuthContext } from '@/lib/context/AuthContext'
 import { useCollectionExtraction } from '../hooks'
 import type {
   ExtractedCollectionData,
@@ -100,6 +102,117 @@ function compressImage(dataUrl: string): Promise<string> {
   })
 }
 
+// ─── Tier-gated create / queue policy (PSY-853) ───
+//
+// Unmatched rows have no existing entity to stage. What the user can do with
+// them depends on trust tier. The backend's tier policy lives in PSY-869's
+// EntityRequestService (autoApproves): admin / local_ambassador auto-approve;
+// trusted_contributor auto-approves only on a FE-confirmed request; everyone
+// else queues for admin review (feedback_human_verify_ai_entity_data — no
+// autonomous AI entity creation for low-trust tiers). We mirror that policy
+// in the UI but DO NOT re-implement authorization client-side — the backend
+// enforces it; this only picks the right affordance.
+//
+// IMPORTANT (architectural constraint, verified against backend on PSY-853):
+// every catalog create endpoint (POST /admin/artists, /releases, …) is
+// rc.Admin-gated, so non-admin trusted tiers CANNOT create entities through
+// them — a 403 path. The ONLY cross-tier create mechanism is
+// POST /entity-requests (PSY-997). On auto-approve that endpoint marks the
+// request approved but does NOT fulfill it into a catalog row, so there is no
+// new entity_id to stage into the bulk-add pipeline yet. The "Create + Add"
+// label therefore files an (auto-approved) request rather than staging the
+// new entity into the collection in the same step. Closing that gap — fulfill
+// on auto-approve + return created_entity_id so the row can stage — is a
+// backend follow-up; it is out of this frontend-only ticket's scope.
+type CreateAffordance = 'create' | 'confirm' | 'queue' | 'none'
+
+/**
+ * Maps an authenticated user's admin flag + trust tier to the create
+ * affordance shown on an unmatched row. Returns 'none' for anonymous or
+ * unknown-tier users (fail-closed — never offer a create action we can't
+ * map to a backend-enforced policy).
+ */
+function createAffordanceFor(
+  isAdmin: boolean | undefined,
+  tier: string | undefined
+): CreateAffordance {
+  if (isAdmin) return 'create'
+  switch (tier) {
+    case 'local_ambassador':
+      return 'create'
+    case 'trusted_contributor':
+      return 'confirm'
+    case 'contributor':
+    case 'new_user':
+      return 'queue'
+    default:
+      // Anonymous, missing, or an unrecognized tier → no create action.
+      return 'none'
+  }
+}
+
+// Outcome of a successful entity-request POST, used to pick the per-row chip.
+// 'requested' = auto-approved (admin / local_ambassador / confirmed trusted) —
+// the request skipped the queue; 'queued' = pending admin review.
+type RequestOutcome = 'requested' | 'queued'
+
+interface QueueEntityRequestVars {
+  /** The unmatched row this request was filed from (used for per-row state). */
+  rowKey: string
+  /** Always 'artist' in V1 — extraction only matches/creates artists today. */
+  entityType: 'artist'
+  /** User-supplied creation payload (artist name from the extracted row). */
+  name: string
+  /**
+   * FE-side confirm step. Only meaningful for trusted_contributor (the backend
+   * auto-approves a confirmed trusted request); ignored for other tiers.
+   */
+  confirmed: boolean
+}
+
+/**
+ * Local queue-create mutation (PSY-853). Intentionally NOT a shared exported
+ * hook — PSY-845 posts to the same POST /entity-requests endpoint from a
+ * different component (AddItemsPicker) and a small, deliberate duplication is
+ * preferred over premature coupling while both land in parallel. A follow-up
+ * dedups once both have shipped (see coordination note in the ticket).
+ *
+ * The body carries source_context: 'ai_extraction' so the admin moderation
+ * surface can see the request originated from the AI collection flow.
+ */
+function useQueueEntityRequest() {
+  return useMutation({
+    mutationFn: async (vars: QueueEntityRequestVars) => {
+      const response = await fetch('/api/entity-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          entity_type: vars.entityType,
+          payload: { name: vars.name },
+          source_context: 'ai_extraction',
+          confirmed: vars.confirmed,
+        }),
+      })
+
+      const data = await response.json().catch(() => null)
+
+      if (!response.ok) {
+        throw new Error(
+          (data && (data.detail || data.message)) ||
+            'Failed to submit entity request'
+        )
+      }
+
+      // decision_state distinguishes auto-approved (skips the queue) from
+      // pending (awaiting admin review) so the row chip reads correctly.
+      const outcome: RequestOutcome =
+        data?.decision_state === 'approved' ? 'requested' : 'queued'
+      return { outcome, rowKey: vars.rowKey }
+    },
+  })
+}
+
 export interface AICollectionFillerProps {
   /**
    * Fires when the user stages one or more extracted items via the per-row
@@ -127,7 +240,17 @@ export function AICollectionFiller({
   const [extractionResult, setExtractionResult] =
     useState<ExtractedCollectionData | null>(null)
   const [warnings, setWarnings] = useState<string[]>([])
+  // Per-row outcome of a filed entity-request, keyed by the row's stable key.
+  // Drives the "Requested" / "Queued" chip and hides the create affordance
+  // once a row has been acted on (prevents double-filing).
+  const [requestedRows, setRequestedRows] = useState<
+    Record<string, RequestOutcome>
+  >({})
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const { user } = useAuthContext()
+  const affordance = createAffordanceFor(user?.is_admin, user?.user_tier)
+  const queueRequest = useQueueEntityRequest()
 
   const { mutate, isPending, error, reset } = useCollectionExtraction()
 
@@ -243,6 +366,9 @@ export function AICollectionFiller({
       if (response.data) {
         setExtractionResult(response.data)
         setWarnings(response.warnings || [])
+        // A fresh extraction replaces the row matrix, so any prior
+        // Requested/Queued chips no longer correspond to a visible row.
+        setRequestedRows({})
       }
     }
 
@@ -335,6 +461,22 @@ export function AICollectionFiller({
       return { ...item, artist_suggestions: undefined }
     })
     setExtractionResult({ ...extractionResult, items: updatedItems })
+  }
+
+  // Files an entity-request for an unmatched row. Tier policy is enforced
+  // server-side; `confirmed` is only meaningful for trusted_contributor.
+  // On success the row flips to a Requested/Queued chip (set from the
+  // backend's decision_state, not assumed) so the affordance can't be
+  // double-fired.
+  const requestRow = (rowKey: string, name: string, confirmed: boolean) => {
+    queueRequest.mutate(
+      { rowKey, entityType: 'artist', name, confirmed },
+      {
+        onSuccess: ({ outcome }) => {
+          setRequestedRows(prev => ({ ...prev, [rowKey]: outcome }))
+        },
+      }
+    )
   }
 
   const matchedReadyCount = extractionResult
@@ -492,20 +634,32 @@ export function AICollectionFiller({
             </p>
           ) : (
             <div className="max-h-72 overflow-y-auto space-y-1">
-              {extractionResult.items.map((item, idx) => (
-                <ExtractedRow
-                  key={`${idx}-${item.artist_name}`}
-                  item={item}
-                  alreadyStaged={
-                    item.matched_artist_id
-                      ? alreadyStaged('artist', item.matched_artist_id)
-                      : false
-                  }
-                  onAdd={() => stageItem(item)}
-                  onAcceptSuggestion={s => acceptSuggestion(idx, s)}
-                  onDismissSuggestions={() => dismissSuggestions(idx)}
-                />
-              ))}
+              {extractionResult.items.map((item, idx) => {
+                const rowKey = `${idx}-${item.artist_name}`
+                return (
+                  <ExtractedRow
+                    key={rowKey}
+                    item={item}
+                    alreadyStaged={
+                      item.matched_artist_id
+                        ? alreadyStaged('artist', item.matched_artist_id)
+                        : false
+                    }
+                    affordance={affordance}
+                    requestOutcome={requestedRows[rowKey]}
+                    isRequesting={
+                      queueRequest.isPending &&
+                      queueRequest.variables?.rowKey === rowKey
+                    }
+                    onAdd={() => stageItem(item)}
+                    onAcceptSuggestion={s => acceptSuggestion(idx, s)}
+                    onDismissSuggestions={() => dismissSuggestions(idx)}
+                    onRequest={confirmed =>
+                      requestRow(rowKey, item.artist_name, confirmed)
+                    }
+                  />
+                )
+              })}
             </div>
           )}
 
@@ -518,9 +672,9 @@ export function AICollectionFiller({
           )}
 
           <p className="text-xs text-muted-foreground">
-            Unmatched rows show suggestions for the closest existing entity.
-            Creating new artists / releases via the AI flow lands in a
-            follow-up — for V1 only matched (or picked) rows commit.
+            {affordance === 'queue'
+              ? 'Unmatched rows show suggestions for the closest existing entity. New artists you queue go to a moderator for review before they’re created.'
+              : 'Unmatched rows show suggestions for the closest existing entity. New artists you add are submitted for creation.'}
           </p>
         </div>
       )}
@@ -531,16 +685,32 @@ export function AICollectionFiller({
 function ExtractedRow({
   item,
   alreadyStaged,
+  affordance,
+  requestOutcome,
+  isRequesting,
   onAdd,
   onAcceptSuggestion,
   onDismissSuggestions,
+  onRequest,
 }: {
   item: ExtractedCollectionItem
   alreadyStaged: boolean
+  /** Tier-derived create affordance for unmatched rows. */
+  affordance: CreateAffordance
+  /** Set once this row's entity-request resolves (Requested vs Queued chip). */
+  requestOutcome: RequestOutcome | undefined
+  /** True while THIS row's request is in flight. */
+  isRequesting: boolean
   onAdd: () => void
   onAcceptSuggestion: (suggestion: MatchSuggestion) => void
   onDismissSuggestions: () => void
+  /** Files the entity-request. `confirmed` is the trusted_contributor step. */
+  onRequest: (confirmed: boolean) => void
 }) {
+  // trusted_contributor confirm step is INLINE (not a Dialog) so the picker
+  // context stays visible — entity creation is irreversible, so the extra
+  // tap is a deliberate friction point, not a modal interruption.
+  const [confirming, setConfirming] = useState(false)
   const displayName = item.matched_artist_name ?? item.artist_name
   const hasSuggestions =
     !item.matched_artist_id && (item.artist_suggestions?.length ?? 0) > 0
@@ -609,6 +779,78 @@ function ExtractedRow({
             >
               <Plus className="h-3.5 w-3.5 mr-1" />
               Add
+            </Button>
+          ))}
+
+        {/* Tier-gated create / queue affordance for unmatched (NEW) rows.
+            Suggestion (PICK) rows resolve via "Did you mean" below, not here.
+            Authorization is enforced server-side by POST /entity-requests; this
+            only selects the affordance and never bypasses the queue for
+            low-trust tiers (a contributor only ever sees [Queue for review]). */}
+        {isNew &&
+          (requestOutcome ? (
+            <Badge
+              variant="secondary"
+              className="text-xs shrink-0 motion-safe:animate-in motion-safe:fade-in"
+              data-testid="ai-collection-filler-row-request-chip"
+            >
+              {requestOutcome === 'queued' ? 'Queued' : 'Requested'}
+            </Badge>
+          ) : affordance === 'none' ? null : confirming ? (
+            // trusted_contributor inline confirm — irreversible creation.
+            <div className="flex items-center gap-1 shrink-0">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-destructive"
+                disabled={isRequesting}
+                onClick={() => {
+                  setConfirming(false)
+                  onRequest(true)
+                }}
+                data-testid="ai-collection-filler-row-confirm"
+              >
+                {isRequesting ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  'Confirm'
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-muted-foreground"
+                disabled={isRequesting}
+                onClick={() => setConfirming(false)}
+                data-testid="ai-collection-filler-row-cancel"
+              >
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 shrink-0"
+              disabled={isRequesting}
+              onClick={() => {
+                if (affordance === 'confirm') {
+                  setConfirming(true)
+                } else {
+                  // admin / local_ambassador (create) and contributor /
+                  // new_user (queue) both file immediately; the backend's
+                  // tier policy decides auto-approve vs pending.
+                  onRequest(false)
+                }
+              }}
+              data-testid="ai-collection-filler-row-request"
+            >
+              {isRequesting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+              ) : (
+                <Plus className="h-3.5 w-3.5 mr-1" />
+              )}
+              {affordance === 'queue' ? 'Queue for review' : 'Create + Add'}
             </Button>
           ))}
       </div>

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -246,6 +246,10 @@ export function AICollectionFiller({
   const [requestedRows, setRequestedRows] = useState<
     Record<string, RequestOutcome>
   >({})
+  // Per-row error message for a failed entity-request POST (403 / 422 / 5xx /
+  // network). Surfaced inline on the row so the action isn't a silent no-op;
+  // the create/queue button stays so the user can retry.
+  const [requestErrors, setRequestErrors] = useState<Record<string, string>>({})
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const { user } = useAuthContext()
@@ -367,8 +371,10 @@ export function AICollectionFiller({
         setExtractionResult(response.data)
         setWarnings(response.warnings || [])
         // A fresh extraction replaces the row matrix, so any prior
-        // Requested/Queued chips no longer correspond to a visible row.
+        // Requested/Queued chips + row errors no longer correspond to a
+        // visible row.
         setRequestedRows({})
+        setRequestErrors({})
       }
     }
 
@@ -469,11 +475,27 @@ export function AICollectionFiller({
   // backend's decision_state, not assumed) so the affordance can't be
   // double-fired.
   const requestRow = (rowKey: string, name: string, confirmed: boolean) => {
+    // Clear any prior error on this row so a retry starts clean.
+    setRequestErrors(prev => {
+      if (!(rowKey in prev)) return prev
+      const next = { ...prev }
+      delete next[rowKey]
+      return next
+    })
     queueRequest.mutate(
       { rowKey, entityType: 'artist', name, confirmed },
       {
         onSuccess: ({ outcome }) => {
           setRequestedRows(prev => ({ ...prev, [rowKey]: outcome }))
+        },
+        onError: (err: unknown) => {
+          setRequestErrors(prev => ({
+            ...prev,
+            [rowKey]:
+              err instanceof Error
+                ? err.message
+                : 'Failed to submit. Please try again.',
+          }))
         },
       }
     )
@@ -647,6 +669,7 @@ export function AICollectionFiller({
                     }
                     affordance={affordance}
                     requestOutcome={requestedRows[rowKey]}
+                    requestError={requestErrors[rowKey]}
                     isRequesting={
                       queueRequest.isPending &&
                       queueRequest.variables?.rowKey === rowKey
@@ -687,6 +710,7 @@ function ExtractedRow({
   alreadyStaged,
   affordance,
   requestOutcome,
+  requestError,
   isRequesting,
   onAdd,
   onAcceptSuggestion,
@@ -699,6 +723,8 @@ function ExtractedRow({
   affordance: CreateAffordance
   /** Set once this row's entity-request resolves (Requested vs Queued chip). */
   requestOutcome: RequestOutcome | undefined
+  /** Set if this row's entity-request POST failed (inline error). */
+  requestError: string | undefined
   /** True while THIS row's request is in flight. */
   isRequesting: boolean
   onAdd: () => void
@@ -879,6 +905,17 @@ function ExtractedRow({
             Skip
           </button>
         </div>
+      )}
+
+      {/* Inline error for a failed create/queue POST — the button stays so the
+          user can retry; never a silent no-op. */}
+      {requestError && (
+        <p
+          className="ml-0 mt-1.5 text-xs text-destructive"
+          data-testid="ai-collection-filler-row-request-error"
+        >
+          {requestError}
+        </p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Wires trust-tier-gated per-row actions onto the **unmatched (NEW) rows** in the AI collection-extraction preview (`AICollectionFiller`). PSY-824 shipped Matched + Ambiguous(Pick); PSY-962 shipped the chip visuals. This adds the create/queue **actions** that were deferred.

Affordance per tier (derived from `useAuthContext().user.is_admin` + `user.user_tier`):

| Tier | Action | Behaviour |
|------|--------|-----------|
| admin / local_ambassador | **[Create + Add]** | POST `/entity-requests` (auto-approved server-side) → **"Requested"** chip |
| trusted_contributor | inline **[Confirm] / [Cancel]** | POST `/entity-requests` `confirmed:true` (auto-approved) → **"Requested"** chip |
| contributor / new_user | **[Queue for review]** | POST `/entity-requests` (pending) → **"Queued"** chip — no autonomous creation |
| anonymous / unknown tier | none | fail-closed, no create/queue affordance |

The matched-row **[Add]** bulk-add happy path (PSY-823) is unchanged. The queue-create call is a **local** `useMutation` inside `AICollectionFiller.tsx` (not a shared hook — small intentional duplication with the parallel PSY-845, per the coordination note).

**Files changed** (frontend-only, no backend):
- `frontend/features/collections/components/AICollectionFiller.tsx`
- `frontend/features/collections/components/AICollectionFiller.test.tsx`

### Architectural note / scope boundary (verified against backend)

Every catalog create endpoint (`POST /admin/artists`, `/releases`, …) is `rc.Admin`-gated, so **non-admin trusted tiers cannot create entities through them** (403). The only cross-tier create mechanism is `POST /entity-requests` (PSY-997), whose service-side `autoApproves()` policy is exactly this ticket's tier policy. So **all** tiers route through `/entity-requests`; the UI only selects the affordance — **authorization is enforced server-side** (a `contributor` sending `confirmed:true` still queues, never auto-creates).

Two known gaps, both **backend-constrained, out of this frontend-only ticket's scope** (flagged for follow-up):
1. **Auto-approve does not stage into the collection.** The create handler marks the request approved but does NOT fulfill it into a catalog row (no `created_entity_id`), so "Create + Add" files an auto-approved request rather than staging the new entity into the collection in the same step. Closing it = fulfill-on-auto-approve + return `created_entity_id`.
2. **Source excerpt not sent.** The body carries `source_context: 'ai_extraction'` but not the raw article text — the `entity_requests` envelope + `ArtistRequestPayload` have no slot for free-text provenance.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/collections/components/AICollectionFiller` — 22/22 pass (added per-tier rendering + action + confirm + queue + auto-approve + error + double-submit-guard cases; `useAuthContext` mocked per tier)
- [x] `bun run test:run features/collections` — 379/379 pass (no sibling regression)
- [x] `/code-review` (inline, 9 angles)
- [x] `/adversarial-review` (4 lenses inline)

## Manual repro

Stack up `--mode` (auto-resolved isolated). Signed in as `e2e-admin@test.local`, opened Collections → **Create Collection** → **From text (AI)** tab.

**Honest disclosure (render-only carveout):** the AI extraction route hard-requires `ANTHROPIC_API_KEY` + a live model call, which is **not configured** in the dispatch stack — `POST /api/ai/extract-collection` returns `"AI service not configured"`. So real extracted rows cannot be produced in the live browser, and the unmatched-row tier-gated **actions** cannot be exercised end-to-end through the UI. Per the dispatch's documented fallback, the tier-gated rows are covered by **unit-test DOM assertions** (22 cases, all tiers + outcomes) rather than faked. The screenshots below verify the AI tab mounts, text input works, and the not-configured error surfaces correctly.

## Screenshots

1. AI tab in the Create drawer (textarea + dropzone): https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-44d1e8355ccb80eac28c/01-ai-tab-empty.png
2. Article text entered into the AI textarea: https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-44d1e8355ccb80eac28c/02-ai-extract-attempt.png
3. Extraction blocked — "AI service not configured" (no `ANTHROPIC_API_KEY` in stack): https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-44d1e8355ccb80eac28c/03-ai-not-configured-error.png

## Code review

`/code-review` (inline, 9 finder angles). 1 CONFIRMED finding:
- **[correctness/UX]** The queue/create mutation threw on a non-ok POST (403/422/5xx/network) but nothing consumed the error → silent no-op, violating the project inline-error mutation-feedback convention. **Fixed** in `df307e5f`: per-row `requestErrors` state set in `onError`, rendered inline under the row; button stays for retry; cleared on retry / fresh extraction. Added a 403 regression test.

## Adversarial review

`/adversarial-review` — 4 lenses inline; verdict **CONCERNS** (no HIGH/CRITICAL). Fixes in `ac85eb21`.
- **[MEDIUM] Saboteur** — clicking a second NEW row's button while a first request was in flight could double-file (shared `useMutation` only tracks its latest variables; no backend create-side dedup). **Fixed**: per-row `inFlightRows` Set + re-entrancy guard in `requestRow`; added a double-click regression test.
- **[CLEAN] Security** (load-bearing AC) — tier gating is enforced server-side by `autoApproves()`; a `contributor` cannot bypass the client affordance to trigger inline creation. Client gating is purely UX.
- **[MEDIUM] Completeness** — source excerpt not sent → **disclosed** above (backend-constrained, follow-up).
- **[LOW] Future-Maintainer** — dense nested ternary in the row affordance; accepted (commented, each branch clear).

Reviewers ran against the branch diff with the finding bar applied.

Closes PSY-853
