### PR TITLE
PSY-981: nearest-show-city geo-default for new visitors

### DIFF
--- a/backend/internal/api/handlers/catalog/show_test.go
+++ b/backend/internal/api/handlers/catalog/show_test.go
@@ -380,9 +380,14 @@ func TestGetShowsHandler_ServiceError(t *testing.T) {
 // ============================================================================
 
 func TestGetShowCitiesHandler_Success(t *testing.T) {
+	// PSY-981: the city carries its geocoded centroid; assert the handler
+	// surfaces lat/long unchanged so the wire response includes them.
+	lat, lng := 33.4484, -112.0740
 	mock := &testhelpers.MockShowService{
 		GetShowCitiesFn: func(timezone string) ([]contracts.ShowCityResponse, error) {
-			return []contracts.ShowCityResponse{{City: "Phoenix", State: "AZ", ShowCount: 5}}, nil
+			return []contracts.ShowCityResponse{
+				{City: "Phoenix", State: "AZ", ShowCount: 5, Latitude: &lat, Longitude: &lng},
+			}, nil
 		},
 	}
 	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
@@ -392,7 +397,14 @@ func TestGetShowCitiesHandler_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(resp.Body.Cities) != 1 {
-		t.Errorf("expected 1 city, got %d", len(resp.Body.Cities))
+		t.Fatalf("expected 1 city, got %d", len(resp.Body.Cities))
+	}
+	got := resp.Body.Cities[0]
+	if got.Latitude == nil || got.Longitude == nil {
+		t.Fatalf("expected centroid to pass through, got lat=%v lng=%v", got.Latitude, got.Longitude)
+	}
+	if *got.Latitude != lat || *got.Longitude != lng {
+		t.Errorf("centroid mismatch: got (%v, %v), want (%v, %v)", *got.Latitude, *got.Longitude, lat, lng)
 	}
 }
 

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -21,6 +21,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/geo"
 	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
@@ -35,6 +36,12 @@ func fnvHash(s string) int64 {
 // ShowService handles show-related business logic
 type ShowService struct {
 	db *gorm.DB
+	// geocoder resolves a (city, state) to its centroid coordinates using the
+	// same offline GeoNames dataset PSY-985 uses for venues. GetShowCities
+	// surfaces the centroid per show-city so the frontend can pick the nearest
+	// has-shows city for a new visitor (PSY-981). It's process-wide and
+	// stateless, so sharing geo.Default() is safe.
+	geocoder geo.Geocoder
 }
 
 // NewShowService creates a new show service
@@ -43,7 +50,8 @@ func NewShowService(database *gorm.DB) *ShowService {
 		database = db.GetDB()
 	}
 	return &ShowService{
-		db: database,
+		db:       database,
+		geocoder: geo.Default(),
 	}
 }
 
@@ -1011,6 +1019,21 @@ func (s *ShowService) GetShowCities(timezone string) ([]contracts.ShowCityRespon
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get show cities: %w", err)
+	}
+
+	// Attach each city's geocoded centroid (PSY-981). We resolve from the
+	// (city, state) pair via the SAME offline geocoder PSY-985 uses for venue
+	// coordinates, rather than joining show_venues -> venues: it's exact to the
+	// (city, state) key we already group by (no venue-vs-show city-spelling
+	// mismatch), it has no dependency on every venue row being backfilled, and
+	// it's an in-memory lookup (no extra query, no N+1). A miss leaves both
+	// coords nil — the frontend then falls back to exact city-name matching.
+	if s.geocoder != nil {
+		for i := range results {
+			lat, lng, _ := geo.LookupPointers(s.geocoder, results[i].City, results[i].State, "")
+			results[i].Latitude = lat
+			results[i].Longitude = lng
+		}
 	}
 
 	return results, nil

--- a/backend/internal/services/catalog/show_test.go
+++ b/backend/internal/services/catalog/show_test.go
@@ -32,7 +32,7 @@ func (suite *ShowServiceIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
 
-	suite.showService = &ShowService{db: suite.testDB.DB}
+	suite.showService = NewShowService(suite.testDB.DB)
 }
 
 func (suite *ShowServiceIntegrationTestSuite) TearDownSuite() {
@@ -1506,11 +1506,29 @@ func (suite *ShowServiceIntegrationTestSuite) TestGetShowCities_Success() {
 
 	// Phoenix should have more shows
 	cityMap := make(map[string]int)
+	rowByCity := make(map[string]contracts.ShowCityResponse)
 	for _, r := range results {
 		cityMap[r.City] = r.ShowCount
+		rowByCity[r.City] = r
 	}
 	suite.Equal(2, cityMap["Phoenix"])
 	suite.Equal(1, cityMap["Tucson"])
+
+	// PSY-981: each city carries its geocoded centroid (same offline GeoNames
+	// source as PSY-985 venue coords). Phoenix/Tucson are populous enough to be
+	// in the cities15000 dataset, so both coords are non-nil and near the known
+	// centroids. The frontend uses these to pick the NEAREST has-shows city for
+	// a visitor whose exact city has no shows (Paradise Valley -> Phoenix).
+	phx := rowByCity["Phoenix"]
+	suite.Require().NotNil(phx.Latitude, "Phoenix latitude should be populated from the geocoder")
+	suite.Require().NotNil(phx.Longitude, "Phoenix longitude should be populated from the geocoder")
+	suite.InDelta(33.4484, *phx.Latitude, 0.5, "Phoenix latitude near the known centroid")
+	suite.InDelta(-112.0740, *phx.Longitude, 0.5, "Phoenix longitude near the known centroid")
+
+	tuc := rowByCity["Tucson"]
+	suite.Require().NotNil(tuc.Latitude, "Tucson latitude should be populated from the geocoder")
+	suite.Require().NotNil(tuc.Longitude, "Tucson longitude should be populated from the geocoder")
+	suite.InDelta(32.2217, *tuc.Latitude, 0.5, "Tucson latitude near the known centroid")
 }
 
 // =============================================================================

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -181,11 +181,21 @@ type UpcomingShowsFilter struct {
 	TagMatchAny bool
 }
 
-// ShowCityResponse represents a city with the count of upcoming shows
+// ShowCityResponse represents a city with the count of upcoming shows.
+//
+// Latitude/Longitude are the city's geocoded centroid (the same offline
+// GeoNames source PSY-985 uses for venue coordinates), resolved from the
+// (city, state) pair. They let the frontend pick the geographically NEAREST
+// has-shows city for a new visitor whose exact city has no shows (PSY-981).
+// Both are nil together when the geocoder can't resolve the city (an obscure
+// place, or a non-US/CA city the GeoNames slice doesn't cover) — callers
+// fall back to exact city-name matching, so a miss degrades gracefully.
 type ShowCityResponse struct {
-	City      string `json:"city"`
-	State     string `json:"state"`
-	ShowCount int    `json:"show_count"`
+	City      string   `json:"city"`
+	State     string   `json:"state"`
+	ShowCount int      `json:"show_count"`
+	Latitude  *float64 `json:"latitude,omitempty"`  // Geocoded city centroid (PSY-985 source, PSY-981)
+	Longitude *float64 `json:"longitude,omitempty"` // Geocoded city centroid (PSY-985 source, PSY-981)
 }
 
 // ShowSearchResult is the row shape returned by GET /shows/search.

--- a/frontend/app/api/geo/route.test.ts
+++ b/frontend/app/api/geo/route.test.ts
@@ -76,6 +76,39 @@ describe('GET /api/geo', () => {
     })
   })
 
