### PR TITLE
PSY-853: wire inline create-and-add (consume created_entity_id)

### DIFF
--- a/frontend/features/collections/components/AICollectionFiller.test.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.test.tsx
@@ -401,41 +401,59 @@ describe('AICollectionFiller', () => {
     items: [{ artist_name: 'Some Made Up Band', release_title: 'Nowhere Album' }],
   }
 
-  /** Stub global.fetch with a single JSON response for the entity-request POST. */
-  function stubFetch(decisionState: 'approved' | 'pending', ok = true) {
+  /**
+   * Stub global.fetch with a single JSON response for the entity-request POST.
+   * createdEntityId (PSY-1008) is included when provided — that's the
+   * auto-approve-fulfilled path that triggers inline create-and-add.
+   */
+  function stubFetch(
+    decisionState: 'approved' | 'pending',
+    ok = true,
+    createdEntityId?: number
+  ) {
     const fetchMock = vi.fn().mockResolvedValue({
       ok,
-      json: async () => ({ id: 7, decision_state: decisionState }),
+      json: async () => ({
+        id: 7,
+        decision_state: decisionState,
+        ...(createdEntityId !== undefined
+          ? { created_entity_id: createdEntityId }
+          : {}),
+      }),
     })
     vi.stubGlobal('fetch', fetchMock)
     return fetchMock
   }
 
-  async function extractOneUnmatchedRow(user: ReturnType<typeof userEvent.setup>) {
+  async function extractOneUnmatchedRow(
+    user: ReturnType<typeof userEvent.setup>,
+    onStage: AICollectionFillerProps['onStageItems'] = vi.fn()
+  ) {
     mockExtractResult = { data: ONE_UNMATCHED_ROW }
-    renderFiller({ onStageItems: vi.fn(), alreadyStaged: () => false })
+    renderFiller({ onStageItems: onStage, alreadyStaged: () => false })
     await user.type(screen.getByTestId('ai-collection-filler-textarea'), 'list')
     await user.click(screen.getByTestId('ai-collection-filler-extract'))
+    return onStage
   }
 
-  it('admin sees [Submit for creation] on an unmatched row (no Queue button)', async () => {
+  it('admin sees [Create + Add] on an unmatched row (no Queue button)', async () => {
     mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
     const user = userEvent.setup()
     await extractOneUnmatchedRow(user)
 
     const btn = screen.getByTestId('ai-collection-filler-row-request')
-    expect(btn).toHaveTextContent('Submit for creation')
+    expect(btn).toHaveTextContent('Create + Add')
     expect(btn).not.toHaveTextContent('Queue for review')
   })
 
-  it('local_ambassador sees [Submit for creation] (auto-approve tier, not admin)', async () => {
+  it('local_ambassador sees [Create + Add] (auto-approve tier, not admin)', async () => {
     mockUser = { is_admin: false, user_tier: 'local_ambassador' }
     const user = userEvent.setup()
     await extractOneUnmatchedRow(user)
 
     expect(
       screen.getByTestId('ai-collection-filler-row-request')
-    ).toHaveTextContent('Submit for creation')
+    ).toHaveTextContent('Create + Add')
   })
 
   it('contributor sees [Queue for review] (never an inline create)', async () => {
@@ -445,7 +463,7 @@ describe('AICollectionFiller', () => {
 
     const btn = screen.getByTestId('ai-collection-filler-row-request')
     expect(btn).toHaveTextContent('Queue for review')
-    expect(btn).not.toHaveTextContent('Submit for creation')
+    expect(btn).not.toHaveTextContent('Create + Add')
   })
 
   it('new_user sees [Queue for review]', async () => {
@@ -536,11 +554,37 @@ describe('AICollectionFiller', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('auto-approved (admin) request shows a "Requested" chip', async () => {
+  it('auto-approved create-and-add stages the created entity and shows "Added"', async () => {
     mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
-    stubFetch('approved')
+    // PSY-1008: auto-approve fulfills the entity and returns created_entity_id.
+    stubFetch('approved', true, 99)
     const user = userEvent.setup()
-    await extractOneUnmatchedRow(user)
+    const onStage = await extractOneUnmatchedRow(user)
+
+    await user.click(screen.getByTestId('ai-collection-filler-row-request'))
+
+    // The newly created entity is staged into the collection (true create-and-add).
+    await waitFor(() =>
+      expect(onStage).toHaveBeenCalledWith([
+        {
+          entityType: 'artist',
+          entityId: 99,
+          name: 'Some Made Up Band',
+          subtitle: null,
+        },
+      ])
+    )
+    const chip = await screen.findByTestId(
+      'ai-collection-filler-row-request-chip'
+    )
+    expect(chip).toHaveTextContent('Added')
+  })
+
+  it('auto-approved WITHOUT created_entity_id (deferred fulfillment) shows "Requested" and does not stage', async () => {
+    mockUser = { is_admin: true, user_tier: 'trusted_contributor' }
+    stubFetch('approved') // approved but not fulfilled — no created_entity_id
+    const user = userEvent.setup()
+    const onStage = await extractOneUnmatchedRow(user)
 
     await user.click(screen.getByTestId('ai-collection-filler-row-request'))
 
@@ -548,6 +592,7 @@ describe('AICollectionFiller', () => {
       'ai-collection-filler-row-request-chip'
     )
     expect(chip).toHaveTextContent('Requested')
+    expect(onStage).not.toHaveBeenCalled()
   })
 
   it('a failed entity-request shows an inline error and keeps the button', async () => {

--- a/frontend/features/collections/components/AICollectionFiller.tsx
+++ b/frontend/features/collections/components/AICollectionFiller.tsx
@@ -117,13 +117,12 @@ function compressImage(dataUrl: string): Promise<string> {
 // every catalog create endpoint (POST /admin/artists, /releases, …) is
 // rc.Admin-gated, so non-admin trusted tiers CANNOT create entities through
 // them — a 403 path. The ONLY cross-tier create mechanism is
-// POST /entity-requests (PSY-997). On auto-approve that endpoint marks the
-// request approved but does NOT fulfill it into a catalog row, so there is no
-// new entity_id to stage into the bulk-add pipeline yet. The "Submit for creation"
-// label therefore files an (auto-approved) request rather than staging the
-// new entity into the collection in the same step. Closing that gap — fulfill
-// on auto-approve + return created_entity_id so the row can stage — is a
-// backend follow-up; it is out of this frontend-only ticket's scope.
+// POST /entity-requests (PSY-997). On auto-approve (admin / local_ambassador /
+// confirmed trusted) that endpoint now FULFILLS the entity inline and returns
+// created_entity_id (PSY-1008), so the "Create + Add" affordance both creates
+// the entity AND stages it into the collection in one step (true inline
+// create-and-add). contributor / new_user still file a pending request for
+// admin review ("Queue for review").
 type CreateAffordance = 'create' | 'confirm' | 'queue' | 'none'
 
 /**
@@ -152,9 +151,11 @@ function createAffordanceFor(
 }
 
 // Outcome of a successful entity-request POST, used to pick the per-row chip.
-// 'requested' = auto-approved (admin / local_ambassador / confirmed trusted) —
-// the request skipped the queue; 'queued' = pending admin review.
-type RequestOutcome = 'requested' | 'queued'
+// 'created' = auto-approved AND fulfilled (PSY-1008) — the entity now exists and
+// is staged into the collection (true inline create-and-add); 'requested' =
+// approved but not staged (fulfillment deferred, e.g. show/festival); 'queued' =
+// pending admin review.
+type RequestOutcome = 'created' | 'requested' | 'queued'
 
 interface QueueEntityRequestVars {
   /** The unmatched row this request was filed from (used for per-row state). */
@@ -204,11 +205,21 @@ function useQueueEntityRequest() {
         )
       }
 
-      // decision_state distinguishes auto-approved (skips the queue) from
-      // pending (awaiting admin review) so the row chip reads correctly.
+      // PSY-1008: an auto-approved request now fulfills the entity inline and
+      // returns created_entity_id. When present, the caller stages the new
+      // entity into the collection (true create-and-add). decision_state still
+      // distinguishes approved from pending for the non-fulfilled fallback.
+      const createdEntityId =
+        typeof data?.created_entity_id === 'number'
+          ? data.created_entity_id
+          : undefined
       const outcome: RequestOutcome =
-        data?.decision_state === 'approved' ? 'requested' : 'queued'
-      return { outcome, rowKey: vars.rowKey }
+        createdEntityId !== undefined
+          ? 'created'
+          : data?.decision_state === 'approved'
+            ? 'requested'
+            : 'queued'
+      return { outcome, rowKey: vars.rowKey, createdEntityId }
     },
   })
 }
@@ -501,7 +512,17 @@ export function AICollectionFiller({
     queueRequest.mutate(
       { rowKey, entityType: 'artist', name, confirmed },
       {
-        onSuccess: ({ outcome }) => {
+        onSuccess: ({ outcome, createdEntityId }) => {
+          // PSY-853 inline create-and-add: when the auto-approve path fulfilled
+          // the entity (PSY-1008 returns created_entity_id), stage the new
+          // entity into the collection immediately — same bulk-add pipeline a
+          // matched row uses. The chip flips to "Added" via the 'created'
+          // outcome below.
+          if (createdEntityId !== undefined) {
+            onStageItems([
+              { entityType: 'artist', entityId: createdEntityId, name, subtitle: null },
+            ])
+          }
           setRequestedRows(prev => ({ ...prev, [rowKey]: outcome }))
           clearInFlight()
         },
@@ -835,7 +856,11 @@ function ExtractedRow({
               className="text-xs shrink-0 motion-safe:animate-in motion-safe:fade-in"
               data-testid="ai-collection-filler-row-request-chip"
             >
-              {requestOutcome === 'queued' ? 'Queued' : 'Requested'}
+              {requestOutcome === 'created'
+                ? 'Added'
+                : requestOutcome === 'queued'
+                  ? 'Queued'
+                  : 'Requested'}
             </Badge>
           ) : affordance === 'none' ? null : confirming ? (
             // trusted_contributor inline confirm — irreversible creation.
@@ -891,7 +916,7 @@ function ExtractedRow({
               ) : (
                 <Plus className="h-3.5 w-3.5 mr-1" />
               )}
-              {affordance === 'queue' ? 'Queue for review' : 'Submit for creation'}
+              {affordance === 'queue' ? 'Queue for review' : 'Create + Add'}
             </Button>
           ))}
       </div>


### PR DESCRIPTION
Closes PSY-853.

## Summary

Wires the **true inline create-and-add** for AICollectionFiller — the last user-facing piece of the Frictionless-Curation wave, now unblocked by PSY-1008 (merged).

When an auto-approve tier (admin / local_ambassador / confirmed trusted) hits **"Create + Add"** on an unmatched row, the entity-request response now carries `created_entity_id` (PSY-1008 fulfills the entity inline). This change:
- The `useQueueEntityRequest` mutation reads `created_entity_id` and returns it.
- `requestRow`'s `onSuccess` **stages the new entity** into the collection via the same `onStageItems` bulk-add path a matched row uses — true create-and-add.
- New `'created'` outcome → the row chip reads **"Added"**; an approved-but-unfulfilled response (deferred, e.g. show/festival) falls back to **"Requested"**; pending stays **"Queued"**.
- Relabels the auto-approve button **"Submit for creation" → "Create + Add"** (PSY-1008 makes the honest label true) and refreshes the now-stale architecture comment.

## Adversarial review

`/adversarial-review` — **CLEAN**. Reviewer verified end-to-end against the backend contract: `name` scope correct, `created_entity_id` guard robust (backend `*uint` PK is always ≥1), three independent no-double-stage guards (`inFlightRows` + chip-replaces-button + `stageBatch` dedup), the `created`/`requested`/`queued` chip logic, no conflict with the matched-row "Added" path, and that the tests genuinely assert staging-on-fulfilled + no-staging-on-deferred. V1 artist-only confirmed. Non-blocking: a 409 ArtistExists conflict surfaces as an inline retryable row error (safe, out of scope).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run` AICollectionFiller + AddItemsPicker — **61 pass**. New: auto-approve+fulfilled stages `{entityType:'artist', entityId, name, subtitle:null}` + "Added" chip; deferred (approved-no-id) → "Requested" + no staging; "Create + Add" label assertions.
- [x] full frontend suite green (5763 tests this branch base)
- [x] `eslint` changed files — clean
- [x] `/adversarial-review` — CLEAN

## Coverage gaps

- Rendered screenshot of the create-and-add flow is **not** included: it requires the full auth + AI-extraction stack (image/text → extract → unmatched row → Create+Add → observe "Added" + staged item). The staging behavior is asserted precisely in vitest (`onStageItems` called with the created entity), which is the load-bearing verification; the full authed AI-extraction render for a screenshot is disproportionate. The label + chip changes are structural and unit-covered.
