### PR TITLE
PSY-1001: adopt top-bar tag filter on /artists

### DIFF
--- a/frontend/features/artists/components/ArtistList.test.tsx
+++ b/frontend/features/artists/components/ArtistList.test.tsx
@@ -75,7 +75,11 @@ vi.mock('@/components/shared', () => ({
 }))
 
 vi.mock('@/features/tags', () => ({
-  TagFacetPanel: () => <div data-testid="tag-facet-panel" />,
+  // PSY-1001: surface the `layout` prop as `data-layout` so the test can
+  // assert the desktop facet panel renders as the top bar (not the old rail).
+  TagFacetPanel: ({ layout }: { layout?: 'rail' | 'bar' }) => (
+    <div data-testid="tag-facet-panel" data-layout={layout ?? 'rail'} />
+  ),
   TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
   parseTagsParam: (s: string | null) => (s ? s.split(',').filter(Boolean) : []),
   buildTagsParam: (slugs: string[]) => slugs.join(','),
@@ -153,6 +157,17 @@ describe('ArtistList', () => {
   it('renders density toggle with current density', () => {
     renderWithProviders(<ArtistList />)
     expect(screen.getByTestId('density-toggle')).toHaveTextContent('comfortable')
+  })
+
+  // PSY-1001: the desktop tag facet is a full-width top bar above a
+  // full-width list (Variant A), not the old left rail. The shared
+  // TagFacetPanel must receive layout="bar".
+  it('renders the desktop tag facet as a top bar (layout="bar")', () => {
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByTestId('tag-facet-panel')).toHaveAttribute(
+      'data-layout',
+      'bar'
+    )
   })
 
   it('renders empty state when no artists', () => {

--- a/frontend/features/artists/components/ArtistList.tsx
+++ b/frontend/features/artists/components/ArtistList.tsx
@@ -134,6 +134,8 @@ export function ArtistList() {
         )}
       </div>
 
+      {/* Mobile: Sheet trigger + density toggle. Desktop hides the Sheet (the
+          bar below takes over) but keeps the density toggle on this row. */}
       <div className="flex items-center justify-between mb-4 gap-2">
         <TagFacetSheet
           selectedSlugs={selectedTags}
@@ -145,57 +147,58 @@ export function ArtistList() {
         <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <aside className="hidden lg:block lg:w-64 lg:shrink-0">
-          <TagFacetPanel
-            selectedSlugs={selectedTags}
-            onToggle={handleTagsChange}
-            onClear={handleTagsClear}
-            heading="Filter artists by tag"
-            entityType="artist"
-          />
-        </aside>
+      {/* PSY-1001: full-width top-bar tag filter above a full-width list (no
+          left rail). Desktop only — mobile uses the Sheet trigger above. */}
+      <div className="mb-4 hidden lg:block">
+        <TagFacetPanel
+          selectedSlugs={selectedTags}
+          onToggle={handleTagsChange}
+          onClear={handleTagsClear}
+          heading="Filter artists by tag"
+          entityType="artist"
+          layout="bar"
+        />
+      </div>
 
-        <div className={`flex-1 min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
-          <p className="mb-3 text-sm text-muted-foreground" data-testid="artist-count">
-            {artists.length} {artists.length === 1 ? 'artist' : 'artists'}
-            {hasTagFilter && ` matching ${selectedTags.join(', ')}`}
-          </p>
-          {artists.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p>
-                {hasAnyFilter
-                  ? 'No artists match the current filters.'
-                  : 'No artists available at this time.'}
-              </p>
-              {hasAnyFilter && (
-                <button
-                  onClick={() => {
-                    if (hasTagFilter) handleTagsClear()
-                    if (selectedCities.length > 0) handleFilterChange([])
-                  }}
-                  className="mt-4 text-primary hover:underline"
-                >
-                  Clear filters
-                </button>
-              )}
+      <div className={`min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
+        <p className="mb-3 text-sm text-muted-foreground" data-testid="artist-count">
+          {artists.length} {artists.length === 1 ? 'artist' : 'artists'}
+          {hasTagFilter && ` matching ${selectedTags.join(', ')}`}
+        </p>
+        {artists.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {hasAnyFilter
+                ? 'No artists match the current filters.'
+                : 'No artists available at this time.'}
+            </p>
+            {hasAnyFilter && (
+              <button
+                onClick={() => {
+                  if (hasTagFilter) handleTagsClear()
+                  if (selectedCities.length > 0) handleFilterChange([])
+                }}
+                className="mt-4 text-primary hover:underline"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="@container">
+            <div className={
+              density === 'compact'
+                ? 'flex flex-col gap-px'
+                : density === 'expanded'
+                  ? 'grid grid-cols-1 gap-5'
+                  : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+            }>
+              {artists.map(artist => (
+                <ArtistCard key={artist.id} artist={artist} density={density} />
+              ))}
             </div>
-          ) : (
-            <div className="@container">
-              <div className={
-                density === 'compact'
-                  ? 'flex flex-col gap-px'
-                  : density === 'expanded'
-                    ? 'grid grid-cols-1 gap-5'
-                    : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-              }>
-                {artists.map(artist => (
-                  <ArtistCard key={artist.id} artist={artist} density={density} />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary

Mechanical adoption of the Variant A top-bar tag filter shipped on `/shows` in
PSY-1000 (#1017). `/artists` rendered the shared `TagFacetPanel` in a left rail
(`aside lg:w-64`), which left a large empty column and squeezed the artist list
into a narrow strip.

Restructure `ArtistList` to render the desktop tag facet as a full-width
horizontal bar (`hidden lg:block`) above a full-width list, passing
`layout="bar"` to the existing shared `TagFacetPanel`. The 2-column
`lg:flex-row` rail is removed; the list drops to a plain `min-w-0` full-width
container (mirrors the post-#1017 `ShowList`). The mobile Sheet trigger +
density toggle row is unchanged. No `TagFacetPanel` change — bar mode and the
`data-layout="bar"` test seam already exist from PSY-1000.

Unlike `/shows`, `/artists` passes no `selectedCities`. Counts, disabled
zero-result facets, the "show all tags" expander, and AND/ANY tag selection all
carry over unchanged (same shared panel, same data).

Files changed (2): `frontend/features/artists/components/ArtistList.tsx`
(restructure) + `ArtistList.test.tsx` (bar-layout assertion).

## Test plan

- [x] `cd frontend && bun run typecheck` — passes (`tsc --noEmit`, no errors)
- [x] `cd frontend && bun run lint` — 0 errors (153 pre-existing warnings, none in touched files)
- [x] `cd frontend && bun run test:run features/artists features/tags` — 555 passed / 35 files (incl. the new `ArtistList` bar-layout test; `ArtistList.test.tsx` now 18 tests)

## Manual repro

Dispatch stack (`--mode=shared`, escalated to isolated; no shared :8080 backend), frontend on `:56428`. Seeded a handful of genre/other tags and applied them to seed artists so the facet bar has live counts (the default dev seed has no artist tags). Exercised on desktop (1440px):

- Full-width "Filter artists by tag" bar renders above a full-width 3-column artist grid — no left rail. DOM-verified: panel width 1088px, list width 1088px, panel sits above the list (`data-layout="bar"`).
- Facet chips render with counts (Emo 3, Indie Rock 3, Pop Punk 3, Post-Punk 2, Shoegaze 1, Local Legend 2) plus the "Show all tags" expander.
- Selecting "Indie Rock" filters the list to exactly the 3 expected artists (Calexico, Jimmy Eat World, Dear and the Headlights), URL → `?tags=indie-rock`, chip shows `aria-pressed`, "Clear all" appears.
- Light + dark both verified.

## Screenshots

![Light mode — top bar over full-width list](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1001-screenshots/artists-bar-light.png)
*Light mode: full-width "Filter artists by tag" bar with counts above the full-width artist grid (no rail).*

![Light mode — filtered](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1001-screenshots/artists-bar-light-filtered.png)
*Light mode, "Indie Rock" selected: chip highlighted, "Clear all" shown, list narrowed to the 3 matching artists.*

![Dark mode — top bar over full-width list](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1001-screenshots/artists-bar-dark.png)
*Dark mode: same bar layout and counts verified in dark theme.*

## Code review

`/code-review` (xhigh, run inline — dispatched sub-agent has no Agent tool, per the documented worktree fallback). 9 finder angles + sweep against the diff: no findings. The change is a clean mechanical mirror of the canonical `ShowList` pattern; `@container` grid context preserved, empty/filtered/error states unchanged, no call-site or behavior regressions.

## Adversarial review

`/adversarial-review` — CLEAN, no findings (no fix commit needed). Panel run inline (Saboteur · Future-Maintainer · Security · Completeness) — dispatched sub-agent has no Agent tool, the documented fallback. Saboteur: no mobile dead-end (Sheet still serves <lg), no new state/async/writes. Future-Maintainer: "why" comments + test seam match the sibling convention. Security: pure client-side layout, no trust boundary touched. Completeness: all 4 acceptance criteria met, no `selectedCities` passed (per ticket), `TagFacetPanel` untouched.

Closes PSY-1001
