### PR TITLE
PSY-1015: refine Contribute menu into two-column Figma panel

### DIFF
--- a/frontend/components/layout/nav/ContributeMenu.tsx
+++ b/frontend/components/layout/nav/ContributeMenu.tsx
@@ -2,15 +2,16 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { ChevronDown, ExternalLink } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import {
   contributeItems,
@@ -21,30 +22,69 @@ import {
   type NavLink as NavLinkData,
 } from './navData'
 
-// Contribute ▾ — the call-to-action menu. PSY-1013 ships the functional menu;
-// PSY-1015 refines presentation and resolves whether Editorial (Blog / DJ Sets /
-// Substack) lives here or under Browse → Curation.
+// Contribute ▾ — the What.cd "request system as call-to-action". PSY-1015
+// refines the PSY-1013 functional menu into the two-column Participate /
+// Editorial panel from Figma (frame 460:3): "+ Submit a show" is the primary
+// (orange) action and lives in the menu, not as a standalone bar CTA (OQ-2).
+// Text-only links per the design — no item icons. Radix gives the trigger
+// aria-haspopup / aria-expanded and full APG keyboard operation; arrow keys
+// traverse every item across both columns in DOM order, and Escape returns
+// focus to the trigger.
+
+// Per-item color: primary (orange + semibold) for the "+ Submit a show"
+// call-to-action, muted for the trailing "hub" / external links, foreground
+// for the rest — matching the Figma panel. The color is pinned on the focus
+// state too so the item keeps its own color (the default item chrome would
+// otherwise swap to accent-foreground on hover/keyboard focus).
+function itemClassName(item: NavLinkData): string {
+  if (item.submitPrimary) {
+    return 'font-semibold text-primary focus:text-primary'
+  }
+  const trailing = item.external || item.href === '/contribute'
+  return cn(
+    'font-medium',
+    trailing
+      ? 'text-muted-foreground focus:text-muted-foreground'
+      : 'text-foreground focus:text-foreground'
+  )
+}
+
+function renderItem(item: NavLinkData) {
+  // Submit's label is "Submit a Show" in shared nav data; the Contribute panel
+  // presents it as the "+ Submit a show" call-to-action per Figma.
+  const label = item.submitPrimary ? '+ Submit a show' : item.label
+  // Trailing affordance: ↗ for external (Substack), → for the internal hub.
+  const trailingGlyph = item.external ? ' ↗' : item.href === '/contribute' ? ' →' : ''
+
+  return (
+    <DropdownMenuItem
+      key={item.href}
+      asChild
+      // Override the default item chrome: text-only editorial links with no
+      // background highlight box; hover/keyboard focus shows an underline and
+      // keeps the item's own color instead of the accent-foreground default.
+      className="px-0 py-0 text-[15px] focus:bg-transparent focus:underline"
+    >
+      <Link
+        href={item.href}
+        target={item.external ? '_blank' : undefined}
+        rel={item.external ? 'noopener noreferrer' : undefined}
+        className={cn('rounded-sm', itemClassName(item))}
+      >
+        {label}
+        {trailingGlyph}
+      </Link>
+    </DropdownMenuItem>
+  )
+}
+
+const groupLabelClassName =
+  'px-0 py-0 font-mono text-[11px] font-bold uppercase tracking-[1.2px] text-muted-foreground'
+
 export function ContributeMenu() {
   const pathname = usePathname()
   const { isAuthenticated } = useAuthContext()
   const active = contributeHrefs.some(href => isNavActive(pathname, href))
-
-  const renderItem = (item: NavLinkData) => {
-    const Icon = item.icon
-    return (
-      <DropdownMenuItem key={item.href} asChild>
-        <Link
-          href={item.href}
-          target={item.external ? '_blank' : undefined}
-          rel={item.external ? 'noopener noreferrer' : undefined}
-        >
-          {Icon && <Icon aria-hidden />}
-          {item.label}
-          {item.external && <ExternalLink className="ml-auto size-3 opacity-50" aria-hidden />}
-        </Link>
-      </DropdownMenuItem>
-    )
-  }
 
   return (
     <DropdownMenu>
@@ -52,15 +92,20 @@ export function ContributeMenu() {
         Contribute
         <ChevronDown className="size-3.5 opacity-70" aria-hidden />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-56">
-        {contributeItems
-          .filter(item => isAuthenticated || !item.authOnly)
-          .map(renderItem)}
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/60">
-          Editorial
-        </DropdownMenuLabel>
-        {editorialItems.map(renderItem)}
+      <DropdownMenuContent
+        align="start"
+        className="flex w-auto items-start gap-12 rounded-[10px] px-7 py-6"
+      >
+        <DropdownMenuGroup className="flex flex-col gap-3">
+          <DropdownMenuLabel className={groupLabelClassName}>Participate</DropdownMenuLabel>
+          {contributeItems
+            .filter(item => isAuthenticated || !item.authOnly)
+            .map(renderItem)}
+        </DropdownMenuGroup>
+        <DropdownMenuGroup className="flex flex-col gap-3">
+          <DropdownMenuLabel className={groupLabelClassName}>Editorial</DropdownMenuLabel>
+          {editorialItems.map(renderItem)}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/frontend/components/layout/nav/PrimaryNav.test.tsx
+++ b/frontend/components/layout/nav/PrimaryNav.test.tsx
@@ -64,7 +64,7 @@ describe('PrimaryNav', () => {
     const user = userEvent.setup()
     render(<PrimaryNav />)
     await user.click(screen.getByRole('button', { name: 'Contribute' }))
-    expect(await screen.findByRole('menuitem', { name: 'Submit a Show' })).toBeInTheDocument()
+    expect(await screen.findByRole('menuitem', { name: '+ Submit a show' })).toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: 'My Submissions' })).not.toBeInTheDocument()
   })
 
@@ -74,5 +74,33 @@ describe('PrimaryNav', () => {
     render(<PrimaryNav />)
     await user.click(screen.getByRole('button', { name: 'Contribute' }))
     expect(await screen.findByRole('menuitem', { name: 'My Submissions' })).toHaveAttribute('href', '/submissions')
+  })
+
+  it('renders the Contribute panel: primary Submit CTA, Participate + Editorial links', async () => {
+    const user = userEvent.setup()
+    render(<PrimaryNav />)
+    await user.click(screen.getByRole('button', { name: 'Contribute' }))
+    // Primary call-to-action (lives in the menu, not a standalone bar CTA).
+    expect(await screen.findByRole('menuitem', { name: '+ Submit a show' })).toHaveAttribute(
+      'href',
+      '/shows/submit'
+    )
+    // Participate group destinations.
+    expect(screen.getByRole('menuitem', { name: 'Requests' })).toHaveAttribute('href', '/requests')
+    expect(screen.getByRole('menuitem', { name: 'Leaderboard' })).toHaveAttribute(
+      'href',
+      '/community/leaderboard'
+    )
+    expect(screen.getByRole('menuitem', { name: 'Contribute hub →' })).toHaveAttribute(
+      'href',
+      '/contribute'
+    )
+    // Editorial group destinations.
+    expect(screen.getByRole('menuitem', { name: 'Blog' })).toHaveAttribute('href', '/blog')
+    expect(screen.getByRole('menuitem', { name: 'DJ Sets' })).toHaveAttribute('href', '/dj-sets')
+    const substack = screen.getByRole('menuitem', { name: 'Substack ↗' })
+    expect(substack).toHaveAttribute('href', 'https://psychichomily.substack.com/')
+    expect(substack).toHaveAttribute('target', '_blank')
+    expect(substack).toHaveAttribute('rel', 'noopener noreferrer')
   })
 })