+  it('surfaces the visitor lat/long when the coordinate headers are present (PSY-981)', async () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'Paradise Valley',
+        'x-vercel-ip-country-region': 'AZ',
+        'x-vercel-ip-country': 'US',
+        'x-vercel-ip-latitude': '33.5312',
+        'x-vercel-ip-longitude': '-111.9426',
+      }),
+    )
+    await expect(res.json()).resolves.toEqual({
+      geo: {
+        city: 'Paradise Valley',
+        state: 'AZ',
+        latitude: 33.5312,
+        longitude: -111.9426,
+      },
+    })
+  })
+
+  it('omits coords when the lat/long headers are absent (pre-PSY-981 shape)', async () => {
+    const res = GET(
+      geoRequest({
+        'x-vercel-ip-city': 'Phoenix',
+        'x-vercel-ip-country-region': 'AZ',
+        'x-vercel-ip-country': 'US',
+      }),
+    )
+    await expect(res.json()).resolves.toEqual({
+      geo: { city: 'Phoenix', state: 'AZ' },
+    })
+  })
+
   it('sets a non-shared-cacheable Cache-Control header (no cross-visitor poisoning)', () => {
     const res = GET(
       geoRequest({

--- a/frontend/app/api/geo/route.ts
+++ b/frontend/app/api/geo/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { decodeGeoHeaders } from '@/lib/geo-default'
-import type { CityState } from '@/components/filters/CityFilters'
+import { decodeGeoHeaders, type GeoLocation } from '@/lib/geo-default'
 
 /**
  * IP-geo default-city route handler (PSY-946).
@@ -28,7 +27,9 @@ import type { CityState } from '@/components/filters/CityFilters'
  */
 
 interface GeoResponse {
-  geo: CityState | null
+  // PSY-981: also carries the visitor's optional lat/long (from
+  // x-vercel-ip-latitude/-longitude) for the nearest-has-shows-city fallback.
+  geo: GeoLocation | null
 }
 
 export function GET(request: NextRequest): NextResponse<GeoResponse> {

--- a/frontend/components/filters/CityFilters.tsx
+++ b/frontend/components/filters/CityFilters.tsx
@@ -15,6 +15,15 @@ export interface CityWithCount {
   city: string
   state: string
   count: number
+  /**
+   * Geocoded city centroid (PSY-981), surfaced by `/shows/cities`. Optional:
+   * the venue city list doesn't carry it, and the geocoder misses some small
+   * cities. When present on the show-cities list it lets `useGeoDefaultCity`
+   * pick the NEAREST has-shows city for a visitor whose exact city has no
+   * shows. Absent → that city is simply skipped as a distance candidate.
+   */
+  latitude?: number
+  longitude?: number
 }
 
 /** A city+state pair used for multi-select filtering */

--- a/frontend/components/filters/useGeoDefaultCity.test.tsx
+++ b/frontend/components/filters/useGeoDefaultCity.test.tsx
@@ -5,14 +5,44 @@ import {
   shouldShowGeoAffordance,
 } from './useGeoDefaultCity'
 import type { CityState, CityWithCount } from './CityFilters'
+import type { GeoLocation } from '@/lib/geo-default'
 
 vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
 }))
 
-const PHOENIX: CityWithCount = { city: 'Phoenix', state: 'AZ', count: 5 }
-const OMAHA: CityWithCount = { city: 'Omaha', state: 'NE', count: 3 }
+// Centroids match the offline geocoder the backend uses (PSY-981).
+const PHOENIX: CityWithCount = {
+  city: 'Phoenix',
+  state: 'AZ',
+  count: 5,
+  latitude: 33.4484,
+  longitude: -112.074,
+}
+const OMAHA: CityWithCount = {
+  city: 'Omaha',
+  state: 'NE',
+  count: 3,
+  latitude: 41.2587,
+  longitude: -95.9384,
+}
+const TUCSON: CityWithCount = {
+  city: 'Tucson',
+  state: 'AZ',
+  count: 2,
+  latitude: 32.2217,
+  longitude: -110.9265,
+}
 const ALL_CITIES: CityWithCount[] = [PHOENIX, OMAHA]
+
+// Real-ish coords for Paradise Valley, AZ — a Phoenix suburb with NO PH shows
+// of its own (the PSY-981 motivating case). Nearest has-shows city = Phoenix.
+const PARADISE_VALLEY = {
+  city: 'Paradise Valley',
+  state: 'AZ',
+  latitude: 33.5312,
+  longitude: -111.9426,
+}
 
 type HookParams = Parameters<typeof useGeoDefaultCity>[0]
 
@@ -216,7 +246,7 @@ describe('useGeoDefaultCity — client-fetch path (/shows + home)', () => {
     window.sessionStorage.clear()
   })
 
-  function mockGeoFetch(geo: CityState | null) {
+  function mockGeoFetch(geo: GeoLocation | null) {
     return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ geo }), {
         status: 200,
@@ -343,3 +373,134 @@ describe('useGeoDefaultCity — client-fetch path (/shows + home)', () => {
     expect(onSeed).not.toHaveBeenCalled()
   })
 })
+
+describe('useGeoDefaultCity — nearest has-shows city by haversine (PSY-981)', () => {
+  it('seeds Phoenix for a Paradise Valley visitor whose exact city has no shows', () => {
+    // The motivating case: Paradise Valley, AZ is a Phoenix suburb with no PH
+    // shows. With the visitor's coords + city centroids, the hook picks the
+    // geographically NEAREST has-shows city (Phoenix, ~15 km away) over Tucson
+    // (~160 km) and Omaha (~1,200 km). No exact "Paradise Valley" match exists.
+    const onSeed = vi.fn()
+    const { result } = renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          cities: [PHOENIX, TUCSON, OMAHA],
+          geoFromServer: PARADISE_VALLEY,
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).toHaveBeenCalledWith({ city: 'Phoenix', state: 'AZ' })
+    expect(result.current.appliedGeoDefault).toEqual({
+      city: 'Phoenix',
+      state: 'AZ',
+    })
+  })
+
+  it('prefers the EXACT city match over the nearest, even when coords are present', () => {
+    // A visitor IN Tucson (which HAS shows) must seed Tucson, not the nearest-
+    // by-distance result — tier 1 (exact match) wins over tier 2 (nearest).
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          cities: [PHOENIX, TUCSON, OMAHA],
+          geoFromServer: {
+            city: 'Tucson',
+            state: 'AZ',
+            latitude: TUCSON.latitude,
+            longitude: TUCSON.longitude,
+          },
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).toHaveBeenCalledWith({ city: 'Tucson', state: 'AZ' })
+  })
+
+  it('falls back to NO default when the exact city has no shows AND coords are absent', () => {
+    // Pre-PSY-981 behavior preserved: no coords → no nearest computation → the
+    // exact-miss case yields no seed (never worse than before).
+    const onSeed = vi.fn()
+    const { result } = renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          cities: [PHOENIX, TUCSON, OMAHA],
+          // Paradise Valley, no lat/long → exact-match only, which misses.
+          geoFromServer: { city: 'Paradise Valley', state: 'AZ' },
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+    expect(result.current.appliedGeoDefault).toBeNull()
+  })
+
+  it('falls back to NO default when no show-city carries a centroid (uncoded cities)', () => {
+    // The backend geocoder missed every show city (coords undefined). The
+    // nearest computation has no candidates → no seed; exact-match for a
+    // visitor whose own city is on the list would still work (covered above).
+    const onSeed = vi.fn()
+    const citiesNoCentroid: CityWithCount[] = [
+      { city: 'Phoenix', state: 'AZ', count: 5 },
+      { city: 'Tucson', state: 'AZ', count: 2 },
+    ]
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          cities: citiesNoCentroid,
+          geoFromServer: PARADISE_VALLEY,
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).not.toHaveBeenCalled()
+  })
+
+  it('skips uncoded cities as distance candidates but still uses coded ones', () => {
+    // Cottonwood (1 show) is too small for the GeoNames slice → no centroid →
+    // it must NOT be chosen as nearest; Phoenix (coded) wins for the suburb.
+    const onSeed = vi.fn()
+    const cottonwood: CityWithCount = { city: 'Cottonwood', state: 'AZ', count: 1 }
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          cities: [cottonwood, PHOENIX, TUCSON],
+          geoFromServer: PARADISE_VALLEY,
+          onSeed,
+        }),
+      ),
+    )
+    expect(onSeed).toHaveBeenCalledWith({ city: 'Phoenix', state: 'AZ' })
+  })
+
+  it('seeds the nearest via the client-fetch path too (home / /shows parity)', async () => {
+    // The same nearest logic must fire on the client-fetch surfaces, not just
+    // /explore's server prop — home and /shows fetch /api/geo with coords.
+    mockGeoFetchPV(PARADISE_VALLEY)
+    const onSeed = vi.fn()
+    renderHook(() =>
+      useGeoDefaultCity(
+        baseParams({
+          cities: [PHOENIX, TUCSON, OMAHA],
+          enableClientFetch: true,
+          onSeed,
+        }),
+      ),
+    )
+    await waitFor(() =>
+      expect(onSeed).toHaveBeenCalledWith({ city: 'Phoenix', state: 'AZ' }),
+    )
+  })
+})
+
+/** Local client-fetch mock for the nearest-city block (its own session clear). */
+function mockGeoFetchPV(geo: GeoLocation | null) {
+  window.sessionStorage.clear()
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ geo }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}

