### PR TITLE
PSY-1010: seed representative tags so facet browse pages render non-empty

### DIFF
--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -515,6 +515,142 @@ WHERE email LIKE 'e2e-user%@test.local'
 ON CONFLICT (user_id) DO NOTHING;
 SQL
 
+echo "==> Seeding representative tags + entity_tags so facet panels render non-empty (PSY-1010)..."
+# The dev Go seed (cmd/seed -> exemplars.go) tags its *-exemplar entities, but
+# this E2E/dispatch-stack seed shipped with ZERO tags — so every tag-facet
+# browse page (/shows /artists /releases /venues /labels /festivals) rendered an
+# EMPTY facet panel by default and tag-work agents had to hand-seed to repro.
+#
+# Seed a SMALL, representative vocabulary and apply the SAME few tags across
+# MULTIPLE entity types so cross-entity facets are visible. The facet panel
+# (frontend/features/tags/components/TagFacetPanel.tsx) HIDES zero-count chips
+# per entity type and renders nothing when every chip in a category is zero, so
+# each browse page needs at least one tag with a NON-ZERO count for its type.
+#
+# Transitive types (PSY-499): /shows and /festivals match a tag TRANSITIVELY via
+# their billed artists — there are no direct show/festival tags. So we tag the
+# ARTISTS that are billed on the seeded future shows (the 55-show loop above
+# bills the first 10 artists) and add a lineup to the seeded festival, rather
+# than tagging shows/festivals directly (a direct tag would never surface in the
+# transitive facet count).
+#
+# Tags are authored by the admin user (entity_tags.added_by_user_id is NOT NULL),
+# which is seeded in the users block above. Idempotent via ON CONFLICT so a
+# dispatch stack that re-runs setup-db.sh neither duplicates nor errors.
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
+-- Small representative tag vocabulary. Genre tags drive cross-entity discovery;
+-- one locale tag ('phoenix') populates a second facet-category group so the
+-- panel shows more than the single 'genre' column. is_official=true mirrors
+-- how the dev exemplar seed creates its tags.
+INSERT INTO tags (name, slug, category, is_official, created_at, updated_at)
+VALUES
+  ('Post-Punk', 'post-punk', 'genre',  true, NOW(), NOW()),
+  ('Shoegaze',  'shoegaze',  'genre',  true, NOW(), NOW()),
+  ('Noise',     'noise',     'genre',  true, NOW(), NOW()),
+  ('Ambient',   'ambient',   'genre',  true, NOW(), NOW()),
+  ('Emo',       'emo',       'genre',  true, NOW(), NOW()),
+  ('Phoenix',   'phoenix',   'locale', true, NOW(), NOW())
+ON CONFLICT (slug) DO NOTHING;
+
+DO $$
+DECLARE
+  tagger_id INTEGER;
+  fest_id INTEGER;
+  -- (entity_type, slug, tag_slug) triples: which tag to apply to which entity.
+  -- Artists here are billed on the 55-show loop's bill (first 10 artists) so
+  -- tagging them makes the transitive /shows facet non-empty AND the direct
+  -- /artists facet non-empty. The same few tags repeat across releases /
+  -- venues / labels so a single tag (e.g. 'emo') spans several browse pages.
+  app RECORD;
+  ent_id INTEGER;
+  -- Artists added to the festival lineup so the transitive /festivals facet is
+  -- non-empty (the seeded festival had no lineup). Reuse already-tagged artists.
+  lineup RECORD;
+  pos INTEGER := 0;
+BEGIN
+  SELECT id INTO tagger_id FROM users WHERE email = 'e2e-admin@test.local';
+  IF tagger_id IS NULL THEN
+    RAISE NOTICE 'PSY-1010: admin user not found; skipping tag seed';
+    RETURN;
+  END IF;
+
+  -- Direct entity_tags applications across artist / release / venue / label.
+  FOR app IN
+    SELECT * FROM (VALUES
+      -- Artists (also drive transitive /shows via the bill).
+      ('artist',  'jimmy-eat-world', 'emo'),
+      ('artist',  'jimmy-eat-world', 'shoegaze'),
+      ('artist',  'the-format',      'emo'),
+      ('artist',  'calexico',        'ambient'),
+      ('artist',  'ajj',             'post-punk'),
+      ('artist',  'sundressed',      'emo'),
+      ('artist',  'the-maine',       'shoegaze'),
+      -- Releases (direct /releases facet).
+      ('release', 'futures',              'emo'),
+      ('release', 'clarity',              'emo'),
+      ('release', 'knife-man',            'post-punk'),
+      ('release', 'feast-of-the-mau-mau', 'ambient'),
+      ('release', 'sundressed-ep',        'shoegaze'),
+      -- Venues (direct /venues facet; 'phoenix' locale tag populates a 2nd
+      -- facet category on the venues page).
+      ('venue',   'the-rebel-lounge-phoenix-az', 'phoenix'),
+      ('venue',   'crescent-ballroom-phoenix-az', 'phoenix'),
+      ('venue',   'valley-bar-phoenix-az',        'noise'),
+      ('venue',   'club-congress-tucson-az',      'post-punk'),
+      -- Labels (direct /labels facet).
+      ('label',   'run-for-cover-records', 'emo'),
+      ('label',   'topshelf-records',      'post-punk'),
+      ('label',   'loma-vista-recordings', 'noise')
+    ) AS t(entity_type, entity_slug, tag_slug)
+  LOOP
+    -- Resolve the entity ID from its slug per table.
+    ent_id := NULL;
+    IF app.entity_type = 'artist' THEN
+      SELECT id INTO ent_id FROM artists WHERE slug = app.entity_slug;
+    ELSIF app.entity_type = 'release' THEN
+      SELECT id INTO ent_id FROM releases WHERE slug = app.entity_slug;
+    ELSIF app.entity_type = 'venue' THEN
+      SELECT id INTO ent_id FROM venues WHERE slug = app.entity_slug;
+    ELSIF app.entity_type = 'label' THEN
+      SELECT id INTO ent_id FROM labels WHERE slug = app.entity_slug;
+    END IF;
+
+    IF ent_id IS NOT NULL THEN
+      INSERT INTO entity_tags (tag_id, entity_type, entity_id, added_by_user_id, created_at)
+      SELECT t.id, app.entity_type, ent_id, tagger_id, NOW()
+      FROM tags t WHERE t.slug = app.tag_slug
+      ON CONFLICT (tag_id, entity_type, entity_id) DO NOTHING;
+    END IF;
+  END LOOP;
+
+  -- Festival lineup so the transitive /festivals facet is non-empty. The seeded
+  -- 'e2e-test-fest-2026' festival had no festival_artists rows; bill a few of
+  -- the tagged artists above so their tags surface transitively.
+  SELECT id INTO fest_id FROM festivals WHERE slug = 'e2e-test-fest-2026';
+  IF fest_id IS NOT NULL THEN
+    FOR lineup IN
+      SELECT id, slug FROM artists
+      WHERE slug IN ('jimmy-eat-world', 'the-format', 'calexico', 'ajj')
+      ORDER BY slug
+    LOOP
+      INSERT INTO festival_artists (festival_id, artist_id, billing_tier, position, created_at)
+      VALUES (fest_id, lineup.id, CASE WHEN pos = 0 THEN 'headliner' ELSE 'mid_card' END, pos, NOW())
+      ON CONFLICT (festival_id, artist_id) DO NOTHING;
+      pos := pos + 1;
+    END LOOP;
+  END IF;
+
+  -- Sync each tag's usage_count to its direct entity_tags fan-out (the global
+  -- /tags-browse count; per-entity-type facet counts are recomputed live by the
+  -- backend regardless). Keeps the seed self-consistent.
+  UPDATE tags SET usage_count = sub.cnt
+  FROM (
+    SELECT tag_id, COUNT(*) AS cnt FROM entity_tags GROUP BY tag_id
+  ) sub
+  WHERE tags.id = sub.tag_id;
+END $$;
+SQL
+
 echo "==> Seeding radio stations and shows (generated from backend/internal/seeddata/radio.go)..."
 # PSY-414: single source of truth in backend/internal/seeddata/radio.go,
 # rendered to SQL by cmd/gen-e2e-seed. cmd/seed (for local dev / stage)


