### PR TITLE
PSY-853: relabel inline create affordance honestly (Submit for creation)

### DIFF
--- a/frontend/features/collections/components/AICollectionFiller.test.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.test.tsx
@@ -418,24 +418,24 @@ describe('AICollectionFiller', () => {
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
   }
 
-  it('admin sees [Create + Add] on an unmatched row (no Queue button)', async () => {
+  it('admin sees [Submit for creation] on an unmatched row (no Queue button)', async () => {
     mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
     const user = userEvent.setup()
     await extractOneUnmatchedRow(user)
 
     const btn = screen.getByTestId('ai-collection-filler-row-request')
-    expect(btn).toHaveTextContent('Create + Add')
+    expect(btn).toHaveTextContent('Submit for creation')
     expect(btn).not.toHaveTextContent('Queue for review')
   })
 
-  it('local_ambassador sees [Create + Add] (auto-approve tier, not admin)', async () => {
+  it('local_ambassador sees [Submit for creation] (auto-approve tier, not admin)', async () => {
     mockUser = { is_admin: false, user_tier: 'local_ambassador' }
     const user = userEvent.setup()
     await extractOneUnmatchedRow(user)
 
     expect(
       screen.getByTestId('ai-collection-filler-row-request')
-    ).toHaveTextContent('Create + Add')
+    ).toHaveTextContent('Submit for creation')
   })
 
   it('contributor sees [Queue for review] (never an inline create)', async () => {
@@ -445,7 +445,7 @@ describe('AICollectionFiller', () => {
 
     const btn = screen.getByTestId('ai-collection-filler-row-request')
     expect(btn).toHaveTextContent('Queue for review')
-    expect(btn).not.toHaveTextContent('Create + Add')
+    expect(btn).not.toHaveTextContent('Submit for creation')
   })
 
   it('new_user sees [Queue for review]', async () => {

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -119,7 +119,7 @@ function compressImage(dataUrl: string): Promise<string> {
 // them — a 403 path. The ONLY cross-tier create mechanism is
 // POST /entity-requests (PSY-997). On auto-approve that endpoint marks the
 // request approved but does NOT fulfill it into a catalog row, so there is no
-// new entity_id to stage into the bulk-add pipeline yet. The "Create + Add"
+// new entity_id to stage into the bulk-add pipeline yet. The "Submit for creation"
 // label therefore files an (auto-approved) request rather than staging the
 // new entity into the collection in the same step. Closing that gap — fulfill
 // on auto-approve + return created_entity_id so the row can stage — is a
@@ -891,7 +891,7 @@ function ExtractedRow({
               ) : (
                 <Plus className="h-3.5 w-3.5 mr-1" />
               )}
-              {affordance === 'queue' ? 'Queue for review' : 'Create + Add'}
+              {affordance === 'queue' ? 'Queue for review' : 'Submit for creation'}
             </Button>
           ))}
       </div>


### PR DESCRIPTION
## Summary
- Relabel the AICollectionFiller unmatched-row create affordance from **"Create + Add"** → **"Submit for creation"** for admin / local_ambassador / trusted_contributor tiers.
- The button files an `entity_request` (auto-approved for those tiers) but does **not** yet create + stage the entity inline — that's blocked on backend fulfillment (PSY-1008). "Create + Add" over-promised; this makes the label match actual behavior until PSY-1008 + the admin queue (PSY-871) complete the loop.

## Why a follow-up PR
PSY-853's PR #1012 merged at its pre-relabel commit (a race: the merge landed before this relabel was pushed), so the over-promising label shipped to `main`. This corrects it.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/collections/components/AICollectionFiller` — 22/22 (label assertions + titles updated)

## Manual repro
Copy-only change (button label + the explanatory comment + matching test assertions/titles); no logic or control-flow change. The tier-gating/queue logic it labels was manual-repro'd + reviewed in #1012.

## Adversarial review
Skipped via `ADVERSARIAL_REVIEW_SKIP=1` (documented escape hatch) — this is a copy-only relabel with zero logic change; the underlying affordance's logic was adversarially reviewed in the now-merged #1012 (CONCERNS→fixed). Nothing new to attack.

Refs PSY-853 · unblocks honest UX ahead of PSY-1008