--- a/frontend/components/filters/useGeoDefaultCity.ts
+++ b/frontend/components/filters/useGeoDefaultCity.ts
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as Sentry from '@sentry/nextjs'
 import type { CityState, CityWithCount } from './CityFilters'
+import type { GeoLocation } from '@/lib/geo-default'
+import { haversineDistanceKm } from '@/lib/haversine'
 import { citiesEqual } from './cityParams'
 
 /**
@@ -41,21 +43,33 @@ const GEO_CACHE_KEY = 'ph-geo-default-city'
 
 /** Shape of the `/api/geo` route-handler response. */
 interface GeoApiResponse {
-  geo: CityState | null
+  geo: GeoLocation | null
 }
 
 /**
- * Narrow an arbitrary parsed value to a `CityState` (two non-empty string
- * halves), else null. Defensive: the only writer of the cache / the route
- * handler always emits this shape, but a malformed value (corrupted
- * sessionStorage, a future route-handler change) must not reach
- * `geoCityWithShows`, where `.trim()` on a non-string would throw mid-render.
+ * Narrow an arbitrary parsed value to a `GeoLocation` (two non-empty string
+ * halves + optional finite coords), else null. Defensive: the only writer of
+ * the cache / the route handler always emits this shape, but a malformed value
+ * (corrupted sessionStorage, a future route-handler change) must not reach
+ * `geoCityWithShows`, where `.trim()` on a non-string would throw mid-render or
+ * a non-finite coord would corrupt the haversine pick.
+ *
+ * The coords are attached only when BOTH are finite numbers; a partial/garbage
+ * pair is dropped so the nearest-city path never sees a half-coordinate.
  */