### PR DESCRIPTION
## Summary

The E2E / dispatch-stack seed (`frontend/e2e/setup-db.sh`) shipped with **zero tags**, so every tag-facet browse page (`/shows`, `/artists`, `/releases`, `/venues`, `/labels`, `/festivals`) rendered an **empty facet panel** out of the box — and every tag-work agent this session had to hand-seed tags to manually repro. The dev Go seed (`cmd/seed` → `exemplars.go`) already tags its `*-exemplar` entities, but dispatch stacks seed via `setup-db.sh` **only** (`scripts/dispatch/stack-up.sh`), so they never got those tags.

This adds a small, representative tag vocabulary to `setup-db.sh` and applies the **same few tags across multiple entity types** so cross-entity facets are visible:

- **Tags:** `post-punk`, `shoegaze`, `noise`, `ambient`, `emo` (genre) + `phoenix` (locale, so a second facet-category group populates).
- **Direct tags** on artists / releases / venues / labels → those four facets non-empty.
- **Transitive types (PSY-499):** `/shows` and `/festivals` match tags via their *billed artists*, not direct show/festival tags. So I tag the **artists billed on the seeded 55-show loop** (makes `/shows` transitive non-empty) and add a **lineup to the previously-lineup-less `e2e-test-fest-2026` festival** (makes `/festivals` transitive non-empty). No direct show/festival tags — they wouldn't surface in the transitive facet count.

