### PR TITLE
PSY-995: cross-entity multi-tag intersection endpoint

### DIFF
--- a/backend/internal/api/handlers/catalog/tag.go
+++ b/backend/internal/api/handlers/catalog/tag.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -154,15 +155,17 @@ func (h *TagHandler) GetTagDetailHandler(ctx context.Context, req *GetTagDetailR
 // Tag Intersection (public) — cross-entity multi-tag intersection (PSY-995)
 // ============================================================================
 
-// intersectionPreviewLimitDefault / Max bound the per-type preview slice.
 const (
-	intersectionPreviewLimitDefault = 4
-	intersectionPreviewLimitMax     = 12
-	intersectionMinTags             = 2
+	intersectionMinTags = 2
+	// intersectionMaxTags bounds the fan-out of a single request: every tag
+	// adds a term to the per-group entity_tags self-joins across all 7 entity
+	// types, and this endpoint is public + unauthenticated. Cap mirrors the
+	// maxCityFilters bound used elsewhere in tag filtering.
+	intersectionMaxTags = 10
 )
 
 type GetTagIntersectionRequest struct {
-	Tags         string `query:"tags" doc:"Comma-separated tag slugs (>= 2)" example:"shoegaze,ambient"`
+	Tags         string `query:"tags" maxLength:"200" doc:"Comma-separated tag slugs (2-10)" example:"shoegaze,ambient"`
 	TagMatch     string `query:"tag_match" required:"false" doc:"all (AND, default) | any (OR)" example:"all"`
 	PreviewLimit int    `query:"preview_limit" required:"false" minimum:"1" maximum:"12" doc:"Per-type preview size (default 4, max 12)" example:"4"`
 }
@@ -184,32 +187,23 @@ func (h *TagHandler) GetTagIntersectionHandler(ctx context.Context, req *GetTagI
 			fmt.Sprintf("at least %d distinct tags are required", intersectionMinTags),
 		)
 	}
-
-	// Resolve every slug up front; an unknown slug is a 400 so the caller fixes
-	// the URL rather than silently getting all-zero groups. Resolution is
-	// slug-only (not the ID-or-slug resolveTag) because the contract is
-	// slug-based and the downstream filter matches on LOWER(tags.slug) — a
-	// numeric ID would resolve here but match nothing in the intersection.
-	for _, slug := range filter.TagSlugs {
-		tag, err := h.tagService.GetTagBySlug(slug)
-		if err != nil {
-			return nil, huma.Error500InternalServerError("Failed to resolve tag")
-		}
-		if tag == nil {
-			return nil, huma.Error400BadRequest(fmt.Sprintf("unknown tag: %s", slug))
-		}
+	if len(filter.TagSlugs) > intersectionMaxTags {
+		return nil, huma.Error400BadRequest(
+			fmt.Sprintf("at most %d tags may be intersected", intersectionMaxTags),
+		)
 	}
 
-	previewLimit := req.PreviewLimit
-	if previewLimit <= 0 {
-		previewLimit = intersectionPreviewLimitDefault
-	}
-	if previewLimit > intersectionPreviewLimitMax {
-		previewLimit = intersectionPreviewLimitMax
-	}
+	previewLimit := contracts.ClampIntersectionPreviewLimit(req.PreviewLimit)
 
+	// The service resolves + validates every slug in a SINGLE batched query and
+	// surfaces an unknown slug as a typed error, so the caller gets a 400 (fix
+	// the URL) rather than silently-empty groups — without a per-slug round-trip.
 	result, err := h.tagService.IntersectEntitiesByTags(filter.TagSlugs, filter.MatchAny, previewLimit)
 	if err != nil {
+		var unknown *contracts.UnknownTagSlugError
+		if errors.As(err, &unknown) {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("unknown tag: %s", unknown.Slug))
+		}
 		return nil, huma.Error500InternalServerError("Failed to compute tag intersection")
 	}
 

--- a/backend/internal/api/handlers/catalog/tag.go
+++ b/backend/internal/api/handlers/catalog/tag.go
@@ -151,6 +151,72 @@ func (h *TagHandler) GetTagDetailHandler(ctx context.Context, req *GetTagDetailR
 }
 
 // ============================================================================
+// Tag Intersection (public) — cross-entity multi-tag intersection (PSY-995)
+// ============================================================================
+
+// intersectionPreviewLimitDefault / Max bound the per-type preview slice.
+const (
+	intersectionPreviewLimitDefault = 4
+	intersectionPreviewLimitMax     = 12
+	intersectionMinTags             = 2
+)
+
+type GetTagIntersectionRequest struct {
+	Tags         string `query:"tags" doc:"Comma-separated tag slugs (>= 2)" example:"shoegaze,ambient"`
+	TagMatch     string `query:"tag_match" required:"false" doc:"all (AND, default) | any (OR)" example:"all"`
+	PreviewLimit int    `query:"preview_limit" required:"false" minimum:"1" maximum:"12" doc:"Per-type preview size (default 4, max 12)" example:"4"`
+}
+
+type GetTagIntersectionResponse struct {
+	Body *contracts.TagIntersectionResponse
+}
+
+// GetTagIntersectionHandler returns entities matching a tag intersection,
+// grouped by entity type with a per-type count + preview (PSY-995). Direct
+// types (artist/release/label/venue/collection) match on their own
+// entity_tags; transitive types (show/festival) match via a billed artist's
+// tags. Each group's "show all" is built client-side from
+// /{entity_type}?tags=<slugs>&tag_match=<match>.
+func (h *TagHandler) GetTagIntersectionHandler(ctx context.Context, req *GetTagIntersectionRequest) (*GetTagIntersectionResponse, error) {
+	filter := parseTagFilter(req.Tags, req.TagMatch)
+	if len(filter.TagSlugs) < intersectionMinTags {
+		return nil, huma.Error400BadRequest(
+			fmt.Sprintf("at least %d distinct tags are required", intersectionMinTags),
+		)
+	}
+
+	// Resolve every slug up front; an unknown slug is a 400 so the caller fixes
+	// the URL rather than silently getting all-zero groups. Resolution is
+	// slug-only (not the ID-or-slug resolveTag) because the contract is
+	// slug-based and the downstream filter matches on LOWER(tags.slug) — a
+	// numeric ID would resolve here but match nothing in the intersection.
+	for _, slug := range filter.TagSlugs {
+		tag, err := h.tagService.GetTagBySlug(slug)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("Failed to resolve tag")
+		}
+		if tag == nil {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("unknown tag: %s", slug))
+		}
+	}
+
+	previewLimit := req.PreviewLimit
+	if previewLimit <= 0 {
+		previewLimit = intersectionPreviewLimitDefault
+	}
+	if previewLimit > intersectionPreviewLimitMax {
+		previewLimit = intersectionPreviewLimitMax
+	}
+
+	result, err := h.tagService.IntersectEntitiesByTags(filter.TagSlugs, filter.MatchAny, previewLimit)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to compute tag intersection")
+	}
+
+	return &GetTagIntersectionResponse{Body: result}, nil
+}
+
+// ============================================================================
 // List Tagged Entities (public)
 // ============================================================================
 

--- a/backend/internal/api/handlers/catalog/tag_test.go
+++ b/backend/internal/api/handlers/catalog/tag_test.go
@@ -103,13 +103,22 @@ func TestGetTagIntersection_DuplicateCollapsesBelowTwo(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 400)
 }
 