--- a/frontend/components/layout/nav/navData.ts
+++ b/frontend/components/layout/nav/navData.ts
@@ -18,6 +18,12 @@ export interface NavLink {
   icon?: LucideIcon
   external?: boolean
   authOnly?: boolean
+  /**
+   * Marks the Contribute menu's call-to-action ("+ Submit a show"), which the
+   * Figma design (frame 460:3) renders in the primary color. Submit lives in
+   * this menu rather than as a standalone top-bar CTA (OQ-2, resolved).
+   */
+  submitPrimary?: boolean
 }
 
 export interface NavGroup {
@@ -55,12 +61,16 @@ export const browseGroups: NavGroup[] = [
 ]
 
 // Contribute ▾ — the What.cd "request system as call-to-action". PSY-1015
-// refines presentation; Editorial (consume-not-contribute) is a labelled
-// sub-group here pending its final home (Contribute vs. Browse → Curation).
+// lays this out as the two-column Participate / Editorial panel from Figma
+// (frame 460:3). Leaderboard appears in Participate as a contributor-standing
+// destination; it is ALSO reachable from Browse → Curation (it's a plain link,
+// so two entry points is fine). The Editorial sub-group is consume-not-
+// contribute (resolved to live here per OQ-6).
 export const contributeItems: NavLink[] = [
-  { href: '/shows/submit', label: 'Submit a Show', icon: Music },
+  { href: '/shows/submit', label: 'Submit a Show', icon: Music, submitPrimary: true },
   { href: '/requests', label: 'Requests', icon: MessageSquarePlus },
   { href: '/submissions', label: 'My Submissions', icon: Send, authOnly: true },
+  { href: '/community/leaderboard', label: 'Leaderboard', icon: Trophy },
   { href: '/contribute', label: 'Contribute hub', icon: HeartHandshake },
 ]
 


### PR DESCRIPTION
## Summary
Refines the PSY-1013 functional Contribute dropdown into the two-column **Participate / Editorial** panel from Figma (frame `460:3`), the What.cd "request system as call-to-action".

- **Participate**: `+ Submit a show` · Requests · My Submissions (auth) · Leaderboard · Contribute hub →
- **Editorial**: Blog · DJ Sets · Substack ↗
- `+ Submit a show` is the **primary (orange) action** and lives in the menu, not as a standalone bar CTA (OQ-2, resolved). Its shared nav label stays `Submit a Show`; the panel presents it as the CTA via a new `submitPrimary` flag.
- Text-only editorial links per the design (item icons dropped); trailing `→` on the internal hub, `↗` on the external Substack link.
- Leaderboard added to the Participate group; it is also reachable from Browse → Curation (a plain link, so two entry points is fine — not removed from Browse).
- `My Submissions` stays auth-gated via `useAuthContext`.
- Trigger keeps `navItemClassName` for row consistency; Radix preserves APG menu a11y (hover + click + keyboard, Escape returns focus to the trigger).

`navData.ts` edits are additive and scoped to the Contribute-owned `contributeItems` export (+ a `submitPrimary` interface field), disjoint from PSY-1014's `browseGroups`.

## Test plan
- [x] `cd frontend && bun run typecheck` — clean (`tsc --noEmit`, 0 errors)
- [x] `cd frontend && bun run lint` — 0 errors (pre-existing warnings only, none in changed files)
- [x] `cd frontend && bun run test:run components/layout` — 15 files / 193 tests pass, incl. new Contribute-panel test asserting all 8 hrefs, the `+ Submit a show` primary label, and Substack `target=_blank` + `rel=noopener noreferrer`

## Manual repro
Per-worktree shared dispatch stack + agent-browser (isolated Chrome):
- **Anon**: opened Contribute — two columns render; `+ Submit a show` is orange; `Contribute hub →` and `Substack ↗` are muted with arrows; **My Submissions correctly hidden** when logged out.
- **Keyboard/a11y**: Enter opens + focuses first item; ArrowDown traverses across both columns in DOM order; **Escape closes the menu and returns focus to the Contribute trigger** (`aria-expanded=false`).
- **Authenticated** (signed in as the seeded e2e user): **My Submissions appears** between Requests and Leaderboard → `/submissions`. All hrefs verified: `/shows/submit`, `/requests`, `/submissions`, `/community/leaderboard`, `/contribute`, `/blog`, `/dj-sets`, `https://psychichomily.substack.com/` (`target=_blank`).

## Screenshots
Contribute menu open (anon — My Submissions hidden):

![Contribute menu open](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1015-screenshots/contribute-open.png)

## Code review
`/code-review` (xhigh, inline in worktree — no Agent tool): **no correctness defects**. Two non-blocking observations, both intentional/out-of-scope: (1) arrow glyphs (`↗`/`→`) are part of the link accessible name — for external links this arguably aids AT; (2) on `/community/leaderboard` both the Browse and Contribute triggers light active (cross-menu active-precedence is a design call owned by the in-flight Browse mega-menu, PSY-1014). No code change warranted.

## Adversarial review
`/adversarial-review` — **CLEAN** (inline 4 lenses; reviewers ran with no prior session context against the branch diff). Saboteur · Future-Maintainer · Security · Completeness.
- The strongest candidate (Radix `asChild` className merge possibly letting the default `focus:text-accent-foreground` override the pinned item color on hover) was **REFUTED by live browser evidence** — colors render correctly; the pinned `focus:` variants win.
- Security: links are static hardcoded routes (no input/injection surface); Substack uses `rel=noopener noreferrer`; the auth gate is presentation-only UX (the `/submissions` route enforces auth server-side). CLEAN.
- Remaining items are LOW and intentional (string coupling to `/contribute`, glyph voicing, Space-Mono group-label divergence per Figma). No fixes needed → no separate adversarial commit.

Closes PSY-1015