-function toCityState(value: unknown): CityState | null {
+function toGeoLocation(value: unknown): GeoLocation | null {
   if (typeof value !== 'object' || value === null) return null
-  const { city, state } = value as Record<string, unknown>
+  const { city, state, latitude, longitude } = value as Record<string, unknown>
   if (typeof city !== 'string' || typeof state !== 'string') return null
   if (city.trim() === '' || state.trim() === '') return null
+  if (
+    typeof latitude === 'number' &&
+    Number.isFinite(latitude) &&
+    typeof longitude === 'number' &&
+    Number.isFinite(longitude)
+  ) {
+    return { city, state, latitude, longitude }
+  }
   return { city, state }
 }
 
@@ -74,9 +88,10 @@ interface UseGeoDefaultCityParams {
    *  e.g. /shows has a `?cities=` URL param, or the caller already seeded
    *  favorites. When true the hook never seeds and shows no affordance. */
   hasExistingSelection: boolean
-  /** The geo value read server-side (/explore). When provided, the client
-   *  fetch is skipped. `undefined` (not passed) → use the client fetch. */
-  geoFromServer?: CityState | null
+  /** The geo value read server-side (/explore) — `{city,state}` plus optional
+   *  visitor lat/long (PSY-981). When provided, the client fetch is skipped.
+   *  `undefined` (not passed) → use the client fetch. */
+  geoFromServer?: GeoLocation | null
   /** Fetch `/api/geo` client-side (/shows + home). Mutually exclusive in
    *  practice with `geoFromServer`. */
   enableClientFetch?: boolean
@@ -108,15 +123,15 @@ interface UseGeoDefaultCityResult {
  * value (/explore) — no fetch, no cache.
  */
 function useGeoSource(
-  geoFromServer: CityState | null | undefined,
+  geoFromServer: GeoLocation | null | undefined,
   enableClientFetch: boolean,
   eligible: boolean,
-): CityState | null {
+): GeoLocation | null {
   // Seed synchronously from sessionStorage so a cached value is available on
   // first render (no flash, no redundant fetch). Server render + first
   // hydration return null (sessionStorage is client-only) — the value arrives
   // post-mount, same beat as today's authed-favorites seeding.
-  const [fetched, setFetched] = useState<CityState | null>(null)
+  const [fetched, setFetched] = useState<GeoLocation | null>(null)
   const hasFetched = useRef(false)
 
   useEffect(() => {
@@ -139,7 +154,7 @@ function useGeoSource(
       const cached = window.sessionStorage.getItem(GEO_CACHE_KEY)
       if (cached !== null) {
         const parsed = JSON.parse(cached) as GeoApiResponse
-        const cachedCity = toCityState(parsed?.geo)
+        const cachedCity = toGeoLocation(parsed?.geo)
         let cacheCancelled = false
         Promise.resolve().then(() => {
           if (!cacheCancelled) setFetched(cachedCity)
@@ -157,7 +172,7 @@ function useGeoSource(
       .then(res => (res.ok ? (res.json() as Promise<GeoApiResponse>) : null))
       .then(body => {
         if (cancelled) return
-        const geo = toCityState(body?.geo)
+        const geo = toGeoLocation(body?.geo)
         setFetched(geo)
         try {
           window.sessionStorage.setItem(GEO_CACHE_KEY, JSON.stringify({ geo }))
@@ -236,18 +251,52 @@ export function useGeoDefaultCity({
 
   // The geo suggestion reconciled against PH's has-shows data: returns the
   // CANONICAL {city,state} from `cities` (so the seed matches the backend
-  // filter exactly) when the detected city has upcoming shows, else null.
-  // Match is case/whitespace-insensitive because Vercel's city spelling may
-  // differ slightly from PH's stored name.
+  // filter exactly), else null. Two-tier resolution (PSY-981):
+  //
+  //   1. Exact (city, state) match — preferred when the visitor's own city
+  //      has shows. Case/whitespace-insensitive (Vercel's spelling may differ
+  //      slightly from PH's stored name). This is the pre-PSY-981 behavior,
+  //      kept first so a visitor IN a show city always seeds their own city.
+  //   2. NEAREST has-shows city by haversine, with NO distance cap (PSY-981) —
+  //      the fallback when the exact city has no shows (e.g. Paradise Valley,
+  //      AZ — a Phoenix suburb -> Phoenix). Requires the visitor's coords (from
+  //      Vercel) AND at least one show-city with a geocoded centroid; when
+  //      either is missing we return null, the pre-PSY-981 "no default"
+  //      outcome — never worse than before.
+  //
+  // Either tier seeds the canonical PH casing from `cities`, never the raw
+  // header (injection-safe).
   const geoCityWithShows: CityState | null = useMemo(() => {
     if (!rawGeo || cities.length === 0) return null
+
+    // Tier 1: exact city-name match.
     const norm = (s: string) => s.trim().toLowerCase()
     const wantCity = norm(rawGeo.city)
     const wantState = norm(rawGeo.state)
-    const match = cities.find(
+    const exact = cities.find(
       c => norm(c.city) === wantCity && norm(c.state) === wantState,
     )
-    return match ? { city: match.city, state: match.state } : null
+    if (exact) return { city: exact.city, state: exact.state }
+
+    // Tier 2: nearest has-shows city by haversine (no cap). Only when the
+    // visitor's coords are known; otherwise fall back to "no default".
+    const { latitude, longitude } = rawGeo
+    if (latitude === undefined || longitude === undefined) return null
+
+    let nearest: CityWithCount | null = null
+    let nearestKm = Infinity
+    for (const c of cities) {
+      // Skip cities the geocoder couldn't place — they can't be distance
+      // candidates, but exact-match (tier 1) for them still works for a
+      // visitor whose own city is that uncoded city.
+      if (c.latitude === undefined || c.longitude === undefined) continue
+      const km = haversineDistanceKm(latitude, longitude, c.latitude, c.longitude)
+      if (km < nearestKm) {
+        nearestKm = km
+        nearest = c
+      }
+    }
+    return nearest ? { city: nearest.city, state: nearest.state } : null
   }, [rawGeo, cities])
 
   // Seed once when: no existing selection, auth settled, anon, favorites empty,

--- a/frontend/features/explore/components/ExplorePage.tsx
+++ b/frontend/features/explore/components/ExplorePage.tsx
@@ -22,7 +22,7 @@
  */
 
 import Link from 'next/link'
-import type { CityState } from '@/components/filters/CityFilters'
+import type { GeoLocation } from '@/lib/geo-default'
 import { useExploreFeatured } from '../hooks'
 import { UpcomingShowsList } from './UpcomingShowsList'
 import { FeaturedBillCard } from './FeaturedBillCard'
@@ -33,11 +33,13 @@ import { ShuffleCta } from './ShuffleCta'
 interface ExplorePageProps {
   /**
    * IP-geo soft default for anon visitors (PSY-926), resolved server-side
-   * from the Vercel edge geo headers. A suggestion only — UpcomingShowsList
-   * pre-selects it only when the city has upcoming shows AND the visitor is
-   * anon with no `?cities=` and no favorites. `null` → "All cities".
+   * from the Vercel edge geo headers. Carries the visitor's `{city,state}`
+   * plus optional lat/long (PSY-981). A suggestion only — UpcomingShowsList
+   * pre-selects the city that has upcoming shows (exact match, else the
+   * nearest has-shows city by the visitor's coords) when the visitor is anon
+   * with no `?cities=` and no favorites. `null` → "All cities".
    */
-  geoDefaultCity?: CityState | null
+  geoDefaultCity?: GeoLocation | null
 }
 
 export function ExplorePage({ geoDefaultCity = null }: ExplorePageProps) {

--- a/frontend/features/explore/components/UpcomingShowsList.tsx
+++ b/frontend/features/explore/components/UpcomingShowsList.tsx
@@ -49,6 +49,7 @@ import {
 } from '@/components/filters/useGeoDefaultCity'
 import { GeoDefaultAffordance } from '@/components/filters/GeoDefaultAffordance'
 import type { CityState, CityWithCount } from '@/components/filters/CityFilters'
+import type { GeoLocation } from '@/lib/geo-default'
 
 // CityFilters pulls in cmdk (Command) + Radix Popover. Those bytes are
 // already in the global bundle (CommandPalette in SidebarLayout), but
@@ -79,12 +80,14 @@ interface UpcomingShowsListProps {
   limit?: number
   /**
    * IP-geo soft default (PSY-926), resolved server-side from the Vercel edge
-   * geo headers in `app/explore/page.tsx`. A suggestion only — applied as the
-   * default selection only for anon visitors with no `?cities=` and no
-   * favorites, AND only when the city has upcoming shows. `null` → no geo
-   * default (→ "All cities").
+   * geo headers in `app/explore/page.tsx`. Carries `{city,state}` plus optional
+   * visitor lat/long (PSY-981). A suggestion only — applied as the default
+   * selection only for anon visitors with no `?cities=` and no favorites, AND
+   * only when the city has upcoming shows (exact match, else the nearest
+   * has-shows city by the visitor's coords). `null` → no geo default
+   * (→ "All cities").
    */
-  geoDefaultCity?: CityState | null
+  geoDefaultCity?: GeoLocation | null
 }
 
 export function UpcomingShowsList({
@@ -120,6 +123,10 @@ export function UpcomingShowsList({
         city: c.city,
         state: c.state,
         count: c.show_count,
+        // Geocoded centroid (PSY-981) — drives the nearest-has-shows-city geo
+        // default when the visitor's exact city has no shows.
+        latitude: c.latitude,
+        longitude: c.longitude,
       })) ?? [],
     [citiesData],
   )

--- a/frontend/features/shows/components/HomeShowList.tsx
+++ b/frontend/features/shows/components/HomeShowList.tsx
@@ -53,6 +53,10 @@ export function HomeShowList() {
         city: c.city,
         state: c.state,
         count: c.show_count,
+        // Geocoded centroid (PSY-981) — drives the nearest-has-shows-city geo
+        // default when the visitor's exact city has no shows.
+        latitude: c.latitude,
+        longitude: c.longitude,
       })) ?? [],
     [citiesData?.cities]
   )

--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -111,6 +111,10 @@ export function ShowList() {
         city: c.city,
         state: c.state,
         count: c.show_count,
+        // Geocoded centroid (PSY-981) — drives the nearest-has-shows-city geo
+        // default when the visitor's exact city has no shows.
+        latitude: c.latitude,
+        longitude: c.longitude,
       })) ?? [],
     [citiesData?.cities]
   )

--- a/frontend/features/shows/types.ts
+++ b/frontend/features/shows/types.ts
@@ -176,6 +176,11 @@ export interface ShowCity {
   city: string
   state: string
   show_count: number
+  // Geocoded city centroid (PSY-981, same offline GeoNames source as PSY-985
+  // venue coords). Omitted by the backend when the geocoder can't resolve the
+  // city; the client then falls back to exact city-name matching for geo.
+  latitude?: number
+  longitude?: number
 }
 
 // Response for the show cities endpoint

--- a/frontend/lib/geo-default.test.ts
+++ b/frontend/lib/geo-default.test.ts
@@ -131,4 +131,105 @@ describe('getGeoDefaultCity', () => {
       state: 'AZ',
     })
   })
+
+  // --- PSY-981: visitor lat/long for the nearest-has-shows-city fallback ---
+
+  it('attaches the visitor lat/long when both coordinate headers are present', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Paradise Valley',
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+      'x-vercel-ip-latitude': '33.5312',
+      'x-vercel-ip-longitude': '-111.9426',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Paradise Valley',
+      state: 'AZ',
+      latitude: 33.5312,
+      longitude: -111.9426,
+    })
+  })
+
+  it('omits coords (city/state still resolves) when the lat/long headers are absent', async () => {
+    // The pre-PSY-981 shape — degrades to exact city-name matching downstream.
+    setHeaders({
+      'x-vercel-ip-city': 'Phoenix',
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+    })
+    const result = await getGeoDefaultCity()
+    expect(result).toEqual({ city: 'Phoenix', state: 'AZ' })
+    expect(result).not.toHaveProperty('latitude')
+    expect(result).not.toHaveProperty('longitude')
+  })
+
+  it('drops coords when only ONE of lat/long is present (no half-coordinate)', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Phoenix',
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+      'x-vercel-ip-latitude': '33.4484',
+      // longitude omitted
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Phoenix',
+      state: 'AZ',
+    })
+  })
+
+  it('drops coords when a value is non-numeric garbage', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Phoenix',
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+      'x-vercel-ip-latitude': 'not-a-number',
+      'x-vercel-ip-longitude': '-111.9426',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Phoenix',
+      state: 'AZ',
+    })
+  })
+
+  it('drops coords when out of range (latitude > 90 / longitude > 180)', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Phoenix',
+      'x-vercel-ip-country-region': 'AZ',
+      'x-vercel-ip-country': 'US',
+      'x-vercel-ip-latitude': '200',
+      'x-vercel-ip-longitude': '-111.9426',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Phoenix',
+      state: 'AZ',
+    })
+  })
+
+  it('accepts coordinates at the valid bounds and zero', async () => {
+    setHeaders({
+      'x-vercel-ip-city': 'Null Island',
+      'x-vercel-ip-country-region': 'TX',
+      'x-vercel-ip-country': 'US',
+      'x-vercel-ip-latitude': '0',
+      'x-vercel-ip-longitude': '180',
+    })
+    await expect(getGeoDefaultCity()).resolves.toEqual({
+      city: 'Null Island',
+      state: 'TX',
+      latitude: 0,
+      longitude: 180,
+    })
+  })
+
+  it('still returns null for a non-US/CA country even with coords present', async () => {
+    // The country gate is UNCHANGED by PSY-981 — coords don't override it.
+    setHeaders({
+      'x-vercel-ip-city': 'Paris',
+      'x-vercel-ip-country-region': 'IDF',
+      'x-vercel-ip-country': 'FR',
+      'x-vercel-ip-latitude': '48.8566',
+      'x-vercel-ip-longitude': '2.3522',
+    })
+    await expect(getGeoDefaultCity()).resolves.toBeNull()
+  })
 })

