### PR TITLE
PSY-993: rebuild /tags/{slug} detail content-first (no tabs)

### DIFF
--- a/backend/internal/api/handlers/catalog/tag.go
+++ b/backend/internal/api/handlers/catalog/tag.go
@@ -156,7 +156,15 @@ func (h *TagHandler) GetTagDetailHandler(ctx context.Context, req *GetTagDetailR
 // ============================================================================
 
 const (
-	intersectionMinTags = 2
+	// intersectionMinTags = 1: a single tag is a degenerate "intersection" of
+	// one set (its own matches). PSY-993's rebuilt /tags/{slug} detail page
+	// renders its grouped sections from this same endpoint with one tag, then
+	// the "+ add another tag" pivot re-queries with 2+. Serving both through one
+	// path means single-tag sections inherit the transitive show/festival
+	// matching + per-type default sort + public gates for free, instead of
+	// duplicating that logic in GetTagEntities (which is direct-only and would
+	// render an empty Upcoming-shows section).
+	intersectionMinTags = 1
 	// intersectionMaxTags bounds the fan-out of a single request: every tag
 	// adds a term to the per-group entity_tags self-joins across all 7 entity
 	// types, and this endpoint is public + unauthenticated. Cap mirrors the
@@ -165,7 +173,7 @@ const (
 )
 
 type GetTagIntersectionRequest struct {
-	Tags         string `query:"tags" maxLength:"200" doc:"Comma-separated tag slugs (2-10)" example:"shoegaze,ambient"`
+	Tags         string `query:"tags" maxLength:"200" doc:"Comma-separated tag slugs (1-10)" example:"shoegaze,ambient"`
 	TagMatch     string `query:"tag_match" required:"false" doc:"all (AND, default) | any (OR)" example:"all"`
 	PreviewLimit int    `query:"preview_limit" required:"false" minimum:"1" maximum:"12" doc:"Per-type preview size (default 4, max 12)" example:"4"`
 }

--- a/backend/internal/api/handlers/catalog/tag_test.go
+++ b/backend/internal/api/handlers/catalog/tag_test.go
@@ -90,17 +90,35 @@ func TestListTagEntities_ServiceError(t *testing.T) {
 // GetTagIntersectionHandler (PSY-995)
 // ============================================================================
 
-func TestGetTagIntersection_FewerThanTwoTags(t *testing.T) {
+func TestGetTagIntersection_NoTags(t *testing.T) {
+	// Empty/whitespace tags param resolves to zero distinct slugs → below the
+	// minimum of 1 → 400 before the service is touched.
 	h := NewTagHandler(&testhelpers.MockTagService{}, nil)
-	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze"})
+	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: " , "})
 	testhelpers.AssertHumaError(t, err, 400)
 }
 
-func TestGetTagIntersection_DuplicateCollapsesBelowTwo(t *testing.T) {
-	// "shoegaze,shoegaze" dedupes to one distinct slug → still < 2 → 400.
-	h := NewTagHandler(&testhelpers.MockTagService{}, nil)
+func TestGetTagIntersection_SingleTagAllowed(t *testing.T) {
+	// PSY-993: a single tag is a valid degenerate intersection (the tag's own
+	// matches). The rebuilt /tags/{slug} detail page renders its grouped
+	// sections from this endpoint with one tag, so single-tag must pass through
+	// to the service (not 400). "shoegaze,shoegaze" dedupes to one distinct slug
+	// — still valid.
+	var gotSlugs []string
+	mock := &testhelpers.MockTagService{
+		IntersectEntitiesByTagsFn: func(slugs []string, _ bool, _ int) (*contracts.TagIntersectionResponse, error) {
+			gotSlugs = slugs
+			return &contracts.TagIntersectionResponse{TagMatch: "all"}, nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
 	_, err := h.GetTagIntersectionHandler(context.Background(), &GetTagIntersectionRequest{Tags: "shoegaze,shoegaze"})
-	testhelpers.AssertHumaError(t, err, 400)
+	if err != nil {
+		t.Fatalf("unexpected error for single-tag intersection: %v", err)
+	}
+	if len(gotSlugs) != 1 || gotSlugs[0] != "shoegaze" {
+		t.Errorf("expected single resolved slug [shoegaze], got %v", gotSlugs)
+	}
 }
 
 func TestGetTagIntersection_TooManyTags(t *testing.T) {

--- a/backend/internal/services/catalog/tag_intersection.go
+++ b/backend/internal/services/catalog/tag_intersection.go
@@ -154,10 +154,13 @@ func (s *TagService) intersectGroup(entityType string, filter TagFilter, preview
 	}
 
 	// Preview IDs: page 1 in the same default sort the per-type browse uses.
+	// artist/venue order by upcoming-show count DESC — matching their public
+	// browse lists (GetAllArtists orders upcoming_show_count DESC; the design
+	// surfaces the busiest entities first) — which needs a joined count column,
+	// so those types get the join here rather than a plain ORDER string.
 	var ids []uint
-	if err := filtered().
-		Select(idColumn).
-		Order(s.intersectPreviewOrder(entityType)).
+	previewQuery := s.applyPreviewOrder(filtered().Select(idColumn), entityType)
+	if err := previewQuery.
 		Limit(previewLimit).
 		Scan(&ids).Error; err != nil {
 		return group, fmt.Errorf("preview id scan failed: %w", err)
@@ -259,8 +262,45 @@ func (s *TagService) applyIntersectionTagFilter(query *gorm.DB, entityType, idCo
 	}
 }
 
-// intersectPreviewOrder returns the ORDER BY clause for a type's preview so the
-// preview matches page 1 of the per-type browse's default sort.
+// applyPreviewOrder applies a type's default preview sort to the preview-ID
+// query so the preview matches page 1 of that type's "show all" browse.
+//
+// Most types order by a plain column expression (intersectPreviewOrder).
+// artist and venue order by upcoming-show count DESC — the busiest entities
+// first, matching GetAllArtists' `upcoming_show_count DESC` browse sort and the
+// PSY-993 design's "12 shows / 8 shows / 5 shows" rows. That count isn't a base
+// column, so those two types LEFT JOIN the same upcoming-count subquery the
+// enrich* helpers use and order by it (name ASC as the stable tiebreaker).
+func (s *TagService) applyPreviewOrder(query *gorm.DB, entityType string) *gorm.DB {
+	switch entityType {
+	case catalogm.TagEntityArtist:
+		return query.
+			Joins(`LEFT JOIN (
+				SELECT sa.artist_id, COUNT(DISTINCT s.id) AS cnt
+				FROM show_artists sa
+				JOIN shows s ON s.id = sa.show_id
+				WHERE s.event_date >= NOW()
+				GROUP BY sa.artist_id
+			) usc ON usc.artist_id = artists.id`).
+			Order("COALESCE(usc.cnt, 0) DESC, artists.name ASC")
+	case catalogm.TagEntityVenue:
+		return query.
+			Joins(`LEFT JOIN (
+				SELECT sv.venue_id, COUNT(DISTINCT s.id) AS cnt
+				FROM show_venues sv
+				JOIN shows s ON s.id = sv.show_id
+				WHERE s.event_date >= NOW()
+				GROUP BY sv.venue_id
+			) usc ON usc.venue_id = venues.id`).
+			Order("COALESCE(usc.cnt, 0) DESC, venues.name ASC")
+	default:
+		return query.Order(s.intersectPreviewOrder(entityType))
+	}
+}
+
+// intersectPreviewOrder returns the ORDER BY clause for the types whose preview
+// sort is a plain column expression (no joined computed column). artist/venue
+// are handled in applyPreviewOrder because they order by a joined show count.
 func (s *TagService) intersectPreviewOrder(entityType string) string {
 	switch entityType {
 	case catalogm.TagEntityShow:
@@ -272,10 +312,6 @@ func (s *TagService) intersectPreviewOrder(entityType string) string {
 	case catalogm.TagEntityRelease:
 		// ListReleases default ("newest"): newest year first.
 		return "releases.release_year DESC NULLS LAST, releases.title ASC"
-	case catalogm.TagEntityArtist:
-		return "artists.name ASC"
-	case catalogm.TagEntityVenue:
-		return "venues.name ASC"
 	case catalogm.TagEntityLabel:
 		return "labels.name ASC"
 	case catalogm.TagEntityCollection:

--- a/backend/internal/services/catalog/tag_intersection_test.go
+++ b/backend/internal/services/catalog/tag_intersection_test.go
@@ -413,6 +413,70 @@ func (s *TagIntersectionIntegrationTestSuite) TestIntersection_TagsEcho() {
 	s.Equal("all", resp.TagMatch)
 }
 
+// TestIntersection_SingleTagTransitiveShow: PSY-993 drives the rebuilt
+// /tags/{slug} detail page's grouped sections through this endpoint with a
+// SINGLE tag. The load-bearing case is the Upcoming-shows section: a show is
+// never directly tagged, so a direct entity_tags lookup would report 0 — but
+// through the transitive lineup path the show's count + preview populate from a
+// single billed-artist tag. This is the gap the old GetTagEntities (direct-only)
+// would have shipped as an empty section.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_SingleTagTransitiveShow() {
+	// One artist directly tagged shoegaze.
+	artist := s.seedArtist("SoloShoegaze")
+	s.tag("artist", artist, "shoegaze")
+
+	// An upcoming show whose lineup includes that artist (no direct show tag).
+	show := s.seedApprovedUpcomingShow("ShoegazeShow")
+	s.addArtistToShow(show, artist, 0)
+
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze"}, false, 4)
+	s.Require().NoError(err)
+
+	byCount := map[string]int64{}
+	byPreview := map[string][]string{}
+	for _, g := range resp.Groups {
+		byCount[g.EntityType] = g.Count
+		for _, p := range g.Preview {
+			byPreview[g.EntityType] = append(byPreview[g.EntityType], p.Name)
+		}
+	}
+	s.Equal(int64(1), byCount["artist"], "single-tag artist match")
+	s.Equal(int64(1), byCount["show"], "single-tag show counted transitively, NOT direct-only 0")
+	s.Contains(byPreview["show"], "ShoegazeShow", "transitive show appears in the preview")
+}
+
+// TestIntersection_ArtistPreviewOrderedByShowCount: the artist preview must lead
+// with the busiest artists (upcoming-show count DESC), matching the public
+// /artists?tags= browse sort and the PSY-993 design. Tag two artists with the
+// same tag; the one billed on more upcoming shows must come first in the preview.
+func (s *TagIntersectionIntegrationTestSuite) TestIntersection_ArtistPreviewOrderedByShowCount() {
+	busy := s.seedArtist("BusyArtist")
+	quiet := s.seedArtist("QuietArtist")
+	s.tag("artist", busy, "shoegaze")
+	s.tag("artist", quiet, "shoegaze")
+
+	// busy plays two upcoming shows; quiet plays none.
+	for i := 0; i < 2; i++ {
+		sh := s.seedApprovedUpcomingShow(fmt.Sprintf("BusyShow%d", i))
+		s.addArtistToShow(sh, busy, 0)
+	}
+
+	resp, err := s.tagService.IntersectEntitiesByTags([]string{"shoegaze"}, false, 4)
+	s.Require().NoError(err)
+
+	var artistPreview []string
+	for _, g := range resp.Groups {
+		if g.EntityType == "artist" {
+			for _, p := range g.Preview {
+				artistPreview = append(artistPreview, p.Name)
+			}
+		}
+	}
+	s.Require().Len(artistPreview, 2)
+	s.Equal("BusyArtist", artistPreview[0], "busiest artist leads the preview (show-count DESC)")
+	s.Equal("QuietArtist", artistPreview[1])
+}
+
 // counts collapses an IntersectEntitiesByTags result into entity_type → count,
 // failing the test on error.
 func (s *TagIntersectionIntegrationTestSuite) counts(resp *contracts.TagIntersectionResponse, err error) map[string]int64 {

--- a/frontend/features/tags/components/TagDetail.test.tsx
+++ b/frontend/features/tags/components/TagDetail.test.tsx
@@ -1,17 +1,22 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import type { TagEnrichedDetailResponse } from '../types'
+import type {
+  TagEnrichedDetailResponse,
+  TagIntersectionResponse,
+} from '../types'
 
 // ── Mocks ──────────────────────────────────────────
 
 const mockUseTagDetail = vi.fn()
-const mockUseTagEntities = vi.fn()
+const mockUseTagIntersection = vi.fn()
+const mockUseSearchTags = vi.fn()
 vi.mock('../hooks', () => ({
   useTagDetail: (...args: unknown[]) => mockUseTagDetail(...args),
-  useTagEntities: (...args: unknown[]) => mockUseTagEntities(...args),
+  useTagIntersection: (...args: unknown[]) => mockUseTagIntersection(...args),
+  useSearchTags: (...args: unknown[]) => mockUseSearchTags(...args),
 }))
 
 vi.mock('next/link', () => ({
@@ -30,18 +35,20 @@ vi.mock('next/link', () => ({
   ),
 }))
 
+// Router + search params are driven by a module-level mutable so individual
+// tests can seed the ?with= pivot state and assert router.replace calls.
+const mockReplace = vi.fn()
+let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
   usePathname: () => '/tags/test-tag',
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => mockSearchParams,
 }))
 
 vi.mock('@/features/notifications', () => ({
-  NotifyMeButton: ({
-    entityName,
-  }: {
-    entityType: string
-    entityId: number
-    entityName: string
-  }) => <button data-testid="notify-me-button">Notify {entityName}</button>,
+  NotifyMeButton: ({ entityName }: { entityName: string }) => (
+    <button data-testid="notify-me-button">Notify {entityName}</button>
+  ),
 }))
 
 vi.mock('@/components/shared', () => ({
@@ -56,26 +63,13 @@ vi.mock('@/components/shared', () => ({
   }) => (
     <nav aria-label="Breadcrumb" data-testid="breadcrumb-stub">
       <a href={fallback.href}>{fallback.label}</a>
-      {(intermediate ?? []).map(c => (
+      {(intermediate ?? []).map((c) => (
         <a key={c.href} href={c.href} data-testid="breadcrumb-intermediate">
           {c.label}
         </a>
       ))}
       <span>{currentPage}</span>
     </nav>
-  ),
-  EntityCardTitle: ({
-    name,
-    href,
-    ariaLabel,
-  }: {
-    name: string
-    href: string
-    ariaLabel?: string
-  }) => (
-    <a href={href} aria-label={ariaLabel ?? name}>
-      <h3 title={name}>{name}</h3>
-    </a>
   ),
 }))
 
@@ -101,10 +95,9 @@ function makeTagDetail(
   overrides: Partial<TagEnrichedDetailResponse> = {}
 ): TagEnrichedDetailResponse {
   return {
-    // thin fields
     id: 1,
-    name: 'Rock',
-    slug: 'rock',
+    name: 'Shoegaze',
+    slug: 'shoegaze',
     category: 'genre',
     is_official: false,
     usage_count: 42,
@@ -115,7 +108,6 @@ function makeTagDetail(
     aliases: [],
     created_at: '2025-01-01T00:00:00Z',
     updated_at: '2025-01-01T00:00:00Z',
-    // enriched fields
     description_html: '',
     parent: null,
     children: [],
@@ -134,17 +126,49 @@ function makeTagDetail(
   }
 }
 
-describe('TagDetail', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    // Default: no entities loaded
-    mockUseTagEntities.mockReturnValue({
-      data: { entities: [], total: 0 },
-      isLoading: false,
-    })
-  })
+function makeIntersection(
+  overrides: Partial<TagIntersectionResponse> = {}
+): TagIntersectionResponse {
+  return {
+    tags: [
+      {
+        id: 1,
+        name: 'Shoegaze',
+        slug: 'shoegaze',
+        category: 'genre',
+        is_official: false,
+        usage_count: 42,
+      },
+    ],
+    tag_match: 'all',
+    // Canonical backend order: artist, release, label, show, venue, festival,
+    // collection. Component reorders to the design's display order.
+    groups: [
+      { entity_type: 'artist', count: 0, preview: [] },
+      { entity_type: 'release', count: 0, preview: [] },
+      { entity_type: 'label', count: 0, preview: [] },
+      { entity_type: 'show', count: 0, preview: [] },
+      { entity_type: 'venue', count: 0, preview: [] },
+      { entity_type: 'festival', count: 0, preview: [] },
+      { entity_type: 'collection', count: 0, preview: [] },
+    ],
+    ...overrides,
+  }
+}
 
-  // ── Loading state ──
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSearchParams = new URLSearchParams()
+  // Default: tag with no entities loaded.
+  mockUseTagIntersection.mockReturnValue({
+    data: makeIntersection(),
+    isLoading: false,
+  })
+  mockUseSearchTags.mockReturnValue({ data: { tags: [] }, isLoading: false })
+})
+
+describe('TagDetail', () => {
+  // ── Loading / error states ──
 
   it('shows loading spinner while tag is loading', () => {
     mockUseTagDetail.mockReturnValue({
@@ -152,110 +176,9 @@ describe('TagDetail', () => {
       isLoading: true,
       error: null,
     })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    const spinner = document.querySelector('.animate-spin')
-    expect(spinner).toBeInTheDocument()
+    renderWithProviders(<TagDetail slug="shoegaze" />)
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
   })
-
-  // ── Regression: loading → success transition (PSY-447) ──
-  // Rules of Hooks violation: earlier versions called useMemo below the
-  // early returns for loading/error/!tag, so the hook count changed when
-  // data arrived (tag went from undefined → populated). In production
-  // React logs "change in the order of Hooks" / "Rendered more hooks than
-  // during the previous render" and the error boundary renders a 500.
-  //
-  // The other tests all pass with the broken code because the mocked
-  // `useTagDetail` does not call any real React hooks, so when the
-  // component body goes from "0 hooks (early return)" to "1 hook (useMemo)",
-  // React has nothing to compare against. In production the real
-  // `useTagDetail` (via TanStack Query's `useQuery`) calls several real
-  // hooks before the component's own early return, so the mismatch is
-  // detected.
-  //
-  // This regression test makes the mock call a real React hook (`useState`)
-  // so that the 0-to-1 transition in the component body becomes a
-  // 1-to-2 transition, which is what React's hook-tracker can detect.
-  it('renders without hook-order errors during the loading → success transition', () => {
-    // Custom mock implementation that calls a real React hook. This
-    // mimics TanStack Query's internal hook calls so React's hook-order
-    // tracker sees the true mismatch introduced by hooks below an
-    // early return.
-    let dataState: TagEnrichedDetailResponse | undefined = undefined
-    let isLoadingState = true
-    mockUseTagDetail.mockImplementation(() => {
-      // Real React hook — ensures the number of hooks this "replacement"
-      // contributes is stable across renders.
-      useState(0)
-      return { data: dataState, isLoading: isLoadingState, error: null }
-    })
-
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    // Initial render: loading
-    const queryClient = createQueryClient()
-    const { rerender } = render(
-      <QueryClientProvider client={queryClient}>
-        <TagDetail slug="shoegaze" />
-      </QueryClientProvider>
-    )
-
-    // Transition to populated data — this is what triggered the
-    // hook-order violation in production.
-    dataState = makeTagDetail({
-      name: 'Shoegaze',
-      usage_count: 18,
-      usage_breakdown: {
-        artist: 15,
-        venue: 0,
-        show: 3,
-        release: 0,
-        label: 0,
-        festival: 0,
-      },
-    })
-    isLoadingState = false
-
-    let threwDuringRerender: Error | null = null
-    try {
-      rerender(
-        <QueryClientProvider client={queryClient}>
-          <TagDetail slug="shoegaze" />
-        </QueryClientProvider>
-      )
-    } catch (e) {
-      threwDuringRerender = e as Error
-    }
-
-    // A hook-order violation throws during render with a message like
-    // "Rendered more hooks than during the previous render." or
-    // "change in the order of Hooks". React also logs a dev-only
-    // console.error about it.
-    const allErrorOutput = [
-      ...(threwDuringRerender ? [threwDuringRerender.message] : []),
-      ...errorSpy.mock.calls.map(([msg]) =>
-        typeof msg === 'string' ? msg : ''
-      ),
-    ]
-    const hookErrors = allErrorOutput.filter(
-      (msg) =>
-        msg.includes('change in the order of Hooks') ||
-        msg.includes('Rendered more hooks than during the previous render') ||
-        msg.includes('Rendered fewer hooks than expected')
-    )
-    expect(hookErrors).toEqual([])
-    expect(threwDuringRerender).toBeNull()
-
-    // Sanity check: populated content actually renders after the transition.
-    expect(
-      screen.getByRole('heading', { level: 1, name: 'Shoegaze' })
-    ).toBeInTheDocument()
-
-    errorSpy.mockRestore()
-  })
-
-  // ── Error states ──
 
   it('shows "Tag Not Found" for 404 errors', () => {
     mockUseTagDetail.mockReturnValue({
@@ -263,13 +186,8 @@ describe('TagDetail', () => {
       isLoading: false,
       error: new Error('Tag not found'),
     })
-
     renderWithProviders(<TagDetail slug="nonexistent" />)
-
     expect(screen.getByText('Tag Not Found')).toBeInTheDocument()
-    expect(
-      screen.getByText("The tag you're looking for doesn't exist.")
-    ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Back to Tags/ })).toHaveAttribute(
       'href',
       '/tags'
@@ -282,576 +200,77 @@ describe('TagDetail', () => {
       isLoading: false,
       error: new Error('Server error'),
     })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
+    renderWithProviders(<TagDetail slug="shoegaze" />)
     expect(screen.getByText('Error Loading Tag')).toBeInTheDocument()
-    expect(screen.getByText('Server error')).toBeInTheDocument()
   })
 
-  it('shows "Tag Not Found" when data is null/undefined (no error)', () => {
+  // ── Thin metadata band ──
+
+  it('renders tag name as heading, category chip, and demoted meta', () => {
     mockUseTagDetail.mockReturnValue({
-      data: undefined,
+      data: makeTagDetail({ name: 'Shoegaze', usage_count: 42 }),
       isLoading: false,
       error: null,
     })
-
-    renderWithProviders(<TagDetail slug="ghost" />)
-
-    expect(screen.getByText('Tag Not Found')).toBeInTheDocument()
-  })
-
-  // ── Core header ──
-
-  it('renders tag name as heading', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ name: 'Rock' }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
+    renderWithProviders(<TagDetail slug="shoegaze" />)
 
     expect(
-      screen.getByRole('heading', { level: 1, name: 'Rock' })
+      screen.getByRole('heading', { level: 1, name: 'Shoegaze' })
     ).toBeInTheDocument()
-  })
-
-  it('renders category badge', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ category: 'genre' }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
     expect(screen.getByText('Genre')).toBeInTheDocument()
-  })
-
-  it('renders usage count (plural)', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ usage_count: 42 }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
     expect(screen.getByText('42 uses')).toBeInTheDocument()
   })
 
-  it('renders usage count (singular)', () => {
+  it('renders singular "use" for a 1-use tag', () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({ usage_count: 1 }),
       isLoading: false,
       error: null,
     })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
+    renderWithProviders(<TagDetail slug="shoegaze" />)
     expect(screen.getByText('1 use')).toBeInTheDocument()
   })
 
-  it('renders Official badge when is_official', () => {
+  it('renders the Filter shows action pointing at /shows?tags={slug}', () => {
     mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ is_official: true }),
+      data: makeTagDetail(),
       isLoading: false,
       error: null,
     })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByText('Official')).toBeInTheDocument()
-  })
-
-  it('does not render Official badge when not official', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ is_official: false }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByText('Official')).not.toBeInTheDocument()
-  })
-
-  // ── Description (markdown) ──
-
-  it('renders description HTML when description_html is present', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        description_html: '<p>A genre of <strong>popular</strong> music.</p>',
-        description: 'A genre of **popular** music.',
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    const desc = screen.getByTestId('tag-description')
-    expect(desc).toBeInTheDocument()
-    expect(desc.innerHTML).toContain('<strong>popular</strong>')
-  })
-
-  it('falls back to plain description when description_html is empty', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        description: 'Plain text fallback.',
-        description_html: '',
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByText('Plain text fallback.')).toBeInTheDocument()
-    expect(screen.queryByTestId('tag-description')).not.toBeInTheDocument()
-  })
-
-  it('does not render description when empty', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ description: '', description_html: '' }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByTestId('tag-description')).not.toBeInTheDocument()
-  })
-
-  // ── Parent / children hierarchy (genre only) ──
-
-  it('renders parent tag pill for genre tags with a parent', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        category: 'genre',
-        parent: {
-          id: 5,
-          name: 'Music',
-          slug: 'music',
-          category: 'genre',
-          is_official: false,
-          usage_count: 100,
-        },
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    const hierarchy = screen.getByTestId('tag-hierarchy')
-    expect(hierarchy).toBeInTheDocument()
-    expect(screen.getByText('Parent')).toBeInTheDocument()
-    // Scope to the hierarchy section because PSY-486 also surfaces the
-    // parent in the breadcrumb nav, which means an unscoped lookup matches
-    // two links (breadcrumb intermediate + parent pill).
-    const within = hierarchy.querySelectorAll('a')
-    const parentLink = Array.from(within).find(a =>
-      /Music/.test(a.textContent ?? '')
-    )
-    expect(parentLink).toBeDefined()
-    expect(parentLink).toHaveAttribute('href', '/tags/music')
-  })
-
-  it('renders children pills for genre tags with children', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        category: 'genre',
-        children: [
-          { id: 11, name: 'dream-pop', slug: 'dream-pop', category: 'genre', is_official: false, usage_count: 4 },
-          { id: 12, name: 'nu-gaze', slug: 'nu-gaze', category: 'genre', is_official: false, usage_count: 2 },
-        ],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
     renderWithProviders(<TagDetail slug="shoegaze" />)
-
-    expect(screen.getByText('Children (2)')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /dream-pop/ })).toHaveAttribute(
-      'href',
-      '/tags/dream-pop'
-    )
-    expect(screen.getByRole('link', { name: /nu-gaze/ })).toHaveAttribute(
-      'href',
-      '/tags/nu-gaze'
-    )
-  })
-
-  it('hides hierarchy block for non-genre categories even with parent/children', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        category: 'locale',
-        parent: {
-          id: 5,
-          name: 'West Coast',
-          slug: 'west-coast',
-          category: 'locale',
-          is_official: false,
-          usage_count: 10,
-        },
-        children: [
-          { id: 11, name: 'Phoenix', slug: 'phoenix', category: 'locale', is_official: false, usage_count: 4 },
-        ],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="arizona" />)
-
-    expect(screen.queryByTestId('tag-hierarchy')).not.toBeInTheDocument()
-  })
-
-  it('hides hierarchy block entirely when no parent and no children', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ category: 'genre' }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByTestId('tag-hierarchy')).not.toBeInTheDocument()
-  })
-
-  // ── Aliases ──
-
-  it('renders aliases when present', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ aliases: ['rock and roll', 'rock n roll'] }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByText('Also known as')).toBeInTheDocument()
-    expect(screen.getByText('rock and roll')).toBeInTheDocument()
-    expect(screen.getByText('rock n roll')).toBeInTheDocument()
-  })
-
-  it('does not render aliases section when empty', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ aliases: [] }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByText('Also known as')).not.toBeInTheDocument()
-  })
-
-  // ── Creator attribution ──
-
-  it('renders "Created by @username" from the enriched created_by field', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        created_by: { id: 42, username: 'johndoe' },
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByText('@johndoe')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '@johndoe' })).toHaveAttribute(
-      'href',
-      '/users/johndoe'
-    )
-  })
-
-  it('falls back to legacy created_by_username when created_by is null', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        created_by: null,
-        created_by_username: 'legacyuser',
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByText('@legacyuser')).toBeInTheDocument()
-  })
-
-  it('does not render creator when no creator info is available', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail(),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByText(/Created by/)).not.toBeInTheDocument()
-  })
-
-  // ── Usage breakdown summary row ──
-
-  it('renders non-zero breakdown counts in the header', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        usage_count: 18,
-        usage_breakdown: {
-          artist: 15,
-          venue: 0,
-          show: 3,
-          release: 0,
-          label: 0,
-          festival: 0,
-        },
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    const summary = screen.getByTestId('usage-breakdown-summary')
-    expect(summary).toBeInTheDocument()
-    // 15 artists · 3 shows — zero-count types are hidden
-    expect(summary).toHaveTextContent('15')
-    expect(summary).toHaveTextContent('artists')
-    expect(summary).toHaveTextContent('3')
-    expect(summary).toHaveTextContent('shows')
-    expect(summary).not.toHaveTextContent('0 venues')
-  })
-
-  it('renders singular label when breakdown count is 1', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        usage_count: 1,
-        usage_breakdown: {
-          artist: 1,
-          venue: 0,
-          show: 0,
-          release: 0,
-          label: 0,
-          festival: 0,
-        },
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    const summary = screen.getByTestId('usage-breakdown-summary')
-    expect(summary).toHaveTextContent('1')
-    expect(summary).toHaveTextContent('artist')
-    expect(summary).not.toHaveTextContent('artists')
-  })
-
-  it('hides the breakdown summary when all counts are zero', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail(),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
     expect(
-      screen.queryByTestId('usage-breakdown-summary')
-    ).not.toBeInTheDocument()
+      screen.getByRole('link', { name: 'Filter shows' })
+    ).toHaveAttribute('href', '/shows?tags=shoegaze')
   })
 