+func TestGetTagIntersection_TooManyTags(t *testing.T) {
+	// More than intersectionMaxTags (10) distinct slugs → 400 before the service
+	// is touched, bounding fan-out on this public endpoint.
+	h := NewTagHandler(&testhelpers.MockTagService{}, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{
+		Tags: "t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11",
+	})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
 func TestGetTagIntersection_UnknownTag(t *testing.T) {
+	// The service resolves + validates slugs in one batched query and returns a
+	// typed UnknownTagSlugError for a ghost slug; the handler maps it to 400.
 	mock := &testhelpers.MockTagService{
-		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
-			if slug == "shoegaze" {
-				return &catalogm.Tag{ID: 1, Slug: slug}, nil
-			}
-			return nil, nil // ghost slug → unknown
+		IntersectEntitiesByTagsFn: func(_ []string, _ bool, _ int) (*contracts.TagIntersectionResponse, error) {
+			return nil, &contracts.UnknownTagSlugError{Slug: "ghost"}
 		},
 	}
 	h := NewTagHandler(mock, nil)
@@ -120,9 +129,6 @@ func TestGetTagIntersection_UnknownTag(t *testing.T) {
 func TestGetTagIntersection_PreviewLimitClampedToMax(t *testing.T) {
 	var gotLimit int
 	mock := &testhelpers.MockTagService{
-		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
-			return &catalogm.Tag{ID: 1, Slug: slug}, nil
-		},
 		IntersectEntitiesByTagsFn: func(_ []string, _ bool, previewLimit int) (*contracts.TagIntersectionResponse, error) {
 			gotLimit = previewLimit
 			return &contracts.TagIntersectionResponse{TagMatch: "all"}, nil
@@ -136,8 +142,8 @@ func TestGetTagIntersection_PreviewLimitClampedToMax(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotLimit != intersectionPreviewLimitMax {
-		t.Errorf("expected preview_limit clamped to %d, got %d", intersectionPreviewLimitMax, gotLimit)
+	if gotLimit != contracts.MaxIntersectionPreviewLimit {
+		t.Errorf("expected preview_limit clamped to %d, got %d", contracts.MaxIntersectionPreviewLimit, gotLimit)
 	}
 }
 
@@ -145,9 +151,6 @@ func TestGetTagIntersection_DefaultPreviewLimitAndMatch(t *testing.T) {
 	var gotLimit int
 	var gotMatchAny bool
 	mock := &testhelpers.MockTagService{
-		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
-			return &catalogm.Tag{ID: 1, Slug: slug}, nil
-		},
 		IntersectEntitiesByTagsFn: func(_ []string, matchAny bool, previewLimit int) (*contracts.TagIntersectionResponse, error) {
 			gotLimit = previewLimit
 			gotMatchAny = matchAny
@@ -159,8 +162,8 @@ func TestGetTagIntersection_DefaultPreviewLimitAndMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotLimit != intersectionPreviewLimitDefault {
-		t.Errorf("expected default preview_limit %d, got %d", intersectionPreviewLimitDefault, gotLimit)
+	if gotLimit != contracts.DefaultIntersectionPreviewLimit {
+		t.Errorf("expected default preview_limit %d, got %d", contracts.DefaultIntersectionPreviewLimit, gotLimit)
 	}
 	if gotMatchAny {
 		t.Errorf("expected AND (matchAny=false) by default")
@@ -170,9 +173,6 @@ func TestGetTagIntersection_DefaultPreviewLimitAndMatch(t *testing.T) {
 func TestGetTagIntersection_AnyMatch(t *testing.T) {
 	var gotMatchAny bool
 	mock := &testhelpers.MockTagService{
-		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
-			return &catalogm.Tag{ID: 1, Slug: slug}, nil
-		},
 		IntersectEntitiesByTagsFn: func(_ []string, matchAny bool, _ int) (*contracts.TagIntersectionResponse, error) {
 			gotMatchAny = matchAny
 			return &contracts.TagIntersectionResponse{TagMatch: "any"}, nil
@@ -190,9 +190,6 @@ func TestGetTagIntersection_AnyMatch(t *testing.T) {
 
 func TestGetTagIntersection_ServiceError(t *testing.T) {
 	mock := &testhelpers.MockTagService{
-		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
-			return &catalogm.Tag{ID: 1, Slug: slug}, nil
-		},
 		IntersectEntitiesByTagsFn: func(_ []string, _ bool, _ int) (*contracts.TagIntersectionResponse, error) {
 			return nil, fmt.Errorf("db error")
 		},

--- a/backend/internal/api/handlers/catalog/tag_test.go
+++ b/backend/internal/api/handlers/catalog/tag_test.go
@@ -87,6 +87,122 @@ func TestListTagEntities_ServiceError(t *testing.T) {
 }
 
 // ============================================================================
+// GetTagIntersectionHandler (PSY-995)
+// ============================================================================
+
+func TestGetTagIntersection_FewerThanTwoTags(t *testing.T) {
+	h := NewTagHandler(&testhelpers.MockTagService{}, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze"})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestGetTagIntersection_DuplicateCollapsesBelowTwo(t *testing.T) {
+	// "shoegaze,shoegaze" dedupes to one distinct slug → still < 2 → 400.
+	h := NewTagHandler(&testhelpers.MockTagService{}, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze,shoegaze"})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestGetTagIntersection_UnknownTag(t *testing.T) {
+	mock := &testhelpers.MockTagService{
+		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
+			if slug == "shoegaze" {
+				return &catalogm.Tag{ID: 1, Slug: slug}, nil
+			}
+			return nil, nil // ghost slug → unknown
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze,ghost"})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestGetTagIntersection_PreviewLimitClampedToMax(t *testing.T) {
+	var gotLimit int
+	mock := &testhelpers.MockTagService{
+		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
+			return &catalogm.Tag{ID: 1, Slug: slug}, nil
+		},
+		IntersectEntitiesByTagsFn: func(_ []string, _ bool, previewLimit int) (*contracts.TagIntersectionResponse, error) {
+			gotLimit = previewLimit
+			return &contracts.TagIntersectionResponse{TagMatch: "all"}, nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{
+		Tags:         "shoegaze,ambient",
+		PreviewLimit: 999,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotLimit != intersectionPreviewLimitMax {
+		t.Errorf("expected preview_limit clamped to %d, got %d", intersectionPreviewLimitMax, gotLimit)
+	}
+}
+
+func TestGetTagIntersection_DefaultPreviewLimitAndMatch(t *testing.T) {
+	var gotLimit int
+	var gotMatchAny bool
+	mock := &testhelpers.MockTagService{
+		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
+			return &catalogm.Tag{ID: 1, Slug: slug}, nil
+		},
+		IntersectEntitiesByTagsFn: func(_ []string, matchAny bool, previewLimit int) (*contracts.TagIntersectionResponse, error) {
+			gotLimit = previewLimit
+			gotMatchAny = matchAny
+			return &contracts.TagIntersectionResponse{TagMatch: "all"}, nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze,ambient"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotLimit != intersectionPreviewLimitDefault {
+		t.Errorf("expected default preview_limit %d, got %d", intersectionPreviewLimitDefault, gotLimit)
+	}
+	if gotMatchAny {
+		t.Errorf("expected AND (matchAny=false) by default")
+	}
+}
+
+func TestGetTagIntersection_AnyMatch(t *testing.T) {
+	var gotMatchAny bool
+	mock := &testhelpers.MockTagService{
+		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
+			return &catalogm.Tag{ID: 1, Slug: slug}, nil
+		},
+		IntersectEntitiesByTagsFn: func(_ []string, matchAny bool, _ int) (*contracts.TagIntersectionResponse, error) {
+			gotMatchAny = matchAny
+			return &contracts.TagIntersectionResponse{TagMatch: "any"}, nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze,ambient", TagMatch: "any"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gotMatchAny {
+		t.Errorf("expected matchAny=true for tag_match=any")
+	}
+}
+
+func TestGetTagIntersection_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockTagService{
+		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
+			return &catalogm.Tag{ID: 1, Slug: slug}, nil
+		},
+		IntersectEntitiesByTagsFn: func(_ []string, _ bool, _ int) (*contracts.TagIntersectionResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze,ambient"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
 // GetGenreHierarchyHandler
 // ============================================================================
 

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -3331,6 +3331,7 @@ type MockTagService struct {
 	GetGenreHierarchyFn        func() ([]*catalogm.Tag, error)
 	SetTagParentFn             func(uint, *uint, uint) error
 	GetTagEntitiesFn           func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
+	IntersectEntitiesByTagsFn  func([]string, bool, int) (*contracts.TagIntersectionResponse, error)
 	GetTagDetailFn             func(uint) (*contracts.TagDetailResponse, error)
 	GetLowQualityTagQueueFn    func(int, int) (*contracts.LowQualityTagQueueResponse, error)
 	SnoozeLowQualityTagFn      func(uint, uint) error
@@ -3483,6 +3484,12 @@ func (m *MockTagService) GetTagEntities(tagID uint, entityType string, limit int
 		return m.GetTagEntitiesFn(tagID, entityType, limit, offset)
 	}
 	return nil, 0, nil
+}
+func (m *MockTagService) IntersectEntitiesByTags(tagSlugs []string, matchAny bool, previewLimit int) (*contracts.TagIntersectionResponse, error) {
+	if m.IntersectEntitiesByTagsFn != nil {
+		return m.IntersectEntitiesByTagsFn(tagSlugs, matchAny, previewLimit)
+	}
+	return nil, nil
 }
 func (m *MockTagService) GetTagDetail(tagID uint) (*contracts.TagDetailResponse, error) {
 	if m.GetTagDetailFn != nil {

--- a/backend/internal/api/routes/tags.go
+++ b/backend/internal/api/routes/tags.go
@@ -21,6 +21,10 @@ func setupTagRoutes(rc RouteContext) {
 	// Public tag endpoints
 	huma.Get(rc.API, "/tags", tagHandler.ListTagsHandler)
 	huma.Get(rc.API, "/tags/search", tagHandler.SearchTagsHandler)
+	// PSY-995: cross-entity multi-tag intersection. Registered before the
+	// `/tags/{tag_id}` wildcard so the literal `intersection` segment is not
+	// captured as a tag_id.
+	huma.Get(rc.API, "/tags/intersection", tagHandler.GetTagIntersectionHandler)
 	huma.Get(rc.API, "/tags/{tag_id}", tagHandler.GetTagHandler)
 	huma.Get(rc.API, "/tags/{tag_id}/detail", tagHandler.GetTagDetailHandler)
 	huma.Get(rc.API, "/tags/{tag_id}/aliases", tagHandler.ListAliasesHandler)

--- a/backend/internal/services/catalog/tag_intersection.go
+++ b/backend/internal/services/catalog/tag_intersection.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	catalogm "psychic-homily-backend/internal/models/catalog"
@@ -25,15 +26,15 @@ import (
 // Each type also replicates its browse's "active-entity" gate so the count
 // matches what clicking through returns (see decision in PSY-995):
 //   - artist:     no gate. /artists?tags= sets skip_active_filter=true, so a tag
-//                 page is an evergreen surface (every tagged artist, active or not).
+//     page is an evergreen surface (every tagged artist, active or not).
 //   - venue:      verified = true only (the public /venues list).
 //   - show:       status = approved AND event_date >= start-of-today UTC (upcoming),
-//                 matching GetUpcomingShows; counted transitively via the lineup.
+//     matching GetUpcomingShows; counted transitively via the lineup.
 //   - festival:   no gate; counted transitively via the lineup.
 //   - release:    no gate.
 //   - label:      no gate.
 //   - collection: is_public = true ONLY — private collections must never leak
-//                 through this public surface (load-bearing; asserted in a test).
+//     through this public surface (load-bearing; asserted in a test).
 //
 // tagSlugs is assumed already resolved/validated by the caller; matchAny=false ⇒
 // AND (the lineup collectively covers all tags for show/festival), true ⇒ OR.
@@ -44,7 +45,7 @@ func (s *TagService) IntersectEntitiesByTags(tagSlugs []string, matchAny bool, p
 		return nil, fmt.Errorf("database not initialized")
 	}
 	if previewLimit <= 0 {
-		previewLimit = defaultIntersectionPreviewLimit
+		previewLimit = contracts.DefaultIntersectionPreviewLimit
 	}
 
 	filter := TagFilter{TagSlugs: tagSlugs, MatchAny: matchAny}
@@ -61,7 +62,8 @@ func (s *TagService) IntersectEntitiesByTags(tagSlugs []string, matchAny bool, p
 	}
 
 	// Echo the resolved input tags (in request order) so the chip UI can render
-	// canonical names. Slugs already validated to exist by the handler.
+	// canonical names. resolveTagSummaries also validates existence: an unknown
+	// slug returns *contracts.UnknownTagSlugError (mapped to 400 by the handler).
 	tagSummaries, err := s.resolveTagSummaries(tagSlugs)
 	if err != nil {
 		return nil, err
@@ -79,12 +81,11 @@ func (s *TagService) IntersectEntitiesByTags(tagSlugs []string, matchAny bool, p
 	return resp, nil
 }
 
-// defaultIntersectionPreviewLimit is the per-type preview size when the caller
-// passes a non-positive limit. The handler clamps the upper bound.
-const defaultIntersectionPreviewLimit = 4
-
-// resolveTagSummaries loads the TagSummary for each requested slug, preserving
-// request order. Returns an empty (non-nil) slice when tagSlugs is empty.
+// resolveTagSummaries loads the TagSummary for each requested slug in a single
+// batched query, preserving request order. It doubles as validation: a slug
+// that doesn't resolve returns a typed *contracts.UnknownTagSlugError so the
+// handler can map it to a 400 instead of yielding misleading all-zero groups.
+// Returns an empty (non-nil) slice when tagSlugs is empty.
 func (s *TagService) resolveTagSummaries(tagSlugs []string) ([]contracts.TagSummary, error) {
 	out := make([]contracts.TagSummary, 0, len(tagSlugs))
 	if len(tagSlugs) == 0 {
@@ -94,14 +95,17 @@ func (s *TagService) resolveTagSummaries(tagSlugs []string) ([]contracts.TagSumm
 	if err := s.db.Where("LOWER(slug) IN ?", tagSlugs).Find(&tags).Error; err != nil {
 		return nil, fmt.Errorf("failed to load tag summaries: %w", err)
 	}
+	// Key by the lowercased stored slug so the lookup is robust even if a stored
+	// slug ever carries uppercase; request slugs are already lowercased by
+	// ParseTagFilter.
 	bySlug := make(map[string]catalogm.Tag, len(tags))
 	for _, t := range tags {
-		bySlug[t.Slug] = t
+		bySlug[strings.ToLower(t.Slug)] = t
 	}
 	for _, slug := range tagSlugs {
 		t, ok := bySlug[slug]
 		if !ok {
-			continue
+			return nil, &contracts.UnknownTagSlugError{Slug: slug}
 		}
 		out = append(out, contracts.TagSummary{
 			ID:         t.ID,
@@ -219,8 +223,13 @@ func (s *TagService) intersectBaseQuery(entityType string) *gorm.DB {
 	case catalogm.TagEntityLabel:
 		return s.db.Table("labels")
 	case catalogm.TagEntityShow:
-		// /shows?tags= => GetUpcomingShows: approved + upcoming (>= start of
-		// today, UTC). Past/non-approved shows are excluded from the count.
+		// Shows: approved + upcoming (event_date >= start of today, UTC). This is
+		// a discovery surface, so past shows are excluded from the count. The
+		// boundary is UTC start-of-day — intentionally coarser than ShowService's
+		// timezone-aware upcoming filter, because this endpoint is city-agnostic
+		// and carries no request timezone (see startOfTodayUTC). PSY-993 owns the
+		// "show all shows" link target and must point it at an upcoming-scoped
+		// shows surface so the linked list agrees with this count.
 		return s.db.Table("shows").
 			Where("shows.status = ?", catalogm.ShowStatusApproved).
 			Where("shows.event_date >= ?", startOfTodayUTC())
@@ -300,9 +309,12 @@ func (s *TagService) enrichForType(entityType string, ids []uint) map[uint]contr
 	}
 }
 
-// startOfTodayUTC returns midnight UTC for the current day — the lower bound
-// GetUpcomingShows uses (computed in the request timezone there; UTC is the
-// correct global default for a city-agnostic discovery endpoint).
+// startOfTodayUTC returns midnight UTC for the current day — the lower bound for
+// the upcoming-show gate. ShowService's upcoming filter computes start-of-day in
+// the request timezone; this endpoint is city-agnostic (no request timezone), so
+// it uses UTC start-of-day as the global default. The two boundaries can differ
+// by up to a day near the UTC/local date line — an accepted trade-off for a
+// tag-discovery count, NOT a claim of byte-parity with ShowService.
 func startOfTodayUTC() time.Time {
 	now := time.Now().UTC()
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)

--- a/backend/internal/services/catalog/tag_intersection.go
+++ b/backend/internal/services/catalog/tag_intersection.go
@@ -1,0 +1,309 @@
+package catalog
+
+import (
+	"fmt"
+	"time"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/contracts"
+
+	"gorm.io/gorm"
+)
+
+// IntersectEntitiesByTags computes a cross-entity tag intersection (PSY-995):
+// the entities matching the given tag intersection, grouped by entity type,
+// each group carrying a full match count plus a preview (page 1 of that type's
+// "show all" browse).
+//
+// Reuse, not new union SQL: each type's count + preview-ID lookup runs the same
+// tag-filter primitive its /{type}?tags= browse uses — `ApplyTagFilter` for the
+// five direct types and `ApplyTransitiveArtistTagFilter` for show/festival — and
+// each preview is hydrated through the existing per-type enrich* helpers
+// (enrichArtists/enrichShows/…). This guarantees the count/preview agree with the
+// click-through into `/{type}?tags=<slugs>&tag_match=<match>`.
+//
+// Each type also replicates its browse's "active-entity" gate so the count
+// matches what clicking through returns (see decision in PSY-995):
+//   - artist:     no gate. /artists?tags= sets skip_active_filter=true, so a tag
+//                 page is an evergreen surface (every tagged artist, active or not).
+//   - venue:      verified = true only (the public /venues list).
+//   - show:       status = approved AND event_date >= start-of-today UTC (upcoming),
+//                 matching GetUpcomingShows; counted transitively via the lineup.
+//   - festival:   no gate; counted transitively via the lineup.
+//   - release:    no gate.
+//   - label:      no gate.
+//   - collection: is_public = true ONLY — private collections must never leak
+//                 through this public surface (load-bearing; asserted in a test).
+//
+// tagSlugs is assumed already resolved/validated by the caller; matchAny=false ⇒
+// AND (the lineup collectively covers all tags for show/festival), true ⇒ OR.
+// previewLimit bounds each group's preview slice. Groups for every valid entity
+// type are returned (zero-count groups included) in canonical TagEntityTypes order.
+func (s *TagService) IntersectEntitiesByTags(tagSlugs []string, matchAny bool, previewLimit int) (*contracts.TagIntersectionResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	if previewLimit <= 0 {
+		previewLimit = defaultIntersectionPreviewLimit
+	}
+
+	filter := TagFilter{TagSlugs: tagSlugs, MatchAny: matchAny}
+
+	matchMode := "all"
+	if matchAny {
+		matchMode = "any"
+	}
+
+	resp := &contracts.TagIntersectionResponse{
+		Tags:     []contracts.TagSummary{},
+		TagMatch: matchMode,
+		Groups:   make([]contracts.TagIntersectionGroup, 0, len(catalogm.TagEntityTypes)),
+	}
+
+	// Echo the resolved input tags (in request order) so the chip UI can render
+	// canonical names. Slugs already validated to exist by the handler.
+	tagSummaries, err := s.resolveTagSummaries(tagSlugs)
+	if err != nil {
+		return nil, err
+	}
+	resp.Tags = tagSummaries
+
+	for _, et := range catalogm.TagEntityTypes {
+		group, err := s.intersectGroup(et, filter, previewLimit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute %s intersection group: %w", et, err)
+		}
+		resp.Groups = append(resp.Groups, group)
+	}
+
+	return resp, nil
+}
+
+// defaultIntersectionPreviewLimit is the per-type preview size when the caller
+// passes a non-positive limit. The handler clamps the upper bound.
+const defaultIntersectionPreviewLimit = 4
+
+// resolveTagSummaries loads the TagSummary for each requested slug, preserving
+// request order. Returns an empty (non-nil) slice when tagSlugs is empty.
+func (s *TagService) resolveTagSummaries(tagSlugs []string) ([]contracts.TagSummary, error) {
+	out := make([]contracts.TagSummary, 0, len(tagSlugs))
+	if len(tagSlugs) == 0 {
+		return out, nil
+	}
+	var tags []catalogm.Tag
+	if err := s.db.Where("LOWER(slug) IN ?", tagSlugs).Find(&tags).Error; err != nil {
+		return nil, fmt.Errorf("failed to load tag summaries: %w", err)
+	}
+	bySlug := make(map[string]catalogm.Tag, len(tags))
+	for _, t := range tags {
+		bySlug[t.Slug] = t
+	}
+	for _, slug := range tagSlugs {
+		t, ok := bySlug[slug]
+		if !ok {
+			continue
+		}
+		out = append(out, contracts.TagSummary{
+			ID:         t.ID,
+			Name:       t.Name,
+			Slug:       t.Slug,
+			Category:   t.Category,
+			IsOfficial: t.IsOfficial,
+			UsageCount: t.UsageCount,
+		})
+	}
+	return out, nil
+}
+
+// intersectGroup computes one entity type's (count, preview) for the tag
+// intersection. It builds the type's gated base query, applies the shared
+// tag-filter primitive, counts, then fetches the preview IDs and hydrates them
+// through the existing enrich* helper for that type.
+func (s *TagService) intersectGroup(entityType string, filter TagFilter, previewLimit int) (contracts.TagIntersectionGroup, error) {
+	group := contracts.TagIntersectionGroup{
+		EntityType: entityType,
+		Count:      0,
+		Preview:    []contracts.TaggedEntityItem{},
+	}
+
+	idColumn := intersectIDColumn(entityType)
+
+	// Build the gated + tag-filtered query fresh for each step. GORM mutates the
+	// builder in place (Count injects SELECT count(*), Select/Order/Limit append
+	// clauses), so reusing one *gorm.DB across Count and the preview Scan would
+	// bleed state. A small closure keeps the gate + filter defined once.
+	filtered := func() *gorm.DB {
+		q := s.intersectBaseQuery(entityType)
+		return s.applyIntersectionTagFilter(q, entityType, idColumn, filter)
+	}
+
+	// Count distinct matching entities. The tag-filter primitives use an
+	// `idColumn IN (subquery)` shape, so the base rows are already distinct by
+	// primary key — a plain Count is correct.
+	var total int64
+	if err := filtered().Count(&total).Error; err != nil {
+		return group, fmt.Errorf("count failed: %w", err)
+	}
+	group.Count = total
+	if total == 0 {
+		return group, nil
+	}
+
+	// Preview IDs: page 1 in the same default sort the per-type browse uses.
+	var ids []uint
+	if err := filtered().
+		Select(idColumn).
+		Order(s.intersectPreviewOrder(entityType)).
+		Limit(previewLimit).
+		Scan(&ids).Error; err != nil {
+		return group, fmt.Errorf("preview id scan failed: %w", err)
+	}
+	if len(ids) == 0 {
+		return group, nil
+	}
+
+	enriched := s.enrichForType(entityType, ids)
+	preview := make([]contracts.TaggedEntityItem, 0, len(ids))
+	for _, id := range ids {
+		item, ok := enriched[id]
+		if !ok {
+			// Collections drop private/deleted rows in enrichCollections; skip
+			// rather than emit an empty-name placeholder. (Belt-and-suspenders:
+			// the collection base query already filters is_public = true.)
+			continue
+		}
+		item.EntityType = entityType
+		item.EntityID = id
+		preview = append(preview, item)
+	}
+	group.Preview = preview
+	return group, nil
+}
+
+// intersectIDColumn returns the fully-qualified primary-key column the
+// tag-filter primitives constrain for a given entity type's base table.
+func intersectIDColumn(entityType string) string {
+	switch entityType {
+	case catalogm.TagEntityArtist:
+		return "artists.id"
+	case catalogm.TagEntityVenue:
+		return "venues.id"
+	case catalogm.TagEntityRelease:
+		return "releases.id"
+	case catalogm.TagEntityLabel:
+		return "labels.id"
+	case catalogm.TagEntityShow:
+		return "shows.id"
+	case catalogm.TagEntityFestival:
+		return "festivals.id"
+	case catalogm.TagEntityCollection:
+		return "collections.id"
+	default:
+		return "entity_tags.entity_id"
+	}
+}
+
+// intersectBaseQuery returns the gated base query for an entity type. The gate
+// replicates the type's public browse so the intersection count agrees with the
+// `/{type}?tags=` click-through.
+func (s *TagService) intersectBaseQuery(entityType string) *gorm.DB {
+	switch entityType {
+	case catalogm.TagEntityArtist:
+		// Evergreen: /artists?tags= drops the upcoming-show activity gate.
+		return s.db.Table("artists")
+	case catalogm.TagEntityVenue:
+		// Public /venues lists verified venues only.
+		return s.db.Table("venues").Where("venues.verified = ?", true)
+	case catalogm.TagEntityRelease:
+		return s.db.Table("releases")
+	case catalogm.TagEntityLabel:
+		return s.db.Table("labels")
+	case catalogm.TagEntityShow:
+		// /shows?tags= => GetUpcomingShows: approved + upcoming (>= start of
+		// today, UTC). Past/non-approved shows are excluded from the count.
+		return s.db.Table("shows").
+			Where("shows.status = ?", catalogm.ShowStatusApproved).
+			Where("shows.event_date >= ?", startOfTodayUTC())
+	case catalogm.TagEntityFestival:
+		return s.db.Table("festivals")
+	case catalogm.TagEntityCollection:
+		// Public-only: private collections must never leak through this surface.
+		return s.db.Table("collections").Where("collections.is_public = ?", true)
+	default:
+		// Unreachable: entityType comes from TagEntityTypes. Return a query that
+		// matches nothing so a future type addition fails closed (0 count).
+		return s.db.Table("entity_tags").Where("1 = 0")
+	}
+}
+
+// applyIntersectionTagFilter narrows the base query by the tag filter, choosing
+// the direct (entity owns its tags) or transitive (lineup-cover) primitive to
+// match each type's browse semantics.
+func (s *TagService) applyIntersectionTagFilter(query *gorm.DB, entityType, idColumn string, filter TagFilter) *gorm.DB {
+	switch entityType {
+	case catalogm.TagEntityShow:
+		return ApplyTransitiveArtistTagFilter(query, s.db, "show_artists", "show_id", "artist_id", idColumn, filter)
+	case catalogm.TagEntityFestival:
+		return ApplyTransitiveArtistTagFilter(query, s.db, "festival_artists", "festival_id", "artist_id", idColumn, filter)
+	default:
+		return ApplyTagFilter(query, s.db, entityType, idColumn, filter)
+	}
+}
+
+// intersectPreviewOrder returns the ORDER BY clause for a type's preview so the
+// preview matches page 1 of the per-type browse's default sort.
+func (s *TagService) intersectPreviewOrder(entityType string) string {
+	switch entityType {
+	case catalogm.TagEntityShow:
+		// GetUpcomingShows: soonest first.
+		return "shows.event_date ASC, shows.id ASC"
+	case catalogm.TagEntityFestival:
+		// ListFestivals: most recent edition first.
+		return "festivals.start_date DESC, festivals.name ASC"
+	case catalogm.TagEntityRelease:
+		// ListReleases default ("newest"): newest year first.
+		return "releases.release_year DESC NULLS LAST, releases.title ASC"
+	case catalogm.TagEntityArtist:
+		return "artists.name ASC"
+	case catalogm.TagEntityVenue:
+		return "venues.name ASC"
+	case catalogm.TagEntityLabel:
+		return "labels.name ASC"
+	case catalogm.TagEntityCollection:
+		return "collections.updated_at DESC, collections.id DESC"
+	default:
+		return "entity_tags.entity_id ASC"
+	}
+}
+
+// enrichForType dispatches to the existing per-type enrichment helper (shared
+// with GetTagEntities). Reusing these keeps the intersection preview's card
+// shape identical to the single-tag detail page's cards.
+func (s *TagService) enrichForType(entityType string, ids []uint) map[uint]contracts.TaggedEntityItem {
+	switch entityType {
+	case catalogm.TagEntityArtist:
+		return s.enrichArtists(ids)
+	case catalogm.TagEntityVenue:
+		return s.enrichVenues(ids)
+	case catalogm.TagEntityFestival:
+		return s.enrichFestivals(ids)
+	case catalogm.TagEntityLabel:
+		return s.enrichLabels(ids)
+	case catalogm.TagEntityRelease:
+		return s.enrichReleases(ids)
+	case catalogm.TagEntityShow:
+		return s.enrichShows(ids)
+	case catalogm.TagEntityCollection:
+		return s.enrichCollections(ids)
+	default:
+		return s.enrichBare(entityType, ids)
+	}
+}
+
+// startOfTodayUTC returns midnight UTC for the current day — the lower bound
+// GetUpcomingShows uses (computed in the request timezone there; UTC is the
+// correct global default for a city-agnostic discovery endpoint).
+func startOfTodayUTC() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/backend/internal/services/catalog/tag_intersection_test.go
+++ b/backend/internal/services/catalog/tag_intersection_test.go
@@ -204,6 +204,44 @@ func (s *TagIntersectionIntegrationTestSuite) TestIntersection_CompleteKeysetAnd
 	s.Equal(int64(0), counts["collection"])
 }
 
+// TestIntersection_DirectReleaseAndLabel exercises the two direct types that no
+// other test reaches — release and label — so their count, enrich hydration,
+// and bespoke preview ORDER BY ("releases.release_year DESC NULLS LAST" and
+// "labels.name ASC") run against real rows rather than only zero-count
+// short-circuits.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_DirectReleaseAndLabel() {
+	rBoth := s.seedRelease("RBoth")
+	rOne := s.seedRelease("ROne")
+	s.tag("release", rBoth, "shoegaze")
+	s.tag("release", rBoth, "electronic")
+	s.tag("release", rOne, "shoegaze")
+
+	lBoth := s.seedLabel("LBoth")
+	lOne := s.seedLabel("LOne")
+	s.tag("label", lBoth, "shoegaze")
+	s.tag("label", lBoth, "electronic")
+	s.tag("label", lOne, "electronic")
+
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze", "electronic"}, false, 4)
+	s.Require().NoError(err)
+	groups := map[string]contracts.TagIntersectionGroup{}
+	for _, g := range resp.Groups {
+		groups[g.EntityType] = g
+	}
+
+	// AND ⇒ only the doubly-tagged row in each type; the preview is hydrated
+	// (exercises the per-type ORDER BY + enrich helper).
+	s.Equal(int64(1), groups["release"].Count, "AND release: only the doubly-tagged release")
+	s.Require().Len(groups["release"].Preview, 1)
+	s.Equal("release", groups["release"].Preview[0].EntityType)
+	s.NotEmpty(groups["release"].Preview[0].Name, "release preview hydrated via enrichReleases")
+
+	s.Equal(int64(1), groups["label"].Count, "AND label: only the doubly-tagged label")
+	s.Require().Len(groups["label"].Preview, 1)
+	s.Equal("label", groups["label"].Preview[0].EntityType)
+	s.NotEmpty(groups["label"].Preview[0].Name, "label preview hydrated via enrichLabels")
+}
+
 // TestIntersection_AND_vs_OR_MixDirectAndTransitive: AND requires all tags;
 // OR requires any. Mixes a direct type (artist) and a transitive type (show).
 func (s *TagIntersectionIntegrationTestSuite) TestIntersection_AND_vs_OR_MixDirectAndTransitive() {

--- a/backend/internal/services/catalog/tag_intersection_test.go
+++ b/backend/internal/services/catalog/tag_intersection_test.go
@@ -1,0 +1,387 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// TagIntersectionIntegrationTestSuite exercises IntersectEntitiesByTags
+// (PSY-995): the cross-entity multi-tag intersection grouped by entity type.
+// Seeding mirrors TagFilterIntegrationTestSuite so the per-type gates +
+// direct/transitive split are validated against real rows.
+type TagIntersectionIntegrationTestSuite struct {
+	suite.Suite
+	testDB     *testutil.TestDatabase
+	db         *gorm.DB
+	tagService *TagService
+
+	user *authm.User
+	tags map[string]*catalogm.Tag
+}
+
+func (s *TagIntersectionIntegrationTestSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.tagService = NewTagService(s.db)
+}
+
+func (s *TagIntersectionIntegrationTestSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *TagIntersectionIntegrationTestSuite) SetupTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	for _, tbl := range []string{
+		"tag_votes", "entity_tags", "tag_aliases",
+		"collection_items", "collections",
+		"artist_releases", "artist_labels", "release_labels",
+		"festival_artists", "festival_venues",
+		"show_artists", "show_venues", "shows",
+		"artists", "venues", "festivals", "labels", "releases",
+		"tags", "users",
+	} {
+		_, _ = sqlDB.Exec("DELETE FROM " + tbl)
+	}
+
+	email := fmt.Sprintf("ix-user-%d@test.com", time.Now().UnixNano())
+	name := "Intersect"
+	u := &authm.User{Email: &email, FirstName: &name, IsActive: true, EmailVerified: true}
+	s.Require().NoError(s.db.Create(u).Error)
+	s.user = u
+
+	s.tags = map[string]*catalogm.Tag{}
+	for _, n := range []string{"post-punk", "shoegaze", "phoenix", "electronic"} {
+		cat := "genre"
+		if n == "phoenix" {
+			cat = "locale"
+		}
+		t, err := s.tagService.CreateTag(n, nil, nil, cat, false, nil)
+		s.Require().NoError(err)
+		s.tags[t.Slug] = t
+	}
+}
+
+func TestTagIntersectionIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(TagIntersectionIntegrationTestSuite))
+}
+
+// ── seeding helpers ───────────────────────────────────────────────
+
+func (s *TagIntersectionIntegrationTestSuite) tag(entityType string, entityID uint, slug string) {
+	t, ok := s.tags[slug]
+	s.Require().Truef(ok, "unseeded tag %q", slug)
+	s.Require().NoError(s.db.Create(&catalogm.EntityTag{
+		TagID: t.ID, EntityType: entityType, EntityID: entityID, AddedByUserID: s.user.ID,
+	}).Error)
+}
+
+func (s *TagIntersectionIntegrationTestSuite) seedArtist(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	a := &catalogm.Artist{Name: name, Slug: &slug}
+	s.Require().NoError(s.db.Create(a).Error)
+	return a.ID
+}
+
+func (s *TagIntersectionIntegrationTestSuite) seedVerifiedVenue(name string) uint {
+	v := &catalogm.Venue{Name: name, City: "Phoenix", State: "AZ", Verified: true}
+	s.Require().NoError(s.db.Create(v).Error)
+	return v.ID
+}
+
+func (s *TagIntersectionIntegrationTestSuite) seedUnverifiedVenue(name string) uint {
+	v := &catalogm.Venue{Name: name, City: "Phoenix", State: "AZ"}
+	s.Require().NoError(s.db.Create(v).Error)
+	return v.ID
+}
+
+func (s *TagIntersectionIntegrationTestSuite) seedRelease(title string) uint {
+	slug := fmt.Sprintf("%s-%d", title, time.Now().UnixNano())
+	r := &catalogm.Release{Title: title, Slug: &slug}
+	s.Require().NoError(s.db.Create(r).Error)
+	return r.ID
+}
+
+func (s *TagIntersectionIntegrationTestSuite) seedLabel(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	l := &catalogm.Label{Name: name, Slug: &slug, Status: catalogm.LabelStatusActive}
+	s.Require().NoError(s.db.Create(l).Error)
+	return l.ID
+}
+
+func (s *TagIntersectionIntegrationTestSuite) seedFestival(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	f := &catalogm.Festival{
+		Name: name, Slug: slug, SeriesSlug: slug + "-series",
+		EditionYear: 2026, StartDate: "2026-06-01", EndDate: "2026-06-03",
+		Status: catalogm.FestivalStatusConfirmed,
+	}
+	s.Require().NoError(s.db.Create(f).Error)
+	return f.ID
+}
+
+// seedApprovedUpcomingShow creates an approved show in the future.
+func (s *TagIntersectionIntegrationTestSuite) seedApprovedUpcomingShow(title string) uint {
+	show := &catalogm.Show{
+		Title: title, EventDate: time.Now().Add(48 * time.Hour).UTC(),
+		Status: catalogm.ShowStatusApproved, SubmittedBy: &s.user.ID,
+	}
+	s.Require().NoError(s.db.Create(show).Error)
+	return show.ID
+}
+
+// seedPastApprovedShow creates an approved show in the past (excluded from the
+// upcoming gate).
+func (s *TagIntersectionIntegrationTestSuite) seedPastApprovedShow(title string) uint {
+	show := &catalogm.Show{
+		Title: title, EventDate: time.Now().Add(-72 * time.Hour).UTC(),
+		Status: catalogm.ShowStatusApproved, SubmittedBy: &s.user.ID,
+	}
+	s.Require().NoError(s.db.Create(show).Error)
+	return show.ID
+}
+
+func (s *TagIntersectionIntegrationTestSuite) addArtistToShow(showID, artistID uint, position int) {
+	s.Require().NoError(s.db.Create(&catalogm.ShowArtist{ShowID: showID, ArtistID: artistID, Position: position}).Error)
+}
+
+func (s *TagIntersectionIntegrationTestSuite) addArtistToFestival(festivalID, artistID uint) {
+	s.Require().NoError(s.db.Create(&catalogm.FestivalArtist{FestivalID: festivalID, ArtistID: artistID}).Error)
+}
+
+// seedCollection inserts a collection with an explicit is_public flag. GORM
+// skips zero-value bools on Create (the DB default true wins), so we create
+// then Update is_public to land a genuinely private row.
+func (s *TagIntersectionIntegrationTestSuite) seedCollection(title string, isPublic bool) uint {
+	slug := fmt.Sprintf("%s-%d", title, time.Now().UnixNano())
+	c := &communitym.Collection{
+		Title: title, Slug: slug, CreatorID: s.user.ID, IsPublic: true, DisplayMode: "unranked",
+	}
+	s.Require().NoError(s.db.Create(c).Error)
+	if !isPublic {
+		s.Require().NoError(s.db.Model(&communitym.Collection{}).Where("id = ?", c.ID).Update("is_public", false).Error)
+	}
+	return c.ID
+}
+
+// ── tests ─────────────────────────────────────────────────────────
+
+// TestIntersection_CompleteKeysetAndZeroCounts: all 7 valid types present in
+// canonical order; types with no matches are zero-count groups.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_CompleteKeysetAndZeroCounts() {
+	a := s.seedArtist("OnlyArtist")
+	s.tag("artist", a, "shoegaze")
+	s.tag("artist", a, "electronic")
+
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze", "electronic"}, false, 4)
+	s.Require().NoError(err)
+
+	s.Require().Len(resp.Groups, len(catalogm.TagEntityTypes))
+	for i, et := range catalogm.TagEntityTypes {
+		s.Equal(et, resp.Groups[i].EntityType, "groups in canonical order")
+	}
+
+	counts := map[string]int64{}
+	for _, g := range resp.Groups {
+		counts[g.EntityType] = g.Count
+	}
+	s.Equal(int64(1), counts["artist"])
+	s.Equal(int64(0), counts["release"])
+	s.Equal(int64(0), counts["show"])
+	s.Equal(int64(0), counts["venue"])
+	s.Equal(int64(0), counts["label"])
+	s.Equal(int64(0), counts["festival"])
+	s.Equal(int64(0), counts["collection"])
+}
+
+// TestIntersection_AND_vs_OR_MixDirectAndTransitive: AND requires all tags;
+// OR requires any. Mixes a direct type (artist) and a transitive type (show).
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_AND_vs_OR_MixDirectAndTransitive() {
+	// Direct: artist tagged both vs only one.
+	aBoth := s.seedArtist("ABoth")
+	aOne := s.seedArtist("AOne")
+	s.tag("artist", aBoth, "post-punk")
+	s.tag("artist", aBoth, "shoegaze")
+	s.tag("artist", aOne, "post-punk")
+
+	// Transitive: show whose lineup collectively covers both vs only one.
+	sBoth := s.seedApprovedUpcomingShow("ShowBoth")
+	sOne := s.seedApprovedUpcomingShow("ShowOne")
+	aPP := s.seedArtist("LineupPP")
+	aSG := s.seedArtist("LineupSG")
+	aPPOnly := s.seedArtist("LineupPPOnly")
+	s.addArtistToShow(sBoth, aPP, 0)
+	s.addArtistToShow(sBoth, aSG, 1)
+	s.addArtistToShow(sOne, aPPOnly, 0)
+	s.tag("artist", aPP, "post-punk")
+	s.tag("artist", aSG, "shoegaze")
+	s.tag("artist", aPPOnly, "post-punk")
+
+	// Artist direct matches: aBoth(pp,sg), aOne(pp), and the lineup artists are
+	// themselves directly-tagged artists too — aPP(pp), aSG(sg), aPPOnly(pp).
+	// AND (both tags on the SAME artist) ⇒ only aBoth. OR (either tag) ⇒ all 5.
+	and := s.counts(s.tagService.IntersectEntitiesByTags([]string{"post-punk", "shoegaze"}, false, 4))
+	s.Equal(int64(1), and["artist"], "AND artist: only the doubly-tagged artist")
+	s.Equal(int64(1), and["show"], "AND show: only the lineup that collectively covers both tags")
+
+	or := s.counts(s.tagService.IntersectEntitiesByTags([]string{"post-punk", "shoegaze"}, true, 4))
+	s.Equal(int64(5), or["artist"], "OR artist: every artist carrying either tag (incl. lineup artists)")
+	s.Equal(int64(2), or["show"], "OR show: both (each lineup covers at least one tag)")
+}
+
+// TestIntersection_ShowFestivalTransitive: shows/festivals are counted via a
+// billed artist's tags and appear in the preview.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_ShowFestivalTransitive() {
+	// Show: lineup collectively covers shoegaze + electronic.
+	show := s.seedApprovedUpcomingShow("TransShow")
+	aSG := s.seedArtist("ShowSG")
+	aEL := s.seedArtist("ShowEL")
+	s.addArtistToShow(show, aSG, 0)
+	s.addArtistToShow(show, aEL, 1)
+	s.tag("artist", aSG, "shoegaze")
+	s.tag("artist", aEL, "electronic")
+
+	// Festival: lineup collectively covers both.
+	fest := s.seedFestival("TransFest")
+	fSG := s.seedArtist("FestSG")
+	fEL := s.seedArtist("FestEL")
+	s.addArtistToFestival(fest, fSG)
+	s.addArtistToFestival(fest, fEL)
+	s.tag("artist", fSG, "shoegaze")
+	s.tag("artist", fEL, "electronic")
+
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze", "electronic"}, false, 4)
+	s.Require().NoError(err)
+
+	byType := map[string]int{}
+	previewTitles := map[string][]string{}
+	for i, g := range resp.Groups {
+		byType[g.EntityType] = i
+		for _, p := range g.Preview {
+			previewTitles[g.EntityType] = append(previewTitles[g.EntityType], p.Name)
+		}
+	}
+	s.Equal(int64(1), resp.Groups[byType["show"]].Count, "show counted transitively")
+	s.Equal(int64(1), resp.Groups[byType["festival"]].Count, "festival counted transitively")
+	s.Contains(previewTitles["show"], "TransShow")
+	s.Contains(previewTitles["festival"], "TransFest")
+}
+
+// TestIntersection_CollectionExcludesPrivate: a private collection tagged with
+// both tags must NOT appear in the collection group's count OR preview.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_CollectionExcludesPrivate() {
+	pub := s.seedCollection("PublicCol", true)
+	priv := s.seedCollection("PrivateCol", false)
+	s.tag("collection", pub, "shoegaze")
+	s.tag("collection", pub, "electronic")
+	s.tag("collection", priv, "shoegaze")
+	s.tag("collection", priv, "electronic")
+
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze", "electronic"}, false, 4)
+	s.Require().NoError(err)
+
+	var col *struct {
+		count   int64
+		preview []string
+	}
+	for _, g := range resp.Groups {
+		if g.EntityType == "collection" {
+			names := make([]string, 0, len(g.Preview))
+			for _, p := range g.Preview {
+				names = append(names, p.Name)
+			}
+			col = &struct {
+				count   int64
+				preview []string
+			}{count: g.Count, preview: names}
+		}
+	}
+	s.Require().NotNil(col)
+	s.Equal(int64(1), col.count, "only the public collection is counted")
+	s.Contains(col.preview, "PublicCol")
+	s.NotContains(col.preview, "PrivateCol", "private collection must not leak into the preview")
+}
+
+// TestIntersection_VenueVerifiedGate: an unverified venue tagged with both
+// tags is excluded (mirrors the public /venues list).
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_VenueVerifiedGate() {
+	vVerified := s.seedVerifiedVenue("VerifiedV")
+	vUnverified := s.seedUnverifiedVenue("UnverifiedV")
+	for _, v := range []uint{vVerified, vUnverified} {
+		s.tag("venue", v, "post-punk")
+		s.tag("venue", v, "phoenix")
+	}
+
+	c := s.counts(s.tagService.IntersectEntitiesByTags([]string{"post-punk", "phoenix"}, false, 4))
+	s.Equal(int64(1), c["venue"], "only the verified venue counts")
+}
+
+// TestIntersection_ShowUpcomingApprovedGate: a past (or non-approved) show whose
+// lineup covers both tags is excluded from the show count so it agrees with
+// /shows?tags= (which is upcoming + approved only).
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_ShowUpcomingApprovedGate() {
+	upcoming := s.seedApprovedUpcomingShow("UpcomingShow")
+	past := s.seedPastApprovedShow("PastShow")
+	aSG := s.seedArtist("GateSG")
+	aEL := s.seedArtist("GateEL")
+	for _, sh := range []uint{upcoming, past} {
+		s.addArtistToShow(sh, aSG, 0)
+		s.addArtistToShow(sh, aEL, 1)
+	}
+	s.tag("artist", aSG, "shoegaze")
+	s.tag("artist", aEL, "electronic")
+
+	c := s.counts(s.tagService.IntersectEntitiesByTags([]string{"shoegaze", "electronic"}, false, 4))
+	s.Equal(int64(1), c["show"], "past show is excluded by the upcoming gate")
+}
+
+// TestIntersection_PreviewClampedToLimit: preview size is bounded by the limit
+// while count reflects the full match set.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_PreviewClampedToLimit() {
+	for i := 0; i < 5; i++ {
+		a := s.seedArtist(fmt.Sprintf("Multi%d", i))
+		s.tag("artist", a, "shoegaze")
+		s.tag("artist", a, "electronic")
+	}
+
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze", "electronic"}, false, 2)
+	s.Require().NoError(err)
+	for _, g := range resp.Groups {
+		if g.EntityType == "artist" {
+			s.Equal(int64(5), g.Count, "count is the full match set")
+			s.Len(g.Preview, 2, "preview clamped to the limit")
+		}
+	}
+}
+
+// TestIntersection_TagsEcho: the resolved input tags are echoed in request
+// order with their summaries.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_TagsEcho() {
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze", "post-punk"}, false, 4)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 2)
+	s.Equal("shoegaze", resp.Tags[0].Slug)
+	s.Equal("post-punk", resp.Tags[1].Slug)
+	s.Equal("all", resp.TagMatch)
+}
+
+// counts collapses an IntersectEntitiesByTags result into entity_type → count,
+// failing the test on error.
+func (s *TagIntersectionIntegrationTestSuite) counts(resp *contracts.TagIntersectionResponse, err error) map[string]int64 {
+	s.Require().NoError(err)
+	out := map[string]int64{}
+	for _, g := range resp.Groups {
+		out[g.EntityType] = g.Count
+	}
+	return out
+}

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -196,6 +196,35 @@ type TagIntersectionResponse struct {
 	Groups   []TagIntersectionGroup `json:"groups"`
 }
 
+// Intersection preview-limit policy (PSY-995) — the single source of truth
+// shared by the handler (which clamps the request value) and the service
+// (which floors a non-positive value for direct, non-HTTP callers). Keep the
+// handler's `maximum:"12"` query-param schema tag in sync with
+// MaxIntersectionPreviewLimit.
+const (
+	DefaultIntersectionPreviewLimit = 4
+	MaxIntersectionPreviewLimit     = 12
+)
+
+// ClampIntersectionPreviewLimit applies the default (for non-positive input)
+// and the upper bound.
+func ClampIntersectionPreviewLimit(n int) int {
+	if n <= 0 {
+		return DefaultIntersectionPreviewLimit
+	}
+	if n > MaxIntersectionPreviewLimit {
+		return MaxIntersectionPreviewLimit
+	}
+	return n
+}
+
+// UnknownTagSlugError is returned by IntersectEntitiesByTags when a requested
+// tag slug does not resolve to an existing tag. The handler maps it to a 400
+// (naming the offending slug) rather than a 500, so the caller can fix the URL.
+type UnknownTagSlugError struct{ Slug string }
+
+func (e *UnknownTagSlugError) Error() string { return "unknown tag slug: " + e.Slug }
+
 // TagAliasResponse represents a tag alias returned to clients.
 type TagAliasResponse struct {
 	ID        uint      `json:"id"`
@@ -346,9 +375,9 @@ type TagServiceInterface interface {
 	GetTagEntities(tagID uint, entityType string, limit, offset int) ([]TaggedEntityItem, int64, error)
 
 	// Cross-entity tag intersection (PSY-995): entities matching ≥2 tags,
-	// grouped by entity type with per-type count + preview. tagSlugs must
-	// already be resolved against `tags`; unknown slugs are the caller's
-	// responsibility to reject. matchAny=false ⇒ AND, true ⇒ OR.
+	// grouped by entity type with per-type count + preview. Validates the slugs
+	// itself — an unknown slug returns *UnknownTagSlugError (the handler maps it
+	// to 400). matchAny=false ⇒ AND, true ⇒ OR.
 	IntersectEntitiesByTags(tagSlugs []string, matchAny bool, previewLimit int) (*TagIntersectionResponse, error)
 
 	// Tag detail enrichment

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -171,6 +171,31 @@ type TaggedEntityItem struct {
 	HeadlinerSlug string `json:"headliner_slug,omitempty"`
 }
 
+// TagIntersectionGroup is the per-entity-type slice of a cross-entity tag
+// intersection (PSY-995): the total number of entities of EntityType that
+// match the tag intersection, plus a small preview (page 1 of the per-type
+// "show all" browse). Count is the full match count even when len(Preview)
+// is clamped to the request's preview_limit.
+type TagIntersectionGroup struct {
+	EntityType string             `json:"entity_type"`
+	Count      int64              `json:"count"`
+	Preview    []TaggedEntityItem `json:"preview"`
+}
+
+// TagIntersectionResponse is the body of GET /tags/intersection (PSY-995).
+//
+// Tags echoes the resolved input tags (in request order) so the chip UI can
+// render canonical names. TagMatch is "all" (AND) or "any" (OR). Groups
+// contains one entry per valid tag entity type — including zero-count groups
+// (complete keyset, mirroring GetTagDetail.UsageBreakdown) so the frontend
+// decides which sections to show or hide. Groups are returned in the canonical
+// TagEntityTypes order.
+type TagIntersectionResponse struct {
+	Tags     []TagSummary           `json:"tags"`
+	TagMatch string                 `json:"tag_match"`
+	Groups   []TagIntersectionGroup `json:"groups"`
+}
+
 // TagAliasResponse represents a tag alias returned to clients.
 type TagAliasResponse struct {
 	ID        uint      `json:"id"`
@@ -319,6 +344,12 @@ type TagServiceInterface interface {
 
 	// Tag entities
 	GetTagEntities(tagID uint, entityType string, limit, offset int) ([]TaggedEntityItem, int64, error)
+
+	// Cross-entity tag intersection (PSY-995): entities matching ≥2 tags,
+	// grouped by entity type with per-type count + preview. tagSlugs must
+	// already be resolved against `tags`; unknown slugs are the caller's
+	// responsibility to reject. matchAny=false ⇒ AND, true ⇒ OR.
+	IntersectEntitiesByTags(tagSlugs []string, matchAny bool, previewLimit int) (*TagIntersectionResponse, error)
 
 	// Tag detail enrichment
 	GetTagDetail(tagID uint) (*TagDetailResponse, error)


### PR DESCRIPTION
## Summary

Adds the cross-entity multi-tag intersection endpoint (PSY-995, design decided in the ticket's decision-log comment):

- **`GET /tags/intersection?tags=a,b&tag_match=all`** — returns entities matching a tag intersection **grouped by entity type**, each group with a full match `count` + a capped `preview` (page 1 of that type's "show all"). All 7 `TagEntityTypes` returned incl. zero-count groups; input tags echoed for the chip UI.
- **Reuse-heavy**: each type's count/preview runs the same tag-filter primitive its `/{type}?tags=` browse uses — `ApplyTagFilter` (direct: artist/release/label/venue/collection) and `ApplyTransitiveArtistTagFilter` (transitive lineup-cover: show/festival) — hydrated through the existing `enrich*` helpers, so the count/preview agree with the click-through into `/{type}?tags=<slugs>&tag_match=<match>`.
- **Public-only collections** (private never leak — double-gated + asserted). AND default, `tag_match=any` opt-in. Backend only; the in-place `/tags/{slug}` "+add a tag" pivot is PSY-993's scope.

No migration (the optional `(tag_id, entity_type, entity_id)` index was deferred per the decision — not load-bearing at current scale).

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `go test -count=1 ./internal/services/contracts/... ./internal/services/catalog/... ./internal/api/handlers/catalog/...` — passed (incl. `TagIntersectionIntegrationTestSuite` against real Postgres + handler unit tests)
- [x] `go vet ./internal/services/contracts/... ./internal/services/catalog/... ./internal/api/handlers/catalog/...` — passed
- [x] `gofmt -l` on changed files — clean
- [x] `/code-review` (xhigh) + `/adversarial-review` — see below

## Manual repro

> **Orchestrator takeover disclosure (psy-dispatch stall-takeover carveout).** The implementing agent stalled (600s watchdog) immediately after committing the implementation, at the `/code-review` step. The orchestrator took over: rebased onto current `main` (twice — see below), re-verified `go build` + the full test suite against **real Postgres**, ran both review gates (`/code-review` + `/adversarial-review`), applied the review fixes as a separate commit, and opened this PR.

This is a backend endpoint with **no migration** (stack mode `none`), so per the dispatch convention the **integration suite is the manual repro**. `TagIntersectionIntegrationTestSuite` (9 tests) exercises the real contract against a real Postgres instance:
- `AND_vs_OR_MixDirectAndTransitive` — AND vs OR across a direct (artist) + transitive (show) type.
- `ShowFestivalTransitive` — show/festival counted via a billed artist's tags (count==1 each).
- `CollectionExcludesPrivate` — a genuinely private collection (is_public=false) is absent from **both** count and preview.
- `DirectReleaseAndLabel` *(added in the fixes)* — release + label count + preview hydration + their bespoke `ORDER BY`.
- `VenueVerifiedGate`, `ShowUpcomingApprovedGate`, `CompleteKeysetAndZeroCounts`, `TagsEcho`.
- Handler unit tests: `<2 tags`→400, duplicate-collapse→400, `TooManyTags`(>10)→400, unknown-slug→400, preview clamp, default/`any` match, service-error→500.

A live `curl` was **not** run (the agent stalled before the manual-repro step and the orchestrator substituted the integration suite per the carveout). **Recommended pre-merge:** a spot-check of `GET /tags/intersection?tags=…` on the Vercel preview / local stack.

## Code review
`/code-review` (xhigh, 9 angles + verify + sweep, fresh-context panel): **no correctness bugs** (correctness/completeness angles returned clean; private-collection safety and SQL-injection-safety verified). Cleanup findings — the duplicate preview-limit constant and the double tag-resolution were **fixed** (see below); the table-driven-switch refactor (altitude) is **deferred** as defensible (the per-type comments are good).

## Adversarial review
`/adversarial-review` — 4-lens fresh-context panel, round 1 **BLOCK** → fixes in commit `81f5e83` → round 2 **CLEAN** (Security CLEAN; Saboteur's lone round-2 LOW fixed in the same commit).

- **[HIGH]** DoS / query-amplification on the public endpoint (Saboteur + Security) → **fixed**: cap distinct tags at 10 + `maxLength` on the param; removed the per-slug `GetTagBySlug` preload loop — validation now happens in the service's single batched `resolveTagSummaries` query returning a typed `UnknownTagSlugError` (handler → 400).
- **[HIGH]** Show-gate comments named the wrong endpoint / contradicted themselves (Future-Maintainer) → **fixed**: accurate comments; the "show all shows" link target flagged as PSY-993's contract.
- **[MEDIUM]** Duplicate `=4` preview-limit default → **fixed**: moved default/max + clamp into `contracts` (single source of truth).
- **[MEDIUM]** Release & label direct types untested (`seedRelease`/`seedLabel` orphaned) → **fixed**: added `TestIntersection_DirectReleaseAndLabel`.
- **[LOW]** (round 2) Stale comments contradicting the moved validation → **fixed**.
- **Deferred (disclosed):** table-driven per-type switch refactor; per-endpoint rate limiting (no other public read endpoint — `/tags`, `/tags/search`, `/tags/{id}` — is individually throttled; the tag cap bounds per-request fan-out); enrich-error propagation (pre-existing pattern reused from `GetTagEntities`).

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

## Note: rebased during review
`main` advanced twice while this was in flight — **PSY-1008 (#1023)** and **PSY-987 (#1024)** merged during the dispatch/review. This branch was rebased onto each (both clean, no conflicts); the diff is purely additive (+989, 7 files).

Closes PSY-995
