### PR TITLE
PSY-986: render show times in the venue timezone (frontend)

### DIFF
--- a/cli/src/lib/timezone.ts
+++ b/cli/src/lib/timezone.ts
@@ -23,6 +23,7 @@ const STATE_TIMEZONES: Record<string, string> = {
   MA: "America/New_York",
   MD: "America/New_York",
   ME: "America/New_York",
+  MI: "America/New_York",
   NC: "America/New_York",
   NH: "America/New_York",
   NJ: "America/New_York",
@@ -45,7 +46,10 @@ const STATE_TIMEZONES: Record<string, string> = {
   MN: "America/Chicago",
   MO: "America/Chicago",
   MS: "America/Chicago",
+  ND: "America/Chicago",
+  NE: "America/Chicago",
   OK: "America/Chicago",
+  SD: "America/Chicago",
   TN: "America/Chicago",
   WI: "America/Chicago",
   // Mountain

--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -224,10 +224,10 @@ function SavedShowCard({ show }: { show: SavedShowResponse }) {
 
         <div className="text-right shrink-0">
           <div className="text-sm font-medium text-primary">
-            {formatShowDate(show.event_date, show.state)}
+            {formatShowDate(show.event_date, show.state, false, show.venues?.[0]?.timezone)}
           </div>
           <div className="text-xs text-muted-foreground">
-            {formatShowTime(show.event_date, show.state)}
+            {formatShowTime(show.event_date, show.state, show.venues?.[0]?.timezone)}
           </div>
         </div>
       </div>
@@ -411,7 +411,7 @@ function SubmissionShowCard({
         {/* Left column: Date, Location, and Status */}
         <div className="w-full md:w-1/5 md:pr-4 mb-2 md:mb-0">
           <h2 className="text-sm font-bold tracking-wide text-primary">
-            {formatShowDate(show.event_date, show.state)}
+            {formatShowDate(show.event_date, show.state, false, show.venues?.[0]?.timezone)}
           </h2>
           <h3 className="text-xs text-muted-foreground mt-0.5">
             {show.city}, {show.state}
@@ -629,7 +629,7 @@ function SubmissionShowCard({
               <span>&nbsp;•&nbsp;{show.age_requirement}</span>
             )}
             <span>
-              &nbsp;•&nbsp;{formatShowTime(show.event_date, show.state)}
+              &nbsp;•&nbsp;{formatShowTime(show.event_date, show.state, show.venues?.[0]?.timezone)}
             </span>
             {SHOW_LIST_FEATURE_POLICY.ownership.showDetailsLink && (
               <>

--- a/frontend/app/shows/[slug]/opengraph-image.tsx
+++ b/frontend/app/shows/[slug]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og'
 import * as Sentry from '@sentry/nextjs'
+import { resolveShowTimezone } from '@/lib/utils/formatters'
 
 export const runtime = 'edge'
 export const alt = 'Show details'
@@ -17,17 +18,22 @@ interface ShowData {
   event_date: string
   is_sold_out: boolean
   is_cancelled: boolean
-  venues: Array<{ name: string; city: string; state: string }>
+  venues: Array<{ name: string; city: string; state: string; timezone?: string | null }>
   artists: Array<{ name: string; is_headliner?: boolean | null }>
 }
 
-function formatDate(dateString: string): string {
+function formatDate(
+  dateString: string,
+  state?: string | null,
+  timezone?: string | null
+): string {
   const date = new Date(dateString)
   return date.toLocaleDateString('en-US', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: resolveShowTimezone(state, timezone), // venue-local for share card (PSY-986)
   })
 }
 
@@ -79,7 +85,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
   const venue = show.venues?.[0]
   const venueName = venue?.name || 'TBA'
   const location = venue ? `${venue.city}, ${venue.state}` : ''
-  const showDate = formatDate(show.event_date)
+  const showDate = formatDate(show.event_date, venue?.state, venue?.timezone)
   const displayTitle = show.title || `${headliner} at ${venueName}`
   const otherArtists = show.artists
     ?.filter(a => a.name !== headliner)

--- a/frontend/app/shows/[slug]/page.tsx
+++ b/frontend/app/shows/[slug]/page.tsx
@@ -142,6 +142,7 @@ export default async function ShowPage({ params }: ShowPageProps) {
           address: showData.venues[0].address ?? undefined,
           city: showData.venues[0].city,
           state: showData.venues[0].state,
+          timezone: showData.venues[0].timezone,
         } : undefined,
         artists: showData.artists?.map(a => ({
           name: a.name,

--- a/frontend/app/shows/[slug]/page.tsx
+++ b/frontend/app/shows/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { ShowDetail } from '@/features/shows'
 import type { ShowResponse } from '@/features/shows/types'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateMusicEventSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
+import { resolveShowTimezone } from '@/lib/utils/formatters'
 import { API_BASE_URL } from '@/lib/api-base'
 import { queryKeys } from '@/lib/queryClient'
 import { prefetchEntity } from '@/lib/query-hydration'
@@ -48,13 +49,18 @@ const getShow = cache(async (slug: string): Promise<ShowResponse | null> => {
   return null
 })
 
-function formatShowDate(dateString: string): string {
+function formatShowDate(
+  dateString: string,
+  state?: string | null,
+  timezone?: string | null
+): string {
   const date = new Date(dateString)
   return date.toLocaleDateString('en-US', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: resolveShowTimezone(state, timezone), // venue-local for SEO (PSY-986)
   })
 }
 
@@ -65,7 +71,7 @@ export async function generateMetadata({ params }: ShowPageProps): Promise<Metad
   if (show) {
     const headliner = show.artists?.find(a => a.is_headliner)?.name || show.artists?.[0]?.name || 'Live Music'
     const venueName = show.venues?.[0]?.name || 'TBA'
-    const showDate = formatShowDate(show.event_date)
+    const showDate = formatShowDate(show.event_date, show.venues?.[0]?.state, show.venues?.[0]?.timezone)
     const title = `${headliner} at ${venueName}`
     const generatedDesc = `${headliner} live at ${venueName} on ${showDate}`
     const description = show.description

--- a/frontend/features/artists/components/ArtistShowsList.tsx
+++ b/frontend/features/artists/components/ArtistShowsList.tsx
@@ -41,7 +41,7 @@ function ShowRow({ show, artistId }: { show: ArtistShow; artistId: number }) {
           href={detailsHref}
           className="hover:text-primary hover:underline underline-offset-2"
         >
-          {formatShowDate(show.event_date, state)}
+          {formatShowDate(show.event_date, state, false, show.venue?.timezone)}
         </Link>
       </td>
       <td>
@@ -83,7 +83,7 @@ function ShowRow({ show, artistId }: { show: ArtistShow; artistId: number }) {
         )}
       </td>
       <td className="text-right whitespace-nowrap text-muted-foreground">
-        {formatShowTime(show.event_date, state)}
+        {formatShowTime(show.event_date, state, show.venue?.timezone)}
       </td>
     </tr>
   )

--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -136,6 +136,8 @@ export interface ArtistShowVenue {
   name: string
   city: string
   state: string
+  /** IANA timezone for rendering this show's time in venue-local time (PSY-985/986). Null until backfilled. */
+  timezone?: string | null
 }
 
 /**

--- a/frontend/features/shows/components/CompactShowRow.tsx
+++ b/frontend/features/shows/components/CompactShowRow.tsx
@@ -28,6 +28,8 @@ interface CompactShowVenue {
 interface CompactShowRowProps {
   show: CompactShowData
   state: string | null | undefined
+  /** Venue IANA timezone — preferred over the state map for rendering times (PSY-986). */
+  timezone?: string | null
   isPastShow?: boolean
   showDetailsLink?: boolean
   showVenueLine?: boolean
@@ -98,6 +100,7 @@ function VenueLine({ venue }: { venue: CompactShowVenue | null | undefined }) {
 export function CompactShowRow({
   show,
   state,
+  timezone,
   isPastShow = false,
   showDetailsLink = true,
   showVenueLine = false,
@@ -108,7 +111,7 @@ export function CompactShowRow({
 }: CompactShowRowProps) {
   const timezoneState = state || 'AZ'
   const detailsHref = `/shows/${show.slug || show.id}`
-  const dateBadge = formatShowDateBadge(show.event_date, timezoneState)
+  const dateBadge = formatShowDateBadge(show.event_date, timezoneState, timezone)
 
   return (
     <div className="py-2.5 border-b border-border/30 last:border-b-0">
@@ -173,7 +176,7 @@ export function CompactShowRow({
 
           <div className="text-right text-xs text-muted-foreground shrink-0">
             <div className="font-medium text-foreground/80">
-              {formatShowTime(show.event_date, timezoneState)}
+              {formatShowTime(show.event_date, timezoneState, timezone)}
             </div>
             {show.price != null && <div>{formatPrice(show.price)}</div>}
             {showDetailsLink && (

--- a/frontend/features/shows/components/ShowCard.tsx
+++ b/frontend/features/shows/components/ShowCard.tsx
@@ -175,8 +175,8 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
     (resolvedUserId && show.submitted_by && String(show.submitted_by) === resolvedUserId)
 
   const dateBadge = useMemo(
-    () => formatShowDateBadge(show.event_date, show.state),
-    [show.event_date, show.state]
+    () => formatShowDateBadge(show.event_date, show.state, show.venues?.[0]?.timezone),
+    [show.event_date, show.state, show.venues]
   )
 
   const handleEditSuccess = () => {
@@ -246,7 +246,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
 
         {/* Time */}
         <span className="text-xs text-muted-foreground shrink-0 hidden sm:inline tabular-nums">
-          {formatShowTime(show.event_date, show.state)}
+          {formatShowTime(show.event_date, show.state, show.venues?.[0]?.timezone)}
         </span>
 
         {/* Price */}
@@ -326,7 +326,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
               <div className="shrink-0 flex flex-col items-end gap-1.5">
                 <div className="text-right">
                   <div className="text-sm font-medium">
-                    {formatShowTime(show.event_date, show.state)}
+                    {formatShowTime(show.event_date, show.state, show.venues?.[0]?.timezone)}
                   </div>
                   <div className="text-xs text-muted-foreground">
                     {show.price != null && (
@@ -563,7 +563,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
             <div className="shrink-0 flex flex-col items-end gap-1">
               <div className="text-right">
                 <div className="text-sm font-medium">
-                  {formatShowTime(show.event_date, show.state)}
+                  {formatShowTime(show.event_date, show.state, show.venues?.[0]?.timezone)}
                 </div>
                 <div className="text-xs text-muted-foreground">
                   {show.price != null && (

--- a/frontend/features/shows/components/ShowHeader.tsx
+++ b/frontend/features/shows/components/ShowHeader.tsx
@@ -47,7 +47,7 @@ export function ShowHeader({ show, actions }: ShowHeaderProps) {
         {/* Date and Status Badges */}
         <div className="flex items-center gap-2 mb-2">
           <span className="text-lg font-bold text-primary">
-            {formatShowDate(show.event_date, show.state)}
+            {formatShowDate(show.event_date, show.state, false, show.venues?.[0]?.timezone)}
           </span>
           {show.is_sold_out && (
             <Badge
@@ -145,7 +145,7 @@ export function ShowHeader({ show, actions }: ShowHeaderProps) {
 
         {/* Show Details */}
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground mt-3">
-          <span>{formatShowTime(show.event_date, show.state)}</span>
+          <span>{formatShowTime(show.event_date, show.state, show.venues?.[0]?.timezone)}</span>
           {show.price != null && <span>{formatPrice(show.price)}</span>}
           {show.age_requirement && <span>{show.age_requirement}</span>}
         </div>

--- a/frontend/features/shows/types.ts
+++ b/frontend/features/shows/types.ts
@@ -39,6 +39,8 @@ export interface VenueResponse {
   address?: string | null
   city: string
   state: string
+  /** IANA timezone for rendering this show's time in venue-local time (PSY-985/986). Null until backfilled. */
+  timezone?: string | null
   verified: boolean
 }
 

--- a/frontend/features/venues/components/VenueCard.tsx
+++ b/frontend/features/venues/components/VenueCard.tsx
@@ -155,6 +155,7 @@ export function VenueCard({ venue }: VenueCardProps) {
                   key={show.id}
                   show={show}
                   state={venue.state}
+                  timezone={venue.timezone}
                   showDetailsLink={
                     SHOW_LIST_FEATURE_POLICY.context.showDetailsLink
                   }

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -338,6 +338,7 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
             venueName={venue.name}
             venueCity={venue.city}
             venueState={venue.state}
+            venueTimezone={venue.timezone}
             venueAddress={venue.address}
             venueVerified={venue.verified}
             onShowAdded={handleShowAdded}

--- a/frontend/features/venues/components/VenueShowsList.tsx
+++ b/frontend/features/venues/components/VenueShowsList.tsx
@@ -23,6 +23,7 @@ interface VenueShowsListProps {
   venueName: string
   venueCity: string
   venueState: string
+  venueTimezone?: string | null
   venueAddress?: string | null
   venueVerified?: boolean
   className?: string
@@ -39,9 +40,17 @@ function ShowsLoader() {
   )
 }
 
-function ShowRow({ show, venueState }: { show: VenueShow; venueState: string }) {
-  // Per-show `state` falls back to the venue's state for date/time
-  // formatting when the show row didn't carry one.
+function ShowRow({
+  show,
+  venueState,
+  venueTimezone,
+}: {
+  show: VenueShow
+  venueState: string
+  venueTimezone?: string | null
+}) {
+  // Per-show `state` falls back to the venue's state for date/time formatting;
+  // the venue's timezone (when known) takes precedence over the state map (PSY-986).
   const state = show.state ?? venueState
   const detailsHref = `/shows/${show.slug || show.id}`
   return (
@@ -51,7 +60,7 @@ function ShowRow({ show, venueState }: { show: VenueShow; venueState: string }) 
           href={detailsHref}
           className="hover:text-primary hover:underline underline-offset-2"
         >
-          {formatShowDate(show.event_date, state)}
+          {formatShowDate(show.event_date, state, false, venueTimezone)}
         </Link>
       </td>
       <td className="text-muted-foreground">
@@ -72,7 +81,7 @@ function ShowRow({ show, venueState }: { show: VenueShow; venueState: string }) 
         )}
       </td>
       <td className="text-right whitespace-nowrap text-muted-foreground">
-        {formatShowTime(show.event_date, state)}
+        {formatShowTime(show.event_date, state, venueTimezone)}
       </td>
     </tr>
   )
@@ -82,11 +91,13 @@ function ShowsTable({
   shows,
   total,
   venueState,
+  venueTimezone,
   isPast,
 }: {
   shows: VenueShow[]
   total: number
   venueState: string
+  venueTimezone?: string | null
   isPast: boolean
 }) {
   return (
@@ -104,7 +115,12 @@ function ShowsTable({
         </thead>
         <tbody>
           {shows.map(show => (
-            <ShowRow key={show.id} show={show} venueState={venueState} />
+            <ShowRow
+              key={show.id}
+              show={show}
+              venueState={venueState}
+              venueTimezone={venueTimezone}
+            />
           ))}
         </tbody>
       </DenseTable>
@@ -127,6 +143,7 @@ export function VenueShowsList({
   venueName,
   venueCity,
   venueState,
+  venueTimezone,
   venueAddress,
   venueVerified,
   className,
@@ -179,6 +196,7 @@ export function VenueShowsList({
             shows={upcomingShows}
             total={upcoming.data?.total ?? upcomingShows.length}
             venueState={venueState}
+            venueTimezone={venueTimezone}
             isPast={false}
           />
         )}
@@ -202,6 +220,7 @@ export function VenueShowsList({
               shows={pastShows}
               total={past.data?.total ?? pastShows.length}
               venueState={venueState}
+              venueTimezone={venueTimezone}
               isPast={true}
             />
           )}

--- a/frontend/features/venues/types.ts
+++ b/frontend/features/venues/types.ts
@@ -15,6 +15,8 @@ export interface Venue {
   address: string | null
   city: string
   state: string
+  /** IANA timezone resolved from the venue's location (PSY-985). Null until backfilled. */
+  timezone?: string | null
   zipcode?: string | null
   description?: string | null
   /** Optional venue photo URL (PSY-521). */

--- a/frontend/lib/seo/jsonld.test.ts
+++ b/frontend/lib/seo/jsonld.test.ts
@@ -79,7 +79,9 @@ describe('generateMusicEventSchema', () => {
     expect(schema['@context']).toBe('https://schema.org')
     expect(schema['@type']).toBe('MusicEvent')
     expect(schema.name).toBeDefined()
-    expect(schema.startDate).toBe('2026-03-15T20:00:00Z')
+    // startDate is rendered in the venue's local time with offset (PSY-986):
+    // 20:00Z at The Rebel Lounge (AZ default → America/Phoenix, UTC-7) = 1:00 PM.
+    expect(schema.startDate).toBe('2026-03-15T13:00:00-07:00')
     expect(schema.location).toBeDefined()
     expect(schema.eventAttendanceMode).toBe('https://schema.org/OfflineEventAttendanceMode')
     expect(schema.eventStatus).toBeDefined()

--- a/frontend/lib/seo/jsonld.ts
+++ b/frontend/lib/seo/jsonld.ts
@@ -5,6 +5,9 @@
  * embedded in pages to improve search engine understanding.
  */
 
+import { resolveShowTimezone } from '@/lib/utils/formatters'
+import { toZonedISOString } from '@/lib/utils/timeUtils'
+
 export interface OrganizationSchema {
   '@context': 'https://schema.org'
   '@type': 'Organization'
@@ -205,6 +208,7 @@ export function generateMusicEventSchema(show: {
     address?: string
     city?: string
     state?: string
+    timezone?: string | null
     zip_code?: string
   }
   artists?: Array<{
@@ -223,7 +227,14 @@ export function generateMusicEventSchema(show: {
     '@context': 'https://schema.org',
     '@type': 'MusicEvent',
     name: eventName,
-    startDate: show.date,
+    // Emit the venue-local start time with offset (PSY-986) so crawlers index
+    // the real local time, not the bare UTC instant.
+    startDate: show.venue
+      ? toZonedISOString(
+          show.date,
+          resolveShowTimezone(show.venue.state, show.venue.timezone)
+        )
+      : show.date,
     eventStatus: show.is_cancelled
       ? 'https://schema.org/EventCancelled'
       : 'https://schema.org/EventScheduled',

--- a/frontend/lib/utils/formatters.test.ts
+++ b/frontend/lib/utils/formatters.test.ts
@@ -95,20 +95,28 @@ describe('formatShowTime', () => {
 })
 
 describe('venue timezone preference (PSY-986)', () => {
-  const utcDate = '2026-03-15T02:30:00Z' // 7:30 PM Phoenix / 10:30 PM New York
+  // 05:30 UTC crosses the calendar boundary: Mar 14 10:30 PM in Phoenix (UTC-7)
+  // vs Mar 15 1:30 AM in New York (UTC-4, DST active by Mar 15) — so the
+  // assertions actually discriminate venue-tz from the state fallback.
+  const boundaryUtc = '2026-03-15T05:30:00Z'
 
-  it('formatShowTime prefers the explicit venue timezone over the state fallback', () => {
-    // state=NY alone → 10:30 PM, but an explicit Phoenix tz must win → 7:30 PM.
-    expect(formatShowTime(utcDate, 'NY', 'America/Phoenix')).toBe('7:30 PM')
+  it('formatShowTime prefers the explicit venue timezone over state', () => {
+    expect(formatShowTime(boundaryUtc, 'NY', 'America/Phoenix')).toBe('10:30 PM')
+    expect(formatShowTime(boundaryUtc, 'NY')).toBe('1:30 AM') // state fallback differs
   })
 
-  it('formatShowDate prefers the explicit venue timezone over the state fallback', () => {
-    // In Phoenix (UTC-7) 02:30Z is Mar 14; venue tz must win over NY (Mar 15 here is 10:30 PM, still 14th... use date check).
-    expect(formatShowDate(utcDate, 'NY', false, 'America/Phoenix')).toContain('14')
+  it('formatShowDate prefers the venue timezone over state across a date boundary', () => {
+    // Phoenix → Mar 14; New York → Mar 15. The venue tz (Phoenix) must win.
+    expect(formatShowDate(boundaryUtc, 'NY', false, 'America/Phoenix')).toContain('14')
+    expect(formatShowDate(boundaryUtc, 'NY')).toContain('15')
   })
 
   it('falls back to the state map when no venue timezone is given', () => {
-    expect(formatShowTime(utcDate, 'NY')).toBe('10:30 PM')
+    expect(formatShowTime(boundaryUtc, 'AZ')).toBe('10:30 PM')
+  })
+
+  it('falls back to the state map when the venue timezone is malformed (no crash)', () => {
+    expect(formatShowTime(boundaryUtc, 'AZ', 'Not/AZone')).toBe('10:30 PM')
   })
 })
 

--- a/frontend/lib/utils/formatters.test.ts
+++ b/frontend/lib/utils/formatters.test.ts
@@ -94,6 +94,24 @@ describe('formatShowTime', () => {
   })
 })
 
+describe('venue timezone preference (PSY-986)', () => {
+  const utcDate = '2026-03-15T02:30:00Z' // 7:30 PM Phoenix / 10:30 PM New York
+
+  it('formatShowTime prefers the explicit venue timezone over the state fallback', () => {
+    // state=NY alone → 10:30 PM, but an explicit Phoenix tz must win → 7:30 PM.
+    expect(formatShowTime(utcDate, 'NY', 'America/Phoenix')).toBe('7:30 PM')
+  })
+
+  it('formatShowDate prefers the explicit venue timezone over the state fallback', () => {
+    // In Phoenix (UTC-7) 02:30Z is Mar 14; venue tz must win over NY (Mar 15 here is 10:30 PM, still 14th... use date check).
+    expect(formatShowDate(utcDate, 'NY', false, 'America/Phoenix')).toContain('14')
+  })
+
+  it('falls back to the state map when no venue timezone is given', () => {
+    expect(formatShowTime(utcDate, 'NY')).toBe('10:30 PM')
+  })
+})
+
 describe('formatPrice', () => {
   it('formats integer price', () => {
     expect(formatPrice(20)).toBe('$20.00')

--- a/frontend/lib/utils/formatters.ts
+++ b/frontend/lib/utils/formatters.ts
@@ -8,13 +8,26 @@ import {
 /**
  * Resolve the IANA timezone for rendering a show time. Prefers the venue's
  * resolved `timezone` (PSY-985); falls back to the US state→tz map for venues
- * without one (pre-backfill rows). (PSY-986)
+ * without one (pre-backfill rows). A malformed/unknown `timezone` string falls
+ * through to the state map rather than crashing the render (`Intl` throws a
+ * RangeError on a bad zone), mirroring the backend's EventLocation (PSY-996/986).
  */
 export function resolveShowTimezone(
   state?: string | null,
   timezone?: string | null
 ): string {
-  return timezone || getTimezoneForState(state || 'AZ')
+  if (timezone && isValidTimeZone(timezone)) return timezone
+  return getTimezoneForState(state || 'AZ')
+}
+
+function isValidTimeZone(tz: string): boolean {
+  try {
+    // Throws RangeError for an unknown/malformed IANA name.
+    new Intl.DateTimeFormat('en-US', { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/frontend/lib/utils/formatters.ts
+++ b/frontend/lib/utils/formatters.ts
@@ -6,28 +6,43 @@ import {
 } from './timeUtils'
 
 /**
- * Format a show date in venue timezone: "Mon, Dec 1" or "Mon Dec 1, 2026"
+ * Resolve the IANA timezone for rendering a show time. Prefers the venue's
+ * resolved `timezone` (PSY-985); falls back to the US state→tz map for venues
+ * without one (pre-backfill rows). (PSY-986)
+ */
+export function resolveShowTimezone(
+  state?: string | null,
+  timezone?: string | null
+): string {
+  return timezone || getTimezoneForState(state || 'AZ')
+}
+
+/**
+ * Format a show date in the venue's timezone: "Mon, Dec 1" or "Mon Dec 1, 2026".
+ * Pass the venue's `timezone` when available; `state` is the fallback.
  */
 export function formatShowDate(
   dateString: string,
   state?: string | null,
-  includeYear = false
+  includeYear = false,
+  timezone?: string | null
 ): string {
-  const timezone = getTimezoneForState(state || 'AZ')
+  const tz = resolveShowTimezone(state, timezone)
   return includeYear
-    ? formatDateWithYearInTimezone(dateString, timezone)
-    : formatDateInTimezone(dateString, timezone)
+    ? formatDateWithYearInTimezone(dateString, tz)
+    : formatDateInTimezone(dateString, tz)
 }
 
 /**
- * Format a show time in venue timezone: "7:30 PM"
+ * Format a show time in the venue's timezone: "7:30 PM".
+ * Pass the venue's `timezone` when available; `state` is the fallback.
  */
 export function formatShowTime(
   dateString: string,
-  state?: string | null
+  state?: string | null,
+  timezone?: string | null
 ): string {
-  const timezone = getTimezoneForState(state || 'AZ')
-  return formatTimeInTimezone(dateString, timezone)
+  return formatTimeInTimezone(dateString, resolveShowTimezone(state, timezone))
 }
 
 /**

--- a/frontend/lib/utils/showDateBadge.test.ts
+++ b/frontend/lib/utils/showDateBadge.test.ts
@@ -10,13 +10,14 @@ vi.mock('./timeUtils', () => ({
     }
     return map[state.toUpperCase()] || 'America/Phoenix'
   }),
+  // Honor the passed timezone (the real formatInTimezone does) so tests can
+  // verify venue-tz threading, not just the hardcoded-Phoenix path.
   formatInTimezone: vi.fn(
-    (dateString: string, _timezone: string, options: Intl.DateTimeFormatOptions) => {
-      const date = new Date(dateString)
-      if (options.weekday === 'short') return date.toLocaleString('en-US', { weekday: 'short', timeZone: 'America/Phoenix' })
-      if (options.month === 'short') return date.toLocaleString('en-US', { month: 'short', timeZone: 'America/Phoenix' })
-      if (options.day === 'numeric') return date.toLocaleString('en-US', { day: 'numeric', timeZone: 'America/Phoenix' })
-      return ''
+    (dateString: string, timezone: string, options: Intl.DateTimeFormatOptions) => {
+      return new Date(dateString).toLocaleString('en-US', {
+        ...options,
+        timeZone: timezone,
+      })
     }
   ),
 }))
@@ -40,6 +41,14 @@ describe('formatShowDateBadge', () => {
 
     // Both should produce the same result (AZ timezone)
     expect(result1).toEqual(result2)
+  })
+
+  it('prefers the venue timezone over state (PSY-986)', () => {
+    // 05:30 UTC: Mar 14 in Phoenix vs Mar 15 in New York. Venue tz must win.
+    const result = formatShowDateBadge('2026-03-15T05:30:00Z', 'NY', 'America/Phoenix')
+    expect(result.monthDay).toBe('MAR 14')
+    // State-only (no venue tz) renders the New York date instead.
+    expect(formatShowDateBadge('2026-03-15T05:30:00Z', 'NY').monthDay).toBe('MAR 15')
   })
 
   it('uppercases dayOfWeek and month', () => {

--- a/frontend/lib/utils/showDateBadge.ts
+++ b/frontend/lib/utils/showDateBadge.ts
@@ -1,4 +1,5 @@
-import { getTimezoneForState, formatInTimezone } from './timeUtils'
+import { formatInTimezone } from './timeUtils'
+import { resolveShowTimezone } from './formatters'
 
 export interface DateBadgeParts {
   /** Short day of week, uppercase: "TUE" */
@@ -10,22 +11,24 @@ export interface DateBadgeParts {
 /**
  * Format a show date into stacked badge parts for the card layout.
  * Returns { dayOfWeek: "TUE", monthDay: "MAR 17" } in the venue's timezone.
+ * Pass the venue's `timezone` when available; `state` is the fallback.
  */
 export function formatShowDateBadge(
   dateString: string,
-  state?: string | null
+  state?: string | null,
+  timezone?: string | null
 ): DateBadgeParts {
-  const timezone = getTimezoneForState(state || 'AZ')
+  const tz = resolveShowTimezone(state, timezone)
 
-  const dayOfWeek = formatInTimezone(dateString, timezone, {
+  const dayOfWeek = formatInTimezone(dateString, tz, {
     weekday: 'short',
   }).toUpperCase()
 
-  const month = formatInTimezone(dateString, timezone, {
+  const month = formatInTimezone(dateString, tz, {
     month: 'short',
   }).toUpperCase()
 
-  const day = formatInTimezone(dateString, timezone, {
+  const day = formatInTimezone(dateString, tz, {
     day: 'numeric',
   })
 

--- a/frontend/lib/utils/timeUtils.test.ts
+++ b/frontend/lib/utils/timeUtils.test.ts
@@ -19,6 +19,20 @@ describe('getTimezoneForState', () => {
     expect(getTimezoneForState('NY')).toBe('America/New_York')
   })
 
+  // PSY-986 regression: the map was synced to full US coverage. These states
+  // previously fell through to America/Phoenix (the live display bug).
+  it('covers US states beyond the original 7 (full-US sync)', () => {
+    expect(getTimezoneForState('IL')).toBe('America/Chicago')
+    expect(getTimezoneForState('MN')).toBe('America/Chicago')
+    expect(getTimezoneForState('WA')).toBe('America/Los_Angeles')
+    expect(getTimezoneForState('OR')).toBe('America/Los_Angeles')
+    expect(getTimezoneForState('MA')).toBe('America/New_York')
+    expect(getTimezoneForState('FL')).toBe('America/New_York')
+    expect(getTimezoneForState('UT')).toBe('America/Denver')
+    expect(getTimezoneForState('AK')).toBe('America/Anchorage')
+    expect(getTimezoneForState('HI')).toBe('Pacific/Honolulu')
+  })
+
   it('handles lowercase state codes', () => {
     expect(getTimezoneForState('az')).toBe('America/Phoenix')
     expect(getTimezoneForState('ca')).toBe('America/Los_Angeles')

--- a/frontend/lib/utils/timeUtils.test.ts
+++ b/frontend/lib/utils/timeUtils.test.ts
@@ -6,6 +6,7 @@ import {
   formatDateInTimezone,
   formatTimeInTimezone,
   parseISOToDateAndTime,
+  toZonedISOString,
 } from './timeUtils'
 
 describe('getTimezoneForState', () => {
@@ -413,5 +414,27 @@ describe('error handling', () => {
     // NaN values will be returned for invalid dates
     expect(result.date).toContain('NaN')
     expect(result.time).toContain('NaN')
+  })
+})
+
+describe('toZonedISOString (PSY-986)', () => {
+  // 8 PM Phoenix on Mar 14 is stored as 03:00Z Mar 15.
+  const utc = '2026-03-15T03:00:00Z'
+
+  it('emits ISO 8601 with the venue offset (Phoenix, no DST)', () => {
+    expect(toZonedISOString(utc, 'America/Phoenix')).toBe('2026-03-14T20:00:00-07:00')
+  })
+
+  it('reflects DST for New York (EDT in March)', () => {
+    expect(toZonedISOString(utc, 'America/New_York')).toBe('2026-03-14T23:00:00-04:00')
+  })
+
+  it('handles non-US zones (Europe/Berlin)', () => {
+    // 03:00Z = 04:00 CET (Berlin is UTC+1 in mid-March, before EU DST starts).
+    expect(toZonedISOString(utc, 'Europe/Berlin')).toBe('2026-03-15T04:00:00+01:00')
+  })
+
+  it('uses +00:00 for UTC', () => {
+    expect(toZonedISOString(utc, 'UTC')).toBe('2026-03-15T03:00:00+00:00')
   })
 })

--- a/frontend/lib/utils/timeUtils.test.ts
+++ b/frontend/lib/utils/timeUtils.test.ts
@@ -20,7 +20,8 @@ describe('getTimezoneForState', () => {
   })
 
   // PSY-986 regression: the map was synced to full US coverage. These states
-  // previously fell through to America/Phoenix (the live display bug).
+  // previously fell through to America/Phoenix (the live display bug). MI/ND/NE/SD
+  // were the last gaps found in adversarial review.
   it('covers US states beyond the original 7 (full-US sync)', () => {
     expect(getTimezoneForState('IL')).toBe('America/Chicago')
     expect(getTimezoneForState('MN')).toBe('America/Chicago')
@@ -29,8 +30,28 @@ describe('getTimezoneForState', () => {
     expect(getTimezoneForState('MA')).toBe('America/New_York')
     expect(getTimezoneForState('FL')).toBe('America/New_York')
     expect(getTimezoneForState('UT')).toBe('America/Denver')
+    expect(getTimezoneForState('MI')).toBe('America/New_York')
+    expect(getTimezoneForState('ND')).toBe('America/Chicago')
+    expect(getTimezoneForState('NE')).toBe('America/Chicago')
+    expect(getTimezoneForState('SD')).toBe('America/Chicago')
     expect(getTimezoneForState('AK')).toBe('America/Anchorage')
     expect(getTimezoneForState('HI')).toBe('Pacific/Honolulu')
+  })
+
+  // Stronger guard: every US state + DC must resolve to a real zone, never the
+  // Arizona default (except AZ itself). Catches any future dropped state.
+  it('maps all 50 states + DC without falling back to Phoenix (except AZ)', () => {
+    const allStates = [
+      'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 'GA',
+      'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA',
+      'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY',
+      'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX',
+      'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
+    ]
+    for (const s of allStates) {
+      if (s === 'AZ') continue
+      expect(getTimezoneForState(s)).not.toBe('America/Phoenix')
+    }
   })
 
   it('handles lowercase state codes', () => {

--- a/frontend/lib/utils/timeUtils.ts
+++ b/frontend/lib/utils/timeUtils.ts
@@ -3,8 +3,14 @@
  */
 
 /**
- * Map of US states to their IANA timezones
- * Most shows are in Arizona which doesn't observe DST
+ * Map of US state codes to their IANA timezones. This is the FALLBACK used only
+ * when a venue has no resolved `timezone` (e.g. rows created before PSY-985's
+ * geocoding, until the PSY-987 backfill runs). New code should prefer
+ * `venue.timezone`; this map only narrows the guess for US venues.
+ *
+ * Kept in sync with the CLI's map in cli/src/lib/timezone.ts — both must list
+ * the same states. (PSY-986 fixed the prior drift: this map had only 7 states,
+ * so non-listed US states like IL/WA/MN/MA silently fell back to Arizona time.)
  */
 const STATE_TIMEZONES: Record<string, string> = {
   AZ: 'America/Phoenix',
@@ -14,11 +20,57 @@ const STATE_TIMEZONES: Record<string, string> = {
   NM: 'America/Denver',
   TX: 'America/Chicago',
   NY: 'America/New_York',
-  // Add more as needed
+  // Eastern
+  CT: 'America/New_York',
+  DC: 'America/New_York',
+  DE: 'America/New_York',
+  FL: 'America/New_York',
+  GA: 'America/New_York',
+  MA: 'America/New_York',
+  MD: 'America/New_York',
+  ME: 'America/New_York',
+  NC: 'America/New_York',
+  NH: 'America/New_York',
+  NJ: 'America/New_York',
+  OH: 'America/New_York',
+  PA: 'America/New_York',
+  RI: 'America/New_York',
+  SC: 'America/New_York',
+  VA: 'America/New_York',
+  VT: 'America/New_York',
+  WV: 'America/New_York',
+  // Central
+  AL: 'America/Chicago',
+  AR: 'America/Chicago',
+  IA: 'America/Chicago',
+  IL: 'America/Chicago',
+  IN: 'America/Indiana/Indianapolis',
+  KS: 'America/Chicago',
+  KY: 'America/New_York',
+  LA: 'America/Chicago',
+  MN: 'America/Chicago',
+  MO: 'America/Chicago',
+  MS: 'America/Chicago',
+  OK: 'America/Chicago',
+  TN: 'America/Chicago',
+  WI: 'America/Chicago',
+  // Mountain
+  ID: 'America/Boise',
+  MT: 'America/Denver',
+  UT: 'America/Denver',
+  WY: 'America/Denver',
+  // Pacific
+  OR: 'America/Los_Angeles',
+  WA: 'America/Los_Angeles',
+  // Non-contiguous
+  AK: 'America/Anchorage',
+  HI: 'Pacific/Honolulu',
 }
 
 /**
- * Get timezone for a US state (defaults to America/Phoenix for Arizona shows)
+ * Get the IANA timezone for a US state. Defaults to America/Phoenix (Arizona,
+ * no DST) for unknown/international input — callers should prefer a venue's
+ * resolved `timezone` and use this only as a fallback.
  */
 export function getTimezoneForState(state: string): string {
   return STATE_TIMEZONES[state.toUpperCase()] || 'America/Phoenix'

--- a/frontend/lib/utils/timeUtils.ts
+++ b/frontend/lib/utils/timeUtils.ts
@@ -29,6 +29,7 @@ const STATE_TIMEZONES: Record<string, string> = {
   MA: 'America/New_York',
   MD: 'America/New_York',
   ME: 'America/New_York',
+  MI: 'America/New_York',
   NC: 'America/New_York',
   NH: 'America/New_York',
   NJ: 'America/New_York',
@@ -51,7 +52,10 @@ const STATE_TIMEZONES: Record<string, string> = {
   MN: 'America/Chicago',
   MO: 'America/Chicago',
   MS: 'America/Chicago',
+  ND: 'America/Chicago',
+  NE: 'America/Chicago',
   OK: 'America/Chicago',
+  SD: 'America/Chicago',
   TN: 'America/Chicago',
   WI: 'America/Chicago',
   // Mountain

--- a/frontend/lib/utils/timeUtils.ts
+++ b/frontend/lib/utils/timeUtils.ts
@@ -210,6 +210,37 @@ export function formatTimeInTimezone(
 }
 
 /**
+ * Format a UTC date string as an ISO 8601 string carrying the venue's local UTC
+ * offset, e.g. "2026-03-14T20:00:00-07:00" for an 8 PM Phoenix show. Used for
+ * structured data (JSON-LD MusicEvent.startDate) so crawlers index the local
+ * start time, not the bare UTC instant. `timezone` must be a valid IANA name. (PSY-986)
+ */
+export function toZonedISOString(
+  utcDateString: string,
+  timezone: string
+): string {
+  const date = new Date(utcDateString)
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'longOffset',
+  }).formatToParts(date)
+  const p = (type: string) => parts.find(x => x.type === type)?.value ?? ''
+  let hour = p('hour')
+  if (hour === '24') hour = '00' // Intl may render midnight as 24
+  // longOffset → "GMT-07:00" / "GMT+05:30" / "GMT" (UTC)
+  const match = p('timeZoneName').match(/GMT([+-]\d{2}:\d{2})/)
+  const offset = match ? match[1] : '+00:00'
+  return `${p('year')}-${p('month')}-${p('day')}T${hour}:${p('minute')}:${p('second')}${offset}`
+}
+
+/**
  * Parse an ISO date string into separate date and time strings for form inputs
  * Returns date in YYYY-MM-DD format and time in HH:MM format
  *


### PR DESCRIPTION
## Summary

Render show times in the **venue's local timezone** across the frontend (PR2 of epic PSY-984), so a NYC user viewing a London show sees London local time. Builds on PR1's per-venue `venue.timezone`.

Closes PSY-986

## What

- **Live US display-bug fix**: synced the frontend (and CLI) state→tz map to **full US**. It had only 7 of 50 states, so Chicago/Seattle/Boston/Atlanta/etc. shows rendered in Arizona time. Independent of geocoding — corrects every existing US show's displayed time.
- **`venue.timezone` threaded** through every show-time render that carries it, preferring it over the state fallback: ShowCard, ShowHeader, library, ArtistShowsList, VenueShowsList (venue tz threaded from VenueDetail), CompactShowRow (via VenueCard). Formatters gained an optional `timezone` arg via `resolveShowTimezone`, which **validates the zone** and falls through to the state map on a malformed value (no render crash).
- **SEO surfaces** now venue-local: metadata description, OpenGraph share image, and JSON-LD `MusicEvent.startDate` (ISO 8601 with the venue's UTC offset via `toZonedISOString`).
- FE types (`VenueResponse`, `ArtistShowVenue`, venue `Venue`) carry `timezone`.

## Test plan

- [x] `bun run typecheck` + eslint (0 errors)
- [x] formatters / timeUtils / showDateBadge / jsonld unit tests — venue-tz-beats-state (boundary-crossing instant), malformed-tz fallback, **all 50 states + DC** map coverage, `toZonedISOString` (Phoenix / NY-DST / Berlin / UTC)
- [x] touched component suites (ShowCard, CompactShowRow, VenueShowsList, ArtistShowsList, VenueCard, …) green

## Adversarial review

`/adversarial-review` (Saboteur · Future-Maintainer · Completeness, fresh context) — **2 rounds**. Fixes in `edfd0d8f` + `1c4863b6`:
- **[HIGH]** a malformed `venue.timezone` crashed the render (`Intl` RangeError) → `resolveShowTimezone` validates + falls back to the state map (mirrors the backend's EventLocation, PSY-996).
- **[HIGH]** the map wasn't actually full-US — MI/ND/NE/SD were missing (FE + CLI) → added, plus an all-50-states-plus-DC regression test.
- **[MEDIUM]** the formatter venue-tz test didn't discriminate → boundary-crossing assertions + a badge venue-tz test.
- **[MEDIUM]** SEO metadata / OG image / JSON-LD rendered server-local/UTC → venue-local.

Round 2: both lenses confirmed the HIGHs resolved; no new HIGH.

## Deferred (tracked in PSY-1009)

Flat response types (explore / featured / my-shows / tagged) lack `venue_timezone` → they keep the now-full-US state fallback; admin moderation cards + the field-notes gate stay browser-local; server-side UTC for the create/CLI write path; backend `utils.StateTimezones` full-US sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
