### PR TITLE
PSY-1000: top-bar tag filter on /shows + TagFacetPanel bar mode

### DIFF
--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -263,6 +263,8 @@ export function ShowList() {
         </div>
       )}
 
+      {/* Mobile: Sheet trigger + density toggle. Desktop hides the Sheet (the
+          bar below takes over) but keeps the density toggle on this row. */}
       <div className="flex items-center justify-between mb-4 gap-2">
         <TagFacetSheet
           selectedSlugs={selectedTags}
@@ -275,77 +277,78 @@ export function ShowList() {
         <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <aside className="hidden lg:block lg:w-64 lg:shrink-0">
-          <TagFacetPanel
-            selectedSlugs={selectedTags}
-            onToggle={handleTagsChange}
-            onClear={handleTagsClear}
-            heading="Filter shows by tag"
-            entityType="show"
-            selectedCities={selectedCities}
-          />
-        </aside>
+      {/* PSY-1000: full-width top-bar tag filter above a full-width list (no
+          left rail). Desktop only — mobile uses the Sheet trigger above. */}
+      <div className="mb-4 hidden lg:block">
+        <TagFacetPanel
+          selectedSlugs={selectedTags}
+          onToggle={handleTagsChange}
+          onClear={handleTagsClear}
+          heading="Filter shows by tag"
+          entityType="show"
+          selectedCities={selectedCities}
+          layout="bar"
+        />
+      </div>
 
-        <div className={cn('flex-1 min-w-0', isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75')}>
-          <p className="mb-3 text-sm text-muted-foreground" data-testid="show-count">
-            {allShows.length} {allShows.length === 1 ? 'show' : 'shows'}
-            {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
-          </p>
-          {allShows.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p>
-                {selectedTags.length > 0 || selectedCities.length > 0
-                  ? 'No upcoming shows match the current filters.'
-                  : 'No upcoming shows at this time.'}
-              </p>
-              {(selectedTags.length > 0 || selectedCities.length > 0) && (
-                <button
-                  onClick={() => {
-                    if (selectedTags.length > 0) handleTagsClear()
-                    if (selectedCities.length > 0) handleFilterChange([])
-                  }}
-                  className="mt-4 text-primary hover:underline"
-                >
-                  Clear filters
-                </button>
-              )}
+      <div className={cn('min-w-0', isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75')}>
+        <p className="mb-3 text-sm text-muted-foreground" data-testid="show-count">
+          {allShows.length} {allShows.length === 1 ? 'show' : 'shows'}
+          {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
+        </p>
+        {allShows.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {selectedTags.length > 0 || selectedCities.length > 0
+                ? 'No upcoming shows match the current filters.'
+                : 'No upcoming shows at this time.'}
+            </p>
+            {(selectedTags.length > 0 || selectedCities.length > 0) && (
+              <button
+                onClick={() => {
+                  if (selectedTags.length > 0) handleTagsClear()
+                  if (selectedCities.length > 0) handleFilterChange([])
+                }}
+                className="mt-4 text-primary hover:underline"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+        ) : (
+          <>
+            <div className={cn(
+              'flex flex-col',
+              density === 'compact' && 'gap-0.5',
+              density === 'comfortable' && 'gap-3',
+              density === 'expanded' && 'gap-5'
+            )}>
+              {allShows.map(show => (
+                <ShowCard
+                  key={show.id}
+                  show={show}
+                  isAdmin={isAdmin}
+                  userId={user?.id}
+                  isSaved={savedShowIds?.has(show.id)}
+                  density={density}
+                  attendanceData={batchAttendance?.[String(show.id)]}
+                />
+              ))}
             </div>
-          ) : (
-            <>
-              <div className={cn(
-                'flex flex-col',
-                density === 'compact' && 'gap-0.5',
-                density === 'comfortable' && 'gap-3',
-                density === 'expanded' && 'gap-5'
-              )}>
-                {allShows.map(show => (
-                  <ShowCard
-                    key={show.id}
-                    show={show}
-                    isAdmin={isAdmin}
-                    userId={user?.id}
-                    isSaved={savedShowIds?.has(show.id)}
-                    density={density}
-                    attendanceData={batchAttendance?.[String(show.id)]}
-                  />
-                ))}
-              </div>
 
-              {data?.pagination.has_more && (
-                <div className="text-center py-6">
-                  <Button
-                    variant="outline"
-                    onClick={handleLoadMore}
-                    disabled={isFetching}
-                  >
-                    {isFetching ? 'Loading...' : 'Load More'}
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+            {data?.pagination.has_more && (
+              <div className="text-center py-6">
+                <Button
+                  variant="outline"
+                  onClick={handleLoadMore}
+                  disabled={isFetching}
+                >
+                  {isFetching ? 'Loading...' : 'Load More'}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
       </div>
     </section>
   )

--- a/frontend/features/tags/components/TagFacetPanel.test.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.test.tsx
@@ -444,4 +444,127 @@ describe('TagFacetPanel', () => {
       screen.queryByTestId('tag-facet-transitive-info')
     ).not.toBeInTheDocument()
   })
+
+  // PSY-1000: horizontal top-bar layout. Same data + behavior as the rail
+  // default — chips, live counts, selection, disabled zero-result facets,
+  // and the "show all tags" expander all carry over — only the container
+  // changes (one wrapping row above a full-width list instead of a sidebar).
+  describe('bar layout (PSY-1000)', () => {
+    it('defaults to the rail layout when no layout prop is given', () => {
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+        />
+      )
+      expect(screen.getByTestId('tag-facet-panel')).toHaveAttribute(
+        'data-layout',
+        'rail'
+      )
+    })
+
+    it('renders all categories and chips in bar layout', () => {
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+          layout="bar"
+        />
+      )
+      expect(screen.getByTestId('tag-facet-panel')).toHaveAttribute(
+        'data-layout',
+        'bar'
+      )
+      // Every category's chips still render (flowed into one row).
+      expect(screen.getByTestId('tag-facet-chip-post-punk')).toBeInTheDocument()
+      expect(screen.getByTestId('tag-facet-chip-phoenix')).toBeInTheDocument()
+      expect(screen.getByTestId('tag-facet-chip-diy')).toBeInTheDocument()
+    })
+
+    it('toggles a chip in bar layout', async () => {
+      const user = userEvent.setup()
+      const onToggle = vi.fn()
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={['shoegaze']}
+          onToggle={onToggle}
+          onClear={() => {}}
+          layout="bar"
+        />
+      )
+      await user.click(screen.getByTestId('tag-facet-chip-post-punk'))
+      expect(onToggle).toHaveBeenCalledWith(['shoegaze', 'post-punk'])
+    })
+
+    it('shows the Clear all button in bar layout when there is a selection', async () => {
+      const user = userEvent.setup()
+      const onClear = vi.fn()
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={['post-punk']}
+          onToggle={() => {}}
+          onClear={onClear}
+          layout="bar"
+        />
+      )
+      const clearBtn = screen.getByTestId('tag-facet-clear')
+      await user.click(clearBtn)
+      expect(onClear).toHaveBeenCalled()
+    })
+
+    it('renders the "Show all tags" expander in bar layout', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+          entityType="festival"
+          layout="bar"
+        />
+      )
+      // shoegaze is hidden (0 festival applications) until the expander fires.
+      expect(
+        screen.queryByTestId('tag-facet-chip-shoegaze')
+      ).not.toBeInTheDocument()
+      const expander = screen.getByTestId('tag-facet-show-all')
+      await user.click(expander)
+      expect(screen.getByTestId('tag-facet-chip-shoegaze')).toBeInTheDocument()
+    })
+
+    it('disables zero-in-city chips in bar layout (city-scoped show facet)', () => {
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+          entityType="show"
+          selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+          layout="bar"
+        />
+      )
+      // post-punk has Phoenix shows → enabled; shoegaze has 0 → disabled.
+      expect(screen.getByTestId('tag-facet-chip-post-punk')).not.toBeDisabled()
+      expect(screen.getByTestId('tag-facet-chip-shoegaze')).toBeDisabled()
+      // City-scoped mode omits the expander in bar layout too.
+      expect(
+        screen.queryByTestId('tag-facet-show-all')
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders the transitive info tooltip in bar layout for show entityType', () => {
+      renderWithProviders(
+        <TagFacetPanel
+          selectedSlugs={[]}
+          onToggle={() => {}}
+          onClear={() => {}}
+          entityType="show"
+          layout="bar"
+        />
+      )
+      expect(screen.getByTestId('tag-facet-transitive-info')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/features/tags/components/TagFacetPanel.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.tsx
@@ -33,6 +33,18 @@ const TRANSITIVE_TOOLTIP_COPY: Partial<Record<TagEntityType, string>> = {
 
 const DEFAULT_TAGS_PER_CATEGORY = 20
 
+/**
+ * Layout mode for the facet panel.
+ * - `rail` (default): vertical sidebar — categories stacked, each with its
+ *   own heading. The original PSY-309 layout used by the non-migrated browse
+ *   pages and the mobile Sheet.
+ * - `bar` (PSY-1000): horizontal top bar — chips from all categories flow into
+ *   a single wrapping row beside the heading, the list renders full-width
+ *   below. Same data + behavior (live counts, disabled zero-result facets,
+ *   selection, "show all tags"); only the container layout changes.
+ */
+export type TagFacetLayout = 'rail' | 'bar'
+
 export interface TagFacetPanelProps {
   /** Currently selected tag slugs. */
   selectedSlugs: string[]
@@ -46,6 +58,13 @@ export interface TagFacetPanelProps {
   heading?: string
   /** Hide the internal heading (useful when rendered inside a Sheet). */
   hideHeading?: boolean
+  /**
+   * Container layout (PSY-1000). `rail` (default) is the vertical sidebar;
+   * `bar` is the horizontal top-bar used on `/shows`. Default stays vertical
+   * so non-migrated callers (the other browse pages, the mobile Sheet) are
+   * unaffected.
+   */
+  layout?: TagFacetLayout
   /** Tailwind class overrides for the root container. */
   className?: string
   /**
@@ -87,6 +106,7 @@ export function TagFacetPanel({
   tagsPerCategory = DEFAULT_TAGS_PER_CATEGORY,
   heading = 'Filter by tags',
   hideHeading = false,
+  layout = 'rail',
   className,
   entityType,
   selectedCities,
@@ -102,6 +122,7 @@ export function TagFacetPanel({
   // SHOW those chips DISABLED instead of hiding them — the expander is
   // redundant in this mode, and a disabled chip can never dead-end on click.
   const cityScoped = (selectedCities?.length ?? 0) > 0
+  const isBar = layout === 'bar'
   const handleToggle = (slug: string) => {
     if (selectedSet.has(slug)) {
       onToggle(selectedSlugs.filter(s => s !== slug))
@@ -110,10 +131,88 @@ export function TagFacetPanel({
     }
   }
 
+  // The "Show all tags" expander only matters when we hide zero-count chips.
+  // In city-scoped mode they are shown disabled instead, so the expander is
+  // redundant and omitted. Shared between both layouts; bar mode renders it
+  // inline at the end of the chip row, rail mode stacks it below the groups.
+  const showAllExpander = entityType && !cityScoped && (
+    <button
+      type="button"
+      onClick={() => setShowAll(prev => !prev)}
+      className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+      data-testid="tag-facet-show-all"
+    >
+      {showAll ? 'Hide tags with no matches' : 'Show all tags'}
+    </button>
+  )
+
+  // Shared "Clear all" control — the same button, positioned per layout.
+  const clearButton = selectedSlugs.length > 0 && (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-7 px-2 text-xs"
+      onClick={onClear}
+      data-testid="tag-facet-clear"
+    >
+      <X className="mr-1 h-3 w-3" /> Clear all
+    </Button>
+  )
+
+  // Bar layout (PSY-1000): the full vocabulary flows into ONE wrapping row so
+  // the chips sit above a full-width list. We flatten the categories rather
+  // than stacking per-category headings — the chip colors (from
+  // getCategoryColor) already encode the category, matching the Figma
+  // `474:9` "Filter by tag" row. The heading, chips, the "show all"
+  // expander, and "Clear all" all share that single flex-wrap row.
+  if (isBar) {
+    return (
+      <div
+        className={cn('flex flex-wrap items-center gap-x-3 gap-y-2', className)}
+        data-testid="tag-facet-panel"
+        data-layout="bar"
+      >
+        {!hideHeading && (
+          <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+            <TagIcon className="h-3.5 w-3.5" aria-hidden />
+            {heading}
+            {entityType && TRANSITIVE_TOOLTIP_COPY[entityType] && (
+              <TransitiveTagTooltip
+                text={TRANSITIVE_TOOLTIP_COPY[entityType] ?? ''}
+              />
+            )}
+          </h2>
+        )}
+
+        {TAG_CATEGORIES.map(cat => (
+          <CategoryGroup
+            key={cat}
+            category={cat}
+            limit={tagsPerCategory}
+            selectedSet={selectedSet}
+            onToggle={handleToggle}
+            entityType={entityType}
+            selectedCities={selectedCities}
+            showAll={showAll}
+            cityScoped={cityScoped}
+            inline
+          />
+        ))}
+
+        {showAllExpander}
+        {clearButton}
+      </div>
+    )
+  }
+
+  // Rail layout (default, PSY-309): vertical sidebar with stacked,
+  // per-category groups.
   return (
     <aside
       className={cn('space-y-5', className)}
       data-testid="tag-facet-panel"
+      data-layout="rail"
     >
       {!hideHeading && (
         <div className="flex items-center justify-between">
@@ -126,34 +225,12 @@ export function TagFacetPanel({
               />
             )}
           </h2>
-          {selectedSlugs.length > 0 && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-xs"
-              onClick={onClear}
-              data-testid="tag-facet-clear"
-            >
-              <X className="mr-1 h-3 w-3" /> Clear all
-            </Button>
-          )}
+          {clearButton}
         </div>
       )}
 
       {hideHeading && selectedSlugs.length > 0 && (
-        <div className="flex justify-end">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2 text-xs"
-            onClick={onClear}
-            data-testid="tag-facet-clear"
-          >
-            <X className="mr-1 h-3 w-3" /> Clear all
-          </Button>
-        </div>
+        <div className="flex justify-end">{clearButton}</div>
       )}
 
       {TAG_CATEGORIES.map(cat => (
@@ -170,21 +247,7 @@ export function TagFacetPanel({
         />
       ))}
 
-      {/* "Show all tags" expander only matters when we hide zero-count chips.
-          In city-scoped mode they are shown disabled instead, so the expander
-          is redundant and omitted. */}
-      {entityType && !cityScoped && (
-        <div className="pt-1">
-          <button
-            type="button"
-            onClick={() => setShowAll(prev => !prev)}
-            className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
-            data-testid="tag-facet-show-all"
-          >
-            {showAll ? 'Hide tags with no matches' : 'Show all tags'}
-          </button>
-        </div>
-      )}
+      {showAllExpander && <div className="pt-1">{showAllExpander}</div>}
     </aside>
   )
 }
@@ -199,6 +262,12 @@ interface CategoryGroupProps {
   showAll: boolean
   /** When true, zero-count chips are shown disabled instead of hidden. */
   cityScoped: boolean
+  /**
+   * Bar layout (PSY-1000): render the chips bare so they flow into the
+   * parent's single wrapping row — no per-category heading, no own
+   * container. Rail layout (default) keeps the stacked heading + group.
+   */
+  inline?: boolean
 }
 
 function CategoryGroup({
@@ -210,6 +279,7 @@ function CategoryGroup({
   selectedCities,
   showAll,
   cityScoped,
+  inline = false,
 }: CategoryGroupProps) {
   const { data, isLoading } = useTags({
     category,
@@ -240,36 +310,45 @@ function CategoryGroup({
 
   if (!isLoading && visibleTags.length === 0) return null
 
+  const chips = visibleTags.map(tag => (
+    <TagChip
+      key={tag.id}
+      tag={tag}
+      selected={selectedSet.has(tag.slug)}
+      onToggle={onToggle}
+      // Disable only an unselected zero-in-city chip: a selected chip
+      // must stay interactive so the user can always deselect it.
+      disabled={
+        cityScoped && tag.usage_count === 0 && !selectedSet.has(tag.slug)
+      }
+    />
+  ))
+
+  const skeletons = Array.from({ length: 6 }).map((_, i) => (
+    <Skeleton key={i} className="h-6 w-16 rounded-full" />
+  ))
+
+  // Bar layout (PSY-1000): emit chips bare so they flow into the parent's
+  // single wrapping row. No heading, no own container — the chip color
+  // already signals the category. We still tag the group with a testid so
+  // tests can scope assertions to a category in either layout.
+  if (inline) {
+    return (
+      <span
+        className="contents"
+        data-testid={`tag-facet-category-${category}`}
+      >
+        {isLoading ? skeletons : chips}
+      </span>
+    )
+  }
+
   return (
     <div className="space-y-2" data-testid={`tag-facet-category-${category}`}>
       <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
         {label}
       </h3>
-      {isLoading ? (
-        <div className="flex flex-wrap gap-1.5">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <Skeleton key={i} className="h-6 w-16 rounded-full" />
-          ))}
-        </div>
-      ) : (
-        <div className="flex flex-wrap gap-1.5">
-          {visibleTags.map(tag => (
-            <TagChip
-              key={tag.id}
-              tag={tag}
-              selected={selectedSet.has(tag.slug)}
-              onToggle={onToggle}
-              // Disable only an unselected zero-in-city chip: a selected chip
-              // must stay interactive so the user can always deselect it.
-              disabled={
-                cityScoped &&
-                tag.usage_count === 0 &&
-                !selectedSet.has(tag.slug)
-              }
-            />
-          ))}
-        </div>
-      )}
+      <div className="flex flex-wrap gap-1.5">{isLoading ? skeletons : chips}</div>
     </div>
   )
 }

--- a/frontend/features/tags/components/index.ts
+++ b/frontend/features/tags/components/index.ts
@@ -8,5 +8,6 @@ export {
   parseTagsParam,
   buildTagsParam,
   type TagFacetPanelProps,
+  type TagFacetLayout,
 } from './TagFacetPanel'
 export { TagFacetSheet, type TagFacetSheetProps } from './TagFacetSheet'

--- a/frontend/features/tags/index.ts
+++ b/frontend/features/tags/index.ts
@@ -59,5 +59,6 @@ export {
 export type {
   AddTagDialogProps,
   TagFacetPanelProps,
+  TagFacetLayout,
   TagFacetSheetProps,
 } from './components'


### PR DESCRIPTION
## Summary

Adopts the **Variant A top filter bar** layout on `/shows` and adds a reusable horizontal bar mode to the shared `TagFacetPanel`.

- **`TagFacetPanel`** gains a `layout` prop (`'rail'` | `'bar'`, default `'rail'`). In `bar` mode the category chips flatten into a single wrapping horizontal row beside the heading; the "show all tags" expander and "Clear all" sit inline at the end of that row. Chip colors (`getCategoryColor`) encode the category, so per-category headings aren't needed — matching Figma `474:9`. Same data + behavior as the rail default: live counts, disabled zero-result facets (PSY-982 city-scoping), selection, and the expander all carry over.
- **`/shows` (`ShowList.tsx`)** moves the tag filter to a full-width top bar (under the city + density controls) and renders the show list at full content width. The old 2-column `lg:flex-row` rail (`aside lg:w-64`) — which left a large empty column and squeezed the list into a narrow strip — is gone.
- The default stays `rail`, so the other five browse pages (`/artists`, `/venues`, `/releases`, `/labels`, `/festivals`) and the mobile `TagFacetSheet` are unaffected. This is the **reference implementation** for the sibling adoption tickets PSY-1001..1005.

Mobile keeps the existing `TagFacetSheet` trigger (the bar is `hidden lg:block`).

## Test plan

- [x] `cd frontend && bun run typecheck` — passes (`tsc --noEmit`, clean)
- [x] `cd frontend && bun run lint` — passes (0 errors; only pre-existing warnings, none in changed files)
- [x] `cd frontend && bun run test:run features/tags features/shows` — **48 files / 656 tests pass**, including 7 new `bar layout (PSY-1000)` tests in `TagFacetPanel.test.tsx` (29 total there, was 22) and the unchanged `ShowList` suite

## Manual repro

Brought up an isolated dispatch stack (`stack-up.sh --mode=shared` escalated to isolated; backend :49915, frontend :49916, seeded E2E DB). The seed ships no tags, so I seeded 9 tags (genre/locale/other) and applied them to artists on upcoming approved shows so the transitive `/shows` facet returns real counts. Then drove `/shows?cities=Phoenix,AZ` via chrome-devtools MCP:

- The tag filter renders as a **full-width top bar** ("Filter shows by tag" + info tooltip, then one wrapping row of chips with live counts: Indie Rock 22, Folk 18, Emo 9, Punk 8, Shoegaze 4, Southwest 14, Arizona 12, Touring 18, All Ages 9) **above a full-width show list** (29 shows). No left rail, no dead column — confirmed `data-layout="bar"` present, `data-layout="rail"` absent in the DOM.
- **Selection filters the list:** clicking "Punk" navigated to `?tags=punk`, set `aria-pressed=true`, surfaced "Clear all", and filtered to "8 shows matching punk".
- **Light + dark both verified** (screenshots below).

**Coverage gap (disclosed):** the disabled zero-result-facet state could not be reproduced in the browser — the E2E seed is fully connected (every seeded artist plays every city), so no tag is zero-in-city. That behavior IS covered by the new unit test `disables zero-in-city chips in bar layout (city-scoped show facet)` (asserts an enabled chip + a disabled chip + no expander). Recommend a quick Vercel-preview spot-check on a city with sparse tag coverage if extra confidence is wanted.

## Screenshots

**Desktop, light mode — full-width bar above full-width list**
![light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1000-screenshots/01-shows-bar-light.png)

**Desktop, dark mode — "Punk" selected, "Clear all" shown, list filtered to 8 shows**
![dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1000-screenshots/02-shows-bar-dark-selected.png)

## Code review

`/code-review` (xhigh, ran inline — no Agent tool in worktree): **no findings.** The diff is a clean refactor — the `clearButton`/`showAllExpander`/`chips`/`skeletons` extractions remove prior duplication, `layout` defaults to `rail` so all other callers are unaffected, and `&&`-guards return falsy (not `0`) so nothing leaks into render. No file changes, so no separate commit.

## Adversarial review

`/adversarial-review` — **CLEAN** (4 lenses run inline; no Agent tool in a dispatched worktree, so the Saboteur / Future-Maintainer / Security / Completeness lenses were applied sequentially against the branch diff — expected fallback, not an error).
- **Saboteur:** no findings — empty/null props render safely (no falsy-zero leak), `display:contents` span only groups real `<button>`s, loading/zero-tag states don't break the flex row.
- **Future-Maintainer:** no findings — the category-flattening + chip-color-encodes-category decision is commented with the Figma reference; `data-layout` is a clean seam for the adoption tickets.
- **Security:** no findings — pure presentational refactor, no new input/auth/fetch surface.
- **Completeness:** all ACs met; one coverage gap (disabled-facet not browser-reproducible on the fully-connected seed) disclosed above and covered by unit test.

No CRITICAL/HIGH/MEDIUM → no fixes → no separate adversarial-review commit.

Closes PSY-1000