-  // ── Top contributors ──
-
-  it('renders top contributors with handles and counts', () => {
+  it('renders NotifyMeButton with the tag name', () => {
     mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        top_contributors: [
-          { user: { id: 1, username: 'alice' }, count: 8 },
-          { user: { id: 2, username: 'bob' }, count: 5 },
-        ],
-      }),
+      data: makeTagDetail({ name: 'Punk' }),
       isLoading: false,
       error: null,
     })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByTestId('top-contributors')).toBeInTheDocument()
-    expect(screen.getByText('Top contributors')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '@alice' })).toHaveAttribute(
-      'href',
-      '/users/alice'
-    )
-    expect(screen.getByRole('link', { name: '@bob' })).toHaveAttribute(
-      'href',
-      '/users/bob'
-    )
-    expect(screen.getByText('(8)')).toBeInTheDocument()
-    expect(screen.getByText('(5)')).toBeInTheDocument()
-  })
-
-  it('hides anonymous contributors and hides the section when all are anonymous (PSY-450)', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        top_contributors: [{ user: { id: 99 }, count: 3 }],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    // Never leak the internal DB id as a fallback label.
-    expect(screen.queryByText(/user #\d+/)).not.toBeInTheDocument()
-    // When every contributor is anonymous the section must be hidden entirely.
-    expect(screen.queryByTestId('top-contributors')).not.toBeInTheDocument()
-  })
-
-  it('shows only named contributors when the list is mixed (PSY-450)', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        top_contributors: [
-          { user: { id: 1, username: 'alice' }, count: 8 },
-          { user: { id: 42 }, count: 6 },
-          { user: { id: 2, username: 'bob' }, count: 2 },
-        ],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByTestId('top-contributors')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '@alice' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '@bob' })).toBeInTheDocument()
-    expect(screen.queryByText(/user #\d+/)).not.toBeInTheDocument()
-  })
-
-  it('hides top contributors section when empty', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ top_contributors: [] }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByTestId('top-contributors')).not.toBeInTheDocument()
-  })
-
-  // ── Related tags ──
-
-  it('renders related tags pills', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({
-        related_tags: [
-          { id: 20, name: 'post-rock', slug: 'post-rock', category: 'genre', is_official: false, usage_count: 5 },
-          { id: 21, name: 'dream-pop', slug: 'dream-pop', category: 'genre', is_official: true, usage_count: 9 },
-        ],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="shoegaze" />)
-
-    const section = screen.getByTestId('related-tags')
-    expect(section).toBeInTheDocument()
-    expect(screen.getByText('Related tags')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /post-rock/ })).toHaveAttribute(
-      'href',
-      '/tags/post-rock'
-    )
-    expect(screen.getByRole('link', { name: /dream-pop/ })).toHaveAttribute(
-      'href',
-      '/tags/dream-pop'
-    )
-  })
-
-  it('hides related tags section when empty', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ related_tags: [] }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByTestId('related-tags')).not.toBeInTheDocument()
-  })
-
-  // ── NotifyMeButton + breadcrumb ──
-
-  it('renders NotifyMeButton with correct props', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ id: 7, name: 'Punk' }),
-      isLoading: false,
-      error: null,
-    })
-
     renderWithProviders(<TagDetail slug="punk" />)
