### PR TITLE
PSY-1005: adopt top-bar tag filter on /festivals

### DIFF
--- a/frontend/features/festivals/components/FestivalList.test.tsx
+++ b/frontend/features/festivals/components/FestivalList.test.tsx
@@ -22,9 +22,15 @@ vi.mock('@/lib/hooks/common/useDensity', () => ({
   useDensity: () => ({ density: 'comfortable', setDensity: vi.fn() }),
 }))
 
-// Tag faceting (pulls in tag query infra otherwise)
+// Tag faceting (pulls in tag query infra otherwise). The panel mock forwards
+// its `layout` prop onto `data-layout` so the test can assert the top-bar
+// adoption (PSY-1005) without rendering the real tag-query stack — the bar
+// rendering itself (counts, disabled facets, expander) is covered by
+// TagFacetPanel.test.tsx.
 vi.mock('@/features/tags', () => ({
-  TagFacetPanel: () => <div data-testid="tag-facet-panel" />,
+  TagFacetPanel: ({ layout }: { layout?: string }) => (
+    <div data-testid="tag-facet-panel" data-layout={layout ?? 'rail'} />
+  ),
   TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
   parseTagsParam: (raw: string | null) =>
     raw ? raw.split(',').filter(Boolean) : [],
@@ -124,6 +130,22 @@ describe('FestivalList', () => {
     expect(
       screen.getByRole('link', { name: 'Desert Daze' })
     ).toBeInTheDocument()
+  })
+
+  it('renders the desktop tag filter as a top bar (PSY-1005), not a rail', () => {
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [makeFestival(1, 'FORM')], count: 1 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<FestivalList />)
+
+    expect(screen.getByTestId('tag-facet-panel')).toHaveAttribute(
+      'data-layout',
+      'bar'
+    )
   })
 
   it('pushes a status filter to the URL when a status chip is clicked', async () => {

--- a/frontend/features/festivals/components/FestivalList.tsx
+++ b/frontend/features/festivals/components/FestivalList.tsx
@@ -157,6 +157,8 @@ export function FestivalList() {
         </div>
       </div>
 
+      {/* Mobile: Sheet trigger + density toggle. Desktop hides the Sheet (the
+          bar below takes over) but keeps the density toggle on this row. */}
       <div className="flex items-center justify-between mb-4 gap-2">
         <TagFacetSheet
           selectedSlugs={selectedTags}
@@ -168,60 +170,62 @@ export function FestivalList() {
         <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <aside className="hidden lg:block lg:w-64 lg:shrink-0">
-          <TagFacetPanel
-            selectedSlugs={selectedTags}
-            onToggle={handleTagsChange}
-            onClear={handleTagsClear}
-            heading="Filter festivals by tag"
-            entityType="festival"
-          />
-        </aside>
+      {/* PSY-1005: full-width top-bar tag filter above a full-width list (no
+          left rail), mirroring /shows (PSY-1000). Desktop only — mobile uses
+          the Sheet trigger above. */}
+      <div className="mb-4 hidden lg:block">
+        <TagFacetPanel
+          selectedSlugs={selectedTags}
+          onToggle={handleTagsChange}
+          onClear={handleTagsClear}
+          heading="Filter festivals by tag"
+          entityType="festival"
+          layout="bar"
+        />
+      </div>
 
-        <div className={`flex-1 min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
-          <p className="mb-3 text-sm text-muted-foreground" data-testid="festival-count">
-            {festivals.length} {festivals.length === 1 ? 'festival' : 'festivals'}
-            {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
-          </p>
-          {festivals.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p>
-                {hasFilters
-                  ? 'No festivals found matching your filters.'
-                  : 'No festivals available at this time.'}
-              </p>
-              {hasFilters && (
-                <button
-                  onClick={clearFilters}
-                  className="mt-4 text-primary hover:underline"
-                >
-                  View all festivals
-                </button>
-              )}
-            </div>
-          ) : (
-            <div className="@container">
-              <div
-                className={
-                  density === 'compact'
-                    ? 'flex flex-col gap-px'
-                    : density === 'expanded'
-                      ? 'grid grid-cols-1 gap-5'
-                      : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-                }
+      <div className={`min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
+        <p className="mb-3 text-sm text-muted-foreground" data-testid="festival-count">
+          {festivals.length} {festivals.length === 1 ? 'festival' : 'festivals'}
+          {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
+        </p>
+        {festivals.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {hasFilters
+                ? 'No festivals found matching your filters.'
+                : 'No festivals available at this time.'}
+            </p>
+            {hasFilters && (
+              <button
+                onClick={clearFilters}
+                className="mt-4 text-primary hover:underline"
               >
-                {festivals.map(festival => (
-                  <FestivalCard
-                    key={festival.id}
-                    festival={festival}
-                    density={density}
-                  />
-                ))}
-              </div>
+                View all festivals
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="@container">
+            <div
+              className={
+                density === 'compact'
+                  ? 'flex flex-col gap-px'
+                  : density === 'expanded'
+                    ? 'grid grid-cols-1 gap-5'
+                    : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+              }
+            >
+              {festivals.map(festival => (
+                <FestivalCard
+                  key={festival.id}
+                  festival={festival}
+                  density={density}
+                />
+              ))}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary

Adopt the top-bar tag filter on `/festivals`, mirroring the reference shipped on
`/shows` in PSY-1000 (#1017). The page previously used a 2-column left-rail
layout (`lg:flex-row` + `aside lg:w-64` + `flex-1` list) which left a large empty
column and squeezed the festival grid into a narrow strip.

Now the desktop tag filter renders as a full-width top bar (the shared
`TagFacetPanel` `layout="bar"` mode, in a `hidden lg:block` wrapper) directly
above a full-width festival list. Mobile is unchanged — it keeps the
`TagFacetSheet` trigger (which is `lg:hidden`), and the bar takes over on desktop.

This is a mechanical adoption of the PSY-1000 reference — no redesign of the
panel, and `TagFacetPanel.tsx` is not modified. Unlike `/shows`, `/festivals`
passes no `selectedCities` (simpler — no city-scoped disabled-facet path).

Counts, the "Show all tags" expander for zero-result facets, and the
transitive-tag info tooltip all carry over (same shared panel; only the
container layout changes).

## Test plan

- [x] `cd frontend && bun run typecheck` — clean (`tsc --noEmit`, 0 errors)
- [x] `cd frontend && bun run lint` — 0 errors (153 pre-existing warnings, none in changed files)
- [x] `cd frontend && bun run test:run features/festivals features/tags` — 30 files, 416 tests passed (incl. new FestivalList bar-layout test)

## Manual repro

Ran a per-worktree dispatch stack (`stack-up.sh --mode=shared`, escalated to
isolated — no shared :8080 backend). Seeded festival tags + a lineup artist so
the transitive (PSY-499) festival facet counts are non-zero, then drove the live
app via `agent-browser`:

- Bar renders in the `hidden lg:block` desktop wrapper, above a full-width list; the old `aside lg:w-64` rail is gone (`railAsideStillPresent: false`).
- Chips render with counts: `Psych Rock 1`, `Desert 1`.
- "Show all tags" expander reveals the zero-count `Shoegaze 0` facet (preserved zero-result handling).
- Selecting `Psych Rock` updates the URL to `?tags=psych-rock`, the count to "1 festival matching psych-rock", marks the chip `aria-pressed=true`, and shows the "Clear all" button — the list filters to the matching festival.
- Light + dark both verified.

## Screenshots

![Festivals top-bar filter, desktop light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1005-screenshots/festivals-desktop-light.png)
*Desktop (light): full-width "Filter festivals by tag" bar with chips + counts above the full-width list — no left rail.*

![Festivals top-bar filter, light, filtered by Psych Rock](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1005-screenshots/festivals-desktop-light-filtered.png)
*Desktop (light), filtered: `Psych Rock` selected, "Clear all" shown, count reads "1 festival matching psych-rock".*

![Festivals top-bar filter, desktop dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1005-screenshots/festivals-desktop-dark.png)
*Desktop (dark): same top-bar layout, chips + counts + expander legible in dark mode.*

## Code review

`/code-review` (xhigh effort) — ran the 9 finder angles + sweep inline (dispatched
sub-agent has no Agent tool, per the project's inline-fallback convention).
No findings: all removed rail behavior is re-established in the bar wrapper, no
caller breaks (`FestivalList` takes no props), no language pitfalls, and
reuse/simplification/efficiency/altitude are clean (the change reuses the shared
panel's `layout="bar"` rather than re-implementing markup). No fixes, no separate commit.

## Adversarial review

`/adversarial-review` — CLEAN. Ran the 4 lenses (Saboteur · Future-Maintainer ·
Security · Completeness) inline against the branch diff (no Agent tool in a
worktree — expected). Zero findings: no double-filter-UI race (the Sheet is
`lg:hidden`, the bar is `hidden lg:block`), convention kept consistent with
FestivalList (template-literal classNames, no spurious `cn` import), no security
surface, and all acceptance criteria met. No fixes, no separate commit.

Closes PSY-1005
