### PR TITLE
PSY-1006: stabilize flaky CI (ShowForm blur-timer flake + E2E mitigations)

### DIFF
--- a/frontend/components/forms/ShowForm.test.tsx
+++ b/frontend/components/forms/ShowForm.test.tsx
@@ -227,6 +227,11 @@ describe('ShowForm — artists list stable keys', () => {
     // any value (see isOpen / showDropdown). aria-expanded reflects the local
     // useState in that specific component instance, which is exactly what
     // leaks across rows when React reuses an instance via a stale key.
+    //
+    // These three assertions are a load-bearing PRECONDITION guard, not just
+    // description: they prove the per-row open state genuinely diverged before
+    // removal. Don't delete them — without this guard the canary at the end of
+    // the test could false-pass if the open-on-change wiring ever broke.
     expect(getInputs()[0]).toHaveAttribute('aria-expanded', 'true')
     expect(getInputs()[1]).toHaveAttribute('aria-expanded', 'false')
     expect(getInputs()[2]).toHaveAttribute('aria-expanded', 'true')

--- a/frontend/components/forms/ShowForm.test.tsx
+++ b/frontend/components/forms/ShowForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
 import type { ExtractedShowData } from '@/lib/types/extraction'
@@ -195,25 +195,33 @@ describe('ShowForm — artists list stable keys', () => {
     resetMockState()
   })
 
-  it('removing the middle artist keeps each remaining row\'s component state with its row (not its index)', async () => {
-    const user = userEvent.setup()
+  it('removing the middle artist keeps each remaining row\'s component state with its row (not its index)', () => {
+    // PSY-1006 flake fix: drive this test with fireEvent, NOT userEvent.
+    // userEvent moves real focus between rows; ArtistInput.handleBlur schedules
+    // setTimeout(close, 150ms) on blur, and that timer raced the synchronous
+    // aria-expanded assertions below — under CI load the 150ms elapsed first,
+    // the dropdown closed (aria-expanded → "false"), and the test failed
+    // intermittently. fireEvent doesn't manage focus, so no blur fires, no
+    // close timer is scheduled, and the open state stays deterministic. The
+    // test only exercises onChange-driven open state + key stability, which
+    // fireEvent covers fully.
     renderWithProviders(<ShowForm mode="create" />)
 
     // Start with 1, add two more → 3 artist rows.
     const addButton = screen.getByRole('button', { name: /add another artist/i })
-    await user.click(addButton)
-    await user.click(addButton)
+    fireEvent.click(addButton)
+    fireEvent.click(addButton)
 
     const getInputs = () =>
       screen.getAllByPlaceholderText('Enter artist name') as HTMLInputElement[]
     expect(getInputs()).toHaveLength(3)
 
-    // Type into rows 0 and 2 with values that visibly differ. Row 1 stays
+    // Set rows 0 and 2 to distinct values (opens their dropdowns). Row 1 stays
     // empty so the bug — if present — surfaces as the third row's local
     // ArtistInput state (typed value + aria-expanded dropdown state) leaking
     // onto the new second slot after the middle row is removed.
-    await user.type(getInputs()[0], 'Artist A')
-    await user.type(getInputs()[2], 'Artist C')
+    fireEvent.change(getInputs()[0], { target: { value: 'Artist A' } })
+    fireEvent.change(getInputs()[2], { target: { value: 'Artist C' } })
 
     // ArtistInput.tsx opens its autocomplete listbox the moment the input has
     // any value (see isOpen / showDropdown). aria-expanded reflects the local
@@ -226,7 +234,7 @@ describe('ShowForm — artists list stable keys', () => {
     // Remove the empty middle row.
     const removeButtons = screen.getAllByRole('button', { name: /remove artist/i })
     expect(removeButtons).toHaveLength(3)
-    await user.click(removeButtons[1])
+    fireEvent.click(removeButtons[1])
 
     const remaining = getInputs()
     expect(remaining).toHaveLength(2)

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -89,10 +89,32 @@ async function startDatabase() {
   log('Starting ephemeral PostgreSQL on port 5433...')
   // Don't use --wait: the migrate container is a one-shot that exits with 0,
   // which docker compose --wait treats as failure.
-  execSync('docker compose -p e2e -f docker-compose.e2e.yml up -d', {
-    cwd: BACKEND_DIR,
-    stdio: 'inherit',
-  })
+  //
+  // PSY-1006: `up -d` pulls the postgres + migrate images from Docker Hub. A
+  // transient registry timeout ("context deadline exceeded" against
+  // registry-1.docker.io) was failing the E2E Smoke gate before any test ran.
+  // Retry the bring-up a few times with backoff so a flaky registry pull can't
+  // fail the whole run. The happy path is unchanged (first attempt succeeds).
+  const upCmd = 'docker compose -p e2e -f docker-compose.e2e.yml up -d'
+  const MAX_ATTEMPTS = 3
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      execSync(upCmd, { cwd: BACKEND_DIR, stdio: 'inherit' })
+      break
+    } catch (err) {
+      if (attempt === MAX_ATTEMPTS) {
+        throw new Error(
+          `docker compose up failed after ${MAX_ATTEMPTS} attempts ` +
+            `(likely a Docker Hub registry timeout): ${(err as Error).message}`
+        )
+      }
+      log(
+        `docker compose up failed (attempt ${attempt}/${MAX_ATTEMPTS}); ` +
+          `retrying in ${attempt * 5}s...`
+      )
+      await new Promise((r) => setTimeout(r, attempt * 5000))
+    }
+  }
   // Wait for DB to be healthy
   log('Waiting for PostgreSQL to be ready...')
   for (let i = 0; i < 30; i++) {

--- a/frontend/e2e/pages/add-to-collection.spec.ts
+++ b/frontend/e2e/pages/add-to-collection.spec.ts
@@ -49,9 +49,18 @@ test.describe('Add to Collection', () => {
       await expect(collectionCheckbox).toBeVisible({ timeout: 5_000 })
       await collectionCheckbox.click()
 
+      // PSY-1006: sync on the check registering BEFORE looking for the submit
+      // button. The button's label reflects the selected count ("Add to 1
+      // collection"); if the click→state→label update hasn't propagated, the
+      // submitButton.click() below auto-waits into the 30s test-level timeout
+      // instead of failing fast here. An explicit, well-scoped wait makes the
+      // sequencing deterministic.
+      await expect(collectionCheckbox).toBeChecked({ timeout: 5_000 })
+
       const submitButton = authenticatedPage.getByRole('button', {
         name: /Add to 1 collection/,
       })
+      await expect(submitButton).toBeVisible({ timeout: 5_000 })
 
       // PSY-430: waitForResponse wraps the mutation so we don't race on the
       // optimistic UI state — the popover updates before the request completes.


### PR DESCRIPTION
Closes PSY-1006.

## Summary

Triages + fixes the flaky required CI gates. PSY-1006 listed three flakes; a focused hunt this session surfaced a **fourth** (a real Frontend-Unit assertion flake), now fixed and verified.

### Fixed (root cause + fix)

- **[Frontend Unit] `ShowForm.test.tsx` "stable keys" flake — FIXED + verified.** Root cause: `ArtistInput.handleBlur` schedules `setTimeout(() => setIsOpen(false), 150)`. The test drove the form with `userEvent`, which moves real focus between rows → each focus change blurred the prior row → its 150ms close-timer raced the test's *synchronous* `aria-expanded='true'` assertions. Under CI load the 150ms elapsed first → dropdown closed → `aria-expanded='false'` → intermittent failure (load-dependent, which is why it flaked on CI). **Fix:** drive the test with `fireEvent` instead of `userEvent` — `fireEvent` doesn't manage focus, so no blur fires, no close-timer is scheduled, and the dropdown-open state is deterministic. The test still exercises onChange-driven open state + key stability fully. **Verified: 20/20 deterministic runs** (was reproducibly flaky before), full suite green.

### Mitigated (documented mitigation)

- **[#1 E2E Smoke] Docker Hub registry timeout** (`global-setup.ts` `docker compose up`, fails before any test runs). Added a 3-attempt retry with backoff around the bring-up so a transient registry pull timeout can't fail the gate. Happy path unchanged.
- **[#2 E2E Smoke] add-to-collection timeout** (`add-to-collection.spec.ts`, ~30s). Root-cause hypothesis: after the checkbox click, the submit button's count-label ("Add to 1 collection") update can lag, so the `submitButton.click()` inside `Promise.all` auto-waits into the **30s test-level** timeout (matching the symptom) instead of failing fast. Added explicit `toBeChecked` + `toBeVisible` sync points so the sequencing is deterministic and any real failure surfaces fast with a clear message.

### Root cause identified (no code change — avoid over-masking)

- **[#3 Frontend Unit] dangling unhandled rejection while all tests pass** (`reviveInvokeError → lib/api.ts / useAdminShows.ts`). Root cause class is **documented in the repo** (`test/setup.ts`, PSY-945): a test renders a query-firing component (e.g. the admin nav via `useAdminShows`) without stubbing it; the real `apiRequest` fetch hits MSW's `onUnhandledRequest:'error'` and, if it's still in flight at worker teardown, the rejection isn't attributable to any test → vitest reports an unattributed error on an otherwise-green run. The ShowForm fix removes one Frontend-Unit flake; pinning the *exact* unstubbed test for #3 needs a live catch (it's a teardown-timing race — resisted ~9 local reproduction attempts this session). Per the ticket's own tradeoff note ("retries/masks hide real failures — prefer targeted root-cause"), I did **not** add a blanket `dangerouslyIgnoreUnhandledErrors` mask. Recommended follow-up: re-run the suite with an `unhandledRejection` logger in `test/setup.ts` until it fires, then stub the offending test (the technique that pinned ShowForm).

## Test plan

- [x] `ShowForm.test.tsx` — **20/20 consecutive passes** (was flaky)
- [x] `bun run typecheck` — clean
- [x] `bun run test:run` (full suite) — **461 files / 5763 tests pass**; no unattributed error this run
- [x] `eslint` changed files — clean (the lone `_config` warning is pre-existing)
- [x] add-to-collection E2E spec — local run **passed (1 passed, 43.4s)** with the global-setup retry + spec sync points; clean teardown (exercises #1 + #2 happy paths)

## Verification notes

- The Frontend-Unit fix (ShowForm) is fully reproducibly verified locally.
- The E2E changes (#1/#2) are low-risk, happy-path-preserving mitigations; the flakes themselves are **CI-environmental** (registry timeout; CI-load race) and can't be reproduced locally, so the CI E2E gate is the verifying signal for the flake elimination. The local E2E run confirms the spec's happy path still passes.
- #3 is documented (root cause class identified) with a recommended follow-up; AC#3's full guarantee depends on pinning + stubbing the exact unstubbed test.