-
     expect(screen.getByTestId('notify-me-button')).toHaveTextContent(
       'Notify Punk'
     )
   })
 
-  // PSY-460 / dogfood tags-audit-4 ISSUE-003: at 375px the h1 + Official
-  // badge + NotifyMeButton cluster overflowed the viewport by ~31px,
-  // clipping "Notify me". Fix mirrors the PSY-467 pattern: the cluster
-  // uses flex-wrap + min-w-0 so the NotifyMeButton can break to a new
-  // row under the title on narrow viewports. jsdom can't verify actual
-  // layout, so we assert the structural classes are present — enough to
-  // catch a regression that strips the wrap.
-  it('header cluster allows the NotifyMeButton to wrap on narrow viewports (ISSUE-003)', () => {
+  it('renders description HTML when present', () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({
-        name: 'Shoegaze',
-        is_official: true,
+        description_html: '<p>Dreamy <strong>guitar</strong> textures.</p>',
       }),
       isLoading: false,
       error: null,
     })
-
     renderWithProviders(<TagDetail slug="shoegaze" />)
-
-    const heading = screen.getByRole('heading', { level: 1, name: 'Shoegaze' })
-    const cluster = heading.parentElement as HTMLElement
-    expect(cluster.className).toContain('flex-wrap')
-    expect(cluster.className).toContain('min-w-0')
-    // The heading itself must be allowed to shrink so long tag names break
-    // instead of forcing the whole cluster off-screen.
-    expect(heading.className).toContain('min-w-0')
+    const desc = screen.getByTestId('tag-description')
+    expect(desc.innerHTML).toContain('<strong>guitar</strong>')
   })
 
-  it('renders breadcrumb with tag name', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ name: 'Jazz' }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="jazz" />)
-
-    const jazzElements = screen.getAllByText('Jazz')
-    expect(jazzElements.length).toBeGreaterThanOrEqual(2)
-  })
-
-  // PSY-486: when a genre tag has a parent, the breadcrumb chain renders
-  // `Tags > <parent> > <tag>` so visitors can climb the hierarchy.
-  it('includes the parent tag as an intermediate breadcrumb crumb when present', () => {
+  it('includes the parent tag as an intermediate breadcrumb when present', () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({
-        name: 'shoegaze',
-        slug: 'shoegaze',
         category: 'genre',
         parent: {
           id: 5,
@@ -865,336 +284,349 @@ describe('TagDetail', () => {
       isLoading: false,
       error: null,
     })
-
     renderWithProviders(<TagDetail slug="shoegaze" />)
-
     const intermediates = screen.getAllByTestId('breadcrumb-intermediate')
     expect(intermediates).toHaveLength(1)
-    expect(intermediates[0]).toHaveTextContent('post-punk')
     expect(intermediates[0]).toHaveAttribute('href', '/tags/post-punk')
   })
 
-  it('omits the intermediate crumb for genre tags with no parent', () => {
+  // ── Co-visible sections (not tabs) ──
+
+  it('renders co-visible sections in the fixed display order, suppressing empties', () => {
     mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ name: 'rock', category: 'genre' }),
+      data: makeTagDetail({ usage_count: 100 }),
       isLoading: false,
       error: null,
     })
+    mockUseTagIntersection.mockReturnValue({
+      data: makeIntersection({
+        groups: [
+          {
+            entity_type: 'artist',
+            count: 12,
+            preview: [
+              {
+                entity_type: 'artist',
+                entity_id: 1,
+                name: 'Whirr',
+                slug: 'whirr',
+                city: 'Oakland',
+                state: 'CA',
+                upcoming_show_count: 8,
+              },
+            ],
+          },
+          { entity_type: 'release', count: 0, preview: [] },
+          { entity_type: 'label', count: 3, preview: [
+            {
+              entity_type: 'label',
+              entity_id: 5,
+              name: 'Slumberland Records',
+              slug: 'slumberland',
+              city: 'Oakland',
+              state: 'CA',
+              release_count: 34,
+            },
+          ] },
+          {
+            entity_type: 'show',
+            count: 2,
+            preview: [
+              {
+                entity_type: 'show',
+                entity_id: 9,
+                name: 'Whirr Show',
+                slug: 'whirr-show',
+                headliner_name: 'Whirr',
+                venue_name: 'The Rebel Lounge',
+                city: 'Phoenix',
+                state: 'AZ',
+                event_date: '2026-07-28T03:00:00Z',
+              },
+            ],
+          },
+          { entity_type: 'venue', count: 0, preview: [] },
+          { entity_type: 'festival', count: 0, preview: [] },
+          { entity_type: 'collection', count: 0, preview: [] },
+        ],
+      }),
+      isLoading: false,
+    })
 
-    renderWithProviders(<TagDetail slug="rock" />)
+    renderWithProviders(<TagDetail slug="shoegaze" />)
 
+    // Non-empty sections rendered; empty ones suppressed.
+    expect(screen.getByTestId('tag-section-artist')).toBeInTheDocument()
+    expect(screen.getByTestId('tag-section-show')).toBeInTheDocument()
+    expect(screen.getByTestId('tag-section-label')).toBeInTheDocument()
+    expect(screen.queryByTestId('tag-section-release')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tag-section-venue')).not.toBeInTheDocument()
     expect(
-      screen.queryByTestId('breadcrumb-intermediate')
+      screen.queryByTestId('tag-section-festival')
     ).not.toBeInTheDocument()
+
+    // Display order: artist (Artists) before show (Upcoming shows) before label.
+    const sections = within(screen.getByTestId('tag-sections')).getAllByRole(
+      'heading',
+      { level: 2 }
+    )
+    const order = sections.map((h) => h.textContent)
+    expect(order[0]).toContain('Artists')
+    expect(order[1]).toContain('Upcoming shows')
+    expect(order[2]).toContain('Labels')
+
+    // Dense rows surface name + metric (scope to the artist section because
+    // "Whirr" is also the headliner of the show row).
+    const artistSection = screen.getByTestId('tag-section-artist')
+    expect(
+      within(artistSection).getByRole('link', { name: 'Whirr' })
+    ).toHaveAttribute('href', '/artists/whirr')
+    expect(within(artistSection).getByText('8 shows')).toBeInTheDocument()
   })
 
-  it('does not render parent crumb for non-genre categories even if parent is set', () => {
-    // Defensive: hierarchy is genre-only, so even a stray parent_id on a
-    // locale tag should not produce a misleading breadcrumb chain.
+  it('builds "Show all N" links to the existing per-type browse filtered by tag', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ usage_count: 100 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagIntersection.mockReturnValue({
+      data: makeIntersection({
+        groups: [
+          {
+            entity_type: 'artist',
+            count: 142,
+            preview: [
+              {
+                entity_type: 'artist',
+                entity_id: 1,
+                name: 'Whirr',
+                slug: 'whirr',
+                upcoming_show_count: 8,
+              },
+            ],
+          },
+          { entity_type: 'release', count: 0, preview: [] },
+          { entity_type: 'label', count: 0, preview: [] },
+          { entity_type: 'show', count: 0, preview: [] },
+          { entity_type: 'venue', count: 0, preview: [] },
+          { entity_type: 'festival', count: 0, preview: [] },
+          { entity_type: 'collection', count: 0, preview: [] },
+        ],
+      }),
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagDetail slug="shoegaze" />)
+    expect(
+      screen.getByTestId('tag-section-showall-artist')
+    ).toHaveAttribute('href', '/artists?tags=shoegaze')
+  })
+
+  // ── Sparse state (frame 437:7) ──
+
+  it('renders the "Help grow this tag" CTA for a single-item sparse tag', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ name: 'dungeon synth', usage_count: 1 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagIntersection.mockReturnValue({
+      data: makeIntersection({
+        groups: [
+          {
+            entity_type: 'artist',
+            count: 1,
+            preview: [
+              {
+                entity_type: 'artist',
+                entity_id: 1,
+                name: 'Old Sorcery',
+                slug: 'old-sorcery',
+                city: 'Tasmania',
+                state: 'AU',
+                upcoming_show_count: 0,
+              },
+            ],
+          },
+          { entity_type: 'release', count: 0, preview: [] },
+          { entity_type: 'label', count: 0, preview: [] },
+          { entity_type: 'show', count: 0, preview: [] },
+          { entity_type: 'venue', count: 0, preview: [] },
+          { entity_type: 'festival', count: 0, preview: [] },
+          { entity_type: 'collection', count: 0, preview: [] },
+        ],
+      }),
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagDetail slug="dungeon-synth" />)
+
+    expect(screen.getByTestId('tag-section-artist')).toBeInTheDocument()
+    expect(screen.queryByTestId('tag-section-release')).not.toBeInTheDocument()
+    expect(screen.getByTestId('help-grow-cta')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Suggest something/ })
+    ).toBeInTheDocument()
+  })
+
+  it('does NOT show the Help-grow CTA when the tag has multiple populated sections', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ usage_count: 50 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagIntersection.mockReturnValue({
+      data: makeIntersection({
+        groups: [
+          {
+            entity_type: 'artist',
+            count: 12,
+            preview: [
+              { entity_type: 'artist', entity_id: 1, name: 'Whirr', slug: 'whirr' },
+            ],
+          },
+          {
+            entity_type: 'release',
+            count: 5,
+            preview: [
+              { entity_type: 'release', entity_id: 2, name: 'Loveless', slug: 'loveless' },
+            ],
+          },
+          { entity_type: 'label', count: 0, preview: [] },
+          { entity_type: 'show', count: 0, preview: [] },
+          { entity_type: 'venue', count: 0, preview: [] },
+          { entity_type: 'festival', count: 0, preview: [] },
+          { entity_type: 'collection', count: 0, preview: [] },
+        ],
+      }),
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagDetail slug="shoegaze" />)
+    expect(screen.queryByTestId('help-grow-cta')).not.toBeInTheDocument()
+  })
+
+  // ── Related tags rail + "+ add another tag" pivot ──
+
+  it('renders related-tag chips that add the tag to the intersection in place', async () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({
-        category: 'locale',
-        parent: {
-          id: 5,
-          name: 'West Coast',
-          slug: 'west-coast',
-          category: 'locale',
-          is_official: false,
-          usage_count: 1,
-        },
+        related_tags: [
+          {
+            id: 20,
+            name: 'ambient',
+            slug: 'ambient',
+            category: 'genre',
+            is_official: false,
+            usage_count: 9,
+          },
+        ],
       }),
       isLoading: false,
       error: null,
     })
 
-    renderWithProviders(<TagDetail slug="arizona" />)
-
-    expect(
-      screen.queryByTestId('breadcrumb-intermediate')
-    ).not.toBeInTheDocument()
-  })
-
-  // ── Tagged Entities (PSY-485 — tabs + entity cards) ──
-
-  it('renders one tab per entity type with non-zero items, hiding empty tabs', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ usage_count: 3 }),
-      isLoading: false,
-      error: null,
-    })
-    mockUseTagEntities.mockReturnValue({
-      data: {
-        entities: [
-          {
-            entity_type: 'artist',
-            entity_id: 1,
-            name: 'Radiohead',
-            slug: 'radiohead',
-            city: 'Oxford',
-            state: 'UK',
-            upcoming_show_count: 0,
-          },
-          {
-            entity_type: 'artist',
-            entity_id: 2,
-            name: 'Portishead',
-            slug: 'portishead',
-            city: 'Bristol',
-            state: 'UK',
-            upcoming_show_count: 1,
-          },
-          {
-            entity_type: 'venue',
-            entity_id: 10,
-            name: 'The Rebel Lounge',
-            slug: 'the-rebel-lounge',
-            city: 'Phoenix',
-            state: 'AZ',
-            verified: true,
-            upcoming_show_count: 5,
-          },
-        ],
-        total: 3,
-      },
-      isLoading: false,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByText('Tagged Entities')).toBeInTheDocument()
-    // Tabs render only for entity types with items.
-    expect(screen.getByTestId('tagged-entities-tab-artist')).toBeInTheDocument()
-    expect(screen.getByTestId('tagged-entities-tab-venue')).toBeInTheDocument()
-    expect(
-      screen.queryByTestId('tagged-entities-tab-festival')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId('tagged-entities-tab-label')
-    ).not.toBeInTheDocument()
-    // First tab (artist) is active by default — its panel content shows.
-    expect(screen.getByRole('link', { name: 'Radiohead' })).toHaveAttribute(
-      'href',
-      '/artists/radiohead'
-    )
-    expect(screen.getByRole('link', { name: 'Portishead' })).toHaveAttribute(
-      'href',
-      '/artists/portishead'
-    )
-  })
-
-  it('switches the visible card grid when a different tab is activated', async () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ usage_count: 3 }),
-      isLoading: false,
-      error: null,
-    })
-    mockUseTagEntities.mockReturnValue({
-      data: {
-        entities: [
-          {
-            entity_type: 'artist',
-            entity_id: 1,
-            name: 'Radiohead',
-            slug: 'radiohead',
-            city: 'Oxford',
-            state: 'UK',
-            upcoming_show_count: 0,
-          },
-          {
-            entity_type: 'venue',
-            entity_id: 10,
-            name: 'The Rebel Lounge',
-            slug: 'the-rebel-lounge',
-            city: 'Phoenix',
-            state: 'AZ',
-            verified: true,
-            upcoming_show_count: 5,
-          },
-        ],
-        total: 2,
-      },
-      isLoading: false,
-    })
-
     const user = userEvent.setup()
