### PR TITLE
PSY-987: backfill venue timezones + re-anchor show times + iCal

### DIFF
--- a/backend/cmd/backfill-venue-timezones/main.go
+++ b/backend/cmd/backfill-venue-timezones/main.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -60,7 +61,11 @@ func main() {
 	if confirm {
 		mode = "LIVE"
 	}
-	fmt.Printf("=== Venue Timezone Backfill (%s) — PSY-987 ===\n\n", mode)
+	fmt.Printf("=== Venue Timezone Backfill (%s) — PSY-987 ===\n", mode)
+	// Surface the resolved target so a mistargeted --confirm (e.g. prod via the
+	// wrong --env) is caught before any write. Credentials are redacted.
+	fmt.Printf("Target: ENVIRONMENT=%q  db=%s\n\n",
+		os.Getenv(config.EnvEnvironment), redactDBHost(cfg.Database.URL))
 
 	report, err := catalog.BackfillVenueTimezones(database, geo.Default(), catalog.BackfillOptions{
 		DryRun:  !confirm,
@@ -90,6 +95,16 @@ func loadEnv() {
 	log.Println("no .env loaded; using process environment")
 }
 
+// redactDBHost extracts host[:port]/dbname from a database URL, dropping any
+// embedded credentials, so the target can be logged without leaking secrets.
+func redactDBHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "<unparseable>"
+	}
+	return u.Host + u.Path
+}
+
 func printReport(r *catalog.BackfillReport) {
 	fmt.Println("--- Venue geocoding ---")
 	for _, c := range r.VenueChanges {
@@ -97,6 +112,9 @@ func printReport(r *catalog.BackfillReport) {
 		case "set", "updated":
 			fmt.Printf("  [%s] venue %d %q (%s, %s): %s -> %s\n",
 				c.Action, c.VenueID, c.Name, c.City, c.State, tzStr(c.OldTz), tzStr(c.NewTz))
+		case "coords":
+			fmt.Printf("  [coords] venue %d %q (%s, %s): coordinates updated (tz unchanged: %s)\n",
+				c.VenueID, c.Name, c.City, c.State, tzStr(c.NewTz))
 		case "miss":
 			fmt.Printf("  [miss] venue %d %q (%s, %s): no geocode match (left %s)\n",
 				c.VenueID, c.Name, c.City, c.State, tzStr(c.OldTz))
@@ -135,6 +153,7 @@ func printReport(r *catalog.BackfillReport) {
 	fmt.Printf("Venues scanned:    %d\n", r.VenuesScanned)
 	fmt.Printf("  tz set:          %d\n", r.VenuesSet)
 	fmt.Printf("  tz updated:      %d\n", r.VenuesUpdated)
+	fmt.Printf("  coords only:     %d\n", r.VenuesCoordsOnly)
 	fmt.Printf("  unchanged:       %d\n", r.VenuesUnchanged)
 	fmt.Printf("  no geocode hit:  %d\n", r.VenuesMissed)
 	fmt.Printf("Shows scanned:     %d\n", r.ShowsScanned)

--- a/backend/cmd/backfill-venue-timezones/main.go
+++ b/backend/cmd/backfill-venue-timezones/main.go
@@ -1,0 +1,165 @@
+// Command backfill-venue-timezones geocodes existing venues (latitude,
+// longitude, IANA timezone) from their city/state/country and re-anchors show
+// event_date instants that were stored under a wrong assumed timezone before
+// the venue-timezone epic (PSY-984). This is PR3 / the backfill step (PSY-987).
+//
+// Usage:
+//
+//	go run ./cmd/backfill-venue-timezones                    # dry-run (default)
+//	go run ./cmd/backfill-venue-timezones --confirm          # apply changes
+//	go run ./cmd/backfill-venue-timezones --verbose          # per-row detail
+//	go run ./cmd/backfill-venue-timezones --env .env.stage   # target a specific env
+//
+// Dry-run prints exactly what a live run would change and writes nothing. The
+// re-anchor pass is conservative — it only rewrites shows it can confidently
+// recognize as mis-zoned date-only shows and lists anything ambiguous for
+// manual review (see services/catalog.reanchorEventDate). Re-anchoring rewrites
+// both shows.event_date and the denormalized show_artists.event_date inside a
+// per-show transaction. The command is idempotent: a second run reports zero
+// changes.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/services/catalog"
+	"psychic-homily-backend/internal/services/geo"
+)
+
+var (
+	confirm bool
+	verbose bool
+	envFile string
+)
+
+func main() {
+	flag.BoolVar(&confirm, "confirm", false, "Apply changes (default: dry-run only)")
+	flag.BoolVar(&verbose, "verbose", false, "Print per-venue / per-show detail")
+	flag.StringVar(&envFile, "env", "", "Path to .env file (defaults to .env.development / .env)")
+	flag.Parse()
+
+	loadEnv()
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	if err := db.Connect(cfg); err != nil {
+		log.Fatalf("connect db: %v", err)
+	}
+	database := db.GetDB()
+
+	mode := "DRY RUN"
+	if confirm {
+		mode = "LIVE"
+	}
+	fmt.Printf("=== Venue Timezone Backfill (%s) — PSY-987 ===\n\n", mode)
+
+	report, err := catalog.BackfillVenueTimezones(database, geo.Default(), catalog.BackfillOptions{
+		DryRun:  !confirm,
+		Verbose: verbose,
+	})
+	if err != nil {
+		log.Fatalf("backfill: %v", err)
+	}
+
+	printReport(report)
+}
+
+func loadEnv() {
+	if envFile != "" {
+		if err := godotenv.Load(envFile); err != nil {
+			log.Fatalf("load env file %s: %v", envFile, err)
+		}
+		log.Printf("loaded env from %s", envFile)
+		return
+	}
+	for _, ef := range []string{".env.development", ".env"} {
+		if err := godotenv.Load(ef); err == nil {
+			log.Printf("loaded env from %s", ef)
+			return
+		}
+	}
+	log.Println("no .env loaded; using process environment")
+}
+
+func printReport(r *catalog.BackfillReport) {
+	fmt.Println("--- Venue geocoding ---")
+	for _, c := range r.VenueChanges {
+		switch c.Action {
+		case "set", "updated":
+			fmt.Printf("  [%s] venue %d %q (%s, %s): %s -> %s\n",
+				c.Action, c.VenueID, c.Name, c.City, c.State, tzStr(c.OldTz), tzStr(c.NewTz))
+		case "miss":
+			fmt.Printf("  [miss] venue %d %q (%s, %s): no geocode match (left %s)\n",
+				c.VenueID, c.Name, c.City, c.State, tzStr(c.OldTz))
+		case "unchanged":
+			fmt.Printf("  [unchanged] venue %d %q (%s, %s): %s\n",
+				c.VenueID, c.Name, c.City, c.State, tzStr(c.NewTz))
+		}
+	}
+
+	fmt.Println("\n--- Show re-anchoring ---")
+	for _, c := range r.ShowChanges {
+		switch c.Action {
+		case "reanchored":
+			fmt.Printf("  [reanchor] show %d %q (venue %d): %s (%s) -> %s (%s)\n",
+				c.ShowID, c.Title, c.VenueID,
+				c.OldInstant.Format("2006-01-02T15:04:05Z"), c.AssumedTz,
+				c.NewInstant.Format("2006-01-02T15:04:05Z"), c.GeocodedTz)
+		case "ambiguous":
+			fmt.Printf("  [skip:ambiguous] show %d %q (venue %d): %s — not a recognizable date-only show in %s or %s; left unchanged\n",
+				c.ShowID, c.Title, c.VenueID,
+				c.OldInstant.Format("2006-01-02T15:04:05Z"), c.GeocodedTz, c.AssumedTz)
+		case "no-venue-tz":
+			fmt.Printf("  [skip:no-venue-tz] show %d %q (venue %d): venue has no resolved timezone\n",
+				c.ShowID, c.Title, c.VenueID)
+		}
+	}
+
+	if len(r.Errors) > 0 {
+		fmt.Println("\n--- Errors ---")
+		for _, e := range r.Errors {
+			fmt.Printf("  [ERROR] %s\n", e)
+		}
+	}
+
+	fmt.Println("\n=== Summary ===")
+	fmt.Printf("Venues scanned:    %d\n", r.VenuesScanned)
+	fmt.Printf("  tz set:          %d\n", r.VenuesSet)
+	fmt.Printf("  tz updated:      %d\n", r.VenuesUpdated)
+	fmt.Printf("  unchanged:       %d\n", r.VenuesUnchanged)
+	fmt.Printf("  no geocode hit:  %d\n", r.VenuesMissed)
+	fmt.Printf("Shows scanned:     %d\n", r.ShowsScanned)
+	fmt.Printf("  re-anchored:     %d\n", r.ShowsReanchored)
+	fmt.Printf("  already correct: %d\n", r.ShowsAlreadyOK)
+	fmt.Printf("  ambiguous skip:  %d\n", r.ShowsAmbiguous)
+	fmt.Printf("  no venue tz:     %d\n", r.ShowsNoVenueTz)
+	fmt.Printf("Errors:            %d\n", len(r.Errors))
+	fmt.Println()
+
+	if !confirm {
+		fmt.Println("DRY RUN — no DB writes. Re-run with --confirm to apply.")
+	} else {
+		fmt.Println("LIVE — changes committed.")
+	}
+
+	// Exit non-zero if a live run hit errors so CI/cron wrappers can alert.
+	if confirm && len(r.Errors) > 0 {
+		os.Exit(1)
+	}
+}
+
+func tzStr(s *string) string {
+	if s == nil || *s == "" {
+		return "<none>"
+	}
+	return *s
+}

--- a/backend/internal/services/catalog/backfill_timezones.go
+++ b/backend/internal/services/catalog/backfill_timezones.go
@@ -1,0 +1,429 @@
+package catalog
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"gorm.io/gorm"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/geo"
+	"psychic-homily-backend/internal/utils"
+)
+
+// Backfill of venue geocoding + re-anchoring of mis-zoned show instants
+// (PSY-987, the final PR of the venue-timezone epic PSY-984).
+//
+// Two passes, dry-run by default:
+//
+//  1. Geocode every venue offline and populate latitude/longitude/timezone.
+//     Idempotent — re-running yields the same resolved values, so a second run
+//     reports zero changes.
+//
+//  2. Re-anchor show event_date instants that were stored under a WRONG assumed
+//     timezone. Before this epic, a date-only show was stored as 20:00 in a
+//     guessed zone (the US state map, defaulting non-US to America/Phoenix), so
+//     e.g. a Berlin show landed at 20:00 Phoenix → 03:00Z and now renders at
+//     05:00 in Berlin instead of 20:00. Re-anchoring recovers the intended
+//     20:00 wall-time and re-stamps it in the venue's real geocoded zone.
+//
+// The re-anchor pass is deliberately CONSERVATIVE (see reanchorEventDate): it
+// only touches shows it can confidently recognize as mis-zoned date-only shows,
+// and leaves anything ambiguous untouched for manual review. event_date is a
+// destructive rewrite of shared data, so the safe default is to do nothing when
+// unsure.
+
+// defaultEveningHour is the local hour a date-only show defaults to when it is
+// created (mirrors the CLI's normalizeDate, which stamps 20:00 venue-local).
+// It is the signal the re-anchor pass keys on to recognize a date-only show.
+const defaultEveningHour = 20
+
+// coordPrecision is the number of decimal places venue latitude/longitude are
+// stored at (DB column numeric(9,6)). Rounding the geocoder's full-precision
+// result to the same scale before comparing keeps the backfill idempotent —
+// otherwise raw-float vs DB-rounded-float would always look "changed".
+const coordPrecision = 1e6
+
+// BackfillOptions configures a backfill run.
+type BackfillOptions struct {
+	DryRun  bool
+	Verbose bool
+}
+
+// VenueGeoChange records the geocoding outcome for a single venue.
+type VenueGeoChange struct {
+	VenueID uint
+	Name    string
+	City    string
+	State   string
+	OldTz   *string
+	NewTz   *string
+	Action  string // "set", "updated", "unchanged", "miss"
+}
+
+// ShowReanchorChange records the re-anchor outcome for a single show.
+type ShowReanchorChange struct {
+	ShowID     uint
+	Title      string
+	VenueID    uint
+	AssumedTz  string
+	GeocodedTz string
+	OldInstant time.Time
+	NewInstant time.Time
+	Action     string // "reanchored", "already-correct", "ambiguous", "no-venue-tz"
+}
+
+// BackfillReport is the structured outcome of a backfill run.
+type BackfillReport struct {
+	// Venue pass
+	VenuesScanned   int
+	VenuesSet       int // tz set where there was none
+	VenuesUpdated   int // tz changed from an existing value
+	VenuesUnchanged int
+	VenuesMissed    int // no geocode match
+	VenueChanges    []VenueGeoChange
+
+	// Show pass
+	ShowsScanned    int
+	ShowsReanchored int
+	ShowsAlreadyOK  int
+	ShowsAmbiguous  int
+	ShowsNoVenueTz  int
+	ShowChanges     []ShowReanchorChange
+
+	Errors []string
+}
+
+// BackfillVenueTimezones geocodes every venue and re-anchors mis-zoned show
+// instants. With opts.DryRun the report describes exactly what a live run would
+// change without writing anything; the resolved-timezone map is computed the
+// same way in both modes so the dry-run is faithful.
+func BackfillVenueTimezones(database *gorm.DB, g geo.Geocoder, opts BackfillOptions) (*BackfillReport, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	if g == nil {
+		return nil, fmt.Errorf("geocoder not initialized")
+	}
+
+	report := &BackfillReport{}
+
+	// effectiveTz holds the post-backfill IANA zone per venue id: the freshly
+	// geocoded zone on a hit, otherwise the venue's existing stored zone. The
+	// show pass reads this map (NOT the DB) so a dry-run re-anchors against the
+	// zones a live run WOULD have written.
+	effectiveTz := make(map[uint]*string)
+
+	if err := backfillVenuePass(database, g, opts, report, effectiveTz); err != nil {
+		return report, err
+	}
+	if err := reanchorShowPass(database, opts, report, effectiveTz); err != nil {
+		return report, err
+	}
+
+	return report, nil
+}
+
+// backfillVenuePass geocodes each venue and (on a live run) writes the resolved
+// latitude/longitude/timezone.
+func backfillVenuePass(
+	database *gorm.DB,
+	g geo.Geocoder,
+	opts BackfillOptions,
+	report *BackfillReport,
+	effectiveTz map[uint]*string,
+) error {
+	var venues []catalogm.Venue
+	if err := database.Find(&venues).Error; err != nil {
+		return fmt.Errorf("load venues: %w", err)
+	}
+	report.VenuesScanned = len(venues)
+
+	for i := range venues {
+		v := &venues[i]
+		country := ""
+		if v.Country != nil {
+			country = *v.Country
+		}
+
+		res, ok := g.Resolve(v.City, v.State, country)
+		if !ok {
+			// Leave existing values untouched — the backfill only adds data.
+			effectiveTz[v.ID] = v.Timezone
+			report.VenuesMissed++
+			if opts.Verbose {
+				report.VenueChanges = append(report.VenueChanges, VenueGeoChange{
+					VenueID: v.ID, Name: v.Name, City: v.City, State: v.State,
+					OldTz: v.Timezone, NewTz: v.Timezone, Action: "miss",
+				})
+			}
+			continue
+		}
+
+		newTz := res.Timezone
+		newLat := roundCoord(res.Latitude)
+		newLng := roundCoord(res.Longitude)
+		effectiveTz[v.ID] = &newTz
+
+		tzChanged := derefString(v.Timezone) != newTz
+		latChanged := !floatPtrEq(v.Latitude, &newLat)
+		lngChanged := !floatPtrEq(v.Longitude, &newLng)
+
+		switch {
+		case !tzChanged && !latChanged && !lngChanged:
+			report.VenuesUnchanged++
+			if opts.Verbose {
+				report.VenueChanges = append(report.VenueChanges, VenueGeoChange{
+					VenueID: v.ID, Name: v.Name, City: v.City, State: v.State,
+					OldTz: v.Timezone, NewTz: &newTz, Action: "unchanged",
+				})
+			}
+			continue
+		case v.Timezone == nil:
+			report.VenuesSet++
+			report.VenueChanges = append(report.VenueChanges, VenueGeoChange{
+				VenueID: v.ID, Name: v.Name, City: v.City, State: v.State,
+				OldTz: v.Timezone, NewTz: &newTz, Action: "set",
+			})
+		default:
+			report.VenuesUpdated++
+			report.VenueChanges = append(report.VenueChanges, VenueGeoChange{
+				VenueID: v.ID, Name: v.Name, City: v.City, State: v.State,
+				OldTz: v.Timezone, NewTz: &newTz, Action: "updated",
+			})
+		}
+
+		if opts.DryRun {
+			continue
+		}
+		// Plain values, not pointers: a geocode hit always yields all three, and
+		// GORM's map-Updates rejects pointer values with "invalid field".
+		if err := database.Model(&catalogm.Venue{}).
+			Where("id = ?", v.ID).
+			Updates(map[string]interface{}{
+				"latitude":  newLat,
+				"longitude": newLng,
+				"timezone":  newTz,
+			}).Error; err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("venue %d update: %v", v.ID, err))
+		}
+	}
+
+	return nil
+}
+
+// reanchorShowPass re-anchors show instants that were stored under a wrong
+// assumed timezone, using the freshly resolved venue zones in effectiveTz.
+func reanchorShowPass(
+	database *gorm.DB,
+	opts BackfillOptions,
+	report *BackfillReport,
+	effectiveTz map[uint]*string,
+) error {
+	var shows []catalogm.Show
+	if err := database.Preload("Venues").Find(&shows).Error; err != nil {
+		return fmt.Errorf("load shows: %w", err)
+	}
+	report.ShowsScanned = len(shows)
+
+	for i := range shows {
+		show := &shows[i]
+
+		primary, ok := primaryVenue(show.Venues)
+		if !ok {
+			report.ShowsNoVenueTz++
+			continue
+		}
+		venueID := primary.ID
+		tzPtr := effectiveTz[venueID]
+		if tzPtr == nil || *tzPtr == "" {
+			report.ShowsNoVenueTz++
+			if opts.Verbose {
+				report.ShowChanges = append(report.ShowChanges, ShowReanchorChange{
+					ShowID: show.ID, Title: show.Title, VenueID: venueID, Action: "no-venue-tz",
+				})
+			}
+			continue
+		}
+
+		geocoded, err := time.LoadLocation(*tzPtr)
+		if err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("show %d: bad geocoded tz %q: %v", show.ID, *tzPtr, err))
+			continue
+		}
+		// Key the assumed (legacy-fallback) zone on the VENUE's state, mirroring
+		// how the data was written: the CLI's normalizeDate and the backend
+		// notification path both resolve the zone from the venue's state, not the
+		// show's denormalized State (which can be NULL or drift). GetTimezoneForState
+		// defaults unknown states to America/Phoenix — the same default the writers
+		// used — so non-US / unmapped-state shows that were stamped under Phoenix are
+		// recoverable. (Backend StateTimezones is currently 8 states; PSY-1009 will
+		// widen it. Until then an unmapped US state resolves to Phoenix, so a show
+		// stored under its CORRECT non-Phoenix zone is caught by the already-correct
+		// check above, and one stored under Phoenix is recovered; only a show stored
+		// under some THIRD wrong zone stays ambiguous — which the writers don't
+		// produce.)
+		assumedName := utils.GetTimezoneForState(primary.State)
+		assumed, err := time.LoadLocation(assumedName)
+		if err != nil {
+			assumed = time.UTC
+		}
+
+		newInstant, outcome := reanchorEventDate(show.EventDate, geocoded, assumed)
+		switch outcome {
+		case outcomeAlreadyCorrect:
+			report.ShowsAlreadyOK++
+			continue
+		case outcomeAmbiguous:
+			report.ShowsAmbiguous++
+			report.ShowChanges = append(report.ShowChanges, ShowReanchorChange{
+				ShowID: show.ID, Title: show.Title, VenueID: venueID,
+				AssumedTz: assumedName, GeocodedTz: *tzPtr,
+				OldInstant: show.EventDate.UTC(), Action: "ambiguous",
+			})
+			continue
+		}
+
+		// outcomeReanchored
+		report.ShowsReanchored++
+		report.ShowChanges = append(report.ShowChanges, ShowReanchorChange{
+			ShowID: show.ID, Title: show.Title, VenueID: venueID,
+			AssumedTz: assumedName, GeocodedTz: *tzPtr,
+			OldInstant: show.EventDate.UTC(), NewInstant: newInstant.UTC(), Action: "reanchored",
+		})
+
+		if opts.DryRun {
+			continue
+		}
+		// Rewrite shows.event_date AND cascade onto the denormalized
+		// show_artists.event_date in one transaction so the partial unique
+		// index (artist_id, venue_id, event_date) stays consistent. A
+		// per-show transaction keeps a collision on one show from rolling
+		// back the rest (mirrors cmd/dedup-shows).
+		err = database.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Model(&catalogm.Show{}).
+				Where("id = ?", show.ID).
+				Update("event_date", newInstant.UTC()).Error; err != nil {
+				return fmt.Errorf("update event_date: %w", err)
+			}
+			if err := syncShowArtistDedupColumns(tx, show.ID); err != nil {
+				return fmt.Errorf("sync show_artists: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("show %d reanchor: %v", show.ID, err))
+		}
+	}
+
+	return nil
+}
+
+// reanchorOutcome is the single classification of a show's re-anchor decision,
+// so the caller never has to re-derive the "already correct" condition (which
+// would let the report drift from the actual change logic).
+type reanchorOutcome int
+
+const (
+	// outcomeAlreadyCorrect: the instant already reads 20:00 in the geocoded
+	// zone — stored correctly, nothing to do.
+	outcomeAlreadyCorrect reanchorOutcome = iota
+	// outcomeReanchored: recovered a mis-zoned date-only show; the returned
+	// instant is the corrected value.
+	outcomeReanchored
+	// outcomeAmbiguous: cannot confidently classify (explicit non-20:00 time,
+	// or neither zone yields the 20:00 marker) — left untouched.
+	outcomeAmbiguous
+)
+
+// reanchorEventDate decides whether a stored event instant was mis-zoned and,
+// if so, returns the corrected instant. It is intentionally conservative:
+//
+//   - outcomeAlreadyCorrect: the instant already lands on the default evening
+//     wall-time (20:00) in the venue's real (geocoded) zone — stored correctly.
+//   - outcomeReanchored: the instant lands on 20:00 in the zone the writer
+//     ACTUALLY assumed (the legacy state-fallback zone, distinct from the
+//     geocoded one) — a recoverable mis-zoned date-only show, re-stamped to
+//     20:00 local in the geocoded zone.
+//   - outcomeAmbiguous: an explicit non-20:00 time, or a case where neither
+//     zone yields 20:00 — left untouched for manual review.
+//
+// This avoids the data-corruption trap of blindly assuming a single source zone
+// (e.g. "everything was Phoenix"): a correctly-stored show in a zone whose UTC
+// offset differs from the assumed one would otherwise be shifted by an hour. An
+// inaccurate `assumed` zone can only ever cause under-recovery (outcomeAmbiguous
+// instead of outcomeReanchored), never a wrong rewrite — the re-stamp fires only
+// on an exact 20:00 match in the assumed zone.
+func reanchorEventDate(stored time.Time, geocoded, assumed *time.Location) (time.Time, reanchorOutcome) {
+	// Already correct in the venue's real zone.
+	if isDefaultEveningWall(stored.In(geocoded)) {
+		return stored, outcomeAlreadyCorrect
+	}
+	// A different assumed zone that recovers the 20:00 default → re-anchor.
+	if !sameZone(geocoded, assumed) {
+		wall := stored.In(assumed)
+		if isDefaultEveningWall(wall) {
+			corrected := time.Date(
+				wall.Year(), wall.Month(), wall.Day(),
+				defaultEveningHour, 0, 0, 0,
+				geocoded,
+			)
+			return corrected, outcomeReanchored
+		}
+	}
+	// Ambiguous — leave it for manual review.
+	return stored, outcomeAmbiguous
+}
+
+// isDefaultEveningWall reports whether t's wall-clock time is exactly the
+// date-only default (20:00:00.000). A date-only show created via the CLI is
+// stamped at precisely this time in its assumed zone, so it's a reliable marker
+// that the instant carries no meaningful time-of-day.
+func isDefaultEveningWall(t time.Time) bool {
+	return t.Hour() == defaultEveningHour &&
+		t.Minute() == 0 &&
+		t.Second() == 0 &&
+		t.Nanosecond() == 0
+}
+
+// sameZone compares two locations by IANA name.
+func sameZone(a, b *time.Location) bool {
+	return a.String() == b.String()
+}
+
+// primaryVenue returns the venue with the smallest id among a show's venues.
+// This deterministic lowest-venue_id tiebreaker matches syncShowArtistDedupColumns
+// and the partial unique index (artist_id, venue_id, event_date), so re-anchoring
+// the instant against THIS venue's zone keeps the stored event_date consistent
+// with the dedup column the same pass rewrites. ok is false when the show has no
+// venues.
+//
+// Note: render surfaces (ShowCard/ShowHeader, the iCal feed, Discord) display
+// using show.Venues[0], not the lowest id. For the overwhelmingly common
+// single-venue show the two coincide. A multi-venue show whose venues span
+// different zones could therefore read slightly differently across surfaces —
+// an extremely rare, pre-existing ambiguity not introduced by this pass.
+func primaryVenue(venues []catalogm.Venue) (*catalogm.Venue, bool) {
+	if len(venues) == 0 {
+		return nil, false
+	}
+	primary := &venues[0]
+	for i := 1; i < len(venues); i++ {
+		if venues[i].ID < primary.ID {
+			primary = &venues[i]
+		}
+	}
+	return primary, true
+}
+
+func roundCoord(f float64) float64 {
+	return math.Round(f*coordPrecision) / coordPrecision
+}
+
+func floatPtrEq(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}

