### PR TITLE
PSY-1004: adopt top-bar tag filter on /labels

### DIFF
--- a/frontend/features/labels/components/LabelList.test.tsx
+++ b/frontend/features/labels/components/LabelList.test.tsx
@@ -41,7 +41,11 @@ vi.mock('@/components/shared', () => ({
 }))
 
 vi.mock('@/features/tags', () => ({
-  TagFacetPanel: () => <div data-testid="tag-facet-panel" />,
+  // Surface the `layout` prop via data-layout so the suite can assert the
+  // page renders the panel as a top bar (PSY-1004) rather than a rail.
+  TagFacetPanel: ({ layout }: { layout?: string }) => (
+    <div data-testid="tag-facet-panel" data-layout={layout ?? 'rail'} />
+  ),
   TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
   parseTagsParam: (s: string | null) => (s ? s.split(',').filter(Boolean) : []),
   buildTagsParam: (slugs: string[]) => slugs.join(','),
@@ -94,6 +98,14 @@ describe('LabelList', () => {
     renderWithProviders(<LabelList />)
     expect(screen.getByTestId('label-search')).toBeInTheDocument()
     expect(screen.getByTestId('density-toggle')).toHaveTextContent('comfortable')
+  })
+
+  it('renders the tag facet panel as a top bar, not a rail (PSY-1004)', () => {
+    renderWithProviders(<LabelList />)
+    expect(screen.getByTestId('tag-facet-panel')).toHaveAttribute(
+      'data-layout',
+      'bar'
+    )
   })
 
   it('renders the unfiltered empty state when there are no labels', () => {

--- a/frontend/features/labels/components/LabelList.tsx
+++ b/frontend/features/labels/components/LabelList.tsx
@@ -144,6 +144,8 @@ export function LabelList() {
         </div>
       </div>
 
+      {/* Mobile: Sheet trigger + density toggle. Desktop hides the Sheet (the
+          bar below takes over) but keeps the density toggle on this row. */}
       <div className="flex items-center justify-between mb-4 gap-2">
         <TagFacetSheet
           selectedSlugs={selectedTags}
@@ -155,56 +157,57 @@ export function LabelList() {
         <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <aside className="hidden lg:block lg:w-64 lg:shrink-0">
-          <TagFacetPanel
-            selectedSlugs={selectedTags}
-            onToggle={handleTagsChange}
-            onClear={handleTagsClear}
-            heading="Filter labels by tag"
-            entityType="label"
-          />
-        </aside>
+      {/* PSY-1004: full-width top-bar tag filter above a full-width list (no
+          left rail). Desktop only — mobile uses the Sheet trigger above. */}
+      <div className="mb-4 hidden lg:block">
+        <TagFacetPanel
+          selectedSlugs={selectedTags}
+          onToggle={handleTagsChange}
+          onClear={handleTagsClear}
+          heading="Filter labels by tag"
+          entityType="label"
+          layout="bar"
+        />
+      </div>
 
-        <div className={`flex-1 min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
-          <p className="mb-3 text-sm text-muted-foreground" data-testid="label-count">
-            {labels.length} {labels.length === 1 ? 'label' : 'labels'}
-            {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
-          </p>
-          {labels.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p>
-                {hasFilters
-                  ? 'No labels found matching your filters.'
-                  : 'No labels available at this time.'}
-              </p>
-              {hasFilters && (
-                <button
-                  onClick={clearFilters}
-                  className="mt-4 text-primary hover:underline"
-                >
-                  View all labels
-                </button>
-              )}
-            </div>
-          ) : (
-            <div className="@container">
-              <div
-                className={
-                  density === 'compact'
-                    ? 'flex flex-col gap-px'
-                    : density === 'expanded'
-                      ? 'grid grid-cols-1 gap-5'
-                      : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-                }
+      <div className={`min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
+        <p className="mb-3 text-sm text-muted-foreground" data-testid="label-count">
+          {labels.length} {labels.length === 1 ? 'label' : 'labels'}
+          {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
+        </p>
+        {labels.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {hasFilters
+                ? 'No labels found matching your filters.'
+                : 'No labels available at this time.'}
+            </p>
+            {hasFilters && (
+              <button
+                onClick={clearFilters}
+                className="mt-4 text-primary hover:underline"
               >
-                {labels.map(label => (
-                  <LabelCard key={label.id} label={label} density={density} />
-                ))}
-              </div>
+                View all labels
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="@container">
+            <div
+              className={
+                density === 'compact'
+                  ? 'flex flex-col gap-px'
+                  : density === 'expanded'
+                    ? 'grid grid-cols-1 gap-5'
+                    : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+              }
+            >
+              {labels.map(label => (
+                <LabelCard key={label.id} label={label} density={density} />
+              ))}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary

Adopt the top-bar tag filter (Variant A) on `/labels`, mirroring the reference
shipped on `/shows` in PSY-1000 (#1017).

`/labels` previously used the shared `TagFacetPanel` in a left rail
(`aside lg:w-64`) inside a 2-column `lg:flex-row` layout. On desktop this left a
large empty column and squeezed the label grid into a narrow `flex-1` strip.
This restructures `LabelList` to a full-width top bar (`hidden lg:block`
wrapper) above a full-width list, passing `layout="bar"` to the shared panel.

This is a mechanical adoption — it reuses the existing `layout="bar"` mode added
in PSY-1000; `TagFacetPanel` itself is unchanged. Same data + behavior: live
per-label counts, disabled zero-result facets, selection, and the "show all
tags" expander. Unlike `/shows`, `/labels` passes no `selectedCities` (labels
have no city filter). The mobile `TagFacetSheet` trigger is unchanged — on
mobile the desktop bar is hidden and filtering stays in the sheet.

Closes PSY-1004

## Test plan

- [x] `cd frontend && bun run typecheck` — passes (`tsc --noEmit`, clean)
- [x] `cd frontend && bun run lint` — passes (0 errors; only pre-existing warnings in unrelated files; none in changed files)
- [x] `cd frontend && bun run test:run features/labels features/tags` — 405 passed (24 files), incl. the new bar-layout assertion (LabelList: 11 → 12 tests)

## Manual repro

Ran the per-worktree dispatch stack (`stack-up.sh --mode=shared`, escalated to
`isolated` — no shared :8080 backend) and drove `/labels` at 1440px desktop:

- Confirmed the tag facet panel renders `data-layout="bar"` at full content
  width (1088px), with **no left rail** (`aside.lg:w-64` absent).
- The seed DB had zero tags, so to exercise counts + filtering I temporarily
  seeded two genre tags (`emo`, `hardcore`) on labels in the isolated stack DB
  (reverted after). With those:
  - Chips rendered with live per-label counts: **Emo 2**, **Hardcore 1**.
  - Clicking **Emo** updated the URL to `/labels?tags=emo`, the count line to
    "2 labels matching emo", set the chip `aria-pressed="true"`, and filtered
    the list to the 2 emo-tagged labels (Loma Vista correctly dropped).
- Verified both light and dark mode (theme toggle) — bar layout + counts intact
  in both.

## Screenshots

Light — full-width "Filter labels by tag" bar (Emo 2 / Hardcore 1 chips) above a
full-width 3-column label grid, no rail:

![labels bar light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1004-screenshots/labels-bar-light-desktop.png)

Dark — same bar layout and counts, dark theming:

![labels bar dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1004-screenshots/labels-bar-dark-desktop.png)

## Code review

`/code-review` (xhigh, run inline — dispatched sub-agent has no Agent tool):
no findings. The diff is a faithful structural copy of the canonical ShowList
pattern — moved list JSX is byte-identical except the intended `flex-1 min-w-0`
→ `min-w-0` change; all panel props (`entityType`, `heading`, handlers)
preserved; the rail's removed `layout` default (`rail`) re-established as
explicit `layout="bar"`. No dropped guard, no reuse/efficiency issue.

## Adversarial review

`/adversarial-review` — CLEAN, no findings (panel run **inline**: dispatched
sub-agent has no Agent tool to spawn fresh reviewers, per the repo's documented
fallback). All four lenses passed:
- **Saboteur**: pure presentational restructure — no state/data/async/writes
  touched; empty-state + count boundaries preserved; chip row flex-wraps within
  `max-w-6xl`, no overflow.
- **Future Maintainer**: matches the canonical /shows pattern; both new comments
  document the *why*; the new test asserts behavior (`data-layout`) not internals.
- **Security**: no trust boundary / authz / injection / data-exposure surface.
- **Completeness**: all 4 acceptance criteria met; `selectedCities` correctly omitted.

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran
against the branch diff with no prior session context.