-    renderWithProviders(<TagDetail slug="rock" />)
+    renderWithProviders(<TagDetail slug="shoegaze" />)
 
-    // Artist tab is active first; venue link must not be visible yet because
-    // Radix Tabs unmounts inactive panel content.
-    expect(
-      screen.queryByRole('link', { name: /The Rebel Lounge/ })
-    ).not.toBeInTheDocument()
+    const rail = screen.getByTestId('related-tags')
+    expect(within(rail).getByText('Related tags')).toBeInTheDocument()
 
-    // Switch to Venues tab.
-    await user.click(screen.getByTestId('tagged-entities-tab-venue'))
-
-    // Now the venue card renders inside the active panel.
-    const venueLink = await screen.findByRole('link', {
-      name: /The Rebel Lounge/,
-    })
-    expect(venueLink).toHaveAttribute('href', '/venues/the-rebel-lounge')
-    // And the original artist link is gone — proves the panel switched, not
-    // just that we duplicated it.
-    expect(
-      screen.queryByRole('link', { name: 'Radiohead' })
-    ).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('related-tag-ambient'))
+    // Clicking a related tag narrows in place by writing ?with=ambient.
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/tags/shoegaze?with=ambient',
+      { scroll: false }
+    )
   })
 
-  it('renders cards (not bare list items) for tagged entities', () => {
+  it('exposes the "+ add another tag to filter" pivot trigger', () => {
     mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ usage_count: 1 }),
+      data: makeTagDetail(),
       isLoading: false,
       error: null,
     })
-    mockUseTagEntities.mockReturnValue({
-      data: {
-        entities: [
+    renderWithProviders(<TagDetail slug="shoegaze" />)
+    expect(screen.getByTestId('add-tag-pivot-trigger')).toHaveTextContent(
+      '+ add another tag to filter'
+    )
+  })
+
+  it('reflects an active pivot from ?with= and re-queries the intersection', () => {
+    mockSearchParams = new URLSearchParams('with=ambient')
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ usage_count: 100 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagIntersection.mockReturnValue({
+      data: makeIntersection({
+        tags: [
           {
-            entity_type: 'artist',
-            entity_id: 1,
-            name: 'Faetooth',
-            slug: 'faetooth',
-            city: 'Phoenix',
-            state: 'AZ',
-            upcoming_show_count: 3,
+            id: 1,
+            name: 'Shoegaze',
+            slug: 'shoegaze',
+            category: 'genre',
+            is_official: false,
+            usage_count: 42,
+          },
+          {
+            id: 2,
+            name: 'Ambient',
+            slug: 'ambient',
+            category: 'genre',
+            is_official: false,
+            usage_count: 30,
           },
         ],
-        total: 1,
-      },
+        groups: [
+          {
+            entity_type: 'artist',
+            count: 3,
+            preview: [
+              { entity_type: 'artist', entity_id: 1, name: 'Whirr', slug: 'whirr' },
+            ],
+          },
+          { entity_type: 'release', count: 0, preview: [] },
+          { entity_type: 'label', count: 0, preview: [] },
+          { entity_type: 'show', count: 0, preview: [] },
+          { entity_type: 'venue', count: 0, preview: [] },
+          { entity_type: 'festival', count: 0, preview: [] },
+          { entity_type: 'collection', count: 0, preview: [] },
+        ],
+      }),
       isLoading: false,
     })
 
     renderWithProviders(<TagDetail slug="shoegaze" />)
 
-    // ArtistCard renders an <article> wrapper — that's the
-    // "card not bullet" assertion the dogfood ticket called out.
-    const article = document.querySelector('article')
-    expect(article).toBeInTheDocument()
-    // Card surfaces the location and the upcoming-show count we asked the
-    // backend to populate.
-    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
-    expect(screen.getByText('3 upcoming')).toBeInTheDocument()
-  })
+    // The hook is called with BOTH slugs.
+    const calledSlugs = mockUseTagIntersection.mock.calls.at(-1)?.[0]
+    expect(calledSlugs).toEqual(['shoegaze', 'ambient'])
 
-  it('hides Festivals tab on a tag with no festival usage (PSY-485 acceptance)', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ usage_count: 1 }),
-      isLoading: false,
-      error: null,
-    })
-    mockUseTagEntities.mockReturnValue({
-      data: {
-        entities: [
-          {
-            entity_type: 'artist',
-            entity_id: 1,
-            name: 'Solo Artist',
-            slug: 'solo-artist',
-          },
-        ],
-        total: 1,
-      },
-      isLoading: false,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.getByTestId('tagged-entities-tab-artist')).toBeInTheDocument()
+    // Active-filter bar shows the added tag + a remove control.
+    const bar = screen.getByTestId('active-filter-bar')
+    expect(within(bar).getByText('Ambient')).toBeInTheDocument()
     expect(
-      screen.queryByTestId('tagged-entities-tab-festival')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId('tagged-entities-tab-show')
-    ).not.toBeInTheDocument()
-  })
-
-  it('shows a Festivals tab on a festival-only tag (PSY-485 multi-venue scenario)', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ usage_count: 1, name: 'multi-venue' }),
-      isLoading: false,
-      error: null,
-    })
-    mockUseTagEntities.mockReturnValue({
-      data: {
-        entities: [
-          {
-            entity_type: 'festival',
-            entity_id: 7,
-            name: 'M3F',
-            slug: 'm3f-2026',
-            edition_year: 2026,
-            city: 'Phoenix',
-            state: 'AZ',
-            status: 'confirmed',
-            start_date: '2026-03-06',
-            end_date: '2026-03-08',
-            artist_count: 42,
-            venue_count: 3,
-          },
-        ],
-        total: 1,
-      },
-      isLoading: false,
-    })
-
-    renderWithProviders(<TagDetail slug="multi-venue" />)
-
-    expect(
-      screen.getByTestId('tagged-entities-tab-festival')
+      within(bar).getByRole('button', { name: /Remove Ambient filter/ })
     ).toBeInTheDocument()
+
+    // "Show all" deep-links to the multi-tag browse with tag_match=all.
     expect(
-      screen.queryByTestId('tagged-entities-tab-artist')
-    ).not.toBeInTheDocument()
-    // Festival card surfaces the year + status + lineup count.
-    expect(screen.getByRole('link', { name: 'M3F' })).toHaveAttribute(
-      'href',
-      '/festivals/m3f-2026'
-    )
-    expect(screen.getByText('Confirmed')).toBeInTheDocument()
-    expect(screen.getByText('42 artists')).toBeInTheDocument()
+      screen.getByTestId('tag-section-showall-artist')
+    ).toHaveAttribute('href', '/artists?tags=shoegaze%2Cambient&tag_match=all')
   })
 
-  it('does not render tagged entities section when usage_count is 0', () => {
+  it('does not fire the intersection query for a tag with zero usage', () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({ usage_count: 0 }),
       isLoading: false,
       error: null,
     })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    expect(screen.queryByText('Tagged Entities')).not.toBeInTheDocument()
-  })
-
-  it('shows loading spinner while entities are loading', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ usage_count: 5 }),
-      isLoading: false,
-      error: null,
-    })
-    mockUseTagEntities.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    const spinners = document.querySelectorAll('.animate-spin')
-    expect(spinners.length).toBeGreaterThanOrEqual(1)
-  })
-
-  // ── Creation date ──
-
-  it('renders creation date from created_at timestamp', () => {
-    mockUseTagDetail.mockReturnValue({
-      data: makeTagDetail({ created_at: '2025-01-01T00:00:00Z' }),
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<TagDetail slug="rock" />)
-
-    const clockIcons = document.querySelectorAll('.lucide-clock')
-    expect(clockIcons.length).toBeGreaterThanOrEqual(1)
+    renderWithProviders(<TagDetail slug="empty-tag" />)
+    // enabled=false is passed through as the 3rd arg.
+    const lastCall = mockUseTagIntersection.mock.calls.at(-1)
+    expect(lastCall?.[2]).toEqual({ enabled: false })
   })
 })

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -1,96 +1,35 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Hash, Loader2, Library, Music, MapPin, Calendar, Disc3, Tag, Tent, Clock } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { ArrowLeft, Hash, Loader2, X } from 'lucide-react'
 import { NotifyMeButton } from '@/features/notifications'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Breadcrumb } from '@/components/shared'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
-import { useTagDetail, useTagEntities } from '../hooks'
-import { getCategoryColor, getCategoryLabel, getEntityTypePluralLabel } from '../types'
-import type { TaggedEntityItem, TagSummary } from '../types'
+import { useTagDetail, useTagIntersection, useSearchTags } from '../hooks'
+import {
+  getCategoryColor,
+  getCategoryLabel,
+  getTagSectionLabel,
+  getTagSectionBrowseUrl,
+  TAG_DETAIL_SECTION_ORDER,
+} from '../types'
+import type { TagIntersectionGroup, TagSummary } from '../types'
 import { TagOfficialIndicator } from './TagOfficialIndicator'
-import { TaggedEntityCard } from './TaggedEntityCards'
+import { TaggedEntityRow } from './TaggedEntityCards'
 
 interface TagDetailProps {
   slug: string
 }
 
-/**
- * Entity type display order — genre tags use parent/children nav; others are flat.
- *
- * PSY-553: collections (PSY-354) appear after the existing entity-type tabs
- * because they're a meta-type — a collection-of-entities, not a primary
- * entity. Tabs whose count is zero are filtered out below, so the Collections
- * tab is hidden until at least one tagged collection is public.
- */
-const ENTITY_TYPE_ORDER = [
-  'artist',
-  'venue',
-  'show',
-  'release',
-  'label',
-  'festival',
-  'collection',
-] as const
-
-const ENTITY_TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
-  artist: Music,
-  venue: MapPin,
-  show: Calendar,
-  release: Disc3,
-  label: Tag,
-  festival: Tent,
-  collection: Library,
-}
-
-/** Singular display label for entity types used in the breakdown row. */
-function getEntityTypeSingularLabel(entityType: string): string {
-  switch (entityType) {
-    case 'artist':
-      return 'artist'
-    case 'venue':
-      return 'venue'
-    case 'show':
-      return 'show'
-    case 'release':
-      return 'release'
-    case 'label':
-      return 'label'
-    case 'festival':
-      return 'festival'
-    case 'collection':
-      return 'collection'
-    default:
-      return entityType
-  }
-}
+/** Per-type preview size (rows shown before the "Show all" link). */
+const SECTION_PREVIEW_LIMIT = 5
 
 export function TagDetail({ slug }: TagDetailProps) {
   const { data: tag, isLoading, error } = useTagDetail(slug)
-
-  // Usage breakdown: only show non-zero counts. We pad with zeros on the backend
-  // so the object always has all keys, but displaying zero counts is noise.
-  // NOTE: hook must be called unconditionally, above the early returns below.
-  // Guard the logic inside rather than the hook call.
-  const breakdownEntries = useMemo(() => {
-    if (!tag) return []
-    return ENTITY_TYPE_ORDER
-      .map((type) => ({ type, count: tag.usage_breakdown?.[type] ?? 0 }))
-      .filter((e) => e.count > 0)
-  }, [tag])
-
-  // Top contributors: hide anonymous contributors (no username). Rendering
-  // `user #{id}` leaks an internal DB row id and reads like placeholder content
-  // (PSY-450). Contributors without a public username haven't opted in to
-  // public attribution anyway.
-  const visibleContributors = useMemo(() => {
-    if (!tag?.top_contributors) return []
-    return tag.top_contributors.filter((c) => Boolean(c.user.username))
-  }, [tag])
 
   if (isLoading) {
     return (
@@ -147,364 +86,527 @@ export function TagDetail({ slug }: TagDetailProps) {
     )
   }
 
-  // Only genre tags participate in the parent/children hierarchy; other
-  // categories are flat per the tag system design doc.
-  const isGenre = tag.category === 'genre'
-  const hasParent = isGenre && Boolean(tag.parent)
-  const hasChildren = isGenre && tag.children && tag.children.length > 0
+  return <TagDetailContent slug={slug} tag={tag} />
+}
 
-  // Build the parent breadcrumb chain. The detail endpoint exposes only the
-  // direct parent (not the full ancestor chain) — see backend `GetTagDetail`
-  // — so we render at most one intermediate crumb. If we ever expose
-  // ancestors[] we can map them here without changing the Breadcrumb API.
-  // Non-genre categories don't participate in the hierarchy, so skip the
-  // intermediate crumb even if a stray parent_id were ever present.
+// ──────────────────────────────────────────────
+// Loaded content — split out so hooks below can run unconditionally once the
+// tag has resolved (the loading/error/!tag early returns live in TagDetail).
+// ──────────────────────────────────────────────
+
+function TagDetailContent({
+  slug,
+  tag,
+}: {
+  slug: string
+  tag: NonNullable<ReturnType<typeof useTagDetail>['data']>
+}) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  // Added-tag pivot state lives in the URL (?with=slug,…) so it's shareable and
+  // degrades to the single-tag detail when dropped (PSY-995 decision #5). The
+  // page's own slug is always the first tag of the intersection.
+  const addedSlugs = useMemo(() => {
+    const raw = searchParams.get('with')
+    if (!raw) return []
+    return raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => s && s !== slug)
+  }, [searchParams, slug])
+
+  const intersectionSlugs = useMemo(
+    () => [slug, ...addedSlugs],
+    [slug, addedSlugs]
+  )
+  const isFiltering = addedSlugs.length > 0
+
+  const setAddedSlugs = useCallback(
+    (next: string[]) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (next.length > 0) params.set('with', next.join(','))
+      else params.delete('with')
+      const qs = params.toString()
+      router.replace(qs ? `/tags/${slug}?${qs}` : `/tags/${slug}`, {
+        scroll: false,
+      })
+    },
+    [router, searchParams, slug]
+  )
+
+  const { data: intersection, isLoading: groupsLoading } = useTagIntersection(
+    intersectionSlugs,
+    { previewLimit: SECTION_PREVIEW_LIMIT },
+    // Don't fire for a brand-new / unused tag with no entities — its sections
+    // would all be empty and the endpoint resolves the slug anyway.
+    { enabled: tag.usage_count > 0 }
+  )
+
+  // Reorder the backend's canonical groups into the design's fixed display
+  // order, dropping zero-count sections (empty-suppression).
+  const sections = useMemo(() => {
+    const byType = new Map<string, TagIntersectionGroup>()
+    for (const g of intersection?.groups ?? []) byType.set(g.entity_type, g)
+    return TAG_DETAIL_SECTION_ORDER.map((t) => byType.get(t)).filter(
+      (g): g is TagIntersectionGroup => Boolean(g && g.count > 0)
+    )
+  }, [intersection])
+
+  // Sparse = exactly one non-empty section with a single item, and no active
+  // pivot. Matches Figma frame 437:7 (a 1-use tag).
+  const isSparse =
+    !isFiltering &&
+    sections.length === 1 &&
+    sections[0].count === 1 &&
+    !groupsLoading
+
+  // Only genre tags participate in the parent/children hierarchy.
+  const isGenre = tag.category === 'genre'
   const parentCrumbs =
     isGenre && tag.parent
