### PR TITLE
PSY-1002: adopt top-bar tag filter on /releases

### DIFF
--- a/frontend/features/releases/components/ReleaseList.test.tsx
+++ b/frontend/features/releases/components/ReleaseList.test.tsx
@@ -41,8 +41,13 @@ vi.mock('@/components/shared', () => ({
   ),
 }))
 
+// Forward the `layout` prop into `data-layout` so tests can assert the
+// desktop panel renders as the top bar (PSY-1002) without re-testing the
+// real panel internals (covered by TagFacetPanel's own suite).
 vi.mock('@/features/tags', () => ({
-  TagFacetPanel: () => <div data-testid="tag-facet-panel" />,
+  TagFacetPanel: ({ layout }: { layout?: string }) => (
+    <div data-testid="tag-facet-panel" data-layout={layout ?? 'rail'} />
+  ),
   TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
   parseTagsParam: (s: string | null) => (s ? s.split(',').filter(Boolean) : []),
   buildTagsParam: (slugs: string[]) => slugs.join(','),
@@ -100,6 +105,16 @@ describe('ReleaseList', () => {
     renderWithProviders(<ReleaseList />)
     expect(screen.getByTestId('density-toggle')).toHaveTextContent(
       'comfortable'
+    )
+  })
+
+  it('renders the desktop tag filter as a top bar (PSY-1002)', () => {
+    renderWithProviders(<ReleaseList />)
+    // The desktop TagFacetPanel adopts the horizontal bar layout above a
+    // full-width list — no left rail. The mobile Sheet is unaffected.
+    expect(screen.getByTestId('tag-facet-panel')).toHaveAttribute(
+      'data-layout',
+      'bar'
     )
   })
 

--- a/frontend/features/releases/components/ReleaseList.tsx
+++ b/frontend/features/releases/components/ReleaseList.tsx
@@ -308,86 +308,87 @@ export function ReleaseList() {
         </div>
       </div>
 
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <aside className="hidden lg:block lg:w-64 lg:shrink-0">
-          <TagFacetPanel
-            selectedSlugs={selectedTags}
-            onToggle={handleTagsChange}
-            onClear={handleTagsClear}
-            heading="Filter releases by tag"
-            entityType="release"
-          />
-        </aside>
+      {/* PSY-1002: full-width top-bar tag filter above a full-width list (no
+          left rail). Desktop only — mobile uses the Sheet trigger above. */}
+      <div className="mb-4 hidden lg:block">
+        <TagFacetPanel
+          selectedSlugs={selectedTags}
+          onToggle={handleTagsChange}
+          onClear={handleTagsClear}
+          heading="Filter releases by tag"
+          entityType="release"
+          layout="bar"
+        />
+      </div>
 
-        <div className={`flex-1 min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
-          {releases.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p>
-                {hasFilters || selectedTags.length > 0
-                  ? 'No releases found matching your filters.'
-                  : 'No releases available at this time.'}
-              </p>
-              {(hasFilters || selectedTags.length > 0) && (
-                <button
-                  onClick={() => {
-                    clearFilters()
-                    if (selectedTags.length > 0) handleTagsClear()
-                  }}
-                  className="mt-4 text-primary hover:underline"
-                >
-                  View all releases
-                </button>
-              )}
-            </div>
-          ) : (
-            <div className="@container">
-              <div
-                className={
-                  density === 'compact'
-                    ? 'flex flex-col gap-px'
-                    : density === 'expanded'
-                      ? 'grid grid-cols-1 gap-5'
-                      : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-                }
+      <div className={`min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
+        {releases.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {hasFilters || selectedTags.length > 0
+                ? 'No releases found matching your filters.'
+                : 'No releases available at this time.'}
+            </p>
+            {(hasFilters || selectedTags.length > 0) && (
+              <button
+                onClick={() => {
+                  clearFilters()
+                  if (selectedTags.length > 0) handleTagsClear()
+                }}
+                className="mt-4 text-primary hover:underline"
               >
-                {releases.map(release => (
-                  <ReleaseCard
-                    key={release.id}
-                    release={release}
-                    density={density}
-                  />
-                ))}
-              </div>
+                View all releases
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="@container">
+            <div
+              className={
+                density === 'compact'
+                  ? 'flex flex-col gap-px'
+                  : density === 'expanded'
+                    ? 'grid grid-cols-1 gap-5'
+                    : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+              }
+            >
+              {releases.map(release => (
+                <ReleaseCard
+                  key={release.id}
+                  release={release}
+                  density={density}
+                />
+              ))}
             </div>
-          )}
+          </div>
+        )}
 
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-center gap-2 mt-8">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={currentPage <= 1}
-                onClick={() => handlePageChange(currentPage - 1)}
-              >
-                <ChevronLeft className="h-4 w-4 mr-1" />
-                Previous
-              </Button>
-              <span className="text-sm text-muted-foreground px-3">
-                Page {currentPage} of {totalPages}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={currentPage >= totalPages}
-                onClick={() => handlePageChange(currentPage + 1)}
-              >
-                Next
-                <ChevronRight className="h-4 w-4 ml-1" />
-              </Button>
-            </div>
-          )}
-        </div>
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 mt-8">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage <= 1}
+              onClick={() => handlePageChange(currentPage - 1)}
+            >
+              <ChevronLeft className="h-4 w-4 mr-1" />
+              Previous
+            </Button>
+            <span className="text-sm text-muted-foreground px-3">
+              Page {currentPage} of {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage >= totalPages}
+              onClick={() => handlePageChange(currentPage + 1)}
+            >
+              Next
+              <ChevronRight className="h-4 w-4 ml-1" />
+            </Button>
+          </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary

Adopt the shared top-bar tag filter on `/releases` (Variant A, locked 2026-06-06). This is a mechanical adoption of the bar mode shipped in PSY-1000 (#1017) on `/shows`.

`ReleaseList` rendered the shared `TagFacetPanel` in a left rail (`lg:flex-row` + `aside lg:w-64` + `flex-1`), which left a large empty left column and squeezed the release grid into a narrow strip. This restructures it to a full-width horizontal top bar (`layout="bar"`, wrapped in `hidden lg:block`) above a full-width release grid — same data and behavior, just the container layout. Unlike `/shows`, `/releases` passes no `selectedCities` (simpler).

Same data + behavior preserved: live per-entity counts (`entityType="release"`), zero-result facet hiding + the "show all tags" expander, selection, and AND/ANY tag-match. The mobile `TagFacetSheet` is unchanged (the bar is desktop-only).

## Test plan

- [x] `cd frontend && bun run typecheck` — pass (`tsc --noEmit`, clean)
- [x] `cd frontend && bun run lint` — pass (0 errors; only pre-existing warnings, none in `ReleaseList`)
- [x] `cd frontend && bun run test:run features/releases features/tags` — pass (23 files, 417 tests, incl. the new bar-layout test)

## Manual repro

Ran the per-worktree dispatch stack (escalated to isolated; no shared `:8080` backend). Seeded 3 genre tags applied to releases with varied counts (Emo→3, Punk→2, Shoegaze→1) so the facet had real data, then drove an isolated browser at 1440px:

- Desktop (`lg`, 1440px): `data-layout="bar"`, heading "Filter releases by tag", chips with counts (Emo 3 / Punk 2 / Shoegaze 1), no `aside.lg:w-64` rail, full-width 3-column grid, 5 releases.
- Selecting **Emo**: URL → `/releases?tags=emo`, chip `aria-pressed=true`, "Clear all" appears, count → "3 releases matching emo", list narrows to the 3 Emo-tagged releases. Confirms counts + selection + filtering work in the bar layout.
- Light + dark mode both verified.

## Screenshots

**Desktop, light mode — top bar above full-width grid (no rail):**
![light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1002-screenshots/releases-bar-light.png)

**Desktop, light mode — Emo selected → "3 releases matching emo" (tag filter works):**
![light-filtered](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1002-screenshots/releases-bar-light-filtered.png)

**Desktop, dark mode — bar + chips render cleanly:**
![dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1002-screenshots/releases-bar-dark.png)

## Code review

`/code-review` (extra-high effort) ran inline (no Agent tool in a worktree). Verdict: no findings. The change is a faithful structural mirror of the canonical ShowList post-#1017 pattern — all inner JSX (empty state, grid, pagination) is byte-identical, just de-indented; no conditions/variables/behaviors changed; mobile Sheet preserved; verified `layout="bar"` API used.

## Adversarial review

`/adversarial-review` — CLEAN. Ran the 4 lenses (Saboteur · Future-Maintainer · Security · Completeness) inline (no Agent tool in a worktree; expected for a dispatched sub-agent). No CRITICAL/HIGH/MEDIUM findings. One LOW (list wrapper keeps a template-literal vs the reference's `cn()`) declined with rationale: it matches the pre-existing style in this file, so changing it would be gratuitous churn. No fixes → no separate commit.

Closes PSY-1002