--- a/backend/internal/services/catalog/backfill_timezones.go
+++ b/backend/internal/services/catalog/backfill_timezones.go
@@ -22,17 +22,26 @@ import (
 //     reports zero changes.
 //
 //  2. Re-anchor show event_date instants that were stored under a WRONG assumed
-//     timezone. Before this epic, a date-only show was stored as 20:00 in a
-//     guessed zone (the US state map, defaulting non-US to America/Phoenix), so
+//     timezone. The CLI ingest (cli/src/commands/submit-show.ts normalizeDate)
+//     and the web ShowForm stamp a date-only show at 20:00 in a guessed zone
+//     (the state map, defaulting empty/non-US states to America/Phoenix), so
 //     e.g. a Berlin show landed at 20:00 Phoenix → 03:00Z and now renders at
 //     05:00 in Berlin instead of 20:00. Re-anchoring recovers the intended
 //     20:00 wall-time and re-stamps it in the venue's real geocoded zone.
 //
 // The re-anchor pass is deliberately CONSERVATIVE (see reanchorEventDate): it
-// only touches shows it can confidently recognize as mis-zoned date-only shows,
-// and leaves anything ambiguous untouched for manual review. event_date is a
-// destructive rewrite of shared data, so the safe default is to do nothing when
-// unsure.
+// only touches shows it can confidently recognize as mis-zoned 20:00 date-only
+// shows, and leaves anything ambiguous untouched for manual review. event_date
+// is a destructive rewrite of shared data, so the safe default is to do nothing
+// when unsure.
+//
+// NOT every date-only show is a 20:00 show: the AI-discovery pipeline
+// (services/pipeline/discovery.go parseEventDate) stamps date-only events at
+// 00:00 UTC, which this pass deliberately leaves ambiguous (no 20:00 marker) —
+// it does not attempt to recover them. And the safety argument is airtight only
+// for US venues (see reanchorEventDate); for empty/non-US-state venues the
+// assumed zone falls back to Phoenix, so a dry-run review before --confirm is
+// the backstop, not just a courtesy.
 
 // defaultEveningHour is the local hour a date-only show defaults to when it is
 // created (mirrors the CLI's normalizeDate, which stamps 20:00 venue-local).
@@ -71,18 +80,21 @@ type ShowReanchorChange struct {
 	GeocodedTz string
 	OldInstant time.Time
 	NewInstant time.Time
-	Action     string // "reanchored", "already-correct", "ambiguous", "no-venue-tz"
+	// Action is one of "reanchored", "ambiguous", "no-venue-tz". (Already-correct
+	// shows are counted in the report but not recorded as a change row.)
+	Action string
 }
 
 // BackfillReport is the structured outcome of a backfill run.
 type BackfillReport struct {
 	// Venue pass
-	VenuesScanned   int
-	VenuesSet       int // tz set where there was none
-	VenuesUpdated   int // tz changed from an existing value
-	VenuesUnchanged int
-	VenuesMissed    int // no geocode match
-	VenueChanges    []VenueGeoChange
+	VenuesScanned    int
+	VenuesSet        int // tz set where there was none
+	VenuesUpdated    int // tz changed from an existing value
+	VenuesCoordsOnly int // tz unchanged, only latitude/longitude changed
+	VenuesUnchanged  int
+	VenuesMissed     int // no geocode match
+	VenueChanges     []VenueGeoChange
 
 	// Show pass
 	ShowsScanned    int
@@ -186,11 +198,20 @@ func backfillVenuePass(
 				VenueID: v.ID, Name: v.Name, City: v.City, State: v.State,
 				OldTz: v.Timezone, NewTz: &newTz, Action: "set",
 			})
-		default:
+		case tzChanged:
 			report.VenuesUpdated++
 			report.VenueChanges = append(report.VenueChanges, VenueGeoChange{
 				VenueID: v.ID, Name: v.Name, City: v.City, State: v.State,
 				OldTz: v.Timezone, NewTz: &newTz, Action: "updated",
+			})
+		default:
+			// Timezone unchanged; only the coordinates moved (e.g. a GeoNames
+			// refresh shifted the city centroid). Don't print a misleading
+			// "tz -> tz" line.
+			report.VenuesCoordsOnly++
+			report.VenueChanges = append(report.VenueChanges, VenueGeoChange{
+				VenueID: v.ID, Name: v.Name, City: v.City, State: v.State,
+				OldTz: v.Timezone, NewTz: &newTz, Action: "coords",
 			})
 		}
 