The facet panel (`TagFacetPanel.tsx`) hides zero-count chips per entity type and renders nothing when a whole category is zero, so each page needs at least one tag with a non-zero count *for its type*. Idempotent via `ON CONFLICT` so a re-run of `setup-db.sh` is safe.

Seed-path note: only `setup-db.sh` is touched (the shared E2E + dispatch-stack path). The Go dev seed already covered its own exemplars, so no change there.

## Test plan

- [x] `cd backend && go build ./...` — passes (no Go files touched; ran per AC).
- [x] `bash -n frontend/e2e/setup-db.sh` — syntax OK.
- [x] Isolated dispatch stack seeds cleanly (`stack-up.sh --mode=isolated`): the new block emits `INSERT 0 6` (tags) + the `DO` block succeeds.

## Manual repro

Brought up an isolated dispatch stack and confirmed **all six** tag-facet browse pages now render a **non-empty** facet panel against the default seed. Verified both at the API layer (`/tags?entity_type=<type>&sort=usage`) and in the rendered UI via agent-browser:

| Page | Facet chips (tag · count) | Direct/Transitive |
| --- | --- | --- |
| `/shows` | Emo 21 · Ambient 17 · Shoegaze 17 · Post-Punk 12 | **transitive** (via billed artists) |
| `/artists` | Emo 3 · Shoegaze 2 · Ambient 1 · Post-Punk 1 | direct |
| `/releases` | Emo 2 · Ambient 1 · Post-Punk 1 · Shoegaze 1 | direct |
| `/venues` | Phoenix 2 · Noise 1 · Post-Punk 1 | direct (genre + locale groups) |
| `/labels` | Emo 1 · Noise 1 · Post-Punk 1 | direct |
| `/festivals` | Ambient 1 · Emo 1 · Post-Punk 1 · Shoegaze 1 | **transitive** (via seeded lineup) |

Especially confirmed the **transitive `/shows`** counts (non-zero via the tagged billed artists) and **transitive `/festivals`** (non-zero via the lineup added to `e2e-test-fest-2026`). Stack torn down with `stack-down.sh`.

## Screenshots

- `/shows` facet (transitive): https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1010-screenshots/shows-facet.png
- `/artists` facet (direct): https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1010-screenshots/artists-facet.png
- `/festivals` facet (transitive): https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1010-screenshots/festivals-facet.png

## Code review

`/code-review` (xhigh, inline — dispatched sub-agent has no Agent tool, so the 9 finder angles ran inline against the diff). Verified: `ON CONFLICT` targets match the real unique constraints (`tags.slug`, `entity_tags(tag_id,entity_type,entity_id)`, `festival_artists(festival_id,artist_id)`); `usage_count` sync recomputes from a full aggregate (no re-run inflation); no other tag inserts exist to collide on the `LOWER(name)` unique index; block mirrors the file's existing slug→id + `DO $$ ... ON CONFLICT` idiom. **No findings.**

## Adversarial review

`/adversarial-review` — **CLEAN**, no findings (no fix commit). Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran inline (dispatched sub-agent, no Agent tool) against the branch diff with no prior session context.
- Saboteur: idempotency, NULL handling, atomicity, valid billing-tier values all hold.
- Future-Maintainer: one LOW (block couples to specific seed slugs) — mitigated by graceful `IF ... IS NOT NULL` skip that matches the file's existing convention.
- Security: dev/E2E seed data, static literals, no injection surface or new attack surface.
- Completeness: all four ACs met; tagging `setup-db.sh`'s own entities (vs the Go-only `*-exemplar` entities) is the correct fix for this path and explicitly allowed by the ticket.

Closes PSY-1010