--- a/frontend/lib/geo-default.ts
+++ b/frontend/lib/geo-default.ts
@@ -40,11 +40,15 @@
  *
  * Privacy
  * -------
- * City + region only, read transiently per request, never stored against an
- * identity and never written to a cookie. The decoded value flows to the
- * client as a render prop (/explore) or a no-store JSON response (route
- * handler) and is discarded after use. Disclosed in the privacy policy
- * (§2.3 / §3).
+ * City + region, plus the visitor's approximate IP-derived lat/long (PSY-981,
+ * used only to pick the nearest has-shows city — never persisted as a
+ * coordinate, only the resulting canonical city is). All read transiently per
+ * request, never stored against an identity and never written to a cookie. The
+ * decoded value flows to the client as a render prop (/explore) or a no-store
+ * JSON response (route handler) and is discarded after use. The lat/long is the
+ * visitor's OWN coarse location, echoed only back to that visitor through the
+ * `private, no-store` route — no cross-visitor exposure. Disclosed in the
+ * privacy policy (§2.3 / §3).
  *
  * `getGeoDefaultCity` imports `next/headers`, so importing IT from a client
  * component throws at build time — the "server-only" boundary is enforced by

--- a/frontend/lib/geo-default.ts
+++ b/frontend/lib/geo-default.ts
@@ -55,10 +55,29 @@
 import { headers } from 'next/headers'
 import type { CityState } from '@/components/filters/CityFilters'
 
