### PR TITLE
PSY-871: admin moderation queue UI for entity_requests

### DIFF
--- a/backend/internal/api/handlers/community/entity_request.go
+++ b/backend/internal/api/handlers/community/entity_request.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 
@@ -217,11 +218,54 @@ type AdminListEntityRequestsRequest struct {
 	Offset        int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination"`
 }
 
+// AdminEntityRequestView is the admin-queue projection of an EntityRequest with
+// the requester's display name/username resolved (PSY-871). The raw model
+// serializes Requester as json:"-", so the moderation UI can't attribute a
+// request from the model alone; this view resolves it via the canonical
+// user_resolver (mirroring the PendingEdit / EntityReport admin responses).
+// It carries exactly what the moderation card needs: the typed payload for the
+// preview, source context (+ AI source_detail), requester attribution, and the
+// decision/fulfillment fields for non-pending views.
+type AdminEntityRequestView struct {
+	ID                uint             `json:"id"`
+	EntityType        string           `json:"entity_type"`
+	Payload           *json.RawMessage `json:"payload"`
+	SourceContext     string           `json:"source_context"`
+	SourceDetail      *json.RawMessage `json:"source_detail,omitempty"`
+	RequesterID       uint             `json:"requester_id"`
+	RequesterName     string           `json:"requester_name"`
+	RequesterUsername *string          `json:"requester_username"`
+	DecisionState     string           `json:"decision_state"`
+	DecisionNote      *string          `json:"decision_note,omitempty"`
+	CreatedEntityID   *uint            `json:"created_entity_id,omitempty"`
+	CreatedAt         time.Time        `json:"created_at"`
+}
+
+// toAdminEntityRequestView projects a model row onto the admin view, resolving
+// the requester display via the user_resolver. The Requester relation MUST be
+// preloaded by the caller (ListRequests preloads it).
+func toAdminEntityRequestView(r *communitym.EntityRequest) AdminEntityRequestView {
+	return AdminEntityRequestView{
+		ID:                r.ID,
+		EntityType:        r.EntityType,
+		Payload:           r.Payload,
+		SourceContext:     r.SourceContext,
+		SourceDetail:      r.SourceDetail,
+		RequesterID:       r.RequesterID,
+		RequesterName:     servicesshared.ResolveUserName(&r.Requester),
+		RequesterUsername: servicesshared.ResolveUserUsername(&r.Requester),
+		DecisionState:     string(r.DecisionState),
+		DecisionNote:      r.DecisionNote,
+		CreatedEntityID:   r.CreatedEntityID,
+		CreatedAt:         r.CreatedAt,
+	}
+}
+
 // AdminListEntityRequestsResponse is the Huma response for GET /admin/entity-requests.
 type AdminListEntityRequestsResponse struct {
 	Body struct {
-		Requests []communitym.EntityRequest `json:"requests"`
-		Total    int64                      `json:"total"`
+		Requests []AdminEntityRequestView `json:"requests"`
+		Total    int64                    `json:"total"`
 	}
 }
 
@@ -250,8 +294,13 @@ func (h *EntityRequestHandler) AdminListEntityRequestsHandler(ctx context.Contex
 		return nil, huma.Error500InternalServerError("Failed to list entity requests")
 	}
 
+	views := make([]AdminEntityRequestView, 0, len(requests))
+	for i := range requests {
+		views = append(views, toAdminEntityRequestView(&requests[i]))
+	}
+
 	resp := &AdminListEntityRequestsResponse{}
-	resp.Body.Requests = requests
+	resp.Body.Requests = views
 	resp.Body.Total = total
 	return resp, nil
 }

--- a/backend/internal/api/handlers/community/entity_request_test.go
+++ b/backend/internal/api/handlers/community/entity_request_test.go
@@ -492,6 +492,46 @@ func TestAdminListEntityRequests_Success(t *testing.T) {
 	}
 }
 
+// The admin list resolves the requester's display name/username (the raw model
+// serializes Requester as json:"-") and carries the payload so the moderation
+// card can attribute + preview each request. PSY-871.
+func TestAdminListEntityRequests_ResolvesRequesterAndPayload(t *testing.T) {
+	uname := "alice"
+	row := pendingRequest(3, "artist")
+	row.RequesterID = 42
+	row.Requester = authm.User{ID: 42, Username: &uname}
+
+	h := NewEntityRequestHandler(
+		&testhelpers.MockEntityRequestService{
+			ListRequestsFn: func(f *contracts.EntityRequestFilters) ([]communitym.EntityRequest, int64, error) {
+				return []communitym.EntityRequest{*row}, 1, nil
+			},
+		},
+		nil, nil,
+	)
+
+	resp, err := h.AdminListEntityRequestsHandler(erAdminCtx(), &AdminListEntityRequestsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(resp.Body.Requests))
+	}
+	v := resp.Body.Requests[0]
+	if v.RequesterID != 42 {
+		t.Errorf("expected requester_id 42, got %d", v.RequesterID)
+	}
+	if v.RequesterName != "alice" {
+		t.Errorf("expected requester_name alice, got %q", v.RequesterName)
+	}
+	if v.RequesterUsername == nil || *v.RequesterUsername != "alice" {
+		t.Errorf("expected requester_username alice, got %v", v.RequesterUsername)
+	}
+	if v.EntityType != "artist" || v.Payload == nil {
+		t.Errorf("expected entity_type artist + non-nil payload, got %s payload=%v", v.EntityType, v.Payload)
+	}
+}
+
 func TestAdminListEntityRequests_InvalidEntityType(t *testing.T) {
 	h := NewEntityRequestHandler(nil, nil, nil)
 	_, err := h.AdminListEntityRequestsHandler(erAdminCtx(), &AdminListEntityRequestsRequest{EntityType: "wizard"})

--- a/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
@@ -321,6 +321,58 @@ describe('ModerationQueue', () => {
     )
   })
 
