### PR TITLE
PSY-1003: adopt top-bar tag filter on /venues

### DIFF
--- a/frontend/features/venues/components/VenueList.test.tsx
+++ b/frontend/features/venues/components/VenueList.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { VenueList } from './VenueList'
+import type { VenueWithShowCount } from '../types'
+
+// Mock next/navigation
+const mockPush = vi.fn()
+const mockSearchParams = vi.fn(() => ({
+  get: vi.fn((_key: string): string | null => null),
+}))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams(),
+}))
+
+// Mock venue hooks
+const mockUseVenues = vi.fn()
+const mockUseVenueCities = vi.fn()
+vi.mock('../hooks/useVenues', () => ({
+  useVenues: (opts: unknown) => mockUseVenues(opts),
+  useVenueCities: () => mockUseVenueCities(),
+}))
+
+// PSY-1003: mock the tag facet components. The TagFacetPanel mock echoes the
+// `layout` prop into `data-layout` so the test can assert the bar layout via
+// the same `data-layout="bar|rail"` seam the real component exposes.
+vi.mock('@/features/tags', () => ({
+  TagFacetPanel: ({ layout = 'rail' }: { layout?: 'rail' | 'bar' }) => (
+    <div data-testid="tag-facet-panel" data-layout={layout} />
+  ),
+  TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
+  parseTagsParam: (s: string | null) => (s ? s.split(',').filter(Boolean) : []),
+  buildTagsParam: (slugs: string[]) => slugs.join(','),
+}))
+
+// Mock child components
+vi.mock('./VenueCard', () => ({
+  VenueCard: ({ venue }: { venue: VenueWithShowCount }) => (
+    <article data-testid={`venue-card-${venue.id}`}>{venue.name}</article>
+  ),
+}))
+
+vi.mock('./VenueSearch', () => ({
+  VenueSearch: () => <div data-testid="venue-search" />,
+}))
+
+vi.mock('@/components/filters', () => ({
+  CityFilters: () => <div data-testid="city-filters" />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner" />,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}))
+
+function makeVenue(overrides: Partial<VenueWithShowCount> = {}): VenueWithShowCount {
+  return {
+    id: 1,
+    slug: 'test-venue',
+    name: 'Test Venue',
+    address: null,
+    city: 'Phoenix',
+    state: 'AZ',
+    verified: true,
+    upcoming_show_count: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('VenueList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSearchParams.mockReturnValue({
+      get: vi.fn((_key: string): string | null => null),
+    })
+    mockUseVenueCities.mockReturnValue({
+      data: { cities: [] },
+      isLoading: false,
+      isFetching: false,
+    })
+  })
+
+  function mockVenues(venues: VenueWithShowCount[], total = venues.length) {
+    mockUseVenues.mockReturnValue({
+      data: { venues, total, limit: 50, offset: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  }
+
+  describe('top-bar tag filter layout (PSY-1003)', () => {
+    it('renders the tag facet panel in bar layout, not the rail', () => {
+      mockVenues([makeVenue()])
+      render(<VenueList />)
+      // Only the desktop top-bar panel exists (the Sheet is a separate stub).
+      const panel = screen.getByTestId('tag-facet-panel')
+      expect(panel).toHaveAttribute('data-layout', 'bar')
+    })
+
+    it('does not render a left-rail aside wrapper', () => {
+      mockVenues([makeVenue()])
+      const { container } = render(<VenueList />)
+      // The pre-PSY-1003 layout wrapped the panel in `<aside class="lg:w-64">`.
+      // The bar layout drops that rail entirely.
+      expect(container.querySelector('aside.lg\\:w-64')).toBeNull()
+      // And the list column no longer uses the 2-column `flex-1` rail child.
+      expect(container.querySelector('.flex-1')).toBeNull()
+    })
+  })
+
+  describe('list rendering', () => {
+    it('renders a card per venue', () => {
+      mockVenues([
+        makeVenue({ id: 1, name: 'Venue One' }),
+        makeVenue({ id: 2, name: 'Venue Two' }),
+      ])
+      render(<VenueList />)
+      expect(screen.getByTestId('venue-card-1')).toBeInTheDocument()
+      expect(screen.getByTestId('venue-card-2')).toBeInTheDocument()
+    })
+
+    it('shows the venue count', () => {
+      mockVenues([makeVenue()], 1)
+      render(<VenueList />)
+      expect(screen.getByTestId('venue-count')).toHaveTextContent('1 of 1 venue')
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows the default empty message with no filters', () => {
+      mockVenues([], 0)
+      render(<VenueList />)
+      expect(
+        screen.getByText('No venues available at this time.')
+      ).toBeInTheDocument()
+    })
+
+    it('shows the filtered empty message when a tag is selected', () => {
+      mockSearchParams.mockReturnValue({
+        get: vi.fn((key: string): string | null =>
+          key === 'tags' ? 'punk' : null
+        ),
+      })
+      mockVenues([], 0)
+      render(<VenueList />)
+      expect(
+        screen.getByText('No venues match the current filters.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('error state', () => {
+    it('shows error message and retry on failure', async () => {
+      const mockRefetch = vi.fn()
+      mockUseVenues.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isFetching: false,
+        error: new Error('Network error'),
+        refetch: mockRefetch,
+      })
+      const user = userEvent.setup()
+      render(<VenueList />)
+      expect(
+        screen.getByText('Failed to load venues. Please try again later.')
+      ).toBeInTheDocument()
+      await user.click(screen.getByText('Retry'))
+      expect(mockRefetch).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/features/venues/components/VenueList.tsx
+++ b/frontend/features/venues/components/VenueList.tsx
@@ -142,6 +142,8 @@ export function VenueList() {
         )}
       </div>
 
+      {/* Mobile: Sheet trigger row. Desktop hides the Sheet (the bar below
+          takes over). */}
       <div className="flex items-center justify-between mb-4 gap-2">
         <TagFacetSheet
           selectedSlugs={selectedTags}
@@ -152,70 +154,71 @@ export function VenueList() {
         />
       </div>
 
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <aside className="hidden lg:block lg:w-64 lg:shrink-0">
-          <TagFacetPanel
-            selectedSlugs={selectedTags}
-            onToggle={handleTagsChange}
-            onClear={handleTagsClear}
-            heading="Filter venues by tag"
-            entityType="venue"
-          />
-        </aside>
+      {/* PSY-1003: full-width top-bar tag filter above a full-width list (no
+          left rail). Desktop only — mobile uses the Sheet trigger above. */}
+      <div className="mb-4 hidden lg:block">
+        <TagFacetPanel
+          selectedSlugs={selectedTags}
+          onToggle={handleTagsChange}
+          onClear={handleTagsClear}
+          heading="Filter venues by tag"
+          entityType="venue"
+          layout="bar"
+        />
+      </div>
 
-        <div className={`flex-1 min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
-          {(() => {
-            const allVenues = [...accumulatedVenues, ...(data?.venues || [])]
-            const hasAnyFilter = selectedTags.length > 0 || selectedCities.length > 0
-            return (
-              <>
-                <p className="mb-3 text-sm text-muted-foreground" data-testid="venue-count">
-                  {allVenues.length} of {data?.total ?? allVenues.length}{' '}
-                  {(data?.total ?? allVenues.length) === 1 ? 'venue' : 'venues'}
-                  {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
-                </p>
-                {allVenues.length === 0 ? (
-                  <div className="text-center py-12 text-muted-foreground">
-                    <p>
-                      {hasAnyFilter
-                        ? 'No venues match the current filters.'
-                        : 'No venues available at this time.'}
-                    </p>
-                    {hasAnyFilter && (
-                      <button
-                        onClick={() => {
-                          if (selectedTags.length > 0) handleTagsClear()
-                          if (selectedCities.length > 0) handleFilterChange([])
-                        }}
-                        className="mt-4 text-primary hover:underline"
+      <div className={`min-w-0 ${isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}`}>
+        {(() => {
+          const allVenues = [...accumulatedVenues, ...(data?.venues || [])]
+          const hasAnyFilter = selectedTags.length > 0 || selectedCities.length > 0
+          return (
+            <>
+              <p className="mb-3 text-sm text-muted-foreground" data-testid="venue-count">
+                {allVenues.length} of {data?.total ?? allVenues.length}{' '}
+                {(data?.total ?? allVenues.length) === 1 ? 'venue' : 'venues'}
+                {selectedTags.length > 0 && ` matching ${selectedTags.join(', ')}`}
+              </p>
+              {allVenues.length === 0 ? (
+                <div className="text-center py-12 text-muted-foreground">
+                  <p>
+                    {hasAnyFilter
+                      ? 'No venues match the current filters.'
+                      : 'No venues available at this time.'}
+                  </p>
+                  {hasAnyFilter && (
+                    <button
+                      onClick={() => {
+                        if (selectedTags.length > 0) handleTagsClear()
+                        if (selectedCities.length > 0) handleFilterChange([])
+                      }}
+                      className="mt-4 text-primary hover:underline"
+                    >
+                      Clear filters
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <>
+                  {allVenues.map(venue => (
+                    <VenueCard key={venue.id} venue={venue} />
+                  ))}
+
+                  {data && allVenues.length < data.total && (
+                    <div className="text-center py-6">
+                      <Button
+                        variant="outline"
+                        onClick={handleLoadMore}
+                        disabled={isFetching}
                       >
-                        Clear filters
-                      </button>
-                    )}
-                  </div>
-                ) : (
-                  <>
-                    {allVenues.map(venue => (
-                      <VenueCard key={venue.id} venue={venue} />
-                    ))}
-
-                    {data && allVenues.length < data.total && (
-                      <div className="text-center py-6">
-                        <Button
-                          variant="outline"
-                          onClick={handleLoadMore}
-                          disabled={isFetching}
-                        >
-                          {isFetching ? 'Loading...' : 'Load More'}
-                        </Button>
-                      </div>
-                    )}
-                  </>
-                )}
-              </>
-            )
-          })()}
-        </div>
+                        {isFetching ? 'Loading...' : 'Load More'}
+                      </Button>
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          )
+        })()}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary

Adopt the top-bar tag filter (`layout="bar"`) on `/venues`, mirroring the
PSY-1000 / #1017 restructure of `/shows`. The page previously rendered the
shared `TagFacetPanel` in a left rail (`lg:flex-row` + `aside lg:w-64` +
`flex-1` list), which left a large empty column and squeezed the venue list
into a narrow strip. The bar layout reclaims that width: a full-width
horizontal filter bar sits above a full-width list.

This is a mechanical adoption of the reference shipped in #1017 — it reuses the
existing `layout="bar"` mode of the shared panel, with no changes to
`TagFacetPanel`. Same data + behavior in both modes: live per-entity counts,
PSY-484 zero-count hiding with the "show all tags" expander, selection, and
Clear all. The desktop bar is `hidden lg:block`; mobile continues to use the
Sheet trigger above. Unlike `/shows`, `/venues` passes no `selectedCities`.

Files changed (2): `frontend/features/venues/components/VenueList.tsx`
(restructure) and a new `frontend/features/venues/components/VenueList.test.tsx`
(asserts the bar layout via the `data-layout` seam, plus list / count / empty /
error coverage).

## Test plan

- [x] `cd frontend && bun run typecheck` — clean (`tsc --noEmit`)
- [x] `cd frontend && bun run lint` — 0 errors (155 pre-existing warnings, none new beyond the underscore-unused-param convention already used in the sibling ShowList test)
- [x] `cd frontend && bun run test:run features/venues features/tags` — 427/427 passed (25 files). One non-deterministic `waitFor` flake in `EntityTagList.test.tsx` appeared on the first parallel run; it passes in isolation and on full-suite re-run, and is unrelated to this change (that file does not import VenueList).
- [x] New `VenueList.test.tsx` — 7/7 passed (bar-layout seam, no-rail-aside, list render, count, empty states, error/retry)

## Manual repro

Brought up a per-worktree dispatch stack (auto-escalated to isolated mode — no
shared `:8080` backend), seeded data, and exercised `/venues` via
chrome-devtools. Verified on the rendered page:

- `TagFacetPanel` renders with `data-layout="bar"` inside the `mb-4 hidden lg:block` top-bar wrapper; no `aside.lg:w-64` rail present.
- Heading "Filter venues by tag" + "Show all tags" expander render; list shows "10 of 10 venues" full-width below the bar (no empty column).
- Counts / zero-count hiding preserved (PSY-484): no genre chips have venue-usage > 0 in the seed, so they are hidden by default and revealed via "Show all tags".
- Tag filtering drives the list: navigating to `/venues?tags=indie-rock` updates the count to "0 of 0 venues matching indie-rock" and surfaces a "Clear all" control in the bar.

## Screenshots

![Venues bar filter — light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1003-screenshots/venues-bar-light.png)
*Light mode: full-width "Filter venues by tag" bar above a full-width venue list, no left rail.*

![Venues bar filter — dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1003-screenshots/venues-bar-dark.png)
*Dark mode: same full-width bar + list layout.*

## Code review

`/code-review` (xhigh, run inline — dispatched sub-agent has no Agent tool) over
the 9 finder angles + sweep: **no findings**. The change is a faithful
mechanical mirror of the canonical #1017 pattern; the removed rail wrapper's
behavior (counts, zero-count hiding, selection, `min-w-0` overflow guard,
`isUpdating` opacity) is fully re-established on the bar layout. The new test's
`.flex-1` null-assertion is correctly scoped (layout chrome is not in the unit
render tree). No fix commit needed.

## Adversarial review

`/adversarial-review` — **CLEAN**, no findings addressed (no fix commit needed).
Panel: Saboteur · Future-Maintainer · Security · Completeness. Run inline (no
Agent tool in a dispatch worktree) against the branch diff. Saboteur found no
new boundary/race/state failures (nullish guards + pagination guard preserved
verbatim; mobile Sheet path intact). Future-Maintainer: convention-adherent
mirror of /shows, "why" comments present. Security: pure client-side layout, no
new surface. Completeness: all four acceptance criteria met.

Closes PSY-1003