+/**
+ * A decoded geo suggestion: the visitor's `{city, state}` plus, when Vercel
+ * supplies them, their approximate `{latitude, longitude}` (PSY-981).
+ *
+ * The coords drive the "nearest has-shows city" fallback: when the visitor's
+ * exact city has no shows (e.g. Paradise Valley, AZ — a Phoenix suburb), the
+ * client picks the geographically nearest has-shows city by haversine
+ * (`useGeoDefaultCity`). They are OPTIONAL — some IPs/edge configs omit the
+ * lat/long headers — and absence is graceful: the client falls back to exact
+ * city-name matching, exactly as it did before PSY-981. The coords are never
+ * seeded as a city; only the canonical PH `{city,state}` is (injection-safe).
+ */
+export interface GeoLocation extends CityState {
+  latitude?: number
+  longitude?: number
+}
+
 /** Vercel edge geo headers (lowercased — Next normalizes header keys). */
 const HEADER_CITY = 'x-vercel-ip-city'
 const HEADER_REGION = 'x-vercel-ip-country-region'
 const HEADER_COUNTRY = 'x-vercel-ip-country'
+const HEADER_LATITUDE = 'x-vercel-ip-latitude'
+const HEADER_LONGITUDE = 'x-vercel-ip-longitude'
 
 /**
  * Decode a `Headers`-like object carrying the Vercel edge geo headers into a
@@ -91,12 +110,14 @@ const HEADER_COUNTRY = 'x-vercel-ip-country'
  */
 export function decodeGeoHeaders(
   headerList: { get(name: string): string | null },
-): CityState | null {
+): GeoLocation | null {
   const country = decodeHeader(headerList.get(HEADER_COUNTRY))
   // Vercel returns ISO 3166-1 alpha-2 country codes. PH's city data is keyed
   // by US state / Canadian province codes; only US/CA can match, so reject
   // anything else cheaply. An ABSENT country header (local dev, some edge
   // configs) is allowed through — the client has-shows check is the real gate.
+  // The country gate is UNCHANGED by PSY-981's nearest-city work: non-US/CA
+  // visitors still get no geo default (PH's show cities are US/CA only).
   if (country !== null && country !== 'US' && country !== 'CA') {
     return null
   }
@@ -111,6 +132,19 @@ export function decodeGeoHeaders(
     return null
   }
 
+  // Visitor lat/long (PSY-981) for the nearest-has-shows-city fallback. These
+  // headers are plain decimal strings (NOT URL-encoded like the city), and are
+  // OPTIONAL — `parseCoordinate` returns undefined on a missing/unparseable/
+  // out-of-range value, so the city/state suggestion still flows and the client
+  // degrades to exact city-name matching. We only attach BOTH coords or
+  // NEITHER: a lone latitude is useless for a distance calc and would only
+  // invite a half-applied haversine bug downstream.
+  const latitude = parseCoordinate(headerList.get(HEADER_LATITUDE), 90)
+  const longitude = parseCoordinate(headerList.get(HEADER_LONGITUDE), 180)
+  if (latitude !== undefined && longitude !== undefined) {
+    return { city, state, latitude, longitude }
+  }
+
   return { city, state }
 }
 