@@ -252,18 +273,20 @@ func reanchorShowPass(
 			report.Errors = append(report.Errors, fmt.Sprintf("show %d: bad geocoded tz %q: %v", show.ID, *tzPtr, err))
 			continue
 		}
-		// Key the assumed (legacy-fallback) zone on the VENUE's state, mirroring
-		// how the data was written: the CLI's normalizeDate and the backend
-		// notification path both resolve the zone from the venue's state, not the
-		// show's denormalized State (which can be NULL or drift). GetTimezoneForState
-		// defaults unknown states to America/Phoenix — the same default the writers
-		// used — so non-US / unmapped-state shows that were stamped under Phoenix are
-		// recoverable. (Backend StateTimezones is currently 8 states; PSY-1009 will
-		// widen it. Until then an unmapped US state resolves to Phoenix, so a show
-		// stored under its CORRECT non-Phoenix zone is caught by the already-correct
-		// check above, and one stored under Phoenix is recovered; only a show stored
-		// under some THIRD wrong zone stays ambiguous — which the writers don't
-		// produce.)
+		// Key the assumed (legacy-fallback) zone on the VENUE's state — the field
+		// the writers keyed on — not the show's denormalized State (which can be
+		// NULL or drift). utils.StateTimezones is the full 50-state + DC map, kept
+		// in sync with the CLI writer's map (cli/src/lib/timezone.ts); for US
+		// states this REQUIRED-for-safety match makes a correctly-stored US show
+		// resolve assumed == geocoded so sameZone() short-circuits the recover
+		// branch (a short map defaulting to Phoenix would corrupt a real 11pm
+		// Eastern show — see reanchorEventDate). This is a best-effort
+		// reconstruction, not an exact replay: the web ShowForm stamps 20:00 in
+		// the SUBMITTER'S BROWSER zone when the venue has no state, and non-US
+		// states fall back to Phoenix here. Those cases either land on
+		// outcomeAmbiguous (safe) or are recovered correctly; the one residual
+		// false-positive (a non-US explicit show at exactly 03:00Z) is covered by
+		// the dry-run review (see reanchorEventDate's doc).
 		assumedName := utils.GetTimezoneForState(primary.State)
 		assumed, err := time.LoadLocation(assumedName)
 		if err != nil {
@@ -349,12 +372,22 @@ const (
 //   - outcomeAmbiguous: an explicit non-20:00 time, or a case where neither
 //     zone yields 20:00 — left untouched for manual review.
 //
-// This avoids the data-corruption trap of blindly assuming a single source zone
-// (e.g. "everything was Phoenix"): a correctly-stored show in a zone whose UTC
-// offset differs from the assumed one would otherwise be shifted by an hour. An
-// inaccurate `assumed` zone can only ever cause under-recovery (outcomeAmbiguous
-// instead of outcomeReanchored), never a wrong rewrite — the re-stamp fires only
-// on an exact 20:00 match in the assumed zone.
+// Safety relies on `assumed` matching the zone the data was actually written
+// under. For US shows that holds exactly: StateTimezones is the full 50-state +
+// DC writer map, so a correctly-stored show resolves assumed == geocoded (its
+// real zone) and sameZone() short-circuits before the re-stamp can fire — a real
+// 11pm-Eastern show (= 20:00 Phoenix wall-clock) is therefore left untouched,
+// not corrupted.
+//
+// For empty/non-US-state venues `assumed` falls back to Phoenix (the writers'
+// own default for them), which is what lets the genuinely mis-zoned non-US
+// date-only shows recover. The residual risk: a correctly-stored NON-US
+// explicit-time show whose UTC instant happens to be exactly 03:00:00Z reads as
+// 20:00 in Phoenix and would be wrongly re-anchored. This is an inherent
+// ambiguity (a 20:00-Phoenix date-only show and a foreign 03:00Z explicit show
+// are indistinguishable from the instant alone) — not closable without dropping
+// non-US recovery entirely. The backstop is the mandatory dry-run review before
+// --confirm: every re-anchor is listed old→new for the operator to eyeball.
 func reanchorEventDate(stored time.Time, geocoded, assumed *time.Location) (time.Time, reanchorOutcome) {
 	// Already correct in the venue's real zone.
 	if isDefaultEveningWall(stored.In(geocoded)) {

--- a/backend/internal/services/catalog/backfill_timezones_integration_test.go
+++ b/backend/internal/services/catalog/backfill_timezones_integration_test.go
@@ -1,0 +1,153 @@
+package catalog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/geo"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// stubGeocoder resolves a fixed set of cities, so the backfill write-path test
+// doesn't depend on the embedded GeoNames dataset.
+type stubGeocoder struct{ byCity map[string]geo.Result }
+
+func (s stubGeocoder) Resolve(city, _, _ string) (geo.Result, bool) {
+	r, ok := s.byCity[city]
+	return r, ok
+}
+
+type BackfillIntegrationTestSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+}
+
+func (suite *BackfillIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+}
+
+func (suite *BackfillIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *BackfillIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+}
+
+func TestBackfillIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(BackfillIntegrationTestSuite))
+}
+
+// seedShow creates a venue (with the given state), an artist, a show stamped at
+// `stored`, and the show_venues + show_artists join rows (with the denormalized
+// event_date pre-populated to `stored`, as the create path would).
+func (suite *BackfillIntegrationTestSuite) seedShow(city, state string, stored time.Time) (venueID, showID, artistID uint) {
+	venueSlug := "v-" + city + "-" + state
+	venue := &catalogm.Venue{Name: "Venue " + city, Slug: &venueSlug, City: city, State: state}
+	suite.Require().NoError(suite.db.Create(venue).Error)
+
+	artistName := "Artist " + city + state
+	artistSlug := "a-" + city + state
+	artist := &catalogm.Artist{Name: artistName, Slug: &artistSlug}
+	suite.Require().NoError(suite.db.Create(artist).Error)
+
+	storedUTC := stored.UTC()
+	show := &catalogm.Show{Title: "Show " + city, EventDate: storedUTC, Status: catalogm.ShowStatusApproved}
+	suite.Require().NoError(suite.db.Create(show).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowVenue{ShowID: show.ID, VenueID: venue.ID}).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowArtist{
+		ShowID: show.ID, ArtistID: artist.ID, EventDate: &storedUTC, VenueID: &venue.ID,
+	}).Error)
+
+	return venue.ID, show.ID, artist.ID
+}
+
+// A Berlin show stored under the old Phoenix default re-anchors to 18:00Z and
+// cascades the corrected instant onto show_artists; a second run is a no-op.
+func (suite *BackfillIntegrationTestSuite) TestBackfill_ReanchorsBerlinShowAndCascades() {
+	phoenix := mustLoc(suite.T(), "America/Phoenix")
+	// 20:00 Phoenix on 2026-07-17 = 03:00Z next day; non-US venue stored with
+	// an empty state (so the assumed zone resolves to Phoenix).
+	stored := time.Date(2026, 7, 17, 20, 0, 0, 0, phoenix)
+	venueID, showID, artistID := suite.seedShow("Berlin", "", stored)
+
+	stub := stubGeocoder{byCity: map[string]geo.Result{
+		"Berlin": {Latitude: 52.52, Longitude: 13.405, Timezone: "Europe/Berlin"},
+	}}
+
+	// Dry-run: reports the change but writes nothing.
+	report, err := BackfillVenueTimezones(suite.db, stub, BackfillOptions{DryRun: true})
+	suite.Require().NoError(err)
+	suite.Equal(1, report.ShowsReanchored)
+	suite.Empty(report.Errors)
+
+	var showAfterDry catalogm.Show
+	suite.Require().NoError(suite.db.First(&showAfterDry, showID).Error)
+	suite.True(showAfterDry.EventDate.Equal(stored), "dry-run must not write event_date")
+
+	// Confirm: writes venue tz + re-anchored instant + cascaded show_artists.
+	report, err = BackfillVenueTimezones(suite.db, stub, BackfillOptions{DryRun: false})
+	suite.Require().NoError(err)
+	suite.Equal(1, report.ShowsReanchored)
+	suite.Equal(1, report.VenuesSet)
+	suite.Empty(report.Errors)
+
+	want := "2026-07-17T18:00:00Z" // 20:00 Europe/Berlin (CEST, UTC+2)
+
+	var venue catalogm.Venue
+	suite.Require().NoError(suite.db.First(&venue, venueID).Error)
+	suite.Require().NotNil(venue.Timezone)
+	suite.Equal("Europe/Berlin", *venue.Timezone)
+
+	var show catalogm.Show
+	suite.Require().NoError(suite.db.First(&show, showID).Error)
+	suite.Equal(want, show.EventDate.UTC().Format(time.RFC3339))
+
+	var sa catalogm.ShowArtist
+	suite.Require().NoError(suite.db.Where("show_id = ? AND artist_id = ?", showID, artistID).First(&sa).Error)
+	suite.Require().NotNil(sa.EventDate)
+	suite.Equal(want, sa.EventDate.UTC().Format(time.RFC3339), "show_artists.event_date must be cascaded")
+
+	// Idempotent: a second confirm changes nothing.
+	report, err = BackfillVenueTimezones(suite.db, stub, BackfillOptions{DryRun: false})
+	suite.Require().NoError(err)
+	suite.Equal(0, report.ShowsReanchored)
+	suite.Equal(0, report.VenuesSet)
+	suite.Equal(0, report.VenuesUpdated)
+}
+
+// A correctly-stored explicit-time US show must NOT be re-anchored — the
+// regression guard for the adversarial-review CRITICAL finding, exercised
+// through the real assumed-zone derivation (full StateTimezones map).
+func (suite *BackfillIntegrationTestSuite) TestBackfill_DoesNotCorruptExplicitUSShow() {
+	ny := mustLoc(suite.T(), "America/New_York")
+	// A real 11pm Eastern show: 23:00 EDT = 03:00Z, which is also 20:00 Phoenix.
+	stored := time.Date(2026, 7, 17, 23, 0, 0, 0, ny)
+	_, showID, _ := suite.seedShow("Miami", "FL", stored)
+
+	stub := stubGeocoder{byCity: map[string]geo.Result{
+		"Miami": {Latitude: 25.7617, Longitude: -80.1918, Timezone: "America/New_York"},
+	}}
+
+	report, err := BackfillVenueTimezones(suite.db, stub, BackfillOptions{DryRun: false})
+	suite.Require().NoError(err)
+	suite.Equal(0, report.ShowsReanchored, "explicit-time FL show must not be re-anchored")
+	suite.Equal(1, report.ShowsAmbiguous)
+
+	var show catalogm.Show
+	suite.Require().NoError(suite.db.First(&show, showID).Error)
+	suite.Equal("2026-07-18T03:00:00Z", show.EventDate.UTC().Format(time.RFC3339),
+		"event_date must be left exactly as stored")
+}

