### PR TITLE
PSY-1014: Browse mega-menu (3-column hover+click+keyboard)

### DIFF
--- a/frontend/components/layout/nav/BrowseMenu.test.tsx
+++ b/frontend/components/layout/nav/BrowseMenu.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowseMenu } from './BrowseMenu'
+
+let mockPathname = '/'
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}))
+
+describe('BrowseMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPathname = '/'
+  })
+
+  it('opens on click and renders the three scent-rich column headers', async () => {
+    const user = userEvent.setup()
+    render(<BrowseMenu />)
+    await user.click(screen.getByRole('button', { name: 'Browse the catalog' }))
+    // Column headers carry no role; assert their text is present once open.
+    expect(await screen.findByText('Catalog')).toBeInTheDocument()
+    expect(screen.getByText('Curation')).toBeInTheDocument()
+    expect(screen.getByText('Scenes')).toBeInTheDocument()
+  })
+
+  it('every catalog + curation item is a real link to its route', async () => {
+    const user = userEvent.setup()
+    render(<BrowseMenu />)
+    await user.click(screen.getByRole('button', { name: 'Browse the catalog' }))
+
+    const cases: Array<[string, string]> = [
+      ['Artists', '/artists'],
+      ['Venues', '/venues'],
+      ['Releases', '/releases'],
+      ['Labels', '/labels'],
+      ['Festivals', '/festivals'],
+      ['Collections', '/collections'],
+      ['Charts', '/charts'],
+      ['Tags', '/tags'],
+      ['Leaderboard', '/community/leaderboard'],
+    ]
+    for (const [name, href] of cases) {
+      expect(await screen.findByRole('menuitem', { name })).toHaveAttribute('href', href)
+    }
+  })
+
+  it('renders the curated scene shortcuts with the derived <city>-<state> slug shape', async () => {
+    const user = userEvent.setup()
+    render(<BrowseMenu />)
+    await user.click(screen.getByRole('button', { name: 'Browse the catalog' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Phoenix' })).toHaveAttribute(
+      'href',
+      '/scenes/phoenix-az'
+    )
+    expect(screen.getByRole('menuitem', { name: 'Tucson' })).toHaveAttribute(
+      'href',
+      '/scenes/tucson-az'
+    )
+    expect(screen.getByRole('menuitem', { name: 'Los Angeles' })).toHaveAttribute(
+      'href',
+      '/scenes/los-angeles-ca'
+    )
+    expect(screen.getByRole('menuitem', { name: 'All scenes' })).toHaveAttribute('href', '/scenes')
+  })
+
+  it('opens via keyboard (Enter on the focused trigger) — APG menu pattern', async () => {
+    const user = userEvent.setup()
+    render(<BrowseMenu />)
+    const trigger = screen.getByRole('button', { name: 'Browse the catalog' })
+    trigger.focus()
+    await user.keyboard('{Enter}')
+    expect(await screen.findByRole('menuitem', { name: 'Artists' })).toBeInTheDocument()
+  })
+
+  it('Escape closes the menu and returns focus to the trigger', async () => {
+    const user = userEvent.setup()
+    render(<BrowseMenu />)
+    const trigger = screen.getByRole('button', { name: 'Browse the catalog' })
+    await user.click(trigger)
+    expect(await screen.findByRole('menuitem', { name: 'Artists' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('menuitem', { name: 'Artists' })).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('marks the trigger active when on a destination route', () => {
+    mockPathname = '/venues'
+    render(<BrowseMenu />)
+    // navItemClassName applies the active (foreground) treatment; assert the
+    // active class is present so the trigger reads as selected.
+    expect(screen.getByRole('button', { name: 'Browse the catalog' }).className).toContain(
+      'text-foreground'
+    )
+  })
+})

--- a/frontend/components/layout/nav/BrowseMenu.tsx
+++ b/frontend/components/layout/nav/BrowseMenu.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ChevronDown } from 'lucide-react'
@@ -9,44 +10,97 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { browseGroups, browseHrefs, isNavActive, navItemClassName } from './navData'
 
-// Browse ▾ — the full faceted catalog. PSY-1013 ships it as a grouped dropdown
-// so every catalog/curation/scene destination the retired sidebar exposed stays
-// reachable on desktop; PSY-1014 replaces this with the wide three-column
-// mega-menu (+ optional Fresh rail). Radix gives the trigger aria-haspopup /
-// aria-expanded and full keyboard operation.
+// NN/G hover-intent timing (cited in the redesign brief): open after a short
+// dwell so a pointer merely passing over the trigger doesn't pop the panel;
+// linger briefly before closing so the diagonal travel into the panel doesn't
+// dismiss it; full close-delay after leaving.
+const OPEN_DELAY_MS = 500
+const CLOSE_DELAY_MS = 500
+
+// Browse ▾ — the wide three-column mega-menu (Catalog / Curation / Scenes) per
+// Figma `455:5`. Built on Radix DropdownMenu so it keeps the W3C APG menu
+// pattern for free: arrow-key roving focus across `menuitem`s, type-ahead, and
+// Escape closing + returning focus to the trigger. The Fresh / Trending rail in
+// the mock is intentionally DEFERRED for v1 — there is no recently-added /
+// trending data source yet.
+//
+// DropdownMenu alone is click-only, so this layers NN/G hover-intent on top via
+// a controlled `open` state with open/close timers (Radix still owns click +
+// keyboard). Pointer parity: hovering EITHER the trigger or the panel keeps it
+// open; leaving both closes it after the delay.
 export function BrowseMenu() {
   const pathname = usePathname()
   const active = browseHrefs.some(href => isNavActive(pathname, href))
 
+  const [open, setOpen] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  // Avoid leaking a pending open/close timer if the component unmounts mid-dwell.
+  useEffect(() => clearTimer, [clearTimer])
+
+  const scheduleOpen = useCallback(() => {
+    clearTimer()
+    timerRef.current = setTimeout(() => setOpen(true), OPEN_DELAY_MS)
+  }, [clearTimer])
+
+  const scheduleClose = useCallback(() => {
+    clearTimer()
+    timerRef.current = setTimeout(() => setOpen(false), CLOSE_DELAY_MS)
+  }, [clearTimer])
+
+  // Click / keyboard go through Radix's own open state; cancel any pending hover
+  // timer so a click doesn't get clobbered by a late open/close fire.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      clearTimer()
+      setOpen(next)
+    },
+    [clearTimer]
+  )
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className={navItemClassName(active)} aria-label="Browse the catalog">
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger
+        className={navItemClassName(active)}
+        aria-label="Browse the catalog"
+        onPointerEnter={scheduleOpen}
+        onPointerLeave={scheduleClose}
+      >
         Browse
         <ChevronDown className="size-3.5 opacity-70" aria-hidden />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-56">
-        {browseGroups.map((group, i) => (
-          <DropdownMenuGroup key={group.label}>
-            {i > 0 && <DropdownMenuSeparator />}
-            <DropdownMenuLabel className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/60">
+      <DropdownMenuContent
+        align="start"
+        sideOffset={10}
+        className="flex w-auto gap-12 rounded-[10px] border-border p-0 px-7 py-6 shadow-[0px_2px_8px_0px_rgba(0,0,0,0.08)]"
+        onPointerEnter={clearTimer}
+        onPointerLeave={scheduleClose}
+      >
+        {browseGroups.map(group => (
+          <DropdownMenuGroup key={group.label} className="flex flex-col gap-3">
+            <DropdownMenuLabel className="px-0 py-0 font-mono text-[11px] font-bold uppercase tracking-[1.2px] text-muted-foreground">
               {group.label}
             </DropdownMenuLabel>
-            {group.items.map(item => {
-              const Icon = item.icon
-              return (
-                <DropdownMenuItem key={item.href} asChild>
-                  <Link href={item.href}>
-                    {Icon && <Icon aria-hidden />}
-                    {item.label}
-                  </Link>
-                </DropdownMenuItem>
-              )
-            })}
+            {group.items.map(item => (
+              <DropdownMenuItem
+                key={item.href}
+                asChild
+                className="px-0 py-0 text-[15px] font-medium text-foreground focus:bg-transparent focus:text-foreground focus:underline data-[highlighted]:bg-transparent data-[highlighted]:underline"
+              >
+                <Link href={item.href}>{item.label}</Link>
+              </DropdownMenuItem>
+            ))}
           </DropdownMenuGroup>
         ))}
       </DropdownMenuContent>

--- a/frontend/components/layout/nav/navData.ts
+++ b/frontend/components/layout/nav/navData.ts
@@ -49,8 +49,20 @@ export const browseGroups: NavGroup[] = [
     ],
   },
   {
+    // Scene pages are DERIVED from verified-venue location data, not stored
+    // entities; a `<city>` slug is `<city-lowercased,-spaces→dashes>-<state>`
+    // (backend `buildSceneSlug`, e.g. Phoenix/AZ → `phoenix-az`). These three
+    // are the scent-rich shortcuts the redesign curates per Figma `455:5`
+    // (Browse mega-menu); "All scenes" is the index. A curated city that has
+    // not yet crossed the scene threshold renders a real 404 (the page's
+    // server-side existence check) — acceptable for a hand-picked shortcut.
     label: 'Scenes',
-    items: [{ href: '/scenes', label: 'All scenes', icon: Globe }],
+    items: [
+      { href: '/scenes/phoenix-az', label: 'Phoenix', icon: MapPin },
+      { href: '/scenes/tucson-az', label: 'Tucson', icon: MapPin },
+      { href: '/scenes/los-angeles-ca', label: 'Los Angeles', icon: MapPin },
+      { href: '/scenes', label: 'All scenes', icon: Globe },
+    ],
   },
 ]
 


### PR DESCRIPTION
## Summary

Upgrades the `Browse▾` trigger from the narrow grouped DropdownMenu (PSY-1013) to the wide **three-column mega-menu** per Figma `455:5`:

- **Catalog** — Artists · Venues · Releases · Labels · Festivals
- **Curation** — Collections · Charts · Tags · Leaderboard
- **Scenes** — Phoenix · Tucson · Los Angeles · All scenes

Space Mono uppercase column headers; `bg-popover` surface + `border-border` + `shadow/popover` (`0 2px 8px rgba(0,0,0,0.08)`); columns laid out horizontally with `gap-12`.

Built on Radix `DropdownMenu` so it keeps the **W3C APG menu pattern** for free (arrow-key roving focus across `menuitem`s, type-ahead, Escape closes + returns focus to the trigger). DropdownMenu alone is click-only, so this layers **NN/G hover-intent** (≈0.5s open / 0.5s close) on top via a controlled `open` state with open/close timers covering both the trigger and the panel; Radix still owns click + keyboard parity.

The optional **Fresh / Trending rail** in the mock is **intentionally DEFERRED** for v1 — there is no recently-added / trending data source yet (the 3 columns ship; the rail does not).

`navData.ts` edit is **additive** (the Scenes group only) — disjoint from the `contributeItems`/`editorialItems` that the parallel PSY-1015 touches. Scene shortcuts use the backend's derived `<city>-<state>` slug (`buildSceneSlug`, e.g. `phoenix-az`).

Files changed (3): `BrowseMenu.tsx` (impl), `navData.ts` (additive Scenes group), `BrowseMenu.test.tsx` (new).

## Test plan

- [x] `cd frontend && bun run typecheck` → clean (no errors)
- [x] `cd frontend && bun run lint` (CI gate) → 0 errors (156 pre-existing warnings, none in touched files)
- [x] `cd frontend && bun run test:run components/layout` → 198 passed (16 files), incl. the new `BrowseMenu.test.tsx` (6 tests: 3-column headers, every catalog/curation item links to its route, scene `<city>-<state>` slugs, keyboard-open via Enter, Escape-closes-and-returns-focus, active trigger) and the existing `PrimaryNav.test.tsx` Browse `menuitem` assertions still green.

## Manual repro

Ran the per-worktree dispatch stack (frontend + backend + seeded postgres) and drove it with an isolated agent-browser session:

- Opened `Browse▾` via click → the 3-column panel renders with CATALOG / CURATION / SCENES Space Mono headers, popover surface + border + shadow, anchored under the trigger (matches Figma `455:5`, minus the deferred Fresh rail). Accessibility snapshot confirmed all 13 items expose `role=menuitem`.
- Pressed Escape with the menu open → menu closed and `document.activeElement` returned to the `Browse the catalog` trigger button.
- Checked curated scene routes against the **dev seed**: `/scenes/phoenix-az` → 200, `/scenes/tucson-az` → 200, `/scenes` → 200, `/scenes/los-angeles-ca` → **404** (see Adversarial review — the dev seed has no qualifying LA scene; the page returns a graceful real-404).

## Screenshots

Browse mega-menu, open state (light):

![Browse mega-menu open](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1014-screenshots/browse-open.png)

## Code review

`/code-review` (extra-high effort, inline — dispatched sub-agent has no Agent tool) ran the 9 finder angles against the diff. Verified cross-file safety (`browseGroups` has only two consumers — `BrowseMenu` + the derived `browseHrefs`; `MobileNav` uses `sidebarGroups`, unaffected), the hover-timer lifecycle (single `timerRef`, cleared-before-set, unmount cleanup), and the trigger→panel hover race (500ms close delay amply covers the 10px `sideOffset` gap). **No findings; no changes.**

## Adversarial review

`/adversarial-review` — CONCERNS (1 MEDIUM, disclosed). Panel: Saboteur · Future-Maintainer · Security · Completeness (inline; no prior session context, against the branch diff).

- [MEDIUM] **Curated `Los Angeles` shortcut 404s in the dev seed** (`navData.ts`) → **disclosed, not removed.** "Los Angeles" is an explicit destination in both the ticket prose and Figma `455:5`; scene pages are derived from verified-venue data and return a real HTTP 404 below threshold (graceful, not a crash). Production likely has LA data; the dev seed does not. Kept per spec; documented in the `navData.ts` comment and the Manual repro above.
- Security: CLEAN (all hrefs static internal routes; no user input / injection / new auth surface).
- Held up well: timer lifecycle (no leak), APG keyboard + Escape-returns-focus, additive navData change disjoint from PSY-1015.

Closes PSY-1014