+  it('rejects a request with the trimmed reason', () => {
+    const mutate = vi.fn()
+    mockUseDecideEntityRequest.mockReturnValue({ ...defaultMutationReturn, mutate })
+    setDefaultMocks({ requests: [mockEntityRequest] })
+
+    render(<ModerationQueue />)
+
+    fireEvent.click(screen.getByRole('button', { name: /^reject$/i }))
+    fireEvent.change(screen.getByPlaceholderText(/rejection reason/i), {
+      target: { value: '  not notable  ' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /confirm reject/i }))
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 9, decision: 'rejected', note: 'not notable' }),
+      expect.anything()
+    )
+  })
+
+  it('renders the source line, safe external link, and excerpt for AI requests', () => {
+    setDefaultMocks({ requests: [mockEntityRequest] })
+
+    render(<ModerationQueue />)
+
+    expect(screen.getByText(/via AI extraction/i)).toBeInTheDocument()
+    const sourceLink = screen.getByRole('link', { name: /source/i })
+    expect(sourceLink).toHaveAttribute('href', 'https://example.com/article')
+    expect(screen.getByText(/a great new band announced a tour/i)).toBeInTheDocument()
+  })
+
+  it('disables Create for show/festival requests (fulfillment deferred) but allows Reject', () => {
+    const showRequest: AdminEntityRequest = {
+      ...mockEntityRequest,
+      id: 11,
+      entity_type: 'show',
+      payload: { title: 'Big Fest', event_date: '2026-07-01' },
+      source_detail: null,
+    }
+    setDefaultMocks({ requests: [showRequest] })
+
+    render(<ModerationQueue />)
+
+    // Header uses the payload title; the preview omits the header'd title.
+    expect(screen.getByText('Big Fest')).toBeInTheDocument()
+    expect(screen.queryByText('title:')).not.toBeInTheDocument()
+    expect(screen.getByText('event_date:')).toBeInTheDocument()
+    // Create disabled (unsupported fulfillment), Reject still available + hint.
+    expect(screen.getByRole('button', { name: /create/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^reject$/i })).not.toBeDisabled()
+    expect(screen.getByText(/must be created\s+manually for now/i)).toBeInTheDocument()
+  })
+
   it('renders comment report card for comment-type reports', () => {
     setDefaultMocks({ reports: [mockCommentReport] })
 

--- a/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
@@ -4,6 +4,7 @@ import { ModerationQueue } from './ModerationQueue'
 import type { PendingEditResponse } from '@/lib/hooks/admin/useAdminPendingEdits'
 import type { EntityReportResponse } from '@/lib/hooks/admin/useAdminEntityReports'
 import type { PendingComment } from '@/lib/hooks/admin/useAdminComments'
+import type { AdminEntityRequest } from '@/lib/hooks/admin/useAdminEntityRequests'
 
 // --- Mock data ---
 
@@ -121,6 +122,24 @@ const mockLabelReport: EntityReportResponse = {
   created_at: '2026-04-07T00:00:00Z',
 }
 
+// PSY-871: queued entity-creation request. Carries the resolved requester +
+// the typed payload (rendered key:value) + optional AI source_detail.
+const mockEntityRequest: AdminEntityRequest = {
+  id: 9,
+  entity_type: 'artist',
+  payload: { name: 'Queued Band', city: 'Phoenix' },
+  source_context: 'ai_extraction',
+  source_detail: {
+    url: 'https://example.com/article',
+    excerpt: 'a great new band announced a tour',
+  },
+  requester_id: 9,
+  requester_name: 'requester9',
+  requester_username: null,
+  decision_state: 'pending',
+  created_at: '2026-04-08T00:00:00Z',
+}
+
 // --- Mocks ---
 
 const mockUseAdminPendingEdits = vi.fn()
@@ -134,6 +153,8 @@ const mockUseAdminPendingComments = vi.fn()
 const mockUseAdminApproveComment = vi.fn()
 const mockUseAdminRejectComment = vi.fn()
 const mockUseAdminHideComment = vi.fn()
+const mockUseAdminEntityRequests = vi.fn()
+const mockUseDecideEntityRequest = vi.fn()
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false, isError: false, error: null as Error | null }
 
@@ -159,6 +180,11 @@ vi.mock('@/lib/hooks/admin/useAdminComments', () => ({
   useAdminCommentEditHistory: () => ({ data: undefined as unknown, isLoading: false, error: null as Error | null }),
 }))
 
+vi.mock('@/lib/hooks/admin/useAdminEntityRequests', () => ({
+  useAdminEntityRequests: (...args: unknown[]) => mockUseAdminEntityRequests(...args),
+  useDecideEntityRequest: () => mockUseDecideEntityRequest(),
+}))
+
 // PSY-297: stub the edit-history dialog so the badge interaction test doesn't
 // depend on Radix Dialog or the query client.
 vi.mock('@/features/comments', () => ({
@@ -177,12 +203,14 @@ describe('ModerationQueue', () => {
     mockUseAdminRejectComment.mockReturnValue(defaultMutationReturn)
     mockUseAdminHideComment.mockReturnValue(defaultMutationReturn)
     mockUseAdminHideCollection.mockReturnValue(defaultMutationReturn)
+    mockUseDecideEntityRequest.mockReturnValue(defaultMutationReturn)
   })
 
   function setDefaultMocks(overrides?: {
     edits?: unknown[]
     reports?: unknown[]
     comments?: unknown[]
+    requests?: unknown[]
   }) {
     mockUseAdminPendingEdits.mockReturnValue({
       data: { edits: overrides?.edits ?? [], total: overrides?.edits?.length ?? 0 },
@@ -196,6 +224,11 @@ describe('ModerationQueue', () => {
     })
     mockUseAdminPendingComments.mockReturnValue({
       data: { comments: overrides?.comments ?? [], total: overrides?.comments?.length ?? 0 },
+      isLoading: false,
+      error: null,
+    })
+    mockUseAdminEntityRequests.mockReturnValue({
+      data: { requests: overrides?.requests ?? [], total: overrides?.requests?.length ?? 0 },
       isLoading: false,
       error: null,
     })
@@ -242,6 +275,50 @@ describe('ModerationQueue', () => {
     // text node — rather than a single combined string.
     expect(screen.getByText('commenter1')).toBeInTheDocument()
     expect(screen.getByTestId('comment-body')).toBeInTheDocument()
+  })
+
+  // PSY-871: the 4th card type — queued entity-creation requests.
+  it('renders entity request card with payload preview + Create action', () => {
+    setDefaultMocks({ requests: [mockEntityRequest] })
+
+    render(<ModerationQueue />)
+
+    // Purple "Request" category badge + entity type + payload-derived label.
+    expect(screen.getByText('Request')).toBeInTheDocument()
+    expect(screen.getByText('Artist')).toBeInTheDocument()
+    expect(screen.getByText('Queued Band')).toBeInTheDocument()
+    // Requester attribution (unlinked — no username).
+    expect(screen.getByText('requester9')).toBeInTheDocument()
+    // Payload preview shows the non-header fields as key:value (name/title are
+    // the header, so they're omitted from the preview).
+    expect(screen.getByText('city:')).toBeInTheDocument()
+    expect(screen.queryByText('name:')).not.toBeInTheDocument()
+    // Action label is "Create" (not "Approve"); reject stays available.
+    expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
+  })
+
+  it('shows the Requests filter tab', () => {
+    setDefaultMocks({ requests: [mockEntityRequest] })
+
+    render(<ModerationQueue />)
+
+    expect(screen.getByText('Requests')).toBeInTheDocument()
+  })
+
+  it('fires the decide mutation with approved when Create is clicked', () => {
+    const mutate = vi.fn()
+    mockUseDecideEntityRequest.mockReturnValue({ ...defaultMutationReturn, mutate })
+    setDefaultMocks({ requests: [mockEntityRequest] })
+
+    render(<ModerationQueue />)
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 9, decision: 'approved' }),
+      expect.anything()
+    )
   })
 
   it('renders comment report card for comment-type reports', () => {

--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   ExternalLink,
   History,
+  PlusCircle,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
@@ -35,11 +36,16 @@ import {
   useAdminRejectComment,
   useAdminHideComment,
 } from '@/lib/hooks/admin/useAdminComments'
+import {
+  useAdminEntityRequests,
+  useDecideEntityRequest,
+} from '@/lib/hooks/admin/useAdminEntityRequests'
 import { CommentEditHistory } from '@/features/comments'
 import { EntitySaveSuccessBanner } from '@/features/contributions'
 import type { PendingEditResponse } from '@/lib/hooks/admin/useAdminPendingEdits'
 import type { EntityReportResponse } from '@/lib/hooks/admin/useAdminEntityReports'
 import type { PendingComment } from '@/lib/hooks/admin/useAdminComments'
+import type { AdminEntityRequest } from '@/lib/hooks/admin/useAdminEntityRequests'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -106,7 +112,7 @@ function renderValue(value: unknown): string {
 
 // ─── Filter Types ────────────────────────────────────────────────────────────
 
-type ItemTypeFilter = 'all' | 'edits' | 'reports' | 'comments'
+type ItemTypeFilter = 'all' | 'edits' | 'reports' | 'comments' | 'requests'
 type EntityTypeFilter = '' | 'artist' | 'venue' | 'festival' | 'show' | 'collection' | 'release' | 'label'
 
 // ─── Unified Item Type ───────────────────────────────────────────────────────
@@ -115,6 +121,7 @@ type ModerationItem =
   | { type: 'edit'; data: PendingEditResponse }
   | { type: 'report'; data: EntityReportResponse }
   | { type: 'comment'; data: PendingComment }
+  | { type: 'request'; data: AdminEntityRequest }
 
 // ─── PSY-603: success banner state ───────────────────────────────────────────
 
@@ -256,6 +263,172 @@ function PendingEditCard({
         {(approveMutation.isError || rejectMutation.isError) && (
           <p className="mt-2 text-xs text-destructive">
             {(approveMutation.error || rejectMutation.error)?.message || 'Action failed'}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Entity Request Card (PSY-871) ───────────────────────────────────────────
+
+/** Display label for a request: the payload's name/title, else a type fallback. */
+function requestEntityLabel(req: AdminEntityRequest): string {
+  const p = req.payload || {}
+  const name = p.name ?? p.title
+  if (typeof name === 'string' && name.trim()) return name
+  return `${entityTypeLabel(req.entity_type)} request`
+}
+
+function sourceContextLabel(source: string): string {
+  switch (source) {
+    case 'ai_extraction':
+      return 'AI extraction'
+    case 'paste_mode':
+      return 'paste'
+    case 'manual':
+      return 'manual'
+    default:
+      return source
+  }
+}
+
+// name/title are surfaced as the card header (requestEntityLabel), so the
+// preview omits them to avoid repeating the label — mirroring PendingEditCard,
+// whose preview shows the changes, not the already-headed entity name.
+const PREVIEW_OMIT_KEYS = new Set(['name', 'title'])
+
+/** Non-header payload fields as [key, displayValue] pairs for the preview box. */
+function payloadPreviewEntries(payload: Record<string, unknown>): Array<[string, string]> {
+  return Object.entries(payload || {})
+    .filter(([k, v]) => !PREVIEW_OMIT_KEYS.has(k) && v !== null && v !== undefined && v !== '')
+    .map(
+      ([k, v]) => [k, typeof v === 'object' ? JSON.stringify(v) : String(v)] as [string, string]
+    )
+}
+
+/**
+ * The 4th moderation card type: a queued entity-CREATION request. Mirrors
+ * PendingEditCard's structure (meta row → attribution/source → preview →
+ * action row) so admins keep one scan path. "Create" approves the request →
+ * the backend creates the catalog entity (PSY-1008); "Reject" expands the
+ * shared required-reason textarea. No entity link in the header — the entity
+ * does not exist yet.
+ */
+function RequestCard({
+  request,
+  onActionSuccess,
+}: {
+  request: AdminEntityRequest
+  onActionSuccess: (action: ModerationAction) => void
+}) {
+  const decideMutation = useDecideEntityRequest()
+  const isActioning = decideMutation.isPending
+  // One mutation drives both actions; key each spinner off which decision is in
+  // flight so only the active button spins (the two-mutation cards get this for
+  // free; here we read the mutation's in-flight variables).
+  const pendingDecision = isActioning ? decideMutation.variables?.decision : undefined
+
+  const entityLabel = requestEntityLabel(request)
+  const previewEntries = payloadPreviewEntries(request.payload)
+
+  const handleCreate = useCallback(() => {
+    decideMutation.mutate(
+      { id: request.id, decision: 'approved' },
+      { onSuccess: () => onActionSuccess({ verb: 'approved', entityLabel }) }
+    )
+  }, [decideMutation, request.id, onActionSuccess, entityLabel])
+
+  const handleReject = useCallback(
+    (reason: string) => {
+      decideMutation.mutate(
+        { id: request.id, decision: 'rejected', note: reason },
+        { onSuccess: () => onActionSuccess({ verb: 'rejected', entityLabel }) }
+      )
+    },
+    [decideMutation, request.id, onActionSuccess, entityLabel]
+  )
+
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="p-4">
+        {/* Header row — no entity link: the entity does not exist yet */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <CategoryBadge kind="request" />
+            <Badge variant="outline" className="shrink-0">
+              {entityTypeLabel(request.entity_type)}
+            </Badge>
+            <span className="text-sm font-medium text-foreground truncate">
+              {entityLabel}
+            </span>
+          </div>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {timeAgo(request.created_at)}
+          </span>
+        </div>
+
+        {/* Attribution + source context */}
+        <div className="mt-2 text-sm text-muted-foreground">
+          <span>
+            by{' '}
+            <UserAttribution
+              name={request.requester_name}
+              username={request.requester_username}
+            />
+          </span>
+          <span className="ml-1">
+            &middot; via {sourceContextLabel(request.source_context)}
+          </span>
+          {request.source_detail?.url && (
+            <a
+              href={request.source_detail.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-1 inline-flex items-center gap-0.5 hover:text-foreground hover:underline"
+            >
+              source
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+
+        {/* Source excerpt (AI-extracted requests) */}
+        {request.source_detail?.excerpt && (
+          <p className="mt-1 text-xs italic text-muted-foreground line-clamp-2">
+            &ldquo;{request.source_detail.excerpt}&rdquo;
+          </p>
+        )}
+
+        {/* Payload preview — key:value monospace in a muted box. Always shown
+            (the request payload is small; the action is inline, not
+            expand-to-detail per the locked design). */}
+        {previewEntries.length > 0 && (
+          <div className="mt-2 space-y-0.5 rounded-md border bg-muted/30 p-3 text-xs font-mono">
+            {previewEntries.map(([key, value]) => (
+              <div key={key} className="flex gap-2">
+                <span className="text-muted-foreground">{key}:</span>
+                <span className="text-foreground break-all">{value}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Create-immediate + reject-with-required-reason (same model as edits) */}
+        <RejectWithReasonRow
+          onApprove={handleCreate}
+          onReject={handleReject}
+          isActioning={isActioning}
+          isApproving={pendingDecision === 'approved'}
+          isRejecting={pendingDecision === 'rejected'}
+          approveLabel="Create"
+          approveIcon={PlusCircle}
+          rejectPlaceholder="Rejection reason (required) -- tell the requester why"
+        />
+
+        {decideMutation.isError && (
+          <p className="mt-2 text-xs text-destructive">
+            {decideMutation.error?.message || 'Action failed'}
           </p>
         )}
       </CardContent>
@@ -778,8 +951,19 @@ export function ModerationQueue() {
     error: commentsError,
   } = useAdminPendingComments()
 
-  const isLoading = editsLoading || reportsLoading || commentsLoading
-  const error = editsError || reportsError || commentsError
+  // Fetch pending entity-creation requests (PSY-871). Shares the entity_type
+  // filter; source_context is left unfiltered (the queue shows all origins).
+  const {
+    data: requestsData,
+    isLoading: requestsLoading,
+    error: requestsError,
+  } = useAdminEntityRequests({
+    state: 'pending',
+    entity_type: entityTypeFilter || undefined,
+  })
+
+  const isLoading = editsLoading || reportsLoading || commentsLoading || requestsLoading
+  const error = editsError || reportsError || commentsError || requestsError
 
   // Merge and sort items by created_at (oldest first for review fairness)
   const items = useMemo<ModerationItem[]>(() => {
@@ -796,8 +980,12 @@ export function ModerationQueue() {
       type: 'comment' as const,
       data: c,
     }))
+    const requestItems: ModerationItem[] = (requestsData?.requests || []).map(r => ({
+      type: 'request' as const,
+      data: r,
+    }))
 
-    let merged = [...editItems, ...reportItems, ...commentItems]
+    let merged = [...editItems, ...reportItems, ...commentItems, ...requestItems]
 
     // Apply item type filter
     if (itemTypeFilter === 'edits') {
@@ -806,6 +994,8 @@ export function ModerationQueue() {
       merged = merged.filter(i => i.type === 'report')
     } else if (itemTypeFilter === 'comments') {
       merged = merged.filter(i => i.type === 'comment')
+    } else if (itemTypeFilter === 'requests') {
+      merged = merged.filter(i => i.type === 'request')
     }
 
     // Sort oldest first (review fairness)
@@ -815,12 +1005,13 @@ export function ModerationQueue() {
     )
 
     return merged
-  }, [editsData, reportsData, commentsData, itemTypeFilter])
+  }, [editsData, reportsData, commentsData, requestsData, itemTypeFilter])
 
   const totalEdits = editsData?.total || 0
   const totalReports = reportsData?.total || 0
   const totalComments = commentsData?.total || 0
-  const totalItems = totalEdits + totalReports + totalComments
+  const totalRequests = requestsData?.total || 0
+  const totalItems = totalEdits + totalReports + totalComments + totalRequests
 
   if (isLoading) {
     return (
@@ -882,6 +1073,12 @@ export function ModerationQueue() {
             label="Comments"
             count={totalComments}
           />
+          <FilterButton
+            active={itemTypeFilter === 'requests'}
+            onClick={() => setItemTypeFilter('requests')}
+            label="Requests"
+            count={totalRequests}
+          />
         </div>
 
         {/* Entity type filter */}
@@ -918,7 +1115,9 @@ export function ModerationQueue() {
                 ? 'No pending entity reports to review.'
                 : itemTypeFilter === 'comments'
                   ? 'No pending comments to review.'
-                  : 'No items need moderation. Pending entity edits, reports, and comments will appear here when users submit them.'
+                  : itemTypeFilter === 'requests'
+                    ? 'No pending entity-creation requests to review.'
+                    : 'No items need moderation. Pending entity edits, reports, comments, and creation requests will appear here when users submit them.'
           }
         />
       )}
@@ -938,6 +1137,15 @@ export function ModerationQueue() {
             }
             if (item.type === 'comment') {
               return <PendingCommentCard key={`comment-${item.data.id}`} comment={item.data as PendingComment} />
+            }
+            if (item.type === 'request') {
+              return (
+                <RequestCard
+                  key={`request-${item.data.id}`}
+                  request={item.data as AdminEntityRequest}
+                  onActionSuccess={handleActionSuccess}
+                />
+              )
             }
             // Reports — type-specific cards for kinds that need bespoke
             // moderation actions (hide-comment, hide-collection); generic

--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -125,7 +125,7 @@ type ModerationItem =
 
 // ─── PSY-603: success banner state ───────────────────────────────────────────
 
-type ModerationActionVerb = 'approved' | 'rejected'
+type ModerationActionVerb = 'approved' | 'rejected' | 'created'
 
 interface ModerationAction {
   verb: ModerationActionVerb
@@ -307,6 +307,16 @@ function payloadPreviewEntries(payload: Record<string, unknown>): Array<[string,
     )
 }
 
+// Entity types whose request payloads the backend can fulfill on approve
+// (PSY-1008). show/festival need associations the payload lacks, so their
+// fulfillment is deferred (PSY-998) — the card disables "Create" for them.
+const FULFILLABLE_REQUEST_TYPES = new Set(['artist', 'venue', 'label', 'release'])
+
+/** Returns url only when it's a safe http(s) link, else undefined (no link). */
+function safeHttpUrl(url: string | undefined): string | undefined {
+  return url && /^https?:\/\//i.test(url) ? url : undefined
+}
+
 /**
  * The 4th moderation card type: a queued entity-CREATION request. Mirrors
  * PendingEditCard's structure (meta row → attribution/source → preview →
@@ -331,11 +341,13 @@ function RequestCard({
 
   const entityLabel = requestEntityLabel(request)
   const previewEntries = payloadPreviewEntries(request.payload)
+  const sourceUrl = safeHttpUrl(request.source_detail?.url)
+  const canCreate = FULFILLABLE_REQUEST_TYPES.has(request.entity_type)
 
   const handleCreate = useCallback(() => {
     decideMutation.mutate(
       { id: request.id, decision: 'approved' },
-      { onSuccess: () => onActionSuccess({ verb: 'approved', entityLabel }) }
+      { onSuccess: () => onActionSuccess({ verb: 'created', entityLabel }) }
     )
   }, [decideMutation, request.id, onActionSuccess, entityLabel])
 
@@ -380,9 +392,9 @@ function RequestCard({
           <span className="ml-1">
             &middot; via {sourceContextLabel(request.source_context)}
           </span>
-          {request.source_detail?.url && (
+          {sourceUrl && (
             <a
-              href={request.source_detail.url}
+              href={sourceUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="ml-1 inline-flex items-center gap-0.5 hover:text-foreground hover:underline"
@@ -414,6 +426,15 @@ function RequestCard({
           </div>
         )}
 
+        {/* show/festival can't be fulfilled from the payload yet (PSY-998) —
+            Create is disabled for them, but the admin can still reject. */}
+        {!canCreate && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {entityTypeLabel(request.entity_type)} requests must be created
+            manually for now — Create isn&rsquo;t supported for this type yet.
+          </p>
+        )}
+
         {/* Create-immediate + reject-with-required-reason (same model as edits) */}
         <RejectWithReasonRow
           onApprove={handleCreate}
@@ -423,6 +444,7 @@ function RequestCard({
           isRejecting={pendingDecision === 'rejected'}
           approveLabel="Create"
           approveIcon={PlusCircle}
+          approveDisabled={!canCreate}
           rejectPlaceholder="Rejection reason (required) -- tell the requester why"
         />
 
@@ -1179,9 +1201,14 @@ export function ModerationQueue() {
  * an optional `message` prop.
  */
 function formatModerationActionMessage(action: ModerationAction): string {
-  return action.verb === 'approved'
-    ? `Approved — change applied to ${action.entityLabel}`
-    : 'Rejected — submitter notified of reason'
+  switch (action.verb) {
+    case 'created':
+      return `Created — ${action.entityLabel} added to the catalog`
+    case 'approved':
+      return `Approved — change applied to ${action.entityLabel}`
+    default:
+      return 'Rejected — submitter notified of reason'
+  }
 }
 
 // ─── Filter Button ───────────────────────────────────────────────────────────

--- a/frontend/components/admin/CategoryBadge.test.tsx
+++ b/frontend/components/admin/CategoryBadge.test.tsx
@@ -38,4 +38,16 @@ describe('CategoryBadge', () => {
     const badge = screen.getByText('Edit').closest('div')
     expect(badge).toHaveClass('shrink-0', 'ml-2')
   })
+
+  // PSY-871: the Request kind honors the locked purple (#a855f7); the chart
+  // palette has no second purple besides comment's plum, so this stays a raw
+  // tint until PSY-872 token-ifies the moderation palette.
+  it('renders the Request kind with the purple tint and an icon', () => {
+    const { container } = render(<CategoryBadge kind="request" />)
+
+    const badge = screen.getByText('Request').closest('div')
+    expect(badge?.className).toContain('#a855f7')
+    expect(badge?.className).toContain('text-[#7e22ce]')
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
 })

--- a/frontend/components/admin/CategoryBadge.tsx
+++ b/frontend/components/admin/CategoryBadge.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Flag, MessageSquare, type LucideIcon } from 'lucide-react'
+import { Pencil, Flag, MessageSquare, PlusCircle, type LucideIcon } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils'
  * Moderation "kind" of a queue item. Drives the colored category badge on
  * each moderation card.
  */
-export type AdminCategoryKind = 'edit' | 'report' | 'comment'
+export type AdminCategoryKind = 'edit' | 'report' | 'comment' | 'request'
 
 interface KindConfig {
   label: string
@@ -37,6 +37,17 @@ const KIND_CONFIG: Record<AdminCategoryKind, KindConfig> = {
     label: 'Comment',
     icon: MessageSquare,
     tone: 'bg-chart-7/10 text-chart-7 border-chart-7/30',
+  },
+  // PSY-871: "Request" (queued entity CREATION). Purple "make new thing" tint,
+  // locked in the design decision (#5) as distinct from edit/report/comment.
+  // The categorical --chart-* palette has no second purple (chart-7 plum is
+  // comment's), so this honors the locked purple via a raw hex with a dark
+  // variant. Token-ifying the moderation palette (so all four kinds bind to
+  // --chart-* uniformly) is scoped to PSY-872's admin cohesion pass (#8).
+  request: {
+    label: 'Request',
+    icon: PlusCircle,
+    tone: 'bg-[#a855f7]/10 text-[#7e22ce] border-[#a855f7]/30 dark:text-[#c084fc] dark:border-[#a855f7]/40',
   },
 }
 

--- a/frontend/components/admin/RejectWithReasonRow.test.tsx
+++ b/frontend/components/admin/RejectWithReasonRow.test.tsx
@@ -151,4 +151,16 @@ describe('RejectWithReasonRow', () => {
     const confirm = screen.getByRole('button', { name: /confirm reject/i })
     expect(confirm.querySelector('.animate-spin')).toBeInTheDocument()
   })
+
+  // PSY-871: the request card relabels the primary action "Create"; default
+  // stays "Approve" so the edit/comment cards are unchanged.
+  it('renders a custom approve label and fires onApprove', () => {
+    const { onApprove } = setup({ approveLabel: 'Create' })
+
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^approve$/i })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onApprove).toHaveBeenCalledTimes(1)
+  })
 })

--- a/frontend/components/admin/RejectWithReasonRow.tsx
+++ b/frontend/components/admin/RejectWithReasonRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback } from 'react'
-import { Loader2, Check, X } from 'lucide-react'
+import { Loader2, Check, X, type LucideIcon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 
@@ -36,6 +36,17 @@ export interface RejectWithReasonRowProps {
    * uses the terse "Rejection reason (required)").
    */
   rejectPlaceholder: string
+  /**
+   * Label for the primary (approve) button. Defaults to "Approve"; the
+   * entity-request card (PSY-871) passes "Create" since approving a request
+   * creates the entity.
+   */
+  approveLabel?: string
+  /**
+   * Icon for the primary (approve) button. Defaults to {@link Check}; the
+   * request card passes a "make new thing" icon (e.g. PlusCircle).
+   */
+  approveIcon?: LucideIcon
 }
 
 /**
@@ -59,6 +70,8 @@ export function RejectWithReasonRow({
   isApproving,
   isRejecting,
   rejectPlaceholder,
+  approveLabel = 'Approve',
+  approveIcon: ApproveIcon = Check,
 }: RejectWithReasonRowProps) {
   const [rejecting, setRejecting] = useState(false)
   const [rejectionReason, setRejectionReason] = useState('')
@@ -117,9 +130,9 @@ export function RejectWithReasonRow({
         {isApproving ? (
           <Loader2 className="h-3 w-3 animate-spin mr-1" />
         ) : (
-          <Check className="h-3 w-3 mr-1" />
+          <ApproveIcon className="h-3 w-3 mr-1" />
         )}
-        Approve
+        {approveLabel}
       </Button>
       <Button
         size="sm"

--- a/frontend/components/admin/RejectWithReasonRow.tsx
+++ b/frontend/components/admin/RejectWithReasonRow.tsx
@@ -47,6 +47,13 @@ export interface RejectWithReasonRowProps {
    * request card passes a "make new thing" icon (e.g. PlusCircle).
    */
   approveIcon?: LucideIcon
+  /**
+   * Disables ONLY the approve button while leaving Reject available. The
+   * entity-request card (PSY-871) sets this for show/festival requests, whose
+   * backend fulfillment isn't supported yet (PSY-998) — the admin can still
+   * reject, but can't "Create" until that lands.
+   */
+  approveDisabled?: boolean
 }
 
 /**
@@ -72,6 +79,7 @@ export function RejectWithReasonRow({
   rejectPlaceholder,
   approveLabel = 'Approve',
   approveIcon: ApproveIcon = Check,
+  approveDisabled = false,
 }: RejectWithReasonRowProps) {
   const [rejecting, setRejecting] = useState(false)
   const [rejectionReason, setRejectionReason] = useState('')
@@ -126,7 +134,7 @@ export function RejectWithReasonRow({
 
   return (
     <div className="mt-3 flex items-center gap-2">
-      <Button size="sm" onClick={onApprove} disabled={isActioning}>
+      <Button size="sm" onClick={onApprove} disabled={isActioning || approveDisabled}>
         {isApproving ? (
           <Loader2 className="h-3 w-3 animate-spin mr-1" />
         ) : (

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -216,6 +216,14 @@ export const API_ENDPOINTS = {
       DISMISS: (reportId: string | number) =>
         `${API_BASE_URL}/admin/entity-reports/${reportId}/dismiss`,
     },
+    // PSY-871: queued entity-creation requests (entity_requests). LIST powers
+    // the 4th moderation-queue card type; DECIDE approves (→ creates the
+    // entity, PSY-1008) or rejects with a note.
+    ENTITY_REQUESTS: {
+      LIST: `${API_BASE_URL}/admin/entity-requests`,
+      DECIDE: (requestId: string | number) =>
+        `${API_BASE_URL}/admin/entity-requests/${requestId}/decide`,
+    },
     PIPELINE: {
       VENUES: `${API_BASE_URL}/admin/pipeline/venues`,
       IMPORTS: `${API_BASE_URL}/admin/pipeline/imports`,

--- a/frontend/lib/hooks/admin/useAdminEntityRequests.ts
+++ b/frontend/lib/hooks/admin/useAdminEntityRequests.ts
@@ -1,0 +1,144 @@
+'use client'
+
+/**
+ * Admin Entity-Request Hooks (PSY-871)
+ *
+ * TanStack Query hooks for the moderation queue's 4th card type — queued
+ * entity-CREATION requests (entity_requests). Mirrors useAdminPendingEdits:
+ * one list query + one decide mutation. The decide endpoint approves
+ * (→ creates the catalog entity, PSY-1008) or rejects with a note.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '../../api'
+import { queryKeys, createInvalidateQueries } from '../../queryClient'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * Optional AI-extraction source context attached to a request (PSY-1008).
+ * Stored opaquely server-side; both fields optional.
+ */
+export interface EntityRequestSourceDetail {
+  url?: string
+  excerpt?: string
+}
+
+/**
+ * Admin-queue view of an entity_requests row. The backend resolves the
+ * requester display (the raw model serializes the relation as json:"-") and
+ * carries the typed creation payload for the card's key:value preview.
+ */
+export interface AdminEntityRequest {
+  id: number
+  entity_type: string
+  /** Typed creation payload (shape varies by entity_type); rendered key:value. */
+  payload: Record<string, unknown>
+  source_context: string
+  source_detail?: EntityRequestSourceDetail | null
+  requester_id: number
+  requester_name: string
+  /**
+   * Requester's username when set, null otherwise. Pass to
+   * `<UserAttribution username={...} />` to link the byline to /users/:username.
+   */
+  requester_username: string | null
+  decision_state: 'pending' | 'approved' | 'rejected'
+  decision_note?: string | null
+  /** The catalog entity created when the request was fulfilled (PSY-1008). */
+  created_entity_id?: number | null
+  created_at: string
+}
+
+export interface AdminEntityRequestsListResponse {
+  requests: AdminEntityRequest[]
+  total: number
+}
+
+// ─── Filters ─────────────────────────────────────────────────────────────────
+
+export interface AdminEntityRequestsFilters {
+  state?: string
+  entity_type?: string
+  source_context?: string
+  limit?: number
+  offset?: number
+  /** When false, the query does not fire (e.g. the admin nav badge off-route). Defaults to true. */
+  enabled?: boolean
+}
+
+// ─── Hooks ───────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch queued entity-creation requests for admin review. Defaults to pending.
+ */
+export function useAdminEntityRequests(filters: AdminEntityRequestsFilters = {}) {
+  const {
+    state = 'pending',
+    entity_type,
+    source_context,
+    limit = 50,
+    offset = 0,
+    enabled = true,
+  } = filters
+
+  const params = new URLSearchParams()
+  if (state) params.set('state', state)
+  if (entity_type) params.set('entity_type', entity_type)
+  if (source_context) params.set('source_context', source_context)
+  params.set('limit', limit.toString())
+  params.set('offset', offset.toString())
+
+  const endpoint = `${API_ENDPOINTS.ADMIN.ENTITY_REQUESTS.LIST}?${params.toString()}`
+
+  return useQuery({
+    queryKey: queryKeys.admin.entityRequests({
+      state,
+      entity_type,
+      source_context,
+      limit,
+      offset,
+    }),
+    queryFn: async (): Promise<AdminEntityRequestsListResponse> => {
+      return apiRequest<AdminEntityRequestsListResponse>(endpoint, {
+        method: 'GET',
+      })
+    },
+    staleTime: 30 * 1000, // 30 seconds
+    enabled,
+  })
+}
+
+export interface DecideEntityRequestVars {
+  id: number
+  decision: 'approved' | 'rejected'
+  /** Required by the queue UI when rejecting; omitted on approve. */
+  note?: string
+}
+
+/**
+ * Decide a queued entity request. 'approved' creates the catalog entity
+ * (PSY-1008) and returns created_entity_id; 'rejected' records the note.
+ * Invalidates the request queue + the entity lists an approval may have grown.
+ */
+export function useDecideEntityRequest() {
+  const queryClient = useQueryClient()
+  const invalidateQueries = createInvalidateQueries(queryClient)
+
+  return useMutation({
+    mutationFn: async ({ id, decision, note }: DecideEntityRequestVars) => {
+      return apiRequest(API_ENDPOINTS.ADMIN.ENTITY_REQUESTS.DECIDE(id), {
+        method: 'POST',
+        body: JSON.stringify(note ? { decision, note } : { decision }),
+      })
+    },
+    onSuccess: () => {
+      invalidateQueries.adminEntityRequests()
+      // Approve creates a catalog entity, so refresh the entity lists that may
+      // now include it (matching useApprovePendingEdit's invalidations).
+      invalidateQueries.artists()
+      invalidateQueries.venues()
+      invalidateQueries.festivals()
+    },
+  })
+}

--- a/frontend/lib/hooks/admin/useAdminNavCounts.test.ts
+++ b/frontend/lib/hooks/admin/useAdminNavCounts.test.ts
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   useAdminPendingEdits: vi.fn(),
   useAdminEntityReports: vi.fn(),
   useAdminPendingComments: vi.fn(),
+  useAdminEntityRequests: vi.fn(),
 }))
 vi.mock('./useAdminShows', () => ({ usePendingShows: h.usePendingShows }))
 vi.mock('./useAdminVenues', () => ({ useUnverifiedVenues: h.useUnverifiedVenues }))
@@ -20,6 +21,7 @@ vi.mock('./useAdminArtistReports', () => ({ usePendingArtistReports: h.usePendin
 vi.mock('./useAdminPendingEdits', () => ({ useAdminPendingEdits: h.useAdminPendingEdits }))
 vi.mock('./useAdminEntityReports', () => ({ useAdminEntityReports: h.useAdminEntityReports }))
 vi.mock('./useAdminComments', () => ({ useAdminPendingComments: h.useAdminPendingComments }))
+vi.mock('./useAdminEntityRequests', () => ({ useAdminEntityRequests: h.useAdminEntityRequests }))
 
 import { useAdminNavCounts } from './useAdminNavCounts'
 
@@ -31,7 +33,7 @@ describe('useAdminNavCounts', () => {
     for (const fn of Object.values(h)) fn.mockReturnValue({ data: undefined })
   })
 
-  it('aggregates the four nav counts (moderation = edits + entity reports + comments; reports = show + artist)', () => {
+  it('aggregates the four nav counts (moderation = edits + entity reports + comments + requests; reports = show + artist)', () => {
     h.usePendingShows.mockReturnValue(total(2))
     h.useUnverifiedVenues.mockReturnValue(total(1))
     h.usePendingReports.mockReturnValue(total(3))
@@ -39,11 +41,12 @@ describe('useAdminNavCounts', () => {
     h.useAdminPendingEdits.mockReturnValue(total(5))
     h.useAdminEntityReports.mockReturnValue(total(6))
     h.useAdminPendingComments.mockReturnValue(total(7))
+    h.useAdminEntityRequests.mockReturnValue(total(8))
 
     const { result } = renderHook(() => useAdminNavCounts({ enabled: true }))
 
     expect(result.current).toEqual({
-      moderation: 18, // 5 + 6 + 7
+      moderation: 26, // 5 + 6 + 7 + 8
       pendingShows: 2,
       unverifiedVenues: 1,
       reports: 7, // 3 + 4
@@ -70,6 +73,7 @@ describe('useAdminNavCounts', () => {
     expect(h.usePendingArtistReports).toHaveBeenCalledWith({ enabled: false })
     expect(h.useAdminPendingEdits).toHaveBeenCalledWith({ status: 'pending', enabled: false })
     expect(h.useAdminEntityReports).toHaveBeenCalledWith({ status: 'pending', enabled: false })
+    expect(h.useAdminEntityRequests).toHaveBeenCalledWith({ state: 'pending', enabled: false })
     // positional signature: (limit, offset, options)
     expect(h.useAdminPendingComments).toHaveBeenCalledWith(25, 0, { enabled: false })
   })

--- a/frontend/lib/hooks/admin/useAdminNavCounts.ts
+++ b/frontend/lib/hooks/admin/useAdminNavCounts.ts
@@ -7,12 +7,13 @@ import { usePendingShows } from './useAdminShows'
 import { useAdminPendingEdits } from './useAdminPendingEdits'
 import { useAdminEntityReports } from './useAdminEntityReports'
 import { useAdminPendingComments } from './useAdminComments'
+import { useAdminEntityRequests } from './useAdminEntityRequests'
 
 /**
  * The four attention counts the admin navigation surfaces as badges.
- * `moderation` aggregates the three moderation-queue sources (pending edits +
- * entity reports + pending comments) — the same formula the retired admin tab
- * bar used for its moderation badge.
+ * `moderation` aggregates the four moderation-queue sources (pending edits +
+ * entity reports + pending comments + entity-creation requests) — the same
+ * formula the moderation queue itself uses for its "All" count.
  */
 export interface AdminNavCounts {
   moderation: number
@@ -41,12 +42,14 @@ export function useAdminNavCounts({ enabled }: { enabled: boolean }): AdminNavCo
   const { data: pendingEditsData } = useAdminPendingEdits({ status: 'pending', enabled })
   const { data: entityReportsData } = useAdminEntityReports({ status: 'pending', enabled })
   const { data: pendingCommentsData } = useAdminPendingComments(25, 0, { enabled })
+  const { data: entityRequestsData } = useAdminEntityRequests({ state: 'pending', enabled })
 
   return {
     moderation:
       (pendingEditsData?.total || 0) +
       (entityReportsData?.total || 0) +
-      (pendingCommentsData?.total || 0),
+      (pendingCommentsData?.total || 0) +
+      (entityRequestsData?.total || 0),
     pendingShows: pendingShowsData?.total || 0,
     unverifiedVenues: unverifiedVenuesData?.total || 0,
     reports: (reportsData?.total || 0) + (artistReportsData?.total || 0),

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -184,6 +184,9 @@ export const queryKeys = {
       ['admin', 'pendingEdits', params] as const,
     entityReports: (params?: Record<string, unknown>) =>
       ['admin', 'entityReports', params] as const,
+    // PSY-871: queued entity-creation requests (the moderation queue's 4th type).
+    entityRequests: (params?: Record<string, unknown>) =>
+      ['admin', 'entityRequests', params] as const,
     // Featured slots (admin-curated /explore picks). One list query
     // covers both slot types — list invalidations refresh both
     // panels after Set / Retire.
@@ -478,6 +481,10 @@ export const createInvalidateQueries = (queryClient: QueryClient) => ({
   // Invalidate admin entity reports queries
   adminEntityReports: () =>
     queryClient.invalidateQueries({ queryKey: ['admin', 'entityReports'] }),
+
+  // PSY-871: invalidate admin entity-request (moderation) queries
+  adminEntityRequests: () =>
+    queryClient.invalidateQueries({ queryKey: ['admin', 'entityRequests'] }),
 
   // Invalidate contributor profile queries
   contributor: () =>


### PR DESCRIPTION
Closes PSY-871.

## Summary

Adds the **4th moderation-queue card type — queued entity-CREATION requests** — to the existing unified admin queue (`/admin/moderation`). This completes the queue-for-review loop: PSY-845/853 file `entity_requests` rows, PSY-1008 made approve actually fulfill, and admins can now triage them.

Implements the locked design (the 2026-05-27 decision comment on the ticket — the hybrid-doc source of truth):

- **Unify, not separate** — a `request` variant in the same `ModerationQueue`, alongside Edits/Reports/Comments, with a 4th "Requests" filter tab + count and a shared empty state. The moderation nav badge now aggregates four sources.
- **Inline "Create" + "Reject"** mirroring `PendingEditCard` — Create approves (→ the backend creates the catalog entity, PSY-1008); Reject expands the shared required-reason textarea (`RejectWithReasonRow`, reused via new backward-compatible `approveLabel`/`approveIcon` props). Reject stays Outline/Small.
- **Purple "Request" `CategoryBadge`**, key:value monospace payload preview in a muted box (name/title omitted — they're the card header), source line (`source_context` + PSY-1008 `source_detail` URL/excerpt for AI-origin rows).
- **Post-Create**: the row unmounts, the queue refreshes, the admin stays — a "Created — … added to the catalog" success banner confirms.

**Backend** (the only backend change): a new `AdminEntityRequestView` projection resolves the requester's display name/username via the canonical `user_resolver` (the model serializes `Requester` as `json:"-"`) and carries the payload + `source_detail` the card needs — mirroring the `PendingEdit`/`EntityReport` admin responses. The list/decide endpoints + fulfillment already shipped (PSY-997/PSY-1008).

## Adversarial review

A fresh 4-lens panel (Saboteur · Completeness/design-adherence · Security · Reuse/Quality), no prior session context, against the branch diff. Verdict: **CLEAN/PASS** — every locked decision + AC verified; security actually *reduces* exposure vs the old raw `[]EntityRequest` response. Findings, fixed in `4765da8b`:

- **[MEDIUM]** show/festival can't be fulfilled from the payload yet (PSY-998), so approving one 422s and orphans an approved row → **Create is now disabled** for non-fulfillable types with a "create manually" hint (new `approveDisabled` prop); Reject stays available. (Visible on the Show card in the screenshot.)
- **[LOW]** success-banner copy was edit-oriented → added a `created` verb ("Created — … added to the catalog").
- **[LOW]** `source_detail.url` rendered as an `href` with no scheme guard → added an http(s)-only guard (don't introduce a new `javascript:` sink; a shared `safeExternalHref` for the repo's other URL sinks is a separate cleanup).

## Test plan

- [x] `go build ./...`, `gofmt -l`, `go vet` — clean
- [x] `go test ./internal/api/handlers/community/` — pass (new: admin list resolves requester_name/username + carries payload)
- [x] `bun run typecheck` — clean; `eslint` on changed files — clean
- [x] `bun run test:run` on `ModerationQueue` + `CategoryBadge` + `RejectWithReasonRow` — **44 pass**. New: RequestCard render (badge/label/preview/Create), Create fires `{decision:'approved'}`, reject fires `{decision:'rejected', note}`, source line + external link + excerpt, show/festival disabled-Create + title-omit, Requests filter tab, CategoryBadge `request` kind, RejectWithReasonRow custom `approveLabel`.
- [x] `/code-review` + `/adversarial-review` — fresh panels vs the branch diff; HIGH/MEDIUM fixed in `4765da8b`.
- [x] **Rendered repro**: isolated dev stack + seeded pending `entity_requests` (artist/AI, release/paste, show/manual), logged in as admin → `/admin/moderation` → Requests filter. See screenshot.

## Screenshot

Moderation queue, Requests filter — artist (AI source + excerpt + source link, Create enabled), release (paste), and show (Create **disabled** with the "create manually" hint; Reject available). Payload previews omit the header'd name/title.

![PSY-871 moderation queue — entity request cards](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-5c80e9cfd85db8961a00/psy-871-moderation-requests-full.png)

## Coverage gaps / notes

- The `request` `CategoryBadge` uses the locked purple (`#a855f7`) as a raw hex because the `--chart-*` palette has no second purple (`chart-7` plum is comment's). Token-ifying the moderation palette is scoped to **PSY-872**'s admin cohesion pass (per the locked decisions).
- Reviewed in a dedicated worktree (the main checkout was held by a parallel session); `/code-review` + `/adversarial-review` ran as fresh sub-agents pointed at the branch diff.