--- a/backend/internal/services/catalog/backfill_timezones_test.go
+++ b/backend/internal/services/catalog/backfill_timezones_test.go
@@ -114,6 +114,63 @@ func TestReanchorEventDate(t *testing.T) {
 	}
 }
 
+// Regression for the adversarial-review CRITICAL finding: a correctly-stored
+// explicit-time show must NOT be re-anchored. The trap is that an 11pm Eastern
+// show (= 03:00Z in summer) reads as exactly 20:00 in America/Phoenix, so if the
+// assumed zone is wrongly Phoenix (the old 8-state map default for unmapped
+// states) it would be falsely "recovered" and corrupted 3 hours earlier. With
+// the assumed zone correctly resolved from the full StateTimezones map
+// (FL -> America/New_York == geocoded), sameZone() short-circuits and the show
+// is left untouched.
+func TestReanchorEventDate_ExplicitTimeNotCorrupted(t *testing.T) {
+	ny := mustLoc(t, "America/New_York")
+	phoenix := mustLoc(t, "America/Phoenix")
+
+	// A real 11pm Eastern show in summer: 23:00 EDT (UTC-4) = 03:00Z next day,
+	// which is also exactly 20:00 in America/Phoenix (UTC-7).
+	stored := time.Date(2026, 7, 17, 23, 0, 0, 0, ny)
+	if got := stored.UTC().Format(time.RFC3339); got != "2026-07-18T03:00:00Z" {
+		t.Fatalf("test setup wrong: stored=%s, want 2026-07-18T03:00:00Z", got)
+	}
+
+	// Correct assumed zone (full map: FL/GA/... -> America/New_York == geocoded).
+	if _, outcome := reanchorEventDate(stored, ny, ny); outcome != outcomeAmbiguous {
+		t.Errorf("explicit 11pm show with correct assumed zone: outcome=%v, want ambiguous (left untouched)", outcome)
+	}
+
+	// The bug the full map prevents: a Phoenix assumed zone (old short-map
+	// default) WOULD have wrongly re-anchored this correctly-stored show.
+	if _, outcome := reanchorEventDate(stored, ny, phoenix); outcome != outcomeReanchored {
+		t.Errorf("sanity: with a wrong Phoenix assumed zone the bug should manifest as a re-anchor; outcome=%v", outcome)
+	}
+}
+
+// Documents the one residual false-positive (adversarial-review round 2): a
+// correctly-stored NON-US explicit-time show whose UTC instant is exactly
+// 03:00Z reads as 20:00 in the Phoenix fallback (the assumed zone for
+// empty/non-US-state venues) and IS re-anchored. This is inherent ambiguity — a
+// 20:00-Phoenix date-only show and a foreign 03:00Z explicit show are
+// indistinguishable from the instant — and cannot be closed without dropping
+// non-US date-only recovery (the item-5 deliverable). The backstop is the
+// mandatory dry-run review before --confirm. This test pins the behavior so a
+// future change to it is a conscious decision, not an accident.
+func TestReanchorEventDate_NonUSExplicitAt0300Z_KnownLimitation(t *testing.T) {
+	phoenix := mustLoc(t, "America/Phoenix")
+	kolkata := mustLoc(t, "Asia/Kolkata")
+
+	// 08:30 Kolkata (IST, UTC+5:30) = 03:00Z — a real morning show, correctly
+	// stored, that unfortunately coincides with 20:00 Phoenix.
+	stored := time.Date(2026, 7, 17, 8, 30, 0, 0, kolkata)
+	if got := stored.UTC().Format(time.RFC3339); got != "2026-07-17T03:00:00Z" {
+		t.Fatalf("setup: stored=%s want 2026-07-17T03:00:00Z", got)
+	}
+	_, outcome := reanchorEventDate(stored, kolkata, phoenix)
+	if outcome != outcomeReanchored {
+		t.Errorf("documented limitation changed: non-US explicit show at 03:00Z outcome=%v (was reanchored). "+
+			"If this is intentional, update the dry-run-review guidance accordingly.", outcome)
+	}
+}
+
 // Re-anchoring must be idempotent: feeding a freshly corrected instant back
 // through reanchorEventDate (with the same geocoded zone) yields no change.
 func TestReanchorEventDateIsIdempotent(t *testing.T) {

--- a/backend/internal/services/catalog/backfill_timezones_test.go
+++ b/backend/internal/services/catalog/backfill_timezones_test.go
@@ -1,0 +1,187 @@
+package catalog
+
+import (
+	"testing"
+	"time"
+
+	// Embed the IANA tz database so LoadLocation works in any CI image,
+	// independent of system zoneinfo. Test-only — not linked into the server.
+	_ "time/tzdata"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+)
+
+func mustLoc(t *testing.T, name string) *time.Location {
+	t.Helper()
+	l, err := time.LoadLocation(name)
+	if err != nil {
+		t.Fatalf("load location %s: %v", name, err)
+	}
+	return l
+}
+
+func TestReanchorEventDate(t *testing.T) {
+	phoenix := mustLoc(t, "America/Phoenix")     // UTC-7 year round
+	berlin := mustLoc(t, "Europe/Berlin")        // UTC+2 in summer
+	la := mustLoc(t, "America/Los_Angeles")      // UTC-7 summer / UTC-8 winter
+	toronto := mustLoc(t, "America/Toronto")     // UTC-4 in summer
+	ny := mustLoc(t, "America/New_York")         // UTC-4 in summer
+
+	cases := []struct {
+		name        string
+		stored      time.Time
+		geocoded    *time.Location
+		assumed     *time.Location
+		wantOutcome reanchorOutcome
+		wantUTC     string // expected corrected instant (RFC3339, UTC) when reanchored
+	}{
+		{
+			// The ticket's canonical round-trip: a Berlin show stored under the
+			// old Phoenix assumption (20:00 MST -> 03:00Z) recovers to 18:00Z,
+			// which renders as 20:00 in Berlin.
+			name:        "berlin show mis-stored as phoenix re-anchors to 18:00Z",
+			stored:      time.Date(2026, 7, 17, 20, 0, 0, 0, phoenix),
+			geocoded:    berlin,
+			assumed:     phoenix,
+			wantOutcome: outcomeReanchored,
+			wantUTC:     "2026-07-17T18:00:00Z",
+		},
+		{
+			name:        "montreal show mis-stored as phoenix re-anchors to toronto 20:00",
+			stored:      time.Date(2026, 7, 17, 20, 0, 0, 0, phoenix),
+			geocoded:    toronto,
+			assumed:     phoenix,
+			wantOutcome: outcomeReanchored,
+			wantUTC:     "2026-07-18T00:00:00Z",
+		},
+		{
+			name:        "correctly-stored LA show is left unchanged",
+			stored:      time.Date(2026, 7, 17, 20, 0, 0, 0, la),
+			geocoded:    la,
+			assumed:     la,
+			wantOutcome: outcomeAlreadyCorrect,
+		},
+		{
+			// WA venue: the CLI stored 20:00 in America/Los_Angeles (its full-US
+			// map), but the backend's 8-state fallback would "assume" Phoenix.
+			// The already-correct-in-geocoded check must win so we DON'T shift it.
+			name:        "CLI-stored WA show is not corrupted by a wrong assumed zone",
+			stored:      time.Date(2026, 7, 17, 20, 0, 0, 0, la),
+			geocoded:    la,
+			assumed:     phoenix,
+			wantOutcome: outcomeAlreadyCorrect,
+		},
+		{
+			// The exact case the naive "assume Phoenix" rule would corrupt:
+			// a winter (PST, UTC-8) CA show stored correctly. Detection keeps it.
+			name:        "winter LA show correctly stored is left unchanged",
+			stored:      time.Date(2026, 1, 15, 20, 0, 0, 0, la),
+			geocoded:    la,
+			assumed:     la,
+			wantOutcome: outcomeAlreadyCorrect,
+		},
+		{
+			name:        "explicit 9pm show in its real zone is ambiguous, left unchanged",
+			stored:      time.Date(2026, 7, 17, 21, 0, 0, 0, ny),
+			geocoded:    ny,
+			assumed:     ny,
+			wantOutcome: outcomeAmbiguous,
+		},
+		{
+			name:        "non-default wall time recoverable in neither zone is left unchanged",
+			stored:      time.Date(2026, 7, 17, 21, 30, 0, 0, phoenix),
+			geocoded:    berlin,
+			assumed:     phoenix,
+			wantOutcome: outcomeAmbiguous,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, outcome := reanchorEventDate(c.stored, c.geocoded, c.assumed)
+			if outcome != c.wantOutcome {
+				t.Fatalf("outcome = %v, want %v (got=%s)", outcome, c.wantOutcome, got.UTC().Format(time.RFC3339))
+			}
+			if c.wantOutcome == outcomeReanchored {
+				if g := got.UTC().Format(time.RFC3339); g != c.wantUTC {
+					t.Errorf("corrected instant = %s, want %s", g, c.wantUTC)
+				}
+			} else if !got.Equal(c.stored) {
+				t.Errorf("non-reanchored case must return the stored instant; got %s want %s",
+					got.UTC().Format(time.RFC3339), c.stored.UTC().Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+// Re-anchoring must be idempotent: feeding a freshly corrected instant back
+// through reanchorEventDate (with the same geocoded zone) yields no change.
+func TestReanchorEventDateIsIdempotent(t *testing.T) {
+	phoenix := mustLoc(t, "America/Phoenix")
+	berlin := mustLoc(t, "Europe/Berlin")
+
+	stored := time.Date(2026, 7, 17, 20, 0, 0, 0, phoenix)
+	corrected, outcome := reanchorEventDate(stored, berlin, phoenix)
+	if outcome != outcomeReanchored {
+		t.Fatalf("expected first pass to re-anchor, got outcome %v", outcome)
+	}
+	// Second pass: geocoded zone is now authoritative; assumed no longer matters.
+	if _, outcome := reanchorEventDate(corrected, berlin, phoenix); outcome != outcomeAlreadyCorrect {
+		t.Errorf("second pass should be already-correct (idempotent), got outcome %v", outcome)
+	}
+}
+
+func TestIsDefaultEveningWall(t *testing.T) {
+	phoenix := mustLoc(t, "America/Phoenix")
+	tests := []struct {
+		name string
+		t    time.Time
+		want bool
+	}{
+		{"exactly 20:00", time.Date(2026, 7, 17, 20, 0, 0, 0, phoenix), true},
+		{"20:00:30 is not default", time.Date(2026, 7, 17, 20, 0, 30, 0, phoenix), false},
+		{"20:01 is not default", time.Date(2026, 7, 17, 20, 1, 0, 0, phoenix), false},
+		{"19:00 is not default", time.Date(2026, 7, 17, 19, 0, 0, 0, phoenix), false},
+		{"sub-second is not default", time.Date(2026, 7, 17, 20, 0, 0, 1, phoenix), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDefaultEveningWall(tc.t); got != tc.want {
+				t.Errorf("isDefaultEveningWall(%s) = %v, want %v", tc.t, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrimaryVenue(t *testing.T) {
+	if _, ok := primaryVenue(nil); ok {
+		t.Errorf("empty venues should return ok=false")
+	}
+	got, ok := primaryVenue([]catalogm.Venue{{ID: 7}, {ID: 3}, {ID: 9}})
+	if !ok || got.ID != 3 {
+		t.Errorf("primaryVenue id = %v (ok=%v), want id=3, ok=true", got, ok)
+	}
+}
+
+func TestRoundCoord(t *testing.T) {
+	if got := roundCoord(52.5200066); got != 52.520007 {
+		t.Errorf("roundCoord = %v, want 52.520007", got)
+	}
+}
+
+func TestFloatPtrEq(t *testing.T) {
+	a, b := 1.5, 1.5
+	c := 2.0
+	if !floatPtrEq(&a, &b) {
+		t.Errorf("equal values should be equal")
+	}
+	if floatPtrEq(&a, &c) {
+		t.Errorf("different values should not be equal")
+	}
+	if !floatPtrEq(nil, nil) {
+		t.Errorf("nil,nil should be equal")
+	}
+	if floatPtrEq(&a, nil) {
+		t.Errorf("value,nil should not be equal")
+	}
+}

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -316,6 +316,14 @@ func (s *ShowService) GetShows(filters map[string]interface{}) ([]*contracts.Sho
 	if state, ok := filters["state"].(string); ok && state != "" {
 		query = query.Where("state = ?", state)
 	}
+	// Timezone note (PSY-987): from_date/to_date are matched against the stored
+	// UTC event_date verbatim — this endpoint does NOT reinterpret a bare
+	// calendar date into a venue-local day window. Callers that want a
+	// "venue-local calendar day" window must convert the boundaries to UTC
+	// themselves before calling, the way the ph CLI's showDedupWindow does
+	// (PSY-999): a date-only show is stored at 20:00 venue-local -> UTC, which
+	// lands on the next UTC day for US zones, so a naive midnight-UTC window
+	// would miss it.
 	if fromDate, ok := filters["from_date"].(time.Time); ok {
 		query = query.Where("event_date >= ?", fromDate.UTC())
 	}

--- a/backend/internal/services/engagement/calendar.go
+++ b/backend/internal/services/engagement/calendar.go
@@ -16,7 +16,17 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/utils"
 )
+
+// icalLocalTimeFormat is RFC 5545's "date with local time" layout
+// (golang-ical's unexported icalTimestampFormatLocal). Used for DTSTART/DTEND
+// values that carry an explicit TZID parameter instead of a trailing Z.
+const icalLocalTimeFormat = "20060102T150405"
+
+// defaultShowDuration is the assumed length of a show when building calendar
+// events (the source data has no end time).
+const defaultShowDuration = 3 * time.Hour
 
 const (
 	// CalendarTokenPrefix is prepended to calendar tokens for identification
@@ -205,9 +215,18 @@ func (s *CalendarService) GenerateICSFeed(userID uint, frontendURL string) ([]by
 		event := cal.AddEvent(fmt.Sprintf("show-%d@psychichomily.com", show.ID))
 		event.SetCreatedTime(show.CreatedAt)
 		event.SetModifiedAt(show.UpdatedAt)
-		event.SetStartAt(show.EventDate)
-		// Default to 3-hour duration for shows
-		event.SetEndAt(show.EventDate.Add(3 * time.Hour))
+
+		// Anchor the event to the venue's local timezone so it reads at the
+		// correct wall-clock time for every subscriber (PSY-987). A bare UTC
+		// DTSTART would let each client re-shift the show into the viewer's
+		// own zone — wrong for a fixed-location event.
+		var venueTimezone *string
+		var venueState string
+		if len(show.Venues) > 0 {
+			venueTimezone = show.Venues[0].Timezone
+			venueState = show.Venues[0].State
+		}
+		setVenueLocalEventTimes(event, show.EventDate, defaultShowDuration, venueTimezone, venueState)
 
 		// Summary
 		summary := show.Title
@@ -261,4 +280,34 @@ func (s *CalendarService) GenerateICSFeed(userID uint, frontendURL string) ([]by
 	}
 
 	return []byte(cal.Serialize()), nil
+}
+
+// setVenueLocalEventTimes writes DTSTART/DTEND anchored to the venue's local
+// timezone instead of UTC. A show happens at a fixed wall-clock time in the
+// venue's city, so the calendar event must read e.g. "8:00 PM" for every
+// subscriber regardless of where they live — a bare UTC DTSTART would be
+// silently re-shifted into the viewer's own zone by their calendar client.
+//
+// We emit DTSTART;TZID=<IANA>:<local time> using the venue's IANA zone
+// (PSY-985 geocoding, falling back to the legacy state map via
+// utils.EventLocation). We deliberately do NOT emit a VTIMEZONE component:
+// golang-ical cannot synthesize the DST transition RRULEs a correct VTIMEZONE
+// needs, and a hand-rolled partial one would be less accurate than letting the
+// client resolve the well-known IANA TZID against its own bundled tz database
+// (Google Calendar, Apple Calendar, and modern Outlook all do this). If no
+// usable zone resolves (loc collapses to UTC) we fall back to the prior UTC
+// instant. (PSY-987)
+func setVenueLocalEventTimes(event *ics.VEvent, start time.Time, duration time.Duration, venueTimezone *string, venueState string) {
+	loc := utils.EventLocation(venueTimezone, venueState)
+	tzid := loc.String()
+	if tzid == "" || tzid == "UTC" {
+		event.SetStartAt(start)
+		event.SetEndAt(start.Add(duration))
+		return
+	}
+
+	localStart := start.In(loc)
+	localEnd := localStart.Add(duration)
+	event.SetProperty(ics.ComponentPropertyDtStart, localStart.Format(icalLocalTimeFormat), ics.WithTZID(tzid))
+	event.SetProperty(ics.ComponentPropertyDtEnd, localEnd.Format(icalLocalTimeFormat), ics.WithTZID(tzid))
 }

--- a/backend/internal/services/engagement/calendar_test.go
+++ b/backend/internal/services/engagement/calendar_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 	"time"
 
+	// Embed the IANA tz database so LoadLocation works in any CI image.
+	// Test-only — not linked into the server.
+	_ "time/tzdata"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
@@ -81,6 +85,49 @@ func TestGenerateICSFeed_Format(t *testing.T) {
 	assert.Contains(t, unfolded, "Artist Two")
 	assert.Contains(t, icsStr, "https://psychichomily.com/shows/test-show")
 	assert.Contains(t, icsStr, "METHOD:PUBLISH")
+}
+
+func TestGenerateICSFeed_VenueLocalTime(t *testing.T) {
+	nyLoc, err := time.LoadLocation("America/New_York")
+	assert.NoError(t, err)
+	nyTzid := "America/New_York"
+
+	// A future instant so the 30-day-past cutoff never filters it, regardless
+	// of the wall clock running the test.
+	eventDate := time.Now().Add(48 * time.Hour)
+	expectedLocal := eventDate.In(nyLoc).Format("20060102T150405")
+	expectedEnd := eventDate.In(nyLoc).Add(defaultShowDuration).Format("20060102T150405")
+
+	mockShows := []*contracts.SavedShowResponse{
+		{
+			ShowResponse: contracts.ShowResponse{
+				ID:        7,
+				Slug:      "ny-show",
+				Title:     "NY Show",
+				EventDate: eventDate,
+				Status:    "approved",
+				Venues: []contracts.VenueResponse{
+					{ID: 1, Name: "Brooklyn Steel", City: "Brooklyn", State: "NY", Timezone: ptrString(nyTzid)},
+				},
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	mockSvc := &mockSavedShowSvc{shows: mockShows, total: 1}
+
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+
+	icsStr := string(data)
+	// DTSTART/DTEND must carry the venue's IANA TZID and the venue-local time,
+	// not a bare UTC instant (which a calendar client would re-shift into the
+	// viewer's own zone).
+	assert.Contains(t, icsStr, "DTSTART;TZID="+nyTzid+":"+expectedLocal)
+	assert.Contains(t, icsStr, "DTEND;TZID="+nyTzid+":"+expectedEnd)
+	// No floating/UTC DTSTART form for this event.
+	assert.NotContains(t, icsStr, "DTSTART:"+eventDate.UTC().Format("20060102T150405")+"Z")
 }
 
 func TestGenerateICSFeed_SoldOutLabel(t *testing.T) {

--- a/backend/internal/services/explore/explore.go
+++ b/backend/internal/services/explore/explore.go
@@ -101,6 +101,17 @@ func (s *ExploreService) GetUpcomingShows(limit, offset int, cities []contracts.
 		offset = 0
 	}
 
+	// Timezone caveat (PSY-987): this list is deliberately UTC-bounded
+	// (event_date >= now UTC) rather than "start of today in the viewer's
+	// timezone" the way services/catalog.GetUpcomingShows is. /explore is
+	// SSR-prefetched with no viewer context, and keeping the query
+	// timezone-free is what lets that prefetch stay cacheable/seedable. The
+	// only observable difference is a show that already started earlier *today*
+	// in the viewer's zone but is still before UTC "now": it drops off this
+	// list slightly early. The picker-count vs row-count consequence of that is
+	// documented on applyUpcomingCityFilter below. Show *times* still render in
+	// venue-local zones everywhere via the venue timezone (PSY-985/986); only
+	// this list's day boundary is UTC.
 	now := time.Now().UTC()
 
 	// Count first so the response carries an authoritative total

--- a/backend/internal/utils/timezone.go
+++ b/backend/internal/utils/timezone.go
@@ -5,16 +5,78 @@ import (
 	"time"
 )
 
-// StateTimezones maps US state abbreviations to IANA timezone names.
+// StateTimezones maps US state (and DC) abbreviations to IANA timezone names.
+//
+// This is the full 50-state + DC map. It MUST stay in sync with the writer-side
+// maps the show data was actually stored under — cli/src/lib/timezone.ts and
+// frontend/lib/utils/timeUtils.ts (PSY-1009) — because the venue-timezone
+// backfill (PSY-987) derives the zone a date-only show was *written* under from
+// this map: a short map (defaulting most states to Phoenix) would make a
+// correctly-stored explicit-time show in an unmapped state read as a false 20:00
+// Phoenix default and be wrongly re-anchored. States that span two zones use
+// their predominant zone (the same approximation the writers made).
+//
+// The three maps are identical as of PSY-987, but the sync is NOT enforced by
+// CI (they're Go vs TypeScript): TestGetTimezoneForState_FullMapCoverage only
+// guards this Go map's own coverage. If you edit any of the three, edit all
+// three — drift here silently re-opens the re-anchor corruption class.
 var StateTimezones = map[string]string{
-	"AZ": "America/Phoenix",
+	// Pacific
 	"CA": "America/Los_Angeles",
 	"NV": "America/Los_Angeles",
+	"OR": "America/Los_Angeles",
+	"WA": "America/Los_Angeles",
+	// Mountain
+	"AZ": "America/Phoenix", // no DST
 	"CO": "America/Denver",
 	"NM": "America/Denver",
+	"MT": "America/Denver",
+	"UT": "America/Denver",
+	"WY": "America/Denver",
+	"ID": "America/Boise",
+	// Central
 	"IL": "America/Chicago",
 	"TX": "America/Chicago",
+	"AL": "America/Chicago",
+	"AR": "America/Chicago",
+	"IA": "America/Chicago",
+	"KS": "America/Chicago",
+	"LA": "America/Chicago",
+	"MN": "America/Chicago",
+	"MO": "America/Chicago",
+	"MS": "America/Chicago",
+	"ND": "America/Chicago",
+	"NE": "America/Chicago",
+	"OK": "America/Chicago",
+	"SD": "America/Chicago",
+	"TN": "America/Chicago",
+	"WI": "America/Chicago",
+	"IN": "America/Indiana/Indianapolis",
+	// Eastern
 	"NY": "America/New_York",
+	"CT": "America/New_York",
+	"DC": "America/New_York",
+	"DE": "America/New_York",
+	"FL": "America/New_York",
+	"GA": "America/New_York",
+	"KY": "America/New_York",
+	"MA": "America/New_York",
+	"MD": "America/New_York",
+	"ME": "America/New_York",
+	"MI": "America/New_York",
+	"NC": "America/New_York",
+	"NH": "America/New_York",
+	"NJ": "America/New_York",
+	"OH": "America/New_York",
+	"PA": "America/New_York",
+	"RI": "America/New_York",
+	"SC": "America/New_York",
+	"VA": "America/New_York",
+	"VT": "America/New_York",
+	"WV": "America/New_York",
+	// Non-contiguous
+	"AK": "America/Anchorage",
+	"HI": "Pacific/Honolulu",
 }
 
 // GetTimezoneForState returns the IANA timezone for a US state abbreviation.

--- a/backend/internal/utils/timezone_test.go
+++ b/backend/internal/utils/timezone_test.go
@@ -18,6 +18,37 @@ func TestGetTimezoneForState_KnownStates(t *testing.T) {
 	assert.Equal(t, "America/New_York", GetTimezoneForState("NY"))
 }
 
+// The map must cover all 50 states + DC (PSY-987/PSY-1009). A short map that
+// defaulted unmapped states to Phoenix would reintroduce the venue-timezone
+// backfill corruption (a correctly-stored explicit-time show reading as a false
+// 20:00 Phoenix default). Spot-check representative states across every zone.
+func TestGetTimezoneForState_FullMapCoverage(t *testing.T) {
+	cases := map[string]string{
+		"WA": "America/Los_Angeles",          // Pacific
+		"OR": "America/Los_Angeles",          // Pacific
+		"ID": "America/Boise",                // Mountain (distinct zone)
+		"MT": "America/Denver",               // Mountain
+		"UT": "America/Denver",               // Mountain
+		"WI": "America/Chicago",              // Central
+		"TN": "America/Chicago",              // Central
+		"MO": "America/Chicago",              // Central
+		"IN": "America/Indiana/Indianapolis", // Eastern-ish (distinct zone)
+		"FL": "America/New_York",             // Eastern
+		"GA": "America/New_York",             // Eastern
+		"MA": "America/New_York",             // Eastern
+		"MI": "America/New_York",             // Eastern
+		"DC": "America/New_York",             // Eastern (district)
+		"KY": "America/New_York",             // split-state, predominant Eastern
+		"AK": "America/Anchorage",            // non-contiguous
+		"HI": "Pacific/Honolulu",             // non-contiguous
+	}
+	for state, want := range cases {
+		assert.Equalf(t, want, GetTimezoneForState(state), "state %s", state)
+	}
+	// All 50 states + DC must resolve to a real (non-default) entry.
+	assert.Len(t, StateTimezones, 51, "expected 50 states + DC")
+}
+
 func TestGetTimezoneForState_CaseInsensitive(t *testing.T) {
 	assert.Equal(t, "America/Phoenix", GetTimezoneForState("az"))
 	assert.Equal(t, "America/Los_Angeles", GetTimezoneForState("ca"))


### PR DESCRIPTION
Closes PSY-987. Final PR of the venue-timezone epic (PSY-984).

## Summary
- **Backfill command** `backend/cmd/backfill-venue-timezones` (`--dry-run` default, `--confirm`, `--verbose`, `--env`). Two idempotent passes: (1) geocode every venue → set `latitude/longitude/timezone`; (2) re-anchor show `event_date` instants that were stored under a wrong assumed timezone before this epic. Logic lives in `internal/services/catalog/backfill_timezones.go` (mirrors the `cmd/dedup-shows` shape).
- **Conservative re-anchor**: only rewrites shows it can confidently recognize as mis-zoned 20:00 date-only shows, leaving anything ambiguous untouched (`event_date` is a destructive rewrite of shared data). It rewrites **both** `shows.event_date` and the denormalized `show_artists.event_date` (via `syncShowArtistDedupColumns`) inside a per-show transaction so the `(artist_id, venue_id, event_date)` partial unique index stays consistent.
- **iCal venue-local time**: `GenerateICSFeed` now emits `DTSTART/DTEND;TZID=<IANA>:<local>` using the venue's zone instead of a bare UTC instant, so a show reads at its real wall-clock time for every subscriber.
- **Backend `utils.StateTimezones` expanded to the full 50 states + DC** (was 8) to match the CLI/FE writer maps — required for the re-anchor's safety (see Adversarial review) and also closes **PSY-1009 #4** + improves the notification/slug/discovery fallbacks.

## Scope notes (per the ticket's 5 items)
- **#2 (CLI dedup window)** — already shipped separately by **PSY-999** (`showDedupWindow`, merged #1010). Excluded here; cross-referenced in a `show.go` comment.
- **#4 (timezone-aware queries)** — `/shows/upcoming` is already viewer-tz-aware. `/explore` and `/shows?from_date/to_date` keep their **deliberate UTC boundaries** (the ticket's "document the residual caveat if SSR-seedability forces UTC" branch): `/explore` is SSR-prefetched with no viewer context, and the CLI caller already converts the window (PSY-999). Documented in code comments.
- **#5 (stage cleanup)** — ran `--confirm` against stage: **12 shows re-anchored** (the BIG|BRAVE Europe/Canada rows → Europe/Lisbon, Amsterdam, Zurich, Ljubljana, Warsaw, America/Toronto + Midwife/BIG|BRAVE US tour dates → Chicago/New_York), 53 venue timezones set, 0 errors, idempotent on re-run. One residual: a Sidney, NE venue resolved to the wrong zone — a geocoder small-town limitation, filed as **PSY-1012** (not introduced by this PR).

## Deferred / follow-ups
- **PSY-1012** (filed) — geocoder mis-resolves sub-15k US towns to wrong-state namesakes (wrong timezone). Surfaced on stage (Sidney NE → America/New_York). Affects all venue write paths, not just the backfill.
- **PSY-1009 #4** — done here (commented on the ticket). The 3 state→tz maps (Go/CLI/FE) are kept in sync **manually**; a cross-language parity guard would be a good hardening follow-up (noted on PSY-1009).

## Heads up from `/code-review`
- The backfill loads all venues + all shows into memory (no batching) — fine at current scale and consistent with `cmd/dedup-shows`; would want `FindInBatches` before running against a very large table.

## Adversarial review
`/adversarial-review` — round 1 **BLOCK** (1 CRITICAL) → fixed; round 2 **CONCERNS** → addressed/disclosed. Fixes in commit `55f061bb`, separate from the implementation commit `2c999072`.
- **[CRITICAL] Re-anchor corrupted correctly-stored explicit-time US shows** in states outside the old 8-state map (assumed zone defaulted to Phoenix; an 11pm-Eastern show = 20:00 Phoenix wall-clock looked like a recoverable default). → Fixed by the full 50-state+DC map: a US show resolves `assumed == geocoded` so `sameZone()` short-circuits the re-stamp. Regression tests added (unit `TestReanchorEventDate_ExplicitTimeNotCorrupted` + integration `TestBackfill_DoesNotCorruptExplicitUSShow`). Independently re-verified resolved by the round-2 Completeness reviewer.
- **[MEDIUM] DB write path untested** → added `backfill_timezones_integration_test.go` (txn + `show_artists` cascade + dry-run-vs-live + idempotency).
- **[MEDIUM] Venue pass mislabeled a coords-only change as a tz "update"** (misleading `X -> X` line) → split into a distinct `coords` action/counter.
- **[LOW] No last-chance target signal on a destructive command** → prints resolved `ENVIRONMENT` + **redacted** DB host before the run.
- **[MEDIUM, disclosed] iCal emits `TZID` without a `VTIMEZONE` component** → deliberate: golang-ical can't synthesize DST `RRULE`s, and Google/Apple/modern Outlook resolve bare IANA TZIDs from their own tz DB. Strict RFC validators / older Outlook may not — accepted tradeoff, documented in code.
- **[documented limitation] Non-US explicit-time show at exactly `03:00Z`** reads as 20:00 in the Phoenix fallback and would be re-anchored. This is inherent ambiguity (indistinguishable from a 20:00-Phoenix date-only show) and can't be closed without dropping non-US date-only recovery; the mandatory **dry-run review before `--confirm`** is the backstop. Test-pinned (`TestReanchorEventDate_NonUSExplicitAt0300Z_KnownLimitation`).

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet` (catalog / utils / engagement / explore / cmd) — clean
- [x] `go test ./internal/services/catalog/... ./internal/services/engagement/... ./internal/services/explore/... ./internal/utils/` — all pass (incl. new unit + Postgres-backed integration tests)
- [x] `go test ./internal/services/notification/... ./internal/services/pipeline/...` — pass (the other `StateTimezones`/`EventLocation` consumers — confirms the 8→51-state map expansion doesn't regress Discord/reminder/filter timestamps or discovery slug-date generation)
- [x] Backfill against **local dev DB**: `--dry-run` then `--confirm` → validated the write path + `show_artists.event_date` cascade (confirmed via `psql`: show 673 + both join rows = `2026-04-22T00:00:00Z`, venue 48 = `America/New_York`); second run reports 0 changes (idempotent)
- [x] Backfill against **stage** `--confirm` → 12 re-anchored, 53 tz set, 0 errors; re-run = 0 changes
- [x] iCal output format verified via `TestGenerateICSFeed_VenueLocalTime` (`DTSTART;TZID=America/New_York:<local>`); **not** opened in a live calendar client
- [x] `/code-review` — addressed
- [x] `/adversarial-review` — round-1 CRITICAL fixed; round-2 CONCERNS addressed/disclosed (fixes in `55f061bb`)
- [x] `/psy-self-review` — evidence + convention agents clean; 2 coverage warnings addressed (ran notification/pipeline tests above; disclosed the iCal UTC-fallback gap below)

## Coverage gaps / honest disclosure
- **iCal not opened in a real calendar client** — verified by serialized-output assertion only.
- **iCal UTC-fallback branch not directly tested** — `setVenueLocalEventTimes` reverts to a bare-UTC `DTSTART` when no usable zone resolves (`tzid == "" || "UTC"`). After the full state-map expansion this branch is effectively unreachable for any venue with a city/state, so it's left as defensive code; the venue-local path is what's tested.
- **Non-US explicit-`03:00Z` edge** and **iCal bare-TZID on strict/older parsers** — see Adversarial review; both are documented, accepted tradeoffs.
- **3 state→tz maps kept in sync manually** — no cross-language CI guard (hardening follow-up noted on PSY-1009).
- **No UI surface** — backend/CLI only; screenshots skipped.