-      ? [{ href: `/tags/${tag.parent.slug || tag.parent.id}`, label: tag.parent.name }]
+      ? [
+          {
+            href: `/tags/${tag.parent.slug || tag.parent.id}`,
+            label: tag.parent.name,
+          },
+        ]
       : undefined
+
+  const creatorHandle = tag.created_by?.username || tag.created_by_username
 
   return (
     <div className="container max-w-4xl mx-auto px-4 py-6">
-      {/* Breadcrumb Navigation */}
       <Breadcrumb
         fallback={{ href: '/tags', label: 'Tags' }}
         intermediate={parentCrumbs}
         currentPage={tag.name}
       />
 
-      {/* Header */}
-      <header className="mb-8">
-        <div className="flex items-start gap-4">
-          <div
-            className={cn(
-              'mt-1 flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border',
-              getCategoryColor(tag.category)
+      {/* ── Thin metadata band ───────────────────────────────────────────
+          Title + category chip + actions lead; meta (uses · creator · added)
+          and description are DEMOTED below, not the focus. */}
+      <header className="mb-8 mt-2" data-testid="tag-header">
+        <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-3">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 min-w-0">
+            <Hash className="h-6 w-6 shrink-0 text-muted-foreground" aria-hidden />
+            <h1 className="text-3xl font-bold tracking-tight min-w-0 break-words">
+              {tag.name}
+            </h1>
+            <span
+              className={cn(
+                'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
+                getCategoryColor(tag.category)
+              )}
+            >
+              {getCategoryLabel(tag.category)}
+            </span>
+            {tag.is_official && (
+              <TagOfficialIndicator size="md" tagName={tag.name} />
             )}
-          >
-            <Hash className="h-6 w-6" />
           </div>
-          <div className="min-w-0 flex-1">
-            {/* ISSUE-003 (dogfood tags-audit-4): at 375px the h1 + Official
-                badge + NotifyMeButton cluster was clipped ~31px off-screen.
-                flex-wrap + min-w-0 lets the NotifyMeButton break to a new
-                row below the title on narrow viewports; desktop (>=sm)
-                keeps the single-row layout. Same pattern as PSY-467. */}
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 min-w-0 mb-1">
-              <h1 className="text-3xl font-bold tracking-tight min-w-0 break-words">{tag.name}</h1>
-              {tag.is_official && (
-                <TagOfficialIndicator size="md" tagName={tag.name} />
-              )}
-              <NotifyMeButton entityType="tag" entityId={tag.id} entityName={tag.name} />
-            </div>
 
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-4">
-              <span
-                className={cn(
-                  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
-                  getCategoryColor(tag.category)
-                )}
-              >
-                {getCategoryLabel(tag.category)}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
-              </span>
-              {(tag.created_by?.username || tag.created_by_username) && (
-                <>
-                  <span className="text-muted-foreground/40">{'·'}</span>
-                  <span className="text-sm text-muted-foreground">
-                    Created by{' '}
-                    <Link
-                      href={`/users/${tag.created_by?.username || tag.created_by_username}`}
-                      className="hover:underline"
-                    >
-                      @{tag.created_by?.username || tag.created_by_username}
-                    </Link>
-                  </span>
-                </>
-              )}
-              {tag.created_at && (
-                <>
-                  <span className="text-muted-foreground/40">{'·'}</span>
-                  <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
-                    <Clock className="h-3 w-3" />
-                    {formatRelativeTime(tag.created_at)}
-                  </span>
-                </>
-              )}
-            </div>
-
-            {/* Usage breakdown summary row: "15 artists · 0 venues · 3 releases" */}
-            {breakdownEntries.length > 0 && (
-              <div
-                className="flex flex-wrap items-center gap-x-2 gap-y-1 mb-4 text-sm text-muted-foreground"
-                data-testid="usage-breakdown-summary"
-              >
-                {breakdownEntries.map((entry, idx) => (
-                  <span key={entry.type} className="inline-flex items-center gap-1">
-                    {idx > 0 && <span className="text-muted-foreground/40">{'·'}</span>}
-                    <span className="font-medium text-foreground">{entry.count}</span>
-                    <span>
-                      {entry.count === 1
-                        ? getEntityTypeSingularLabel(entry.type)
-                        : getEntityTypePluralLabel(entry.type).toLowerCase()}
-                    </span>
-                  </span>
-                ))}
-              </div>
-            )}
-
-            {/* Description: rendered markdown (goldmark + bluemonday via backend). */}
-            {tag.description_html ? (
-              <div
-                className="prose prose-sm dark:prose-invert max-w-2xl text-muted-foreground"
-                data-testid="tag-description"
-                dangerouslySetInnerHTML={{ __html: tag.description_html }}
-              />
-            ) : tag.description ? (
-              <p className="text-muted-foreground whitespace-pre-line max-w-2xl">
-                {tag.description}
-              </p>
-            ) : null}
+          <div className="flex shrink-0 items-center gap-2">
+            <NotifyMeButton
+              entityType="tag"
+              entityId={tag.id}
+              entityName={tag.name}
+            />
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/shows?tags=${slug}`}>Filter shows</Link>
+            </Button>
           </div>
         </div>
+
+        {/* Demoted one-line meta. */}
+        <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs text-muted-foreground">
+          <span>
+            {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
+          </span>
+          {creatorHandle && (
+            <>
+              <span className="text-muted-foreground/40" aria-hidden>
+                ·
+              </span>
+              <span>
+                created by{' '}
+                <Link
+                  href={`/users/${creatorHandle}`}
+                  className="hover:underline"
+                >
+                  @{creatorHandle}
+                </Link>
+              </span>
+            </>
+          )}
+          {tag.created_at && (
+            <>
+              <span className="text-muted-foreground/40" aria-hidden>
+                ·
+              </span>
+              <span>added {formatRelativeTime(tag.created_at)}</span>
+            </>
+          )}
+        </div>
+
+        {/* Optional description. */}
+        {tag.description_html ? (
+          <div
+            className="prose prose-sm dark:prose-invert max-w-2xl text-muted-foreground mt-3"
+            data-testid="tag-description"
+            dangerouslySetInnerHTML={{ __html: tag.description_html }}
+          />
+        ) : tag.description ? (
+          <p className="text-muted-foreground whitespace-pre-line max-w-2xl mt-3">
+            {tag.description}
+          </p>
+        ) : null}
       </header>
 
-      {/* Parent / Children hierarchy — genre tags only */}
-      {(hasParent || hasChildren) && (
-        <section
-          className="mb-8 rounded-lg border border-border/50 p-4 space-y-3"
-          data-testid="tag-hierarchy"
-        >
-          {hasParent && tag.parent && (
-            <HierarchyRow label="Parent">
-              <TagPill tag={tag.parent} />
-            </HierarchyRow>
-          )}
-          {hasChildren && (
-            <HierarchyRow label={`Children (${tag.children.length})`}>
-              <div className="flex flex-wrap gap-2">
-                {tag.children.map((c) => (
-                  <TagPill key={c.id} tag={c} />
-                ))}
-              </div>
-            </HierarchyRow>
-          )}
-        </section>
+      {/* Active-pivot chip row: shows the added tags + a clear control. */}
+      {isFiltering && intersection && (
+        <ActiveFilterBar
+          baseTag={{ slug, name: tag.name }}
+          addedTags={intersection.tags.filter((t) => t.slug !== slug)}
+          onRemove={(removeSlug) =>
+            setAddedSlugs(addedSlugs.filter((s) => s !== removeSlug))
+          }
+          onClear={() => setAddedSlugs([])}
+        />
       )}
 
-      {/* Metadata cards: aliases. Parent/children moved to the hierarchy row above. */}
-      {tag.aliases && tag.aliases.length > 0 && (
-        <div className="mb-8">
-          <div className="rounded-lg border border-border/50 p-4">
-            <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-              Also known as
-            </h2>
-            <div className="flex flex-wrap gap-2">
-              {tag.aliases.map((alias: string) => (
-                <span
-                  key={alias}
-                  className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground border border-border/50"
-                >
-                  {alias}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Top contributors — anonymous contributors (no username) are hidden;
-          see PSY-450. If every contributor is anonymous, the section is hidden
-          entirely rather than showing an empty header. */}
-      {visibleContributors.length > 0 && (
-        <section className="mb-8" data-testid="top-contributors">
-          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Top contributors
-          </h2>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-            {visibleContributors.map((c, idx) => {
-              const handle = c.user.username as string
-              return (
-                <span key={c.user.id} className="inline-flex items-center gap-1">
-                  {idx > 0 && <span className="text-muted-foreground/40">{'·'}</span>}
-                  <Link
-                    href={`/users/${handle}`}
-                    className="text-foreground hover:underline"
-                  >
-                    @{handle}
-                  </Link>
-                  <span className="text-muted-foreground">({c.count})</span>
-                </span>
-              )
-            })}
-          </div>
-        </section>
-      )}
-
-      {/* Related tags pill row */}
-      {tag.related_tags && tag.related_tags.length > 0 && (
-        <section className="mb-8" data-testid="related-tags">
-          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Related tags
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            {tag.related_tags.map((t) => (
-              <TagPill key={t.id} tag={t} />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Usage Stats + Tagged Entities — preserved from the original layout */}
-      {tag.usage_count > 0 && (
-        <TaggedEntitiesSection slug={slug} />
-      )}
-    </div>
-  )
-}
-
-// ──────────────────────────────────────────────
-// Small presentational helpers
-// ──────────────────────────────────────────────
-
-function HierarchyRow({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex items-start gap-3">
-      <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider min-w-[72px] mt-1.5">
-        {label}
-      </span>
-      <div className="flex-1">{children}</div>
-    </div>
-  )
-}
-
-function TagPill({ tag }: { tag: TagSummary }) {
-  return (
-    <Link
-      href={`/tags/${tag.slug || tag.id}`}
-      className={cn(
-        'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors hover:bg-muted/50',
-        getCategoryColor(tag.category)
-      )}
-    >
-      <Hash className="h-3.5 w-3.5 opacity-70" />
-      {tag.name}
-      {tag.is_official && (
-        <span className="text-[10px] font-medium uppercase tracking-wider opacity-70">
-          official
-        </span>
-      )}
-    </Link>
-  )
-}
-
-// ──────────────────────────────────────────────
-// Tagged entities section (PSY-485 — tabs + entity cards)
-// ──────────────────────────────────────────────
-
-function TaggedEntitiesSection({ slug }: { slug: string }) {
-  const { data, isLoading } = useTagEntities(slug, { limit: 200 })
-
-  const entities = data?.entities
-  const grouped = useMemo(() => {
-    if (!entities) return {}
-    const groups: Record<string, TaggedEntityItem[]> = {}
-    for (const entity of entities) {
-      if (!groups[entity.entity_type]) {
-        groups[entity.entity_type] = []
-      }
-      groups[entity.entity_type].push(entity)
-    }
-    return groups
-  }, [entities])
-
-  // Hide entity types with zero items so a genre-only tag doesn't render an
-  // empty Festivals tab (PSY-485 acceptance criterion).
-  const sortedTypes = useMemo(() => {
-    return ENTITY_TYPE_ORDER.filter((t) => grouped[t]?.length)
-  }, [grouped])
-
-  // Default the active tab to the first non-empty entity type. We can't
-  // recompute this in render because Radix Tabs is a controlled component —
-  // need a real piece of state. The state is initialised lazily so it picks
-  // up the first available type once entities load.
-  const [activeTab, setActiveTab] = useState<string | undefined>(undefined)
-  const effectiveTab =
-    activeTab && sortedTypes.includes(activeTab as (typeof sortedTypes)[number])
-      ? activeTab
-      : sortedTypes[0]
-
-  if (isLoading) {
-    return (
-      <section className="border-t border-border/50 pt-6">
-        <div className="flex items-center justify-center py-8">
+      {/* ── Co-visible entity-type sections ─────────────────────────────── */}
+      {groupsLoading ? (
+        <div className="flex items-center justify-center py-12">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
+      ) : sections.length > 0 ? (
+        <div className="space-y-8" data-testid="tag-sections">
+          {sections.map((group) => (
+            <EntitySection
+              key={group.entity_type}
+              group={group}
+              slugs={intersectionSlugs}
+            />
+          ))}
+        </div>
+      ) : (
+        <EmptyIntersectionState isFiltering={isFiltering} tagName={tag.name} />
+      )}
+
+      {/* "Help grow this tag" CTA for sparse single-item tags (frame 437:7). */}
+      {isSparse && <HelpGrowCta tagName={tag.name} />}
+
+      {/* ── Related tags rail + add-a-tag pivot ─────────────────────────── */}
+      <RelatedTagsRail
+        relatedTags={tag.related_tags ?? []}
+        activeSlugs={intersectionSlugs}
+        onAddTag={(addSlug) =>
+          setAddedSlugs([...addedSlugs, addSlug.toLowerCase()])
+        }
+      />
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Entity-type section
+// ──────────────────────────────────────────────
+
+function EntitySection({
+  group,
+  slugs,
+}: {
+  group: TagIntersectionGroup
+  slugs: string[]
+}) {
+  const label = getTagSectionLabel(group.entity_type)
+  const showAllUrl = getTagSectionBrowseUrl(group.entity_type, slugs)
+
+  return (
+    <section data-testid={`tag-section-${group.entity_type}`}>
+      <div className="mb-1 flex items-baseline justify-between gap-3">
+        <h2 className="flex items-baseline gap-2 text-lg font-semibold">
+          {label}
+          <span className="font-mono text-sm font-normal text-muted-foreground tabular-nums">
+            {group.count}
+          </span>
+        </h2>
+        {showAllUrl && (
+          <Link
+            href={showAllUrl}
+            className="shrink-0 text-sm font-medium text-primary hover:underline"
+            data-testid={`tag-section-showall-${group.entity_type}`}
+          >
+            Show all {group.count} &rarr;
+          </Link>
+        )}
+      </div>
+      <div>
+        {group.preview.map((item) => (
+          <TaggedEntityRow
+            key={`${item.entity_type}-${item.entity_id}`}
+            item={item}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Active-filter bar (pivot chips)
+// ──────────────────────────────────────────────
+
+function ActiveFilterBar({
+  baseTag,
+  addedTags,
+  onRemove,
+  onClear,
+}: {
+  baseTag: { slug: string; name: string }
+  addedTags: TagSummary[]
+  onRemove: (slug: string) => void
+  onClear: () => void
+}) {
+  return (
+    <div
+      className="mb-6 flex flex-wrap items-center gap-2 rounded-lg border border-border/50 bg-muted/20 p-3"
+      data-testid="active-filter-bar"
+    >
+      <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Filtering by
+      </span>
+      <span className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-0.5 text-sm">
+        <Hash className="h-3 w-3 opacity-60" aria-hidden />
+        {baseTag.name}
+      </span>
+      {addedTags.map((t) => (
+        <span
+          key={t.slug}
+          className="inline-flex items-center gap-1 rounded-md border border-primary/40 bg-primary/5 px-2 py-0.5 text-sm"
+        >
+          <Hash className="h-3 w-3 opacity-60" aria-hidden />
+          {t.name}
+          <button
+            type="button"
+            onClick={() => onRemove(t.slug)}
+            className="ml-0.5 rounded-sm text-muted-foreground hover:text-foreground"
+            aria-label={`Remove ${t.name} filter`}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+      <button
+        type="button"
+        onClick={onClear}
+        className="ml-1 text-xs text-muted-foreground hover:text-foreground hover:underline"
+      >
+        Clear
+      </button>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Related-tags rail + "+ add another tag to filter" pivot
+// ──────────────────────────────────────────────
+
+function RelatedTagsRail({
+  relatedTags,
+  activeSlugs,
+  onAddTag,
+}: {
+  relatedTags: TagSummary[]
+  activeSlugs: string[]
+  onAddTag: (slug: string) => void
+}) {
+  const [adding, setAdding] = useState(false)
+
+  // Related tags already in the active intersection are not offerable.
+  const offerable = relatedTags.filter((t) => !activeSlugs.includes(t.slug))
+
+  if (offerable.length === 0 && !adding) {
+    // Nothing to suggest and the picker is closed — still expose the pivot so
+    // the user can search for any tag to intersect.
+    return (
+      <section
+        className="mt-12 border-t border-border/50 pt-6"
+        data-testid="related-tags"
+      >
+        <AddTagPivot
+          activeSlugs={activeSlugs}
+          onAddTag={onAddTag}
+          open={adding}
+          setOpen={setAdding}
+        />
       </section>
     )
   }
 
-  if (sortedTypes.length === 0) {
-    return null
+  return (
+    <section
+      className="mt-12 border-t border-border/50 pt-6"
+      data-testid="related-tags"
+    >
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Related tags
+      </h2>
+      <div className="flex flex-wrap items-center gap-2">
+        {offerable.map((t) => (
+          <button
+            key={t.slug}
+            type="button"
+            onClick={() => onAddTag(t.slug)}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors hover:bg-muted/50',
+              getCategoryColor(t.category)
+            )}
+            data-testid={`related-tag-${t.slug}`}
+          >
+            <Hash className="h-3.5 w-3.5 opacity-70" aria-hidden />
+            {t.name}
+          </button>
+        ))}
+        <AddTagPivot
+          activeSlugs={activeSlugs}
+          onAddTag={onAddTag}
+          open={adding}
+          setOpen={setAdding}
+        />
+      </div>
+    </section>
+  )
+}
+
+/**
+ * The "+ add another tag to filter" control. Closed = an orange-bordered button;
+ * open = a small search-as-you-type picker over the tag corpus. Selecting a tag
+ * narrows the page in place (the parent re-queries the intersection).
+ */
+function AddTagPivot({
+  activeSlugs,
+  onAddTag,
+  open,
+  setOpen,
+}: {
+  activeSlugs: string[]
+  onAddTag: (slug: string) => void
+  open: boolean
+  setOpen: (open: boolean) => void
+}) {
+  const [query, setQuery] = useState('')
+  const { data: results, isLoading } = useSearchTags(query.trim(), 8)
+
+  const matches = (results?.tags ?? []).filter(
+    (t) => !activeSlugs.includes(t.slug)
+  )
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 rounded-md border border-primary/50 px-3 py-1.5 text-sm font-medium text-primary transition-colors hover:bg-primary/5"
+        data-testid="add-tag-pivot-trigger"
+      >
+        + add another tag to filter
+      </button>
+    )
   }
 
   return (
-    <section className="border-t border-border/50 pt-6" data-testid="tagged-entities">
-      <h2 className="text-lg font-semibold mb-4">Tagged Entities</h2>
-
-      <Tabs
-        value={effectiveTab}
-        onValueChange={setActiveTab}
-        className="w-full"
-      >
-        {/* Tabs are scrollable on narrow viewports — six entity types of
-            "Artists/Shows/Venues/..." would push past 375px otherwise. */}
-        <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-          <TabsList className="h-auto flex flex-wrap gap-1 bg-muted/40 p-1">
-            {sortedTypes.map((entityType) => {
-              const count = grouped[entityType].length
-              const Icon = ENTITY_TYPE_ICONS[entityType] || Hash
-              return (
-                <TabsTrigger
-                  key={entityType}
-                  value={entityType}
-                  data-testid={`tagged-entities-tab-${entityType}`}
-                  className="gap-1.5"
+    <div className="relative w-full max-w-xs" data-testid="add-tag-pivot-picker">
+      <input
+        autoFocus
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onBlur={() => {
+          // Defer close so an option click registers first.
+          window.setTimeout(() => setOpen(false), 150)
+        }}
+        placeholder="Search tags to filter…"
+        aria-label="Search tags to filter"
+        className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      />
+      {query.trim().length >= 2 && (
+        <ul className="absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md border border-border bg-popover py-1 shadow-md">
+          {isLoading ? (
+            <li className="px-3 py-2 text-sm text-muted-foreground">
+              Searching…
+            </li>
+          ) : matches.length === 0 ? (
+            <li className="px-3 py-2 text-sm text-muted-foreground">
+              No matching tags
+            </li>
+          ) : (
+            matches.map((t) => (
+              <li key={t.slug}>
+                <button
+                  type="button"
+                  // onMouseDown (not onClick) so it fires before the input's
+                  // onBlur close.
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    onAddTag(t.slug)
+                    setQuery('')
+                    setOpen(false)
+                  }}
+                  className="flex w-full items-center gap-1.5 px-3 py-1.5 text-left text-sm hover:bg-muted/60"
                 >
-                  <Icon className="h-3.5 w-3.5" />
-                  <span>{getEntityTypePluralLabel(entityType)}</span>
-                  <span className="text-xs text-muted-foreground tabular-nums">
-                    {count}
-                  </span>
-                </TabsTrigger>
-              )
-            })}
-          </TabsList>
-        </div>
+                  <Hash className="h-3.5 w-3.5 opacity-60" aria-hidden />
+                  {t.name}
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}
 
-        {sortedTypes.map((entityType) => {
-          const entities = grouped[entityType]
-          return (
-            <TabsContent
-              key={entityType}
-              value={entityType}
-              data-testid={`tagged-entities-panel-${entityType}`}
-              className="mt-4"
-            >
-              <div className="grid gap-3">
-                {entities.map((entity) => (
-                  <TaggedEntityCard
-                    key={`${entity.entity_type}-${entity.entity_id}`}
-                    item={entity}
-                  />
-                ))}
-              </div>
-            </TabsContent>
-          )
-        })}
-      </Tabs>
+// ──────────────────────────────────────────────
+// Empty / sparse states
+// ──────────────────────────────────────────────
+
+function EmptyIntersectionState({
+  isFiltering,
+  tagName,
+}: {
+  isFiltering: boolean
+  tagName: string
+}) {
+  return (
+    <div
+      className="rounded-lg border border-border/50 bg-muted/20 p-6 text-center"
+      data-testid="empty-intersection-state"
+    >
+      <p className="text-muted-foreground">
+        {isFiltering
+          ? 'No entities match all of the selected tags.'
+          : `Nothing is tagged ${tagName} yet.`}
+      </p>
+    </div>
+  )
+}
+
+function HelpGrowCta({ tagName }: { tagName: string }) {
+  return (
+    <section
+      className="mt-8 rounded-lg border border-border/50 bg-muted/20 p-4"
+      data-testid="help-grow-cta"
+    >
+      <h2 className="font-semibold">Help grow this tag</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Be the first to tag a release, show, or venue with {tagName} — it takes
+        seconds.
+      </p>
+      <Button asChild size="sm" className="mt-3">
+        <Link href="/shows/submit">Suggest something &rarr;</Link>
+      </Button>
     </section>
   )
 }

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -301,9 +301,14 @@ function TagDetailContent({
       <RelatedTagsRail
         relatedTags={tag.related_tags ?? []}
         activeSlugs={intersectionSlugs}
-        onAddTag={(addSlug) =>
-          setAddedSlugs([...addedSlugs, addSlug.toLowerCase()])
-        }
+        onAddTag={(addSlug) => {
+          const normalized = addSlug.toLowerCase()
+          // Guard against re-adding an already-active tag (would write a
+          // `?with=ambient,ambient` URL). The backend dedupes anyway, but a
+          // clean URL keeps the chip UI honest.
+          if (normalized === slug || addedSlugs.includes(normalized)) return
+          setAddedSlugs([...addedSlugs, normalized])
+        }}
       />
     </div>
   )

--- a/frontend/features/tags/components/TaggedEntityCards.tsx
+++ b/frontend/features/tags/components/TaggedEntityCards.tsx
@@ -1,302 +1,219 @@
 'use client'
 
 /**
- * Tagged-entity card row renderers (PSY-485).
+ * Dense tagged-entity rows (PSY-993 — content-first tag detail rebuild).
  *
- * Adapts the lightweight `TaggedEntityItem` returned by GET /tags/{slug}/entities
- * into the entity-specific shapes consumed by the existing feature-module cards
- * (ArtistCard, FestivalCard, LabelCard, ReleaseCard) wherever those work with
- * minimal data, and renders venue/show rows inline because the heavyweight
- * VenueCard/ShowCard pull in feature-specific dependencies (favorite buttons,
- * attendance, music embeds) that don't make sense in this context.
+ * Replaces the heavyweight per-type entity cards (ArtistCard / ReleaseCard / …)
+ * with a single density-first row primitive shared across all entity types:
  *
- * Each renderer accepts the raw `TaggedEntityItem` so the parent (TagDetail) can
- * stay agnostic about which fields the backend populated for which type.
+ *     [ primary name ]  · secondary           right-aligned metric
+ *
+ * - primary: bold, links to the entity detail page.
+ * - secondary: muted, ` · `-joined context (location / artist · type / venue ·
+ *   location). Omitted when empty.
+ * - metric: right-aligned Space-Mono data point per the design (12 shows / 1991
+ *   / Jul 28 / 34 releases). Omitted when not applicable.
+ *
+ * A generic <TaggedEntityRow> renders the shape; getRowFields maps each
+ * TaggedEntityItem's per-type fields onto {primary, secondary, metric, href}.
+ * The tag detail page (TagDetail) renders these inside a borderless dense list,
+ * mirroring the PSY-992 /tags browse DenseTable treatment.
  */
 
 import Link from 'next/link'
-import { BadgeCheck, Library, MapPin } from 'lucide-react'
-import { ArtistCard } from '@/features/artists'
-import type { ArtistListItem } from '@/features/artists/types'
-import { FestivalCard } from '@/features/festivals'
-import type { FestivalListItem } from '@/features/festivals/types'
-import { LabelCard } from '@/features/labels'
-import type { LabelListItem } from '@/features/labels/types'
-import { ReleaseCard } from '@/features/releases'
-import type { ReleaseListItem } from '@/features/releases/types'
-import { formatShowDateBadge } from '@/lib/utils/showDateBadge'
+import { BadgeCheck } from 'lucide-react'
+import { resolveShowTimezone } from '@/lib/utils/formatters'
+import { formatInTimezone } from '@/lib/utils/timeUtils'
 import type { TaggedEntityItem } from '../types'
 import { getEntityUrl } from '../types'
 
 // ──────────────────────────────────────────────
-// Per-type adapters
+// Per-type field mapping
 // ──────────────────────────────────────────────
 
-function TaggedArtistCard({ item }: { item: TaggedEntityItem }) {
-  // Adapt to ArtistListItem. ArtistCard only reads name, slug, city, state,
-  // and upcoming_show_count, so we can pass a minimal shape with the rest
-  // stubbed out.
-  const artist: ArtistListItem = {
-    id: item.entity_id,
-    slug: item.slug,
-    name: item.name,
-    city: item.city ?? null,
-    state: item.state ?? null,
-    bandcamp_embed_url: null,
-    description: null,
-    social: {
-      instagram: null,
-      facebook: null,
-      twitter: null,
-      youtube: null,
-      spotify: null,
-      soundcloud: null,
-      bandcamp: null,
-      website: null,
-    },
-    created_at: '',
-    updated_at: '',
-    upcoming_show_count: item.upcoming_show_count ?? 0,
-  }
-  return <ArtistCard artist={artist} density="comfortable" />
+interface RowFields {
+  /** Entity detail URL. */
+  href: string
+  /** Bold primary label (the entity name). */
+  primary: string
+  /** Muted, ` · `-joined secondary context. Empty when none applies. */
+  secondary: string[]
+  /** Right-aligned Space-Mono metric (e.g. "12 shows", "1991"). Null = omit. */
+  metric: string | null
+  /** True for verified venues — renders a check beside the primary name. */
+  verified?: boolean
 }
 
-function TaggedFestivalCard({ item }: { item: TaggedEntityItem }) {
-  // Adapt to FestivalListItem. The card reads name, slug, city, state,
-  // edition_year, start_date, end_date, status, artist_count, venue_count.
-  const festival: FestivalListItem = {
-    id: item.entity_id,
-    name: item.name,
-    slug: item.slug,
-    series_slug: '', // unused by FestivalCard
-    edition_year: item.edition_year ?? 0,
-    city: item.city || null,
-    state: item.state || null,
-    start_date: item.start_date ?? '',
-    end_date: item.end_date ?? '',
-    status: item.status ?? 'announced',
-    artist_count: item.artist_count ?? 0,
-    venue_count: item.venue_count ?? 0,
-  }
-  return <FestivalCard festival={festival} density="comfortable" />
+/** Join city/state into "Phoenix, AZ" (either may be missing). */
+function locationOf(item: TaggedEntityItem): string | null {
+  const parts = [item.city, item.state].filter(Boolean)
+  return parts.length > 0 ? parts.join(', ') : null
 }
 
-function TaggedLabelCard({ item }: { item: TaggedEntityItem }) {
-  const label: LabelListItem = {
-    id: item.entity_id,
-    name: item.name,
-    slug: item.slug,
-    city: item.city || null,
-    state: item.state || null,
-    status: item.status ?? 'active',
-    artist_count: item.artist_count ?? 0,
-    release_count: item.release_count ?? 0,
-  }
-  return <LabelCard label={label} density="comfortable" />
+/** Pluralize a count: countLabel(12, "show") -> "12 shows". */
+function countLabel(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`
 }
 
-function TaggedReleaseCard({ item }: { item: TaggedEntityItem }) {
-  // ReleaseCard expects ReleaseListItem with an `artists` array. The tag
-  // detail endpoint doesn't return per-release artist credits (would require
-  // an extra JOIN per row), so we render an empty artists array — the card
-  // gracefully handles that case (no artist line when the array is empty).
-  const release: ReleaseListItem = {
-    id: item.entity_id,
-    title: item.name,
-    slug: item.slug,
-    release_type: item.release_type ?? 'lp',
-    release_year: item.release_year ?? null,
-    cover_art_url: item.cover_art_url ?? null,
-    artist_count: 0,
-    artists: [],
-    label_name: null,
-    label_slug: null,
-  }
-  return <ReleaseCard release={release} density="comfortable" />
+/** "Jul 28" in the show's venue timezone (matches the design metric format). */
+function formatShowMetric(item: TaggedEntityItem): string | null {
+  if (!item.event_date) return null
+  const tz = resolveShowTimezone(item.state ?? null, null)
+  return formatInTimezone(item.event_date, tz, {
+    month: 'short',
+    day: 'numeric',
+  })
 }
 
 /**
- * Inline venue card. We don't reuse VenueCard because it pulls in
- * useVenueShows, FollowButton, edit/delete dialogs, and other
- * authenticated affordances that aren't appropriate in this read-only,
- * cross-entity browsing context. The visual treatment matches the artist
- * card so the tabs feel cohesive.
+ * Map a TaggedEntityItem to its dense-row fields. Keeping the per-type knowledge
+ * here lets TagDetail stay agnostic about which backend fields each type
+ * populates (mirrors the prior card-adapter split).
  */
-function TaggedVenueRow({ item }: { item: TaggedEntityItem }) {
-  const hasLocation = item.city || item.state
-  const location = hasLocation
-    ? [item.city, item.state].filter(Boolean).join(', ')
-    : null
-  const upcoming = item.upcoming_show_count ?? 0
-  return (
-    <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <Link
-            href={getEntityUrl('venue', item.slug)}
-            className="block group"
-          >
-            <h3 className="font-bold text-base text-foreground group-hover:text-primary transition-colors truncate inline-flex items-center gap-1.5">
-              {item.name}
-              {item.verified && (
-                <BadgeCheck className="h-4 w-4 text-primary shrink-0" aria-label="Verified venue" />
-              )}
-            </h3>
-          </Link>
-          {location && (
-            <div className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
-              <MapPin className="h-3.5 w-3.5 shrink-0" />
-              <span>{location}</span>
-            </div>
-          )}
-        </div>
-        <span
-          className={`text-xs font-medium px-2 py-1 rounded-full shrink-0 ${
-            upcoming > 0
-              ? 'bg-primary/10 text-primary'
-              : 'bg-muted text-muted-foreground'
-          }`}
-        >
-          {upcoming} {upcoming === 1 ? 'show' : 'shows'}
-        </span>
-      </div>
-    </article>
-  )
-}
+export function getRowFields(item: TaggedEntityItem): RowFields {
+  const href = getEntityUrl(item.entity_type, item.slug)
+  const location = locationOf(item)
 
-/**
- * Inline show row. ShowCard wants a full ShowResponse with bill positions,
- * attendance counters, edit/delete affordances, and music embed plumbing —
- * none of which the tag-entities endpoint exposes. We render the headliner +
- * venue + date with the same visual rhythm.
- */
-function TaggedShowRow({ item }: { item: TaggedEntityItem }) {
-  const dateBadge = item.event_date
-    ? formatShowDateBadge(item.event_date, item.state ?? null)
-    : null
-  const headliner = item.headliner_name
-  const venue = item.venue_name
-  const location =
-    item.city && item.state
-      ? `${item.city}, ${item.state}`
-      : item.city || item.state || null
-
-  return (
-    <article className="rounded-lg border border-border/50 bg-card p-3 sm:p-4 transition-shadow hover:shadow-sm">
-      <div className="flex gap-3 sm:gap-4">
-        {dateBadge && (
-          <Link
-            href={getEntityUrl('show', item.slug)}
-            className="shrink-0 flex flex-col items-center justify-center rounded-md bg-muted/50 hover:bg-muted transition-colors w-14 sm:w-16 py-2"
-          >
-            <span className="text-[10px] sm:text-xs font-bold tracking-widest uppercase text-muted-foreground leading-none">
-              {dateBadge.dayOfWeek}
-            </span>
-            <span className="text-xs sm:text-sm font-semibold text-primary leading-tight mt-0.5">
-              {dateBadge.monthDay}
-            </span>
-          </Link>
-        )}
-        <div className="flex-1 min-w-0">
-          <Link href={getEntityUrl('show', item.slug)} className="block group">
-            <h3 className="font-bold text-base sm:text-lg text-foreground group-hover:text-primary transition-colors truncate">
-              {headliner || item.name || 'Show'}
-            </h3>
-          </Link>
-          {venue && (
-            <div className="text-sm text-muted-foreground mt-0.5">
-              {item.venue_slug ? (
-                <Link
-                  href={`/venues/${item.venue_slug}`}
-                  className="text-primary/80 hover:text-primary font-medium transition-colors"
-                >
-                  {venue}
-                </Link>
-              ) : (
-                <span className="text-primary/80 font-medium">{venue}</span>
-              )}
-              {location && (
-                <span className="text-muted-foreground/80">
-                  {' '}&middot; {location}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    </article>
-  )
-}
-
-/**
- * PSY-553: tagged collection row. The backend (`enrichCollections`) only
- * populates name + slug for collections (no city/state/counts), and the
- * full CollectionCard requires a heavyweight shape with item counts,
- * contributor counts, like state, etc. that the tag-entities endpoint
- * doesn't return. Following the TaggedShowRow / TaggedVenueRow precedent,
- * we render a minimal inline row that links to /collections/{slug}.
- */
-function TaggedCollectionRow({ item }: { item: TaggedEntityItem }) {
-  return (
-    <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
-      <div className="flex items-start gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted/50">
-          <Library className="h-5 w-5 text-muted-foreground/70" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Link
-            href={getEntityUrl('collection', item.slug)}
-            className="block group"
-          >
-            <h3 className="font-bold text-base text-foreground group-hover:text-primary transition-colors truncate">
-              {item.name}
-            </h3>
-          </Link>
-        </div>
-      </div>
-    </article>
-  )
+  switch (item.entity_type) {
+    case 'artist': {
+      const upcoming = item.upcoming_show_count ?? 0
+      return {
+        href,
+        primary: item.name,
+        secondary: location ? [location] : [],
+        metric: upcoming > 0 ? countLabel(upcoming, 'show') : null,
+      }
+    }
+    case 'venue': {
+      const upcoming = item.upcoming_show_count ?? 0
+      return {
+        href,
+        primary: item.name,
+        secondary: location ? [location] : [],
+        metric: countLabel(upcoming, 'show'),
+        verified: item.verified ?? false,
+      }
+    }
+    case 'release': {
+      // "Loveless · My Bloody Valentine · LP" — but the tag-entities endpoint
+      // doesn't return per-release artist credits, so secondary carries the
+      // release type only. Metric = release year.
+      const secondary: string[] = []
+      if (item.release_type) secondary.push(item.release_type.toUpperCase())
+      return {
+        href,
+        primary: item.name,
+        secondary,
+        metric: item.release_year ? String(item.release_year) : null,
+      }
+    }
+    case 'show': {
+      // "Whirr · The Rebel Lounge · Phoenix, AZ" — headliner leads, venue +
+      // location in the secondary. Metric = show date.
+      const secondary: string[] = []
+      const venue = item.venue_name
+      if (venue) secondary.push(venue)
+      if (location) secondary.push(location)
+      return {
+        href,
+        primary: item.headliner_name || item.name || 'Show',
+        secondary,
+        metric: formatShowMetric(item),
+      }
+    }
+    case 'label': {
+      const releaseCount = item.release_count ?? 0
+      return {
+        href,
+        primary: item.name,
+        secondary: location ? [location] : [],
+        metric: releaseCount > 0 ? countLabel(releaseCount, 'release') : null,
+      }
+    }
+    case 'festival': {
+      const secondary: string[] = []
+      if (location) secondary.push(location)
+      const artistCount = item.artist_count ?? 0
+      return {
+        href,
+        primary: item.name,
+        secondary,
+        metric: item.edition_year
+          ? String(item.edition_year)
+          : artistCount > 0
+            ? countLabel(artistCount, 'artist')
+            : null,
+      }
+    }
+    case 'collection':
+      return {
+        href,
+        primary: item.name,
+        secondary: [],
+        metric: null,
+      }
+    default:
+      return {
+        href: href === '#' ? getEntityUrl(item.entity_type, item.slug) : href,
+        primary: item.name,
+        secondary: [],
+        metric: null,
+      }
+  }
 }
 
 // ──────────────────────────────────────────────
-// Public renderer
+// Dense row
 // ──────────────────────────────────────────────
 
-interface TaggedEntityCardProps {
+interface TaggedEntityRowProps {
   item: TaggedEntityItem
 }
 
 /**
- * Render a single tagged-entity card based on its type. Any unknown entity
- * type falls back to a minimal link row so we never silently drop data when
- * the backend learns about a new tag-eligible entity type.
+ * A single dense tagged-entity row. The whole left cluster (name + secondary)
+ * sits under one link target; the metric is plain text on the right so the row
+ * keeps a single anchor (avoids nested-link strict-mode collisions).
  */
-export function TaggedEntityCard({ item }: TaggedEntityCardProps) {
-  switch (item.entity_type) {
-    case 'artist':
-      return <TaggedArtistCard item={item} />
-    case 'venue':
-      return <TaggedVenueRow item={item} />
-    case 'festival':
-      return <TaggedFestivalCard item={item} />
-    case 'label':
-      return <TaggedLabelCard item={item} />
-    case 'release':
-      return <TaggedReleaseCard item={item} />
-    case 'show':
-      return <TaggedShowRow item={item} />
-    case 'collection':
-      return <TaggedCollectionRow item={item} />
-    default:
-      return (
-        <article className="rounded-lg border border-border/50 bg-card p-4">
-          <Link
-            href={getEntityUrl(item.entity_type, item.slug)}
-            className="font-medium text-foreground hover:text-primary transition-colors"
-          >
-            {item.name}
-          </Link>
-        </article>
-      )
-  }
+export function TaggedEntityRow({ item }: TaggedEntityRowProps) {
+  const { href, primary, secondary, metric, verified } = getRowFields(item)
+
+  return (
+    <div
+      className="flex items-baseline justify-between gap-3 border-b border-border/30 py-2 last:border-b-0"
+      data-testid={`tagged-row-${item.entity_type}`}
+    >
+      <div className="min-w-0 flex-1 truncate">
+        <Link
+          href={href}
+          className="font-semibold text-foreground hover:underline"
+        >
+          {primary}
+        </Link>
+        {verified && (
+          <BadgeCheck
+            className="ml-1 inline-block h-3.5 w-3.5 -translate-y-px text-primary"
+            aria-label="Verified venue"
+          />
+        )}
+        {secondary.length > 0 && (
+          <span className="text-sm text-muted-foreground">
+            {secondary.map((part, idx) => (
+              <span key={idx}>
+                <span className="mx-1.5 text-muted-foreground/40" aria-hidden>
+                  ·
+                </span>
+                {part}
+              </span>
+            ))}
+          </span>
+        )}
+      </div>
+      {metric && (
+        <span className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
+          {metric}
+        </span>
+      )}
+    </div>
+  )
 }

--- a/frontend/features/tags/components/TaggedEntityCards.tsx
+++ b/frontend/features/tags/components/TaggedEntityCards.tsx
@@ -153,8 +153,10 @@ export function getRowFields(item: TaggedEntityItem): RowFields {
         metric: null,
       }
     default:
+      // Unknown entity type — link via getEntityUrl (returns '#' for types it
+      // doesn't know) and show the bare name so we never silently drop a row.
       return {
-        href: href === '#' ? getEntityUrl(item.entity_type, item.slug) : href,
+        href,
         primary: item.name,
         secondary: [],
         metric: null,

--- a/frontend/features/tags/hooks/index.ts
+++ b/frontend/features/tags/hooks/index.ts
@@ -19,6 +19,7 @@ import type {
   EntityTagsResponse,
   EntityTag,
   TagEntitiesResponse,
+  TagIntersectionResponse,
 } from '../types'
 
 // ──────────────────────────────────────────────
@@ -158,6 +159,40 @@ export function useTagEntities(
     queryKey: queryKeys.tags.tagEntities(idOrSlug, params as Record<string, unknown> | undefined),
     queryFn: () => apiRequest<TagEntitiesResponse>(url),
     enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+  })
+}
+
+/**
+ * Fetch the cross-entity tag intersection (PSY-995). Powers the rebuilt
+ * /tags/{slug} detail page's grouped sections — one tag for the single-tag
+ * detail, 2+ for the "+ add a tag" pivot. Returns per-type groups (count +
+ * preview) so each section renders its top-N dense rows + a "show all N" link.
+ *
+ * `enabled` gates the request: the detail page passes `enabled` only once the
+ * tag's slug is known and usage_count > 0, so a brand-new / unused tag doesn't
+ * fire an intersection query that would 400 (unknown slug) or return all zeros.
+ */
+export function useTagIntersection(
+  slugs: string[],
+  params?: { tagMatch?: 'all' | 'any'; previewLimit?: number },
+  options?: { enabled?: boolean }
+) {
+  const tagMatch = params?.tagMatch ?? 'all'
+  const previewLimit = params?.previewLimit
+
+  const searchParams = new URLSearchParams()
+  searchParams.set('tags', slugs.join(','))
+  if (tagMatch !== 'all') searchParams.set('tag_match', tagMatch)
+  if (previewLimit) searchParams.set('preview_limit', String(previewLimit))
+
+  const url = `${API_ENDPOINTS.TAGS.INTERSECTION}?${searchParams.toString()}`
+
+  return useQuery({
+    queryKey: queryKeys.tags.intersection(slugs, tagMatch, previewLimit),
+    queryFn: () => apiRequest<TagIntersectionResponse>(url),
+    enabled: (options?.enabled ?? true) && slugs.length > 0,
     staleTime: 5 * 60 * 1000,
     placeholderData: keepPreviousData,
   })

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -187,6 +187,91 @@ export interface TagEntitiesResponse {
   total: number
 }
 
+// ──────────────────────────────────────────────
+// Cross-entity tag intersection (GET /tags/intersection — PSY-995)
+// ──────────────────────────────────────────────
+
+/**
+ * One entity-type slice of a tag intersection: the full match `count` plus a
+ * `preview` (page 1 of that type's "show all" browse). The rebuilt tag detail
+ * page (PSY-993) renders its grouped sections from these groups — for both the
+ * single-tag case (`tags=[slug]`) and the multi-tag "+ add a tag" pivot.
+ */
+export interface TagIntersectionGroup {
+  entity_type: string
+  count: number
+  preview: TaggedEntityItem[]
+}
+
+/**
+ * Response body of GET /tags/intersection. `tags` echoes the resolved input
+ * tags (request order) for the chip UI. `groups` carries one entry per valid
+ * entity type — zero-count groups included (complete keyset) so the frontend
+ * decides which sections to show. Groups arrive in the backend's canonical
+ * TagEntityTypes order; the detail page reorders them to the design's fixed
+ * display order (TAG_DETAIL_SECTION_ORDER).
+ */
+export interface TagIntersectionResponse {
+  tags: TagSummary[]
+  tag_match: string
+  groups: TagIntersectionGroup[]
+}
+
+/**
+ * Fixed display order for the rebuilt /tags/{slug} detail page sections
+ * (PSY-993, design frame 424:7). Differs from the backend's canonical
+ * TagEntityTypes order — the design leads with the discovery-relevant types
+ * (artists, releases, upcoming shows) before the supporting ones. Empty-count
+ * sections are suppressed at render time.
+ */
+export const TAG_DETAIL_SECTION_ORDER = [
+  'artist',
+  'release',
+  'show',
+  'venue',
+  'label',
+  'festival',
+  'collection',
+] as const
+
+/**
+ * Section heading label per entity type, matching the design copy. Mostly the
+ * plural label, except shows which read "Upcoming shows" (the section is gated
+ * to upcoming/approved shows by the backend).
+ */
+export function getTagSectionLabel(entityType: string): string {
+  if (entityType === 'show') return 'Upcoming shows'
+  return getEntityTypePluralLabel(entityType)
+}
+
+/**
+ * Build the "show all" deep-link for a section: the existing per-type browse
+ * filtered by the active tag(s). The six entity browse pages
+ * (artists/releases/shows/venues/labels/festivals) already support `?tags=` +
+ * `tag_match=` (PSY-993 decision #1); multiple slugs join with `tag_match=all`.
+ * Collections have no tag-filtered browse, so this returns null for them and
+ * the collection section omits its "show all" link.
+ */
+export function getTagSectionBrowseUrl(
+  entityType: string,
+  slugs: string[]
+): string | null {
+  const base: Record<string, string> = {
+    artist: '/artists',
+    release: '/releases',
+    show: '/shows',
+    venue: '/venues',
+    label: '/labels',
+    festival: '/festivals',
+  }
+  const path = base[entityType]
+  if (!path) return null
+  const params = new URLSearchParams()
+  params.set('tags', slugs.join(','))
+  if (slugs.length > 1) params.set('tag_match', 'all')
+  return `${path}?${params.toString()}`
+}
+
 export interface TagAliasesResponse {
   aliases: TagAlias[]
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -331,6 +331,9 @@ export const API_ENDPOINTS = {
     ALIASES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/aliases`,
     DELETE_ALIAS: (tagId: number, aliasId: number) => `${API_BASE_URL}/tags/${tagId}/aliases/${aliasId}`,
     ENTITIES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/entities`,
+    // Cross-entity tag intersection (PSY-995). Accepts 1+ comma-separated slugs
+    // (PSY-993 drives the single-tag detail sections through this same endpoint).
+    INTERSECTION: `${API_BASE_URL}/tags/intersection`,
     ADMIN_ALIASES_ALL: `${API_BASE_URL}/admin/tags/aliases`,
     ADMIN_ALIASES_BULK: `${API_BASE_URL}/admin/tags/aliases/bulk`,
     ADMIN_MERGE: (sourceId: number) => `${API_BASE_URL}/admin/tags/${sourceId}/merge`,

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -331,6 +331,11 @@ export const queryKeys = {
     genreHierarchy: ['tags', 'hierarchy', 'genre'] as const,
     entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId] as const,
     tagEntities: (idOrSlug: string | number, params?: Record<string, unknown>) => ['tags', 'tagEntities', String(idOrSlug), params] as const,
+    // Cross-entity tag intersection (PSY-995 / PSY-993 detail sections). Keyed on
+    // the normalized (sorted) slug set + match so shoegaze,ambient and
+    // ambient,shoegaze share a cache entry (intersection is symmetric).
+    intersection: (slugs: string[], match: string, previewLimit?: number) =>
+      ['tags', 'intersection', [...slugs].sort().join(','), match, previewLimit ?? null] as const,
   },
 
   // Attendance (going/interested) queries


### PR DESCRIPTION
## Summary

Rebuilds `/tags/{slug}` content-first per the locked PSY-979 design (Figma `424:7`, sparse `437:7`): a thin metadata band over co-visible per-entity-type sections (NOT tabs). Each section is a `Type (count)` header + default-sorted top-N **dense rows** + a `Show all N →` deep-link into the existing per-type browse. A related-tags rail at the bottom carries the in-place **"+ add another tag to filter"** intersection pivot.

**Frontend**
- `TagDetail.tsx` rebuilt: thin band (title + category chip + Official + Notify + Filter shows; demoted mono `uses · creator · added` meta + optional description); 7 fixed-order sections (Artists, Releases, Upcoming shows, Venues, Labels, Festivals, Collections) with empty-suppression; related-tags rail + add-a-tag pivot; sparse "Help grow this tag" CTA for single-item tags.
- `TaggedEntityCards.tsx`: heavyweight per-type cards → one dense-row primitive (`TaggedEntityRow`) + a `getRowFields` per-type field map (bold name + ` · `-joined secondary + right-aligned Space-Mono metric), mirroring the PSY-992 `/tags` `DenseTable` treatment.
- Sections + pivot are driven by the PSY-995 `/tags/intersection` endpoint (one tag for the detail, 2+ for the pivot). The pivot encodes added tags as `?with=slug,…` (shareable; degrades to single-tag detail) and re-renders the same grouped sections in place; each "Show all" deep-links to `/{type}?tags=a,b&tag_match=all`.
- New `useTagIntersection` hook + intersection query key + `INTERSECTION` endpoint + `TagIntersection*` types + section-order/label/url helpers.

**Backend** (transitive-show reconciliation + per-type sort)
- Serve the single-tag detail sections through `/tags/intersection` too, so they inherit transitive show/festival matching, per-type default sort, and public gates — instead of `GetTagEntities`' direct-only path, which would render an **empty Upcoming-shows section** (shows are never directly tagged). `intersectionMinTags` 2→1 (a single tag is a valid degenerate intersection); doc strings + handler tests updated.
- Fixed the artist/venue preview sort to upcoming-show count DESC (joined count) to match `GetAllArtists`' browse sort and the design's "12 shows / 8 shows" rows; other types keep their column `ORDER BY`.

Closes PSY-993

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/services/catalog/... ./internal/api/handlers/catalog/...` — ok (incl. new single-tag transitive-show + artist show-count-DESC ordering + single-tag-allowed/no-tags-400 cases)
- [x] `cd backend && go test ./internal/api/routes/...` — ok (intersection route registration)
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors (155 pre-existing warnings, none in changed files)
- [x] `cd frontend && bun run test:run features/tags` — 250 passed (rewrote `TagDetail.test.tsx`: dropped tab assertions; added section-order + empty-suppression + sparse-state + pivot + "Show all" + zero-usage-gate assertions)

## Manual repro

Isolated dispatch stack (`stack-up.sh --mode=isolated`); the E2E seed ships no tags (PSY-1010), so I seeded `emo` (genre) across artists / releases / labels / a verified venue + an artist billed on upcoming shows; `indie` for the pivot intersection; and a single-artist (show-less) `dungeon-synth` for the sparse state. Browsed via **agent-browser**.

Verified against `$STACK_BACKEND_URL` + the rendered page:
- **Sections lead, metadata demoted**; empty types suppressed; dense rows with right-aligned Space-Mono metrics.
- **Upcoming-shows section shows transitive matches** — `/tags/intersection?tags=emo` returns `show count=28` (NOT 0); shows match via billed emo artists. **This is the core gap the ticket flagged.**
- **Artist ordering** is upcoming-show-count DESC (AJJ 12 → Jimmy Eat World 11 → The Maine 6 → Sundressed 5).
- **"Show all N →"** links resolve to `/artists?tags=emo`, `/shows?tags=emo`, etc.
- **"+ add another tag" pivot** (`# Indie`) narrows in place: URL → `?with=indie`, Artists 1 (Jimmy Eat World), Upcoming shows 11 (transitive AND); "Show all" → `/artists?tags=emo,indie&tag_match=all`.
- **Sparse state** (`dungeon-synth`): single Artist row + "Help grow this tag" CTA, all other types suppressed — matches frame `437:7`.

## Screenshots

| | Light | Dark |
|---|---|---|
| **Populated detail** (`emo`) — sections lead, metadata demoted, dense rows, transitive Upcoming shows | ![populated light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-993-screenshots/01-emo-populated-light.png) | ![populated dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-993-screenshots/02-emo-populated-dark.png) |
| **Sparse state** (`dungeon-synth`) — single item + "Help grow this tag" CTA (frame 437:7) | ![sparse light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-993-screenshots/04-dungeon-synth-sparse-light.png) | ![sparse dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-993-screenshots/05-dungeon-synth-sparse-dark.png) |

**Pivot in action** (`emo ∩ indie`, light) — narrowed in place, FILTERING BY bar + multi-tag "Show all":
![pivot](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-993-screenshots/03-emo-indie-pivot-light.png)

## Code review

`/code-review` (xhigh, run inline — no Agent tool in a worktree). 2 cleanups, both applied in `d32cbca7`:
- Harden the add-tag pivot to skip re-adding an already-active slug (no `?with=ambient,ambient`).
- Drop a tautological `href === '#' ? getEntityUrl(...) : href` no-op in `getRowFields`' default branch.
No correctness bugs found. Re-ran typecheck + lint + scoped tests after the edits — all green.

## Adversarial review

`/adversarial-review` — verdict **CONCERNS** (1 MEDIUM, no HIGH/CRITICAL); panel run **inline** (Saboteur · Future-Maintainer · Security · Completeness — no Agent tool in a worktree).
- **[MEDIUM] Future-Maintainer — dropped header blocks → disclosed** (see Scope deviation below). No code change: the rebuild intentionally drops the old "Top contributors", "Also known as" (aliases), and parent/children hierarchy blocks because the locked design (424:7 / 437:7) shows none of them and demotes metadata; the parent is preserved in the breadcrumb chain.
- **Held up well (probed, found solid):** collection privacy gate through the new single-tag path (preserved + covered by `TestIntersection_CollectionExcludesPrivate`); public-endpoint query amplification (1-tag is strictly cheaper than the already-allowed 2-tag; `intersectionMaxTags=10` cap unchanged); artist-preview `LEFT JOIN` correctness (1:1 grouped subquery, no fan-out); `?with=` param safety (encoded + parameterized `IN`); sparse/load-state gating.

## Scope deviation

- **Header blocks dropped (intentional, per locked design):** the prior page rendered Top contributors, Aliases ("Also known as"), and a parent/children hierarchy box. The content-first redesign (424:7) omits all three (metadata demoted); the parent tag still appears as a breadcrumb crumb. Their data is still served by `/tags/{slug}/detail` and can be re-surfaced later if desired.
- **Backend approach — single-tag sections via `/tags/intersection`, not `GetTagEntities`:** the ticket offered "apply transitive filter in `GetTagEntities` OR report a follow-up." Instead I lowered `intersectionMinTags` to 1 and route the single-tag detail through the already-merged, already-tested PSY-995 intersection path. This is smaller than duplicating transitive + per-type-sort logic into `GetTagEntities`, and gives the detail sections transitive show/festival matching + per-type gates for free. `GetTagEntities` is left untouched (still used nowhere else).
- **Interactive per-section sort control:** deferred (a sensible per-type default ships now), per the ticket's resolved decision #2.
- **Header "Filter shows" action** links to `/shows?tags={base-slug}` even with an active pivot (the section-level "Show all" handles the multi-tag case) — the header action is intentionally the base-tag shortcut.