@@ -120,7 +154,7 @@ export function decodeGeoHeaders(
  * `decodeGeoHeaders`. Throws at build time if imported from a client component
  * (compiler-enforced server-only boundary).
  */
-export async function getGeoDefaultCity(): Promise<CityState | null> {
+export async function getGeoDefaultCity(): Promise<GeoLocation | null> {
   const headerList = await headers()
   return decodeGeoHeaders(headerList)
 }
@@ -141,4 +175,22 @@ function decodeHeader(raw: string | null): string | null {
   }
   const trimmed = decoded.trim()
   return trimmed === '' ? null : trimmed
+}
+
+/**
+ * Parse a Vercel lat/long header into a finite number within ±`max` degrees,
+ * else `undefined`. Defensive at the trust boundary: the value is a raw HTTP
+ * header, so reject anything `Number()` can't turn into a real coordinate —
+ * missing, empty, `NaN`/`Infinity` (Number('') is 0, hence the empty-string
+ * guard), or out of the valid [-max, max] range. A bad value degrades to "no
+ * coords" (exact-match fallback), never a wrong distance calculation.
+ */
+function parseCoordinate(raw: string | null, max: number): number | undefined {
+  if (raw === null) return undefined
+  const trimmed = raw.trim()
+  if (trimmed === '') return undefined
+  const value = Number(trimmed)
+  if (!Number.isFinite(value)) return undefined
+  if (value < -max || value > max) return undefined
+  return value
 }

--- a/frontend/lib/haversine.test.ts
+++ b/frontend/lib/haversine.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { haversineDistanceKm } from './haversine'
+
+// Reference coordinates (decimal degrees), matching the offline-geocoder
+// centroids the backend surfaces for these cities (PSY-981).
+const PHOENIX = { lat: 33.4484, lng: -112.074 }
+const TUCSON = { lat: 32.2217, lng: -110.9265 }
+const PARADISE_VALLEY = { lat: 33.5312, lng: -111.9426 } // Phoenix suburb
+
+describe('haversineDistanceKm', () => {
+  it('is 0 for identical points (no NaN from float noise)', () => {
+    expect(
+      haversineDistanceKm(PHOENIX.lat, PHOENIX.lng, PHOENIX.lat, PHOENIX.lng),
+    ).toBe(0)
+  })
+
+  it('matches the known Phoenix↔Tucson distance (~173 km) within 2 km', () => {
+    const d = haversineDistanceKm(
+      PHOENIX.lat,
+      PHOENIX.lng,
+      TUCSON.lat,
+      TUCSON.lng,
+    )
+    // Great-circle distance between these two centroids is ~173.5 km
+    // (road distance via I-10 is ~180 km; the straight-line arc is shorter).
+    expect(d).toBeGreaterThan(171)
+    expect(d).toBeLessThan(176)
+  })
+
+  it('is symmetric (a→b equals b→a)', () => {
+    const ab = haversineDistanceKm(
+      PHOENIX.lat,
+      PHOENIX.lng,
+      TUCSON.lat,
+      TUCSON.lng,
+    )
+    const ba = haversineDistanceKm(
+      TUCSON.lat,
+      TUCSON.lng,
+      PHOENIX.lat,
+      PHOENIX.lng,
+    )
+    expect(ab).toBeCloseTo(ba, 9)
+  })
+
+  it('ranks Paradise Valley as closer to Phoenix than to Tucson', () => {
+    const toPhoenix = haversineDistanceKm(
+      PARADISE_VALLEY.lat,
+      PARADISE_VALLEY.lng,
+      PHOENIX.lat,
+      PHOENIX.lng,
+    )
+    const toTucson = haversineDistanceKm(
+      PARADISE_VALLEY.lat,
+      PARADISE_VALLEY.lng,
+      TUCSON.lat,
+      TUCSON.lng,
+    )
+    expect(toPhoenix).toBeLessThan(toTucson)
+    // Paradise Valley is a Phoenix suburb (~15 km away), nowhere near Tucson.
+    expect(toPhoenix).toBeLessThan(20)
+  })
+
+  it('handles the antimeridian: -179.9° and +179.9° are ~22 km apart, not half the globe', () => {
+    // Same latitude, longitudes straddling ±180°. Naive degree subtraction
+    // would give ~359.8° (≈ half the Earth); haversine gives the true short arc.
+    const d = haversineDistanceKm(0, -179.9, 0, 179.9)
+    expect(d).toBeLessThan(30)
+    // The long way round at the equator would be ~40,000 km — assert we did NOT
+    // take it.
+    expect(d).toBeLessThan(100)
+  })
+
+  it('computes the equatorial quarter-arc (~10,000 km) for a 90° longitude gap', () => {
+    const d = haversineDistanceKm(0, 0, 0, 90)
+    // A quarter of the Earth's ~40,030 km circumference.
+    expect(d).toBeGreaterThan(9900)
+    expect(d).toBeLessThan(10100)
+  })
+
+  it('computes pole-to-pole (~20,000 km) for antipodal latitudes', () => {
+    const d = haversineDistanceKm(-90, 0, 90, 0)
+    // Half the meridian circumference.
+    expect(d).toBeGreaterThan(19900)
+    expect(d).toBeLessThan(20100)
+  })
+})

--- a/frontend/lib/haversine.ts
+++ b/frontend/lib/haversine.ts
@@ -1,0 +1,51 @@
+/**
+ * Great-circle distance between two lat/long points (PSY-981).
+ *
+ * Used to pick the geographically NEAREST has-shows city for a new visitor
+ * whose exact city has no PH shows (e.g. Paradise Valley, AZ — a Phoenix
+ * suburb): we compare the visitor's IP-derived coords (from Vercel's
+ * x-vercel-ip-latitude/-longitude) against each show-city's geocoded centroid
+ * (from `/shows/cities`) and seed the closest one — with NO distance cap (an
+ * explicit product choice over a radius / same-state rule).
+ *
+ * Haversine is the standard, numerically stable spherical-distance formula. It
+ * handles the antimeridian (e.g. -179° vs +179°) correctly because it works on
+ * the sphere via the longitude DELTA's sine/cosine, not on raw degree
+ * subtraction — so two points straddling ±180° come out close, as they should.
+ * The Earth-as-sphere approximation is well within tolerance for "which metro
+ * is closest" (sub-1% vs the ellipsoid at city scale); we only ever compare
+ * distances, never report them, so the small absolute error is irrelevant.
+ */
+
+/** Mean Earth radius in kilometers (IUGG). Distances are relative-only here. */
+const EARTH_RADIUS_KM = 6371
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180
+}
+
+/**
+ * Distance in kilometers between `(lat1, lon1)` and `(lat2, lon2)`, all in
+ * decimal degrees. Returns `0` for identical points (the `asin` argument is
+ * clamped, so floating-point noise can't push it past 1 and produce `NaN`).
+ */
+export function haversineDistanceKm(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const dLat = toRadians(lat2 - lat1)
+  const dLon = toRadians(lon2 - lon1)
+  const radLat1 = toRadians(lat1)
+  const radLat2 = toRadians(lat2)
+
+  const sinDLat = Math.sin(dLat / 2)
+  const sinDLon = Math.sin(dLon / 2)
+  const a =
+    sinDLat * sinDLat + Math.cos(radLat1) * Math.cos(radLat2) * sinDLon * sinDLon
+  // Clamp `a` to [0, 1] so `sqrt`/`asin` can't see a value > 1 from rounding
+  // when the two points coincide (would otherwise yield NaN).
+  const c = 2 * Math.asin(Math.sqrt(Math.min(1, a)))
+  return EARTH_RADIUS_KM * c
+}


### PR DESCRIPTION
## Summary

