### PR TITLE
PSY-1008: entity_requests fulfillment + created_entity_id + dedup

### DIFF
--- a/backend/db/migrations/20260607015616_entity_requests_fulfillment_source_dedup.down.sql
+++ b/backend/db/migrations/20260607015616_entity_requests_fulfillment_source_dedup.down.sql
@@ -1,0 +1,8 @@
+-- PSY-1008: reverse the fulfillment-outcome / source-context / dedup additions.
+-- Order: drop the index first, then the columns. IF EXISTS guards keep the
+-- down→up round-trip (CI's migrate down -all → up) idempotent.
+
+DROP INDEX IF EXISTS uq_entity_requests_pending_dedup;
+
+ALTER TABLE entity_requests DROP COLUMN IF EXISTS source_detail;
+ALTER TABLE entity_requests DROP COLUMN IF EXISTS created_entity_id;

--- a/backend/db/migrations/20260607015616_entity_requests_fulfillment_source_dedup.up.sql
+++ b/backend/db/migrations/20260607015616_entity_requests_fulfillment_source_dedup.up.sql
@@ -1,0 +1,45 @@
+-- PSY-1008: entity_requests — record fulfillment outcome, carry AI source
+-- context, and dedup duplicate pending requests. Builds on PSY-869's table
+-- (20260601000000_create_entity_requests) + PSY-997's HTTP endpoints.
+--
+-- Multi-statement file ⇒ golang-migrate v4 wraps it in a transaction, so the
+-- index below is a plain CREATE (NOT CONCURRENTLY — that can't run in a txn;
+-- see 20260528172125_radio_plays_unique_index for the single-statement
+-- CONCURRENTLY case). entity_requests is a small, recently-created dogfood
+-- table, so a transactional index build does not lock meaningful write traffic.
+
+-- created_entity_id: the catalog entity row created when this request was
+-- fulfilled (auto-approve create OR admin approve). It is a CROSS-TYPE id —
+-- it points into one of several catalog tables (artists/venues/labels/...),
+-- discriminated by entity_type — so there is intentionally NO foreign key.
+-- NULL means: still pending, rejected, or an ORPHANED approval (approved but
+-- fulfillment failed / was deferred, e.g. show/festival). The admin queue
+-- (PSY-871) uses (decision_state = 'approved' AND created_entity_id IS NULL)
+-- to surface approvals that still need a real entity created.
+ALTER TABLE entity_requests
+    ADD COLUMN created_entity_id BIGINT;
+
+-- source_detail: optional structured context for the request's origin (chiefly
+-- AI extraction): the source article URL + excerpt the requester saw, so the
+-- admin moderation surface can show the requester's intent for AI-origin rows.
+-- Typed in Go (community.EntityRequestSourceDetail) and stored opaquely as
+-- JSONB, mirroring the `payload` column's polymorphism-in-table /
+-- typing-in-Go convention. Distinct from source_context (the origin enum).
+ALTER TABLE entity_requests
+    ADD COLUMN source_detail JSONB;
+
+-- Dedup: at most one PENDING request per (entity_type, requester, normalized
+-- name). Partial (pending-only) so a user can legitimately re-request after a
+-- prior request was approved or rejected. The name is the lower(trim(...)) of
+-- the payload's name-or-title field — artist/venue/label/festival carry 'name',
+-- release/show carry 'title' — extracted with the immutable jsonb ->> operator
+-- so the expression is index-eligible. Auto-approved rows are never 'pending',
+-- so this index does NOT constrain the auto-approve path (dedup there is the
+-- frontend match-before-queue step + the catalog's own concern).
+CREATE UNIQUE INDEX uq_entity_requests_pending_dedup
+    ON entity_requests (
+        entity_type,
+        requester_id,
+        (lower(trim(coalesce(payload->>'name', payload->>'title'))))
+    )
+    WHERE decision_state = 'pending';

--- a/backend/internal/api/handlers/community/entity_request.go
+++ b/backend/internal/api/handlers/community/entity_request.go
@@ -59,12 +59,19 @@ func NewEntityRequestHandler(
 // the handler only enforces it is present + non-empty here.
 type CreateEntityRequestRequest struct {
 	Body struct {
-		EntityType    string          `json:"entity_type" doc:"Entity type to request (artist, venue, label, release, show, festival)"`
-		Payload       json.RawMessage `json:"payload" doc:"Typed creation payload for the entity_type"`
-		SourceContext string          `json:"source_context" required:"false" doc:"How the request originated (ai_extraction, paste_mode, manual); defaults to manual"`
-		Confirmed     bool            `json:"confirmed" required:"false" doc:"FE-side confirm step (only relevant to trusted_contributor tier)"`
+		EntityType    string                                `json:"entity_type" doc:"Entity type to request (artist, venue, label, release, show, festival)"`
+		Payload       json.RawMessage                       `json:"payload" doc:"Typed creation payload for the entity_type"`
+		SourceContext string                                `json:"source_context" required:"false" doc:"How the request originated (ai_extraction, paste_mode, manual); defaults to manual"`
+		SourceDetail  *communitym.EntityRequestSourceDetail `json:"source_detail" required:"false" doc:"Optional origin context (source URL + excerpt), chiefly for AI extraction; shown in the admin moderation queue"`
+		Confirmed     bool                                  `json:"confirmed" required:"false" doc:"FE-side confirm step (only relevant to trusted_contributor tier)"`
 	}
 }
+
+// Defensive caps for the optional source_detail fields at the trust boundary.
+const (
+	maxSourceURLLen     = 2048
+	maxSourceExcerptLen = 10000
+)
 
 // CreateEntityRequestResponse is the Huma response for POST /entity-requests.
 type CreateEntityRequestResponse struct {
@@ -111,7 +118,15 @@ func (h *EntityRequestHandler) CreateEntityRequestHandler(ctx context.Context, r
 		return nil, huma.Error422UnprocessableEntity("Invalid payload for " + entityType + ": " + err.Error())
 	}
 
-	created, err := h.entityRequestService.CreateRequest(user, entityType, req.Body.Payload, sourceContext, req.Body.Confirmed)
+	// Normalize the optional source detail (trim, drop empties) and cap its
+	// fields at the trust boundary. An all-empty detail becomes nil so the row
+	// stores NULL rather than an empty object.
+	sourceDetail, err := normalizeSourceDetail(req.Body.SourceDetail)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := h.entityRequestService.CreateRequest(user, entityType, req.Body.Payload, sourceContext, sourceDetail, req.Body.Confirmed)
 	if err != nil {
 		if mapped := shared.MapEntityRequestError(err); mapped != nil {
 			return nil, mapped
@@ -125,6 +140,42 @@ func (h *EntityRequestHandler) CreateEntityRequestHandler(ctx context.Context, r
 		return nil, huma.Error500InternalServerError("Failed to create entity request")
 	}
 
+	// Auto-approve fulfillment (PSY-1008): when a trusted tier's request lands
+	// already-approved (the service stamped it), create the catalog entity now
+	// and stamp created_entity_id onto the returned row so the frontend can
+	// stage the new entity in the same step (true inline create-and-add). The
+	// CreatedEntityID == nil guard skips the idempotent-dedup path, which only
+	// ever returns an existing PENDING row (never approved/fulfilled).
+	if created.DecisionState == communitym.EntityRequestStateApproved && created.CreatedEntityID == nil {
+		if _, ferr := h.fulfillAndRecord(ctx, created); ferr != nil {
+			if isFulfillUnsupported(ferr) {
+				// show/festival auto-approve: the request is filed-and-approved,
+				// but its catalog Create needs associations the payload lacks
+				// (PSY-998). Leave it approved-but-unfulfilled (created_entity_id
+				// NULL → surfaced by the admin queue) instead of failing the
+				// whole request.
+				logger.FromContext(ctx).Warn("entity_request_autoapprove_fulfill_deferred",
+					"request_id", created.ID,
+					"entity_type", created.EntityType,
+				)
+			} else {
+				// Real fulfillment failure. The row is already approved; surface
+				// so the requester knows the entity was NOT created (and the
+				// staging step won't happen) rather than returning a misleading
+				// success with no created_entity_id.
+				logger.FromContext(ctx).Error("entity_request_autoapprove_fulfill_failed",
+					"request_id", created.ID,
+					"entity_type", created.EntityType,
+					"error", ferr.Error(),
+				)
+				if mapped := shared.MapEntityRequestError(ferr); mapped != nil {
+					return nil, mapped
+				}
+				return nil, huma.Error500InternalServerError("Request approved but creating the entity failed: " + ferr.Error())
+			}
+		}
+	}
+
 	// Fire-and-forget audit log. Distinguish auto-approved (trusted tiers) from
 	// queued so the activity feed reads correctly.
 	if h.auditLogService != nil {
@@ -134,12 +185,16 @@ func (h *EntityRequestHandler) CreateEntityRequestHandler(ctx context.Context, r
 		}
 		reqID := created.ID
 		state := string(created.DecisionState)
+		metadata := map[string]interface{}{
+			"request_id":     reqID,
+			"source_context": sourceContext,
+			"decision_state": state,
+		}
+		if created.CreatedEntityID != nil {
+			metadata["created_entity_id"] = *created.CreatedEntityID
+		}
 		servicesshared.GoSafe(ctx, "audit_log", func() {
-			h.auditLogService.LogAction(user.ID, action, entityType, reqID, map[string]interface{}{
-				"request_id":     reqID,
-				"source_context": sourceContext,
-				"decision_state": state,
-			})
+			h.auditLogService.LogAction(user.ID, action, entityType, reqID, metadata)
 		})
 	}
 
@@ -281,11 +336,13 @@ func (h *EntityRequestHandler) AdminDecideEntityRequestHandler(ctx context.Conte
 	resp.Body.Request = decided
 
 	if newState == communitym.EntityRequestStateApproved {
-		createdID, err := h.fulfillEntity(decided)
+		createdID, err := h.fulfillAndRecord(ctx, decided)
 		if err != nil {
 			// The row is already approved (claimed). Surface the fulfillment
 			// failure so the admin knows the entity was NOT created and can act,
-			// rather than silently returning success.
+			// rather than silently returning success. FulfillUnsupported
+			// (show/festival) maps to a 422 via MapEntityRequestError so the
+			// admin creates those manually (PSY-998).
 			logger.FromContext(ctx).Error("entity_request_fulfill_failed",
 				"request_id", requestID,
 				"admin_id", admin.ID,
@@ -323,4 +380,60 @@ func (h *EntityRequestHandler) AdminDecideEntityRequestHandler(ctx context.Conte
 	}
 
 	return resp, nil
+}
+
+// ============================================================================
+// Shared fulfillment + request-body helpers (PSY-1008)
+// ============================================================================
+
+// fulfillAndRecord creates the catalog entity from an approved request's payload
+// (via the per-type dispatcher) and persists created_entity_id back onto the
+// request row. It sets req.CreatedEntityID so the response body reflects the new
+// entity even if the persistence write fails — best-effort: the entity WAS
+// created, so surfacing a 500 there would wrongly imply it wasn't. The
+// fulfillEntity error is returned verbatim (including the typed
+// FulfillUnsupported for show/festival) so callers classify it via
+// isFulfillUnsupported. Used by both the auto-approve create path and the admin
+// approve path so they record fulfillment identically.
+func (h *EntityRequestHandler) fulfillAndRecord(ctx context.Context, req *communitym.EntityRequest) (uint, error) {
+	createdID, err := h.fulfillEntity(req)
+	if err != nil {
+		return 0, err
+	}
+	idCopy := createdID
+	req.CreatedEntityID = &idCopy
+	if rerr := h.entityRequestService.RecordFulfillment(req.ID, createdID); rerr != nil {
+		// The entity WAS created; only the link-back write failed. Log loudly
+		// and continue — the response already carries created_entity_id (set
+		// above), and the row's created_entity_id is reconcilable later.
+		logger.FromContext(ctx).Error("entity_request_record_fulfillment_failed",
+			"request_id", req.ID,
+			"created_entity_id", createdID,
+			"entity_type", req.EntityType,
+			"error", rerr.Error(),
+		)
+	}
+	return createdID, nil
+}
+
+// normalizeSourceDetail trims + length-caps the optional source detail and
+// marshals it to JSONB bytes for storage. Returns (nil, nil) when there is no
+// usable content (so the row stores NULL, not an empty object), or a 422 when a
+// field exceeds its cap.
+func normalizeSourceDetail(in *communitym.EntityRequestSourceDetail) ([]byte, error) {
+	clean, ok := in.Normalize()
+	if !ok {
+		return nil, nil
+	}
+	if clean.URL != nil && len(*clean.URL) > maxSourceURLLen {
+		return nil, huma.Error422UnprocessableEntity("source_detail.url exceeds maximum length")
+	}
+	if clean.Excerpt != nil && len(*clean.Excerpt) > maxSourceExcerptLen {
+		return nil, huma.Error422UnprocessableEntity("source_detail.excerpt exceeds maximum length")
+	}
+	b, err := json.Marshal(clean)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to encode source detail")
+	}
+	return b, nil
 }

--- a/backend/internal/api/handlers/community/entity_request.go
+++ b/backend/internal/api/handlers/community/entity_request.go
@@ -168,7 +168,10 @@ func (h *EntityRequestHandler) CreateEntityRequestHandler(ctx context.Context, r
 					"entity_type", created.EntityType,
 					"error", ferr.Error(),
 				)
-				if mapped := shared.MapEntityRequestError(ferr); mapped != nil {
+				// A duplicate catalog entity (e.g. ArtistExists) maps to 409 here,
+				// not 500 — inline create-and-add of an already-existing entity is
+				// a benign conflict, not a server fault.
+				if mapped := mapFulfillmentError(ferr); mapped != nil {
 					return nil, mapped
 				}
 				return nil, huma.Error500InternalServerError("Request approved but creating the entity failed: " + ferr.Error())
@@ -341,15 +344,15 @@ func (h *EntityRequestHandler) AdminDecideEntityRequestHandler(ctx context.Conte
 			// The row is already approved (claimed). Surface the fulfillment
 			// failure so the admin knows the entity was NOT created and can act,
 			// rather than silently returning success. FulfillUnsupported
-			// (show/festival) maps to a 422 via MapEntityRequestError so the
-			// admin creates those manually (PSY-998).
+			// (show/festival) maps to 422 and a duplicate catalog entity to 409
+			// via mapFulfillmentError; only an unrecognized fault falls to 500.
 			logger.FromContext(ctx).Error("entity_request_fulfill_failed",
 				"request_id", requestID,
 				"admin_id", admin.ID,
 				"entity_type", decided.EntityType,
 				"error", err.Error(),
 			)
-			if mapped := shared.MapEntityRequestError(err); mapped != nil {
+			if mapped := mapFulfillmentError(err); mapped != nil {
 				return nil, mapped
 			}
 			return nil, huma.Error500InternalServerError("Request approved but creating the entity failed: " + err.Error())

--- a/backend/internal/api/handlers/community/entity_request_fulfill.go
+++ b/backend/internal/api/handlers/community/entity_request_fulfill.go
@@ -1,10 +1,28 @@
 package community
 
 import (
+	"errors"
+
 	apperrors "psychic-homily-backend/internal/errors"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
 )
+
+// isFulfillUnsupported reports whether err is the typed "fulfillment
+// unsupported" error fulfillEntity returns for entity types whose catalog
+// Create contracts need associations the request payload doesn't carry
+// (show / festival; association-resolution tracked in PSY-998). Callers use it
+// to decide whether the error is fatal: the admin decide path surfaces it (422
+// → admin creates the entity manually), while the auto-approve create path
+// swallows it (the request is filed-and-approved; immediate creation is just
+// deferred).
+func isFulfillUnsupported(err error) bool {
+	var reqErr *apperrors.EntityRequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.Code == apperrors.CodeEntityRequestFulfillUnsupported
+	}
+	return false
+}
 
 // PSY-997: fulfillment dispatcher — turns an approved entity_request's typed
 // payload into a real catalog entity via the narrow fulfiller interface.

--- a/backend/internal/api/handlers/community/entity_request_fulfill.go
+++ b/backend/internal/api/handlers/community/entity_request_fulfill.go
@@ -3,6 +3,7 @@ package community
 import (
 	"errors"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	apperrors "psychic-homily-backend/internal/errors"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
@@ -22,6 +23,33 @@ func isFulfillUnsupported(err error) bool {
 		return reqErr.Code == apperrors.CodeEntityRequestFulfillUnsupported
 	}
 	return false
+}
+
+// mapFulfillmentError maps an error from fulfilling a request's payload into a
+// catalog entity to the right HTTP status. fulfillEntity surfaces two error
+// families: request-level errors (FulfillUnsupported → 422, payload corruption
+// → 500, via MapEntityRequestError) and catalog-service errors bubbled up from
+// the create (e.g. ArtistExists / LabelExists / ReleaseExists → 409). Without
+// the catalog mappers, a benign "already exists" conflict on the inline
+// create-and-add path would surface as a 500 leaking the internal error code.
+// Returns nil when err is none of these so the caller falls back to a 500.
+func mapFulfillmentError(err error) error {
+	if mapped := shared.MapEntityRequestError(err); mapped != nil {
+		return mapped
+	}
+	if mapped := shared.MapArtistError(err); mapped != nil {
+		return mapped
+	}
+	if mapped := shared.MapVenueError(err); mapped != nil {
+		return mapped
+	}
+	if mapped := shared.MapLabelError(err); mapped != nil {
+		return mapped
+	}
+	if mapped := shared.MapReleaseError(err); mapped != nil {
+		return mapped
+	}
+	return nil
 }
 
 // PSY-997: fulfillment dispatcher — turns an approved entity_request's typed

--- a/backend/internal/api/handlers/community/entity_request_test.go
+++ b/backend/internal/api/handlers/community/entity_request_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
@@ -44,6 +45,14 @@ func pendingRequest(id uint, entityType string) *communitym.EntityRequest {
 		SourceContext: communitym.EntityRequestSourceManual,
 		DecisionState: communitym.EntityRequestStatePending,
 	}
+}
+
+// approvedRequest is a pendingRequest already flipped to approved — the shape an
+// auto-approve tier's CreateRequest returns (the service stamps the decision).
+func approvedRequest(id uint, entityType string) *communitym.EntityRequest {
+	r := pendingRequest(id, entityType)
+	r.DecisionState = communitym.EntityRequestStateApproved
+	return r
 }
 
 // ============================================================================
@@ -92,7 +101,7 @@ func TestCreateEntityRequest_EmptyPayload(t *testing.T) {
 func TestCreateEntityRequest_PayloadMissingRequiredField(t *testing.T) {
 	h := NewEntityRequestHandler(
 		&testhelpers.MockEntityRequestService{
-			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
 				t.Fatal("service must NOT be called for an invalid payload")
 				return nil, nil
 			},
@@ -111,7 +120,7 @@ func TestCreateEntityRequest_PayloadMissingRequiredField(t *testing.T) {
 func TestCreateEntityRequest_PayloadUnknownField(t *testing.T) {
 	h := NewEntityRequestHandler(
 		&testhelpers.MockEntityRequestService{
-			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
 				t.Fatal("service must NOT be called for an invalid payload")
 				return nil, nil
 			},
@@ -134,7 +143,7 @@ func TestCreateEntityRequest_ContributorQueuesPending(t *testing.T) {
 	want := pendingRequest(7, "artist")
 	h := NewEntityRequestHandler(
 		&testhelpers.MockEntityRequestService{
-			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
 				if user.ID != 2 {
 					t.Errorf("expected requester 2, got %d", user.ID)
 				}
@@ -167,10 +176,229 @@ func TestCreateEntityRequest_ContributorQueuesPending(t *testing.T) {
 	}
 }
 
+// ============================================================================
+// Tests: Queue-create — auto-approve fulfillment + source detail (PSY-1008)
+// ============================================================================
+
+// An auto-approve tier's request is fulfilled inline: the catalog entity is
+// created, created_entity_id is persisted (RecordFulfillment) AND rides back on
+// the response body so the frontend can stage it (true inline create-and-add).
+func TestCreateEntityRequest_AutoApprove_FulfillsAndReturnsID(t *testing.T) {
+	approved := approvedRequest(11, "artist")
+	createCalled := false
+	recordedID := uint(0)
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
+				return approved, nil
+			},
+			RecordFulfillmentFn: func(requestID, createdEntityID uint) error {
+				if requestID != 11 {
+					t.Errorf("expected RecordFulfillment for request 11, got %d", requestID)
+				}
+				recordedID = createdEntityID
+				return nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{
+			CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+				createCalled = true
+				return &contracts.ArtistDetailResponse{ID: 77}, nil
+			},
+		},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Auto Band")
+
+	resp, err := h.CreateEntityRequestHandler(erAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !createCalled {
+		t.Error("expected fulfiller CreateArtist to be called on auto-approve")
+	}
+	if recordedID != 77 {
+		t.Errorf("expected created_entity_id 77 persisted via RecordFulfillment, got %d", recordedID)
+	}
+	if resp.Body.CreatedEntityID == nil || *resp.Body.CreatedEntityID != 77 {
+		t.Errorf("expected created_entity_id 77 on response body, got %v", resp.Body.CreatedEntityID)
+	}
+	if resp.Body.DecisionState != communitym.EntityRequestStateApproved {
+		t.Errorf("expected approved, got %s", resp.Body.DecisionState)
+	}
+}
+
+// Auto-approving a show is gracefully DEFERRED (not an error): the request is
+// filed-and-approved, but show fulfillment needs associations the payload lacks
+// (PSY-998), so no entity is created, no created_entity_id is returned, the
+// link-back is not recorded, and the create still succeeds (200).
+func TestCreateEntityRequest_AutoApprove_ShowDeferredNotError(t *testing.T) {
+	approved := approvedRequest(12, "show")
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
+				return approved, nil
+			},
+			RecordFulfillmentFn: func(requestID, createdEntityID uint) error {
+				t.Fatal("RecordFulfillment must NOT be called when fulfillment is unsupported")
+				return nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	showPayload, err := communitym.MarshalPayload(communitym.ShowRequestPayload{Title: "Big Fest", EventDate: "2026-07-01"})
+	if err != nil {
+		t.Fatalf("marshal show payload: %v", err)
+	}
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "show"
+	req.Body.Payload = showPayload
+
+	resp, err := h.CreateEntityRequestHandler(erAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("auto-approve of an unsupported type must not error, got %v", err)
+	}
+	if resp.Body.CreatedEntityID != nil {
+		t.Errorf("show fulfillment is deferred; expected no created_entity_id, got %v", resp.Body.CreatedEntityID)
+	}
+	if resp.Body.DecisionState != communitym.EntityRequestStateApproved {
+		t.Errorf("expected the request to remain approved, got %s", resp.Body.DecisionState)
+	}
+}
+
+// A real fulfillment failure (catalog error, not unsupported) on the auto-approve
+// path surfaces a 500 so the requester learns the entity was NOT created.
+func TestCreateEntityRequest_AutoApprove_FulfillFails(t *testing.T) {
+	approved := approvedRequest(13, "artist")
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
+				return approved, nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{
+			CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+				return nil, fmt.Errorf("slug collision")
+			},
+		},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boom")
+	_, err := h.CreateEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// source_detail is normalized (trimmed, empties dropped) and marshalled through
+// to the service so the admin queue can show the AI source context.
+func TestCreateEntityRequest_SourceDetailPassthrough(t *testing.T) {
+	want := pendingRequest(14, "artist")
+	var gotDetail []byte
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
+				gotDetail = sourceDetail
+				return want, nil
+			},
+		},
+		nil,
+		&testhelpers.MockAuditLogService{},
+	)
+
+	url := "  https://example.com/show  "
+	excerpt := "  Boris at The Venue  "
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	req.Body.SourceContext = communitym.EntityRequestSourceAIExtraction
+	req.Body.SourceDetail = &communitym.EntityRequestSourceDetail{URL: &url, Excerpt: &excerpt}
+
+	if _, err := h.CreateEntityRequestHandler(erUserCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDetail == nil {
+		t.Fatal("expected source_detail to be passed to the service")
+	}
+	var sd communitym.EntityRequestSourceDetail
+	if err := json.Unmarshal(gotDetail, &sd); err != nil {
+		t.Fatalf("source_detail is not valid json: %v", err)
+	}
+	if sd.URL == nil || *sd.URL != "https://example.com/show" {
+		t.Errorf("expected trimmed url, got %v", sd.URL)
+	}
+	if sd.Excerpt == nil || *sd.Excerpt != "Boris at The Venue" {
+		t.Errorf("expected trimmed excerpt, got %v", sd.Excerpt)
+	}
+}
+
+// An empty (all-blank) source_detail is normalized to nil so the row stores
+// NULL, not an empty object.
+func TestCreateEntityRequest_EmptySourceDetailDropped(t *testing.T) {
+	want := pendingRequest(15, "artist")
+	sawDetail := true
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
+				sawDetail = sourceDetail != nil
+				return want, nil
+			},
+		},
+		nil,
+		&testhelpers.MockAuditLogService{},
+	)
+
+	blank := "   "
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	req.Body.SourceDetail = &communitym.EntityRequestSourceDetail{URL: &blank}
+
+	if _, err := h.CreateEntityRequestHandler(erUserCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawDetail {
+		t.Error("expected an all-blank source_detail to normalize to nil")
+	}
+}
+
+// An over-long source_detail excerpt is rejected at the trust boundary (422)
+// before the service is called.
+func TestCreateEntityRequest_SourceDetailTooLong(t *testing.T) {
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
+				t.Fatal("service must NOT be called when source_detail is invalid")
+				return nil, nil
+			},
+		},
+		nil, nil,
+	)
+
+	huge := strings.Repeat("x", maxSourceExcerptLen+1)
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	req.Body.SourceDetail = &communitym.EntityRequestSourceDetail{Excerpt: &huge}
+	_, err := h.CreateEntityRequestHandler(erUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
 func TestCreateEntityRequest_ServiceError(t *testing.T) {
 	h := NewEntityRequestHandler(
 		&testhelpers.MockEntityRequestService{
-			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
 				return nil, fmt.Errorf("db down")
 			},
 		},
@@ -187,7 +415,7 @@ func TestCreateEntityRequest_ServiceError(t *testing.T) {
 func TestCreateEntityRequest_MapsTypedError(t *testing.T) {
 	h := NewEntityRequestHandler(
 		&testhelpers.MockEntityRequestService{
-			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
 				return nil, apperrors.ErrEntityRequestEmptyPayload("artist")
 			},
 		},

--- a/backend/internal/api/handlers/community/entity_request_test.go
+++ b/backend/internal/api/handlers/community/entity_request_test.go
@@ -299,6 +299,34 @@ func TestCreateEntityRequest_AutoApprove_FulfillFails(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 500)
 }
 
+// A catalog "already exists" conflict on the auto-approve create path maps to
+// 409, NOT 500 — inline create-and-add of an entity that already exists is a
+// benign conflict, not a server fault. (Regression guard for the adversarial
+// finding that catalog errors fell through to 500.)
+func TestCreateEntityRequest_AutoApprove_ExistsConflictIs409(t *testing.T) {
+	approved := approvedRequest(16, "artist")
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			CreateRequestFn: func(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
+				return approved, nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{
+			CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+				return nil, apperrors.ErrArtistExists("Boris")
+			},
+		},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &CreateEntityRequestRequest{}
+	req.Body.EntityType = "artist"
+	req.Body.Payload = artistPayload(t, "Boris")
+	_, err := h.CreateEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 409)
+}
+
 // source_detail is normalized (trimmed, empties dropped) and marshalled through
 // to the service so the admin queue can show the AI source context.
 func TestCreateEntityRequest_SourceDetailPassthrough(t *testing.T) {
@@ -615,6 +643,32 @@ func TestAdminDecide_ApproveFulfillFails(t *testing.T) {
 	req.Body.Decision = "approved"
 	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
 	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// A catalog "already exists" conflict on admin approve maps to 409, not 500
+// (regression guard for the adversarial finding).
+func TestAdminDecide_ApproveExistsConflictIs409(t *testing.T) {
+	decided := pendingRequest(18, "artist")
+	decided.DecisionState = communitym.EntityRequestStateApproved
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			DecideFn: func(requestID, adminID uint, newState communitym.EntityRequestDecisionState, note *string) (*communitym.EntityRequest, error) {
+				return decided, nil
+			},
+		},
+		&testhelpers.MockEntityRequestFulfiller{
+			CreateArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+				return nil, apperrors.ErrArtistExists("Boris")
+			},
+		},
+		&testhelpers.MockAuditLogService{},
+	)
+
+	req := &AdminDecideEntityRequestRequest{ID: "18"}
+	req.Body.Decision = "approved"
+	_, err := h.AdminDecideEntityRequestHandler(erAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 409)
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/shared/error_mappers.go
+++ b/backend/internal/api/handlers/shared/error_mappers.go
@@ -209,6 +209,40 @@ func MapVenueError(err error) error {
 	return nil
 }
 
+// MapLabelError converts a LabelError to an appropriate Huma HTTP error.
+// Returns nil if err is not a *apperrors.LabelError. not-found → 404;
+// already-exists → 409. Mirrors MapArtistError/MapVenueError; used by the
+// entity-request fulfillment path so a duplicate label surfaces as a 409.
+func MapLabelError(err error) error {
+	var labelErr *apperrors.LabelError
+	if errors.As(err, &labelErr) {
+		switch labelErr.Code {
+		case apperrors.CodeLabelNotFound:
+			return huma.Error404NotFound(labelErr.Message)
+		case apperrors.CodeLabelExists:
+			return huma.Error409Conflict(labelErr.Message)
+		}
+	}
+	return nil
+}
+
+// MapReleaseError converts a ReleaseError to an appropriate Huma HTTP error.
+// Returns nil if err is not a *apperrors.ReleaseError. not-found → 404;
+// already-exists → 409. Used by the entity-request fulfillment path so a
+// duplicate release surfaces as a 409.
+func MapReleaseError(err error) error {
+	var releaseErr *apperrors.ReleaseError
+	if errors.As(err, &releaseErr) {
+		switch releaseErr.Code {
+		case apperrors.CodeReleaseNotFound:
+			return huma.Error404NotFound(releaseErr.Message)
+		case apperrors.CodeReleaseExists:
+			return huma.Error409Conflict(releaseErr.Message)
+		}
+	}
+	return nil
+}
+
 // MapFestivalError converts a FestivalError to an appropriate Huma HTTP error.
 // Returns nil if err is not a *apperrors.FestivalError.
 //

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1592,18 +1592,25 @@ func (m *MockEntityRequestFulfiller) CreateRelease(req *contracts.CreateReleaseR
 // ============================================================================
 
 type MockEntityRequestService struct {
-	CreateRequestFn func(*authm.User, string, []byte, string, bool) (*communitym.EntityRequest, error)
-	GetRequestFn    func(uint) (*communitym.EntityRequest, error)
-	ListPendingFn   func(string, int, int) ([]communitym.EntityRequest, int64, error)
-	ListRequestsFn  func(*contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error)
-	DecideFn        func(uint, uint, communitym.EntityRequestDecisionState, *string) (*communitym.EntityRequest, error)
+	CreateRequestFn     func(*authm.User, string, []byte, string, []byte, bool) (*communitym.EntityRequest, error)
+	RecordFulfillmentFn func(uint, uint) error
+	GetRequestFn        func(uint) (*communitym.EntityRequest, error)
+	ListPendingFn       func(string, int, int) ([]communitym.EntityRequest, int64, error)
+	ListRequestsFn      func(*contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error)
+	DecideFn            func(uint, uint, communitym.EntityRequestDecisionState, *string) (*communitym.EntityRequest, error)
 }
 
-func (m *MockEntityRequestService) CreateRequest(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error) {
+func (m *MockEntityRequestService) CreateRequest(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error) {
 	if m.CreateRequestFn != nil {
-		return m.CreateRequestFn(user, entityType, payload, sourceContext, confirmed)
+		return m.CreateRequestFn(user, entityType, payload, sourceContext, sourceDetail, confirmed)
 	}
 	return nil, nil
+}
+func (m *MockEntityRequestService) RecordFulfillment(requestID uint, createdEntityID uint) error {
+	if m.RecordFulfillmentFn != nil {
+		return m.RecordFulfillmentFn(requestID, createdEntityID)
+	}
+	return nil
 }
 func (m *MockEntityRequestService) GetRequest(requestID uint) (*communitym.EntityRequest, error) {
 	if m.GetRequestFn != nil {

--- a/backend/internal/models/community/entity_request.go
+++ b/backend/internal/models/community/entity_request.go
@@ -2,6 +2,7 @@ package community
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"psychic-homily-backend/internal/models/auth"
@@ -34,21 +35,63 @@ const (
 // *json.RawMessage (project convention for JSONB — datatypes.JSON is not in
 // go.mod; mirrors admin.AuditLog / admin.PendingEntityEdit).
 type EntityRequest struct {
-	ID            uint                       `json:"id" gorm:"primaryKey"`
-	EntityType    string                     `json:"entity_type" gorm:"column:entity_type;not null"`
-	Payload       *json.RawMessage           `json:"payload" gorm:"column:payload;type:jsonb;not null"`
-	RequesterID   uint                       `json:"requester_id" gorm:"column:requester_id;not null"`
-	SourceContext string                     `json:"source_context" gorm:"column:source_context;not null;default:'manual'"`
+	ID            uint             `json:"id" gorm:"primaryKey"`
+	EntityType    string           `json:"entity_type" gorm:"column:entity_type;not null"`
+	Payload       *json.RawMessage `json:"payload" gorm:"column:payload;type:jsonb;not null"`
+	RequesterID   uint             `json:"requester_id" gorm:"column:requester_id;not null"`
+	SourceContext string           `json:"source_context" gorm:"column:source_context;not null;default:'manual'"`
+	// SourceDetail (PSY-1008) is optional structured origin context — chiefly
+	// the AI source article URL + excerpt — stored opaquely as JSONB and typed
+	// in Go via EntityRequestSourceDetail. NULL for requests with no source
+	// context. Distinct from SourceContext (the origin enum discriminator).
+	SourceDetail  *json.RawMessage           `json:"source_detail,omitempty" gorm:"column:source_detail;type:jsonb"`
 	DecisionState EntityRequestDecisionState `json:"decision_state" gorm:"column:decision_state;not null;default:'pending'"`
 	DecidedBy     *uint                      `json:"decided_by,omitempty" gorm:"column:decided_by"`
 	DecidedAt     *time.Time                 `json:"decided_at,omitempty" gorm:"column:decided_at"`
 	DecisionNote  *string                    `json:"decision_note,omitempty" gorm:"column:decision_note"`
-	CreatedAt     time.Time                  `json:"created_at"`
-	UpdatedAt     time.Time                  `json:"updated_at"`
+	// CreatedEntityID (PSY-1008) is the catalog entity created when this request
+	// was fulfilled (auto-approve create or admin approve). Cross-type id keyed
+	// by EntityType (no FK). NULL while pending/rejected, or when an approval is
+	// orphaned (approved but fulfillment failed/deferred — e.g. show/festival).
+	CreatedEntityID *uint     `json:"created_entity_id,omitempty" gorm:"column:created_entity_id"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 
 	// Relationships
 	Requester auth.User  `json:"-" gorm:"foreignKey:RequesterID"`
 	Decider   *auth.User `json:"-" gorm:"foreignKey:DecidedBy"`
+}
+
+// EntityRequestSourceDetail is the typed shape of the source_detail JSONB
+// column (PSY-1008): the origin context a requester saw, primarily for
+// AI-extracted requests. Both fields are optional; an all-empty detail is
+// normalized to a nil column rather than an empty object (see Normalize).
+type EntityRequestSourceDetail struct {
+	URL     *string `json:"url,omitempty" doc:"Source article / page URL the request was extracted from"`
+	Excerpt *string `json:"excerpt,omitempty" doc:"Source text excerpt the request was extracted from"`
+}
+
+// Normalize trims both fields, drops them when empty, and reports whether any
+// content remains. A detail with no content after trimming returns ok=false so
+// the caller stores NULL instead of an empty {} object. Keeps the trust-boundary
+// cleanup in the model next to the struct it cleans.
+func (d *EntityRequestSourceDetail) Normalize() (clean EntityRequestSourceDetail, ok bool) {
+	if d == nil {
+		return EntityRequestSourceDetail{}, false
+	}
+	if d.URL != nil {
+		if t := strings.TrimSpace(*d.URL); t != "" {
+			clean.URL = &t
+			ok = true
+		}
+	}
+	if d.Excerpt != nil {
+		if t := strings.TrimSpace(*d.Excerpt); t != "" {
+			clean.Excerpt = &t
+			ok = true
+		}
+	}
+	return clean, ok
 }
 
 // TableName specifies the table name for EntityRequest.

--- a/backend/internal/services/community/entityrequest.go
+++ b/backend/internal/services/community/entityrequest.go
@@ -12,6 +12,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	communitym "psychic-homily-backend/internal/models/community"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // PSY-869: EntityRequestService implements the trust-tier-gated creation flow
@@ -96,6 +97,7 @@ func (s *EntityRequestService) CreateRequest(
 	entityType string,
 	payload []byte,
 	sourceContext string,
+	sourceDetail []byte,
 	confirmed bool,
 ) (*communitym.EntityRequest, error) {
 	if s.db == nil {
@@ -122,6 +124,10 @@ func (s *EntityRequestService) CreateRequest(
 		SourceContext: sourceContext,
 		DecisionState: communitym.EntityRequestStatePending,
 	}
+	if len(sourceDetail) > 0 {
+		sd := json.RawMessage(sourceDetail)
+		req.SourceDetail = &sd
+	}
 
 	if autoApproves(user, confirmed) {
 		now := time.Now().UTC()
@@ -135,9 +141,71 @@ func (s *EntityRequestService) CreateRequest(
 	}
 
 	if err := s.db.Create(req).Error; err != nil {
+		// Dedup (PSY-1008): the partial unique index blocks a second PENDING
+		// request for the same (entity_type, requester, normalized name). Treat
+		// the collision as idempotent — return the existing pending row so a
+		// repeated paste/extraction line resolves to the same queued request
+		// instead of erroring. The index is partial on decision_state='pending',
+		// so only pending rows can collide; this never masks a clash on an
+		// already-decided row.
+		if servicesshared.IsDuplicateKey(err) {
+			if existing, ferr := s.findPendingDuplicate(entityType, user.ID, payload); ferr == nil && existing != nil {
+				return existing, nil
+			}
+		}
 		return nil, fmt.Errorf("failed to create entity request: %w", err)
 	}
 	return req, nil
+}
+
+// findPendingDuplicate returns the existing PENDING request that collides with a
+// would-be-new request on the dedup key (entity_type, requester, normalized
+// name), or (nil, nil) if none. The name comparison uses the SAME Postgres
+// expression as the uq_entity_requests_pending_dedup index —
+// lower(trim(coalesce(payload->>'name', payload->>'title'))) — applied to BOTH
+// the stored row's payload and the candidate payload, so there is no Go-vs-SQL
+// normalization mismatch (e.g. collation-sensitive lowercasing). Requester is
+// preloaded to match GetRequest's shape.
+func (s *EntityRequestService) findPendingDuplicate(entityType string, requesterID uint, payload []byte) (*communitym.EntityRequest, error) {
+	const storedName = "lower(trim(coalesce(payload->>'name', payload->>'title')))"
+	const candidateName = "lower(trim(coalesce(?::jsonb->>'name', ?::jsonb->>'title')))"
+	candidate := string(payload)
+
+	var existing communitym.EntityRequest
+	err := s.db.Preload("Requester").
+		Where("entity_type = ? AND requester_id = ? AND decision_state = ?",
+			entityType, requesterID, communitym.EntityRequestStatePending).
+		Where(storedName+" = "+candidateName, candidate, candidate).
+		First(&existing).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &existing, nil
+}
+
+// RecordFulfillment persists created_entity_id on a fulfilled request (PSY-1008).
+// The handler calls it after the fulfiller creates the catalog entity, on both
+// the auto-approve create path and the admin approve path. A scoped UPDATE of
+// the single column; created_entity_id has no FK (cross-type id keyed by
+// entity_type), so this is a plain write. Not-found is an error so a caller
+// passing a stale id learns of it rather than silently succeeding.
+func (s *EntityRequestService) RecordFulfillment(requestID, createdEntityID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	result := s.db.Model(&communitym.EntityRequest{}).
+		Where("id = ?", requestID).
+		Update("created_entity_id", createdEntityID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to record fulfillment: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return apperrors.ErrEntityRequestNotFound(requestID)
+	}
+	return nil
 }
 
 // GetRequest retrieves an entity request by ID with requester + decider

--- a/backend/internal/services/community/entityrequest.go
+++ b/backend/internal/services/community/entityrequest.go
@@ -149,6 +149,14 @@ func (s *EntityRequestService) CreateRequest(
 		// so only pending rows can collide; this never masks a clash on an
 		// already-decided row.
 		if servicesshared.IsDuplicateKey(err) {
+			// ferr is intentionally swallowed in favor of the original create
+			// error: if the lookup fails OR finds nothing, we fall through to the
+			// wrapped duplicate-key error below. The find returns nothing only in
+			// a narrow race — the colliding pending row was decided (→ no longer
+			// 'pending', so the partial index no longer covers it) between the
+			// constraint violation and this lookup. That yields a rare transient
+			// error the caller can simply retry (a retry would now succeed), not a
+			// data fault.
 			if existing, ferr := s.findPendingDuplicate(entityType, user.ID, payload); ferr == nil && existing != nil {
 				return existing, nil
 			}

--- a/backend/internal/services/community/entityrequest_test.go
+++ b/backend/internal/services/community/entityrequest_test.go
@@ -1,6 +1,7 @@
 package community
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -70,7 +71,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_NewUser_Pendin
 	user := suite.createUser("newbie", tierNewUser, false)
 
 	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
-		suite.marshalArtist("Pending Band"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Pending Band"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(req)
 
@@ -87,7 +88,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_Contributor_Pe
 	user := suite.createUser("contrib", tierContributor, false)
 
 	req, err := suite.service.CreateRequest(user, communitym.EntityRequestVenue,
-		mustMarshalVenue(suite, "The Pending Room"), communitym.EntityRequestSourcePasteMode, false)
+		mustMarshalVenue(suite, "The Pending Room"), communitym.EntityRequestSourcePasteMode, nil, false)
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(communitym.EntityRequestStatePending, req.DecisionState)
@@ -100,7 +101,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_Admin_AutoAppr
 	user := suite.createUser("boss", tierNewUser, true) // tier irrelevant; IsAdmin wins
 
 	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
-		suite.marshalArtist("Auto Approved Band"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Auto Approved Band"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(communitym.EntityRequestStateApproved, req.DecisionState)
@@ -114,7 +115,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_LocalAmbassado
 	user := suite.createUser("amb", tierLocalAmbassador, false)
 
 	req, err := suite.service.CreateRequest(user, communitym.EntityRequestLabel,
-		mustMarshalLabel(suite, "Ambassador Records"), communitym.EntityRequestSourceManual, false)
+		mustMarshalLabel(suite, "Ambassador Records"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(communitym.EntityRequestStateApproved, req.DecisionState)
@@ -127,7 +128,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_TrustedConfirm
 	user := suite.createUser("trusted", tierTrustedContributor, false)
 
 	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
-		suite.marshalArtist("Trusted Confirmed Band"), communitym.EntityRequestSourceManual, true)
+		suite.marshalArtist("Trusted Confirmed Band"), communitym.EntityRequestSourceManual, nil, true)
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(communitym.EntityRequestStateApproved, req.DecisionState)
@@ -140,7 +141,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_TrustedUnconfi
 	user := suite.createUser("trusted2", tierTrustedContributor, false)
 
 	req, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
-		suite.marshalArtist("Trusted Unconfirmed Band"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Trusted Unconfirmed Band"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(communitym.EntityRequestStatePending, req.DecisionState)
@@ -170,7 +171,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestArtistPayload_RoundTr
 	suite.Require().NoError(err)
 
 	created, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
-		raw, communitym.EntityRequestSourceManual, false)
+		raw, communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	// Re-fetch from the DB (not the in-memory struct) to prove JSONB persistence.
@@ -189,21 +190,21 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestArtistPayload_RoundTr
 func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_InvalidEntityType() {
 	user := suite.createUser("bad", tierNewUser, false)
 	_, err := suite.service.CreateRequest(user, "podcast",
-		suite.marshalArtist("X"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("X"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().Error(err)
 }
 
 func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_InvalidSourceContext() {
 	user := suite.createUser("bad2", tierNewUser, false)
 	_, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
-		suite.marshalArtist("X"), "telepathy", false)
+		suite.marshalArtist("X"), "telepathy", nil, false)
 	suite.Require().Error(err)
 }
 
 func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_EmptyPayload() {
 	user := suite.createUser("bad3", tierNewUser, false)
 	_, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
-		nil, communitym.EntityRequestSourceManual, false)
+		nil, communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().Error(err)
 }
 
@@ -215,7 +216,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_ApprovePending
 	admin := suite.createUser("mod", tierNewUser, true)
 
 	pending, err := suite.service.CreateRequest(requester, communitym.EntityRequestArtist,
-		suite.marshalArtist("Needs Review"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Needs Review"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 	suite.Require().Equal(communitym.EntityRequestStatePending, pending.DecisionState)
 
@@ -235,7 +236,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_AlreadyResolve
 
 	// Admin-created request is already approved on create.
 	approved, err := suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
-		suite.marshalArtist("Already Approved"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Already Approved"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 	suite.Require().Equal(communitym.EntityRequestStateApproved, approved.DecisionState)
 
@@ -253,7 +254,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_SecondDecision
 	admin := suite.createUser("mod4", tierNewUser, true)
 
 	pending, err := suite.service.CreateRequest(requester, communitym.EntityRequestArtist,
-		suite.marshalArtist("Contested"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Contested"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	// First decision wins: approve.
@@ -276,7 +277,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestDecide_InvalidTargetS
 	requester := suite.createUser("req2", tierNewUser, false)
 	admin := suite.createUser("mod3", tierNewUser, true)
 	pending, err := suite.service.CreateRequest(requester, communitym.EntityRequestArtist,
-		suite.marshalArtist("X"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("X"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	_, err = suite.service.Decide(pending.ID, admin.ID, communitym.EntityRequestStatePending, nil)
@@ -294,13 +295,13 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestListPending_FiltersAn
 	// One pending artist (new_user), one pending venue (new_user), one approved
 	// artist (admin auto-approve) that must NOT appear.
 	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
-		suite.marshalArtist("Pending A"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Pending A"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 	_, err = suite.service.CreateRequest(newbie, communitym.EntityRequestVenue,
-		mustMarshalVenue(suite, "Pending V"), communitym.EntityRequestSourceManual, false)
+		mustMarshalVenue(suite, "Pending V"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 	_, err = suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
-		suite.marshalArtist("Approved A"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Approved A"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	all, total, err := suite.service.ListPending("", 50, 0)
@@ -324,10 +325,10 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_DefaultP
 	admin := suite.createUser("lr-admin", tierNewUser, true)
 
 	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
-		suite.marshalArtist("LR Pending"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("LR Pending"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 	_, err = suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
-		suite.marshalArtist("LR Approved"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("LR Approved"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{})
@@ -341,7 +342,7 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_DefaultP
 func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_StateApproved() {
 	admin := suite.createUser("lr-admin2", tierNewUser, true)
 	_, err := suite.service.CreateRequest(admin, communitym.EntityRequestArtist,
-		suite.marshalArtist("LR Approved 2"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("LR Approved 2"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{
@@ -358,10 +359,10 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_SourceCo
 	newbie := suite.createUser("lr-src", tierNewUser, false)
 
 	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
-		suite.marshalArtist("Manual one"), communitym.EntityRequestSourceManual, false)
+		suite.marshalArtist("Manual one"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 	_, err = suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
-		suite.marshalArtist("Paste one"), communitym.EntityRequestSourcePasteMode, false)
+		suite.marshalArtist("Paste one"), communitym.EntityRequestSourcePasteMode, nil, false)
 	suite.Require().NoError(err)
 
 	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{
@@ -380,11 +381,11 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_EntityTy
 
 	for i := 0; i < 3; i++ {
 		_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestArtist,
-			suite.marshalArtist(fmt.Sprintf("Page artist %d", i)), communitym.EntityRequestSourceManual, false)
+			suite.marshalArtist(fmt.Sprintf("Page artist %d", i)), communitym.EntityRequestSourceManual, nil, false)
 		suite.Require().NoError(err)
 	}
 	_, err := suite.service.CreateRequest(newbie, communitym.EntityRequestVenue,
-		mustMarshalVenue(suite, "Page venue"), communitym.EntityRequestSourceManual, false)
+		mustMarshalVenue(suite, "Page venue"), communitym.EntityRequestSourceManual, nil, false)
 	suite.Require().NoError(err)
 
 	rows, total, err := suite.service.ListRequests(&contracts.EntityRequestFilters{
@@ -398,6 +399,142 @@ func (suite *EntityRequestServiceIntegrationTestSuite) TestListRequests_EntityTy
 	for _, r := range rows {
 		suite.Assert().Equal(communitym.EntityRequestArtist, r.EntityType)
 	}
+}
+
+// --- PSY-1008: dedup of duplicate PENDING requests --------------------------
+
+// A second PENDING request for the same (entity_type, requester, normalized
+// name) returns the EXISTING row idempotently — no error, no duplicate row.
+// Casing + surrounding whitespace are normalized, matching the unique index.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_DuplicatePending_ReturnsExisting() {
+	user := suite.createUser("dup", tierContributor, false)
+
+	first, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Duplicate Band"), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	suite.Require().Equal(communitym.EntityRequestStatePending, first.DecisionState)
+
+	second, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("  duplicate band  "), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(first.ID, second.ID, "duplicate pending request must resolve to the existing row")
+
+	var count int64
+	suite.Require().NoError(suite.db.Model(&communitym.EntityRequest{}).Count(&count).Error)
+	suite.Assert().Equal(int64(1), count, "no duplicate row should be created")
+}
+
+// Dedup is PENDING-only: once the prior request is decided, an identical new
+// request creates a fresh row (a user may legitimately re-request).
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_DuplicateAfterDecision_CreatesNew() {
+	user := suite.createUser("redup", tierContributor, false)
+	admin := suite.createUser("redup-admin", tierNewUser, true)
+
+	first, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Reborn Band"), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+
+	_, err = suite.service.Decide(first.ID, admin.ID, communitym.EntityRequestStateRejected, nil)
+	suite.Require().NoError(err)
+
+	second, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Reborn Band"), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	suite.Assert().NotEqual(first.ID, second.ID, "after the prior request is decided, a re-request is a new row")
+}
+
+// Dedup is per-requester: two different users requesting the same name each get
+// their own pending row.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_DuplicateAcrossRequesters_Separate() {
+	u1 := suite.createUser("dup-a", tierContributor, false)
+	u2 := suite.createUser("dup-b", tierContributor, false)
+
+	r1, err := suite.service.CreateRequest(u1, communitym.EntityRequestArtist,
+		suite.marshalArtist("Shared Name"), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	r2, err := suite.service.CreateRequest(u2, communitym.EntityRequestArtist,
+		suite.marshalArtist("Shared Name"), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	suite.Assert().NotEqual(r1.ID, r2.ID, "different requesters are not duplicates")
+}
+
+// The dedup key coalesces to the payload's TITLE for release/show (not name),
+// so two release requests with the same title dedup.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_DuplicateReleaseByTitle() {
+	user := suite.createUser("rel-dup", tierContributor, false)
+	raw, err := communitym.MarshalPayload(communitym.ReleaseRequestPayload{Title: "Same Title"})
+	suite.Require().NoError(err)
+
+	first, err := suite.service.CreateRequest(user, communitym.EntityRequestRelease, raw,
+		communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	second, err := suite.service.CreateRequest(user, communitym.EntityRequestRelease, raw,
+		communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(first.ID, second.ID, "release dedup keys on title")
+}
+
+// --- PSY-1008: source_detail persistence ------------------------------------
+
+// source_detail round-trips through the JSONB column intact.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_SourceDetail_RoundTripsThroughDB() {
+	user := suite.createUser("sd", tierNewUser, false)
+	detail, err := json.Marshal(communitym.EntityRequestSourceDetail{
+		URL:     strptr("https://example.com/article"),
+		Excerpt: strptr("Boris announced a tour."),
+	})
+	suite.Require().NoError(err)
+
+	created, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Sourced Band"), communitym.EntityRequestSourceAIExtraction, detail, false)
+	suite.Require().NoError(err)
+
+	fetched, err := suite.service.GetRequest(created.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(fetched.SourceDetail)
+
+	var sd communitym.EntityRequestSourceDetail
+	suite.Require().NoError(json.Unmarshal(*fetched.SourceDetail, &sd))
+	suite.Require().NotNil(sd.URL)
+	suite.Assert().Equal("https://example.com/article", *sd.URL)
+	suite.Require().NotNil(sd.Excerpt)
+	suite.Assert().Equal("Boris announced a tour.", *sd.Excerpt)
+}
+
+// No source_detail → the column is NULL (nil), not an empty object.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestCreate_NoSourceDetail_StoresNull() {
+	user := suite.createUser("nosd", tierNewUser, false)
+	created, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Plain Band"), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+
+	fetched, err := suite.service.GetRequest(created.ID)
+	suite.Require().NoError(err)
+	suite.Assert().Nil(fetched.SourceDetail)
+}
+
+// --- PSY-1008: RecordFulfillment --------------------------------------------
+
+// RecordFulfillment persists created_entity_id onto the request row.
+func (suite *EntityRequestServiceIntegrationTestSuite) TestRecordFulfillment_PersistsCreatedEntityID() {
+	user := suite.createUser("rf", tierNewUser, false)
+	created, err := suite.service.CreateRequest(user, communitym.EntityRequestArtist,
+		suite.marshalArtist("Fulfilled Band"), communitym.EntityRequestSourceManual, nil, false)
+	suite.Require().NoError(err)
+	suite.Require().Nil(created.CreatedEntityID)
+
+	suite.Require().NoError(suite.service.RecordFulfillment(created.ID, 4242))
+
+	fetched, err := suite.service.GetRequest(created.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(fetched.CreatedEntityID)
+	suite.Assert().Equal(uint(4242), *fetched.CreatedEntityID)
+}
+
+// RecordFulfillment on a missing request is an error (no silent success).
+func (suite *EntityRequestServiceIntegrationTestSuite) TestRecordFulfillment_NotFound() {
+	err := suite.service.RecordFulfillment(999999, 1)
+	suite.Require().Error(err)
 }
 
 // strptr is a local pointer helper for the entity-request payload fixtures.

--- a/backend/internal/services/contracts/entity_request.go
+++ b/backend/internal/services/contracts/entity_request.go
@@ -22,7 +22,17 @@ import (
 type EntityRequestServiceInterface interface {
 	// CreateRequest persists a typed entity-creation request, applying
 	// trust-tier gating to decide whether it auto-approves or queues.
-	CreateRequest(user *authm.User, entityType string, payload []byte, sourceContext string, confirmed bool) (*communitym.EntityRequest, error)
+	// sourceDetail is the optional, already-marshalled source-context JSONB
+	// (nil = none). On a duplicate PENDING request (same entity_type +
+	// requester + normalized name), it returns the EXISTING pending row
+	// idempotently rather than erroring (PSY-1008).
+	CreateRequest(user *authm.User, entityType string, payload []byte, sourceContext string, sourceDetail []byte, confirmed bool) (*communitym.EntityRequest, error)
+
+	// RecordFulfillment persists created_entity_id on a request after its
+	// payload has been fulfilled into a real catalog entity (PSY-1008). The
+	// handler calls this on both the auto-approve create path and the admin
+	// approve path once the fulfiller returns the new entity's id.
+	RecordFulfillment(requestID, createdEntityID uint) error
 
 	// GetRequest retrieves a request by ID (requester + decider preloaded);
 	// returns (nil, nil) when not found.


### PR DESCRIPTION
Closes PSY-1008.

## Summary

Backend keystone for the queue-for-review wave — makes the `entity_requests` queue actually fulfill and dedup, unblocking PSY-853's true inline create-and-add and giving PSY-871's admin queue meaningful rows.

- **Auto-approve fulfillment + `created_entity_id`.** When a trusted tier (admin / local_ambassador / confirmed trusted_contributor) queue-creates a request, the handler now fulfills the catalog entity inline (reusing the existing `fulfillEntity` dispatcher) and returns `created_entity_id` so the frontend can stage the new entity in the same step. `created_entity_id` is **persisted** on the row (new column) on both the create-auto-approve path and the admin decide-approve path (new `RecordFulfillment` service method) — the admin queue can link approved→created and flag orphaned approvals (`approved` AND `created_entity_id IS NULL`).
- **AI source context.** New optional `source_detail` JSONB column (typed `{url, excerpt}`), normalized + length-capped at the trust boundary, so the admin queue can show the AI requester's intent for `ai_extraction`-origin rows.
- **Dedup.** New partial unique index `(entity_type, requester_id, lower(trim(coalesce(payload->>'name', payload->>'title')))) WHERE decision_state='pending'`. The service catches the unique violation and returns the existing pending row **idempotently** (200) — repeated paste/extraction lines resolve to the same queued request. Partial-on-pending so a user can re-request after a prior request is decided.

show/festival auto-approve is **gracefully deferred** (200, no entity, `created_entity_id` stays NULL) since their catalog Create contracts need associations the payload lacks — tracked in **PSY-998**.

Design forks were confirmed with the owner before implementation: persist `created_entity_id` as a column, JSONB `source_detail`, idempotent (return-existing) dedup.

## Deferred (tracked elsewhere — not in this PR)

- **show/festival fulfillment** (association-resolution) → **PSY-998**.
- **Frontend create-and-add wiring** (consume `created_entity_id` to stage the new entity) and the now-stale "backend doesn't fulfill" comment in `frontend/features/collections/components/AICollectionFiller.tsx` → **PSY-853** (kept open; this PR is its backend half).

## Adversarial review

A fresh 4-agent panel (Saboteur/correctness · Security · Completeness/Future-Maintainer · Reuse/Quality/Efficiency), no prior session context, reviewed the branch diff. Verdict after fixes: **CLEAN**.

- **[HIGH]** Catalog "already exists" conflicts from the fulfillment dispatcher (`ErrArtistExists`/`ErrLabelExists`/`ErrReleaseExists`) surfaced as **HTTP 500** instead of **409** on both the new create path and the (pre-existing PSY-997) admin decide path — only `MapEntityRequestError` was consulted, which returns nil for catalog errors. → **Fixed** in `d0e3f73b`: added `MapLabelError`/`MapReleaseError` (mirroring artist/venue) + a `mapFulfillmentError` chain helper; both branches now map a duplicate entity to 409. Regression tests added on both paths.
- **[LOW]** Dedup catch-then-find TOCTOU (colliding pending row decided between the unique violation and the lookup → rare transient error the caller can retry) + intentionally-dropped lookup error → **documented** in `d0e3f73b`.
- **[NIT]** nil-guard on the fulfiller return → **considered + skipped**: the fulfiller is an internal trusted interface and the project principle is "validate at boundaries, trust internally"; a misconfigured test mock panics visibly, not silently.
- **Security: CLEAN** — no SQL injection (the dedup lookup binds the candidate payload as a `?::jsonb` param; the SQL fragments are compile-time consts), no tier bypass (`autoApproves` keys only off the DB-loaded user's `IsAdmin`/`UserTier`, never the request body), `created_entity_id` is server-set only, no cross-user leak (dedup lookup is scoped to the caller's own `requester_id`; `Requester` is `json:"-"`), `source_detail` length-capped.

## Test plan

- [x] `go build ./...` — clean
- [x] `gofmt -l` on all changed files — clean
- [x] `go vet ./internal/api/handlers/community/... ./internal/api/handlers/shared/... ./internal/services/community/...` — clean
- [x] `go test ./internal/api/handlers/community/ ./internal/services/community/` — pass (the PSY-1008 AC command set). New coverage: auto-approve fulfill returns+persists `created_entity_id`; show auto-approve graceful-defer (200, no id); real fulfill failure → 500; **catalog exists → 409 on both create and admin-decide paths**; `source_detail` passthrough/trim/empty-drop/length-cap (422); dedup idempotent return + state/requester/title-coalesce scoping; `source_detail` JSONB round-trip; `RecordFulfillment` persist + not-found.
- [x] `go test ./internal/models/community/` — pass
- [x] Migration round-trip on a throwaway Postgres 18: `migrate up` → `down -all` → `up`; `schema_migrations.version` matches the newest file; `uq_entity_requests_pending_dedup` + both columns present after re-up.
- [x] `scripts/check_entity_request_payloads.sh` (CI parity guard) — pass.
- [x] `/code-review` + `/adversarial-review` — full fresh-agent panels run against the branch diff; HIGH fixed in a separate commit (`d0e3f73b`).

No UI surface — screenshots skipped (backend-only).

## Notes on review mechanics

This branch was finished in a dedicated git worktree (the main checkout was held by a parallel session). The `/code-review` and `/adversarial-review` panels were run as fresh sub-agents pointed at this branch's diff (`git diff origin/main...HEAD`) rather than the cwd-default, so coverage is equivalent to the standard flow.