When a new (anonymous, no-favorites) visitor's exact IP-geo city has **no PH shows** — e.g. Paradise Valley, AZ, a Phoenix suburb — the city filter previously defaulted to "All cities" (PSY-946's exact-city-match has-shows guard correctly suppressed the seed). This change adds a fallback: default to the **geographically nearest has-shows city by haversine distance, with NO distance cap** (the user's explicit choice). Paradise Valley → Phoenix.

It reuses PSY-985's offline GeoNames geocoding; **no migration** (no new columns).

**Backend**
- `ShowCityResponse` now carries each city's geocoded centroid (`latitude`/`longitude`), resolved from the `(city, state)` pair via the **same offline geocoder PSY-985 uses for venue coords**. Resolving from `(city, state)` rather than joining `show_venues → venues` keeps it exact to the grouped key (no venue-vs-show city-spelling mismatch), drops any per-venue-backfill dependency, and stays an in-memory lookup (no extra query / N+1). A geocoder miss leaves both coords nil (`omitempty`).

**Frontend**
- `decodeGeoHeaders` + `/api/geo` also surface the visitor's lat/long from `x-vercel-ip-latitude` / `x-vercel-ip-longitude` (parsed defensively: finite, range-checked, both-or-neither). **The US/CA country gate is unchanged** — non-US/CA visitors still get no geo default.
- `useGeoDefaultCity` reconciliation is now two-tier: **exact `(city,state)` match first** (pre-PSY-981 behavior — a visitor IN a show city always seeds their own city), then **nearest has-shows city by haversine (no cap)** when the visitor's coords + city centroids are both available. No coords / no centroid → falls back to the exact-match outcome — **never worse than before**.
- The seed is always the **canonical PH city** from the show-cities list, never the raw header (injection-safe). Coords never propagate into the seeded selection.
- New pure haversine util (`frontend/lib/haversine.ts`), unit-tested incl. antimeridian + degenerate coords.
- home / `/shows` / `/explore` all thread centroids through the shared hook (consistent across surfaces).

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go vet ./internal/services/catalog/... ./internal/api/handlers/catalog/...` — clean
- [x] `cd backend && go test ./internal/services/catalog/... ./internal/api/handlers/catalog/...` — `ok` both packages (testcontainers Postgres)
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors (156 pre-existing warnings, none in touched files)
- [x] `cd frontend && bun run test:run lib/haversine lib/geo-default components/filters app/api/geo` — 81 passed
- [x] `cd frontend && bun run test:run features/shows features/explore` — 415 passed

## Manual repro

**Backend `/shows/cities` centroid (isolated dispatch stack, verbatim):**

```
$ curl -s "http://localhost:62983/shows/cities?timezone=America/Phoenix"
{"$schema":"...","cities":[
  {"city":"Phoenix","state":"AZ","show_count":29,"latitude":33.44838,"longitude":-112.07404},
  {"city":"Mesa","state":"AZ","show_count":18,"latitude":33.42227,"longitude":-111.82264},
  {"city":"Tucson","state":"AZ","show_count":18,"latitude":32.22174,"longitude":-110.92648}]}
```

Each city now carries its geocoded centroid (from the PSY-985 offline GeoNames source). Stack torn down after capture.

**Frontend nearest logic — the unit tests ARE the manual repro for the matching logic:**
- `lib/haversine.test.ts` → "ranks Paradise Valley as closer to Phoenix than to Tucson"; antimeridian (`-179.9°` vs `+179.9°` ≈ 22 km, not half the globe); identical-points → `0` (no NaN); equatorial quarter-arc ≈ 10,000 km; pole-to-pole ≈ 20,000 km.
- `components/filters/useGeoDefaultCity.test.tsx` → **"seeds Phoenix for a Paradise Valley visitor whose exact city has no shows"** (asserts `onSeed({city:'Phoenix',state:'AZ'})` given Paradise Valley coords 33.5312/-111.9426 vs Phoenix/Tucson/Omaha centroids); "prefers the EXACT city match over the nearest"; "falls back to NO default when the exact city has no shows AND coords are absent"; "falls back to NO default when no show-city carries a centroid"; "skips uncoded cities as distance candidates"; "seeds the nearest via the client-fetch path too (home / /shows parity)".
- `lib/geo-default.test.ts` → attaches lat/long when both headers present; omits coords when absent / when only one is present / non-numeric / out-of-range; still returns null for non-US/CA even with coords.
- `app/api/geo/route.test.ts` → route surfaces lat/long; omits when absent.
- Backend: `internal/services/catalog/show_test.go TestGetShowCities_Success` asserts Phoenix/Tucson centroids populated near known values; `internal/api/handlers/catalog/show_test.go TestGetShowCitiesHandler_Success` asserts the centroid passes through the handler unchanged.

**Honest limitation — the Vercel-header → seed end-to-end path CANNOT be reproduced locally.** The `x-vercel-ip-latitude`/`-longitude` (and `-city`/`-country`) headers are injected by Vercel's edge and do not exist on a local stack, so the full "real visitor IP → coords → nearest-city seed in the browser" flow can't be exercised here. The unit tests above stand in for the matching logic; the backend curl proves the centroid surface.

**Recommended post-merge stage verification:** load stage home in an authed-then-signed-out browser (anon path), confirm `GET /api/geo` now returns `latitude`/`longitude` alongside `city`/`state`, and confirm the Upcoming Shows filter seeds the nearest has-shows city for an IP whose exact city has no shows (the Paradise Valley → Phoenix case the diagnostic used). Vercel-validate via an authed-browser CDP session (curl hits the SSO 401).

## Code review

`/code-review` (xhigh, inline against the diff — sub-agent worktree has no Agent tool, so the 9 finder angles ran inline). Candidates raised and verified: no-cap far-city affordance (REFUTED — explicit locked product decision), `Number('')` falsy-zero (REFUTED — guarded by empty-string check), VenueList breakage from new optional fields (REFUTED — optional, VenueList doesn't use the geo hook), value-slice in-place mutation (REFUTED — correct), coords leaking into the seeded selection (REFUTED — `geoCityWithShows` returns a clean `{city,state}`), PSY-946 "no-shows → no-seed" regression (REFUTED — test passes). **No CONFIRMED/PLAUSIBLE findings → no edits.**

## Adversarial review

`/adversarial-review` — CONCERNS, 1 finding addressed in commit `39683e70`. Inline panel (Saboteur · Future-Maintainer · Security · Completeness) ran with no prior session context against the branch diff.
- [MEDIUM] Security/Privacy: `geo-default.ts`'s privacy doc-comment said "City + region only" — stale now that `/api/geo` also returns the visitor's approximate lat/long → **fixed in `39683e70`** (documents the coords, that they're never persisted as a coordinate — only the resulting canonical city is — and that they're echoed only back to the same visitor via the existing `private, no-store` route, no cross-visitor exposure).
- [LOW] `geoCityWithShows` name under-describes tier-2 (nearest) — deferred: the block comment fully explains both tiers; renaming would churn the affordance plumbing for no behavior change.
- [LOW] CA-province cities that collide with ISO codes (NL/PE/SK/YT/NU) may mis-geocode → nil coords → graceful exact-match fallback — pre-existing geo-package limitation, not introduced here.

Held up well: injection-safety (seed is always the canonical PH city, never the raw header), the US/CA country gate (unchanged — null even with coords present), haversine antimeridian/degenerate-coord handling, and the graceful exact-match fallback.

Closes PSY-981
