### PR TITLE
PSY-389: logged-out homepage — discovery landing

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,166 +1,74 @@
 import Link from 'next/link'
 import { HomeShowList } from '@/features/shows'
-import { getBlogSlugs, getBlogPost, getAllMixes, MDXContent, SoundCloud } from '@/features/blog'
+import { HomeHero, LatestRadioShows, ActivityFeedPlaceholder } from '@/features/home'
+import { Button } from '@/components/ui/button'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateWebSiteSchema } from '@/lib/seo/jsonld'
-import { formatContentDate } from '@/lib/utils/formatters'
-import { getTextExcerpt } from '@/lib/utils/markdownExcerpt'
 
+// PSY-389: logged-out discovery landing ("This is not a mirage"). Drops the old
+// "Arizona Music Community" framing. NOTE: Next.js does NOT apply a layout's
+// `title.template` to a page in the SAME route segment as that layout — and the
+// root `page.tsx` shares the root `layout.tsx` segment — so the global
+// "%s | Psychic Homily" template can't decorate this page. We therefore set the
+// full title via `title.absolute` to match that template's output exactly. The
+// logged-in customizable dashboard is a separate project (out of scope).
 export const metadata = {
-  title: 'Psychic Homily | Arizona Music Community',
+  title: { absolute: 'Discover live music | Psychic Homily' },
   description:
-    'Discover upcoming live music shows, blog posts, and DJ sets from the Arizona music scene.',
+    'Find upcoming live shows in any city, dig into artists, labels, releases, and freeform radio — the underground, mapped link by link.',
   alternates: {
     canonical: 'https://psychichomily.com',
   },
   openGraph: {
-    title: 'Psychic Homily | Arizona Music Community',
-    description: 'Discover upcoming live music shows, blog posts, and DJ sets from the Arizona music scene.',
+    title: 'Psychic Homily',
+    description:
+      'Find upcoming live shows in any city, dig into artists, labels, releases, and freeform radio — the underground, mapped link by link.',
     url: '/',
     type: 'website',
   },
 }
 
-/**
- * Extract embed from MDX content
- */
-function extractEmbed(content: string): string | null {
-  const embedMatch = content.match(/<(Bandcamp|SoundCloud)[^>]+\/>/)
-  return embedMatch ? embedMatch[0] : null
-}
-
 export default function Home() {
-  // Get latest blog post
-  const blogSlugs = getBlogSlugs()
-  const allPosts = blogSlugs
-    .map(slug => getBlogPost(slug))
-    .filter((post): post is NonNullable<typeof post> => post !== null)
-    .sort(
-      (a, b) =>
-        new Date(b.frontmatter.date).getTime() -
-        new Date(a.frontmatter.date).getTime()
-    )
-  const latestPost = allPosts[0]
-
-  // Get latest DJ set
-  const allMixes = getAllMixes()
-  const latestMix = allMixes[0]
-
   return (
     <>
-    <JsonLd data={generateWebSiteSchema()} />
-    <div className="flex min-h-screen items-start justify-center">
-      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
-        {/* Upcoming Shows Section */}
-        <section className="mb-14">
-          <div className="flex justify-between items-center mb-5">
-            <h2 className="text-2xl font-bold tracking-tight">
-              Upcoming Shows
-            </h2>
-            <Link
-              href="/shows"
-              className="text-sm text-muted-foreground hover:text-primary transition-colors hover:underline underline-offset-4"
-            >
-              View all →
-            </Link>
-          </div>
-          <HomeShowList />
-        </section>
+      <JsonLd data={generateWebSiteSchema()} />
+      <div className="flex w-full justify-center">
+        <div className="flex w-full max-w-6xl flex-col gap-14 px-4 pb-16 pt-12 md:px-8">
+          <HomeHero />
 
-        {/* Latest Blog Post Section */}
-        {latestPost && (
-          <section className="mb-14">
-            <div className="flex justify-between items-center mb-5">
-              <h2 className="text-2xl font-bold tracking-tight">
-                Latest from the Blog
+          {/* Upcoming shows — the unique advantage, privileged at top. The city
+              filter, geo-default, and popular-cities row all live inside the
+              reused HomeShowList. */}
+          <section aria-labelledby="home-shows-heading" className="flex w-full flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <h2
+                id="home-shows-heading"
+                className="text-2xl font-semibold tracking-tight text-foreground"
+              >
+                Upcoming shows
               </h2>
               <Link
-                href="/blog"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors hover:underline underline-offset-4"
+                href="/shows"
+                className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary hover:underline underline-offset-4"
               >
-                View all →
+                View all shows →
               </Link>
             </div>
-            <article className="bg-card/50 border border-border/50 rounded-xl p-6 hover:border-border transition-colors">
-              <h3 className="text-xl font-semibold leading-tight tracking-tight">
-                <Link
-                  href={`/blog/${latestPost.slug}`}
-                  className="hover:text-primary transition-colors"
-                >
-                  {latestPost.frontmatter.title}
-                </Link>
-              </h3>
-              <div className="text-sm text-muted-foreground mt-1.5">
-                {formatContentDate(latestPost.frontmatter.date)}
-              </div>
 
-              {extractEmbed(latestPost.content) && (
-                <div className="mt-4">
-                  <MDXContent source={extractEmbed(latestPost.content)!} />
-                </div>
-              )}
+            <HomeShowList />
 
-              <div className="mt-3 leading-relaxed text-foreground/85">
-                {getTextExcerpt(latestPost.content)}
-              </div>
-
-              <Link
-                href={`/blog/${latestPost.slug}`}
-                className="inline-block mt-4 px-4 py-2 text-sm bg-muted/50 border border-border/50 rounded-lg hover:bg-muted hover:border-border transition-colors"
-              >
-                Read more
-              </Link>
-            </article>
-          </section>
-        )}
-
-        {/* Latest DJ Set Section */}
-        {latestMix && (
-          <section className="mb-14">
-            <div className="flex justify-between items-center mb-5">
-              <h2 className="text-2xl font-bold tracking-tight">
-                Latest DJ Set
-              </h2>
-              <Link
-                href="/dj-sets"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors hover:underline underline-offset-4"
-              >
-                View all →
-              </Link>
+            <div className="flex justify-center pt-1.5">
+              <Button asChild size="lg">
+                <Link href="/shows">View more shows →</Link>
+              </Button>
             </div>
-            <article className="bg-card/50 border border-border/50 rounded-xl p-6 hover:border-border transition-colors">
-              <h3 className="text-xl font-semibold leading-tight tracking-tight">
-                <Link
-                  href={`/dj-sets/${latestMix.slug}`}
-                  className="hover:text-primary transition-colors"
-                >
-                  {latestMix.title}
-                </Link>
-              </h3>
-              <div className="text-sm text-muted-foreground mt-1.5">
-                {formatContentDate(latestMix.date)} by {latestMix.artist}
-              </div>
-
-              {latestMix.description && (
-                <div className="mt-3 leading-relaxed text-foreground/85">
-                  {latestMix.description}
-                </div>
-              )}
-
-              <div className="mt-4">
-                <SoundCloud
-                  url={latestMix.soundcloud_url}
-                  title={latestMix.title}
-                  artist={latestMix.artist}
-                  artist_url={latestMix.artist_url}
-                  track_url={latestMix.track_url}
-                />
-              </div>
-            </article>
           </section>
-        )}
-      </main>
-    </div>
+
+          <LatestRadioShows />
+
+          <ActivityFeedPlaceholder />
+        </div>
+      </div>
     </>
   )
 }

--- a/frontend/components/layout/Footer.test.tsx
+++ b/frontend/components/layout/Footer.test.tsx
@@ -27,13 +27,37 @@ describe('Footer', () => {
   it('renders copyright with current year', () => {
     render(<Footer />)
     const currentYear = new Date().getFullYear()
-    expect(screen.getByText(`\u00A9 ${currentYear} Psychic Homily`)).toBeInTheDocument()
+    expect(screen.getByText(`© ${currentYear} Psychic Homily`)).toBeInTheDocument()
   })
 
   it('renders footer element', () => {
     render(<Footer />)
     const footer = document.querySelector('footer')
     expect(footer).toBeInTheDocument()
+  })
+
+  it('renders the brand wordmark and sign-off (PSY-389 editorial footer)', () => {
+    render(<Footer />)
+    expect(screen.getByText('PSYCHIC HOMILY')).toBeInTheDocument()
+    expect(
+      screen.getByText('Made by the scene, for the scene.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the four labelled link columns (PSY-389)', () => {
+    render(<Footer />)
+    for (const label of ['Discover', 'Browse', 'Community', 'About']) {
+      expect(screen.getByRole('navigation', { name: label })).toBeInTheDocument()
+    }
+  })
+
+  it('renders Discover column links to real entity routes', () => {
+    render(<Footer />)
+    const discover = screen.getByRole('navigation', { name: 'Discover' })
+    expect(discover.querySelector('a[href="/shows"]')).toBeInTheDocument()
+    expect(discover.querySelector('a[href="/artists"]')).toBeInTheDocument()
+    expect(discover.querySelector('a[href="/venues"]')).toBeInTheDocument()
+    expect(discover.querySelector('a[href="/labels"]')).toBeInTheDocument()
   })
 
   it('renders Privacy Policy link', () => {
@@ -57,6 +81,14 @@ describe('Footer', () => {
     expect(link.closest('a')).toHaveAttribute('href', 'mailto:hello@psychichomily.com')
   })
 
+  it('renders Substack as an external link (new tab, noopener)', () => {
+    render(<Footer />)
+    const link = screen.getByText('Substack ↗').closest('a')!
+    expect(link).toHaveAttribute('href', 'https://psychichomily.substack.com/')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+  })
+
   it('renders Cookie Preferences button', () => {
     render(<Footer />)
     expect(screen.getByText('Cookie Preferences')).toBeInTheDocument()
@@ -77,22 +109,6 @@ describe('Footer', () => {
     expect(mockOpenPreferences).toHaveBeenCalledOnce()
   })
 
-  it('has nav element for navigation links', () => {
-    render(<Footer />)
-    const nav = document.querySelector('nav')
-    expect(nav).toBeInTheDocument()
-  })
-
-  it('renders all four nav items', () => {
-    render(<Footer />)
-    const nav = document.querySelector('nav')
-    // 3 links + 1 button
-    const links = nav?.querySelectorAll('a')
-    const buttons = nav?.querySelectorAll('button')
-    expect(links?.length).toBe(3)
-    expect(buttons?.length).toBe(1)
-  })
-
   it('Cookie Preferences button click fires openPreferences exactly once and does not navigate', async () => {
     const user = userEvent.setup()
     render(<Footer />)
@@ -106,29 +122,19 @@ describe('Footer', () => {
     expect(mockOpenPreferences).toHaveBeenCalledTimes(2)
   })
 
-  it('uses the same href for Privacy and Cookie Preferences contexts (privacy page)', () => {
+  it('keeps Privacy and Cookie Preferences as independent UX paths', () => {
     render(<Footer />)
     // Privacy link is the long-form policy page; the cookie preferences
-    // dialog is a separate trigger. Pin that they're independent UX paths.
+    // dialog is a separate trigger. Pin that they're independent.
     const privacy = screen.getByText('Privacy Policy').closest('a')!
     const cookie = screen.getByText('Cookie Preferences')
     expect(privacy.getAttribute('href')).toBe('/privacy')
     expect(cookie.tagName).toBe('BUTTON') // NOT a link to /privacy
   })
 
-  it('keeps Privacy Policy and Terms of Service links in tab order before Contact', () => {
-    render(<Footer />)
-    const nav = document.querySelector('nav')!
-    const linkTexts = Array.from(nav.querySelectorAll('a')).map(a => a.textContent)
-    // The legal pair must come first so screen-reader / keyboard users hit
-    // them before the mailto. If a future refactor reorders these silently,
-    // this catches it.
-    expect(linkTexts).toEqual(['Privacy Policy', 'Terms of Service', 'Contact'])
-  })
-
   it('renders the year as a 4-digit number, not NaN or 0', () => {
     render(<Footer />)
-    const text = screen.getByText(/Psychic Homily/).textContent ?? ''
+    const text = screen.getByText(/© .* Psychic Homily/).textContent ?? ''
     // Pin the format: 4-digit year, NOT "NaN" or "0" (defensive against
     // a regression that pre-computes the year at module load with a
     // broken Date constructor).

--- a/frontend/components/layout/Footer.tsx
+++ b/frontend/components/layout/Footer.tsx
@@ -3,42 +3,152 @@
 import Link from 'next/link'
 import { useCookieConsent } from '@/lib/context/CookieConsentContext'
 
+/**
+ * Footer (PSY-389) — the editorial site footer from the Navigation & Discovery
+ * Redesign (Figma `491:29`). Rendered globally in `app/layout.tsx`, so it
+ * applies to every page, not just home.
+ *
+ * Brand col + four link columns (Discover / Browse / Community / About) + a
+ * bottom sign-off row. The legacy footer's legal affordances are preserved in
+ * the About column (Privacy, Terms, Contact) plus the Cookie Preferences
+ * trigger — cookie consent is a button (it opens the preferences dialog), never
+ * a navigation link.
+ *
+ * Link destinations are real routes only; the Figma "About / FAQ / Vision"
+ * labels reference pages that don't exist yet, so the About column ships the
+ * meta/legal links we actually have (PSY-389 scope-adjacent note).
+ */
+
+interface FooterColumn {
+  heading: string
+  links: ReadonlyArray<{ href: string; label: string; external?: boolean }>
+}
+
+const FOOTER_COLUMNS: ReadonlyArray<FooterColumn> = [
+  {
+    heading: 'Discover',
+    links: [
+      { href: '/shows', label: 'Shows' },
+      { href: '/artists', label: 'Artists' },
+      { href: '/venues', label: 'Venues' },
+      { href: '/releases', label: 'Releases' },
+      { href: '/labels', label: 'Labels' },
+      { href: '/festivals', label: 'Festivals' },
+    ],
+  },
+  {
+    heading: 'Browse',
+    links: [
+      { href: '/explore', label: 'Explore' },
+      { href: '/collections', label: 'Collections' },
+      { href: '/charts', label: 'Charts' },
+      { href: '/tags', label: 'Tags' },
+      { href: '/scenes', label: 'Scenes' },
+      { href: '/radio', label: 'Radio' },
+    ],
+  },
+  {
+    heading: 'Community',
+    links: [
+      { href: '/contribute', label: 'Contribute' },
+      { href: '/requests', label: 'Requests' },
+      { href: '/community/leaderboard', label: 'Leaderboard' },
+      { href: '/shows/submit', label: 'Submit a show' },
+    ],
+  },
+]
+
 export default function Footer() {
   const { openPreferences } = useCookieConsent()
   const currentYear = new Date().getFullYear()
 
   return (
-    <footer className="w-full border-t border-border/30 mt-auto">
-      <div className="max-w-7xl mx-auto px-4 py-4">
-        <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted-foreground">
-          <p>&copy; {currentYear} Psychic Homily</p>
-          <nav className="flex items-center gap-4">
+    <footer className="mt-auto w-full border-t border-border/60">
+      <div className="mx-auto max-w-7xl px-4 pb-10 pt-11 md:px-8">
+        <div className="flex flex-col gap-10 md:flex-row md:items-start">
+          {/* Brand column */}
+          <div className="flex flex-col gap-2.5 md:w-80">
+            <div className="flex items-center gap-2.5">
+              <span
+                className="size-5 shrink-0 rounded-full bg-primary"
+                aria-hidden
+              />
+              <span className="text-sm font-semibold tracking-wide text-foreground">
+                PSYCHIC HOMILY
+              </span>
+            </div>
+            <p className="text-[13px] text-muted-foreground">
+              Live shows + the knowledge graph. The underground, mapped — link by
+              link.
+            </p>
+          </div>
+
+          {/* Link columns */}
+          {FOOTER_COLUMNS.map(column => (
+            <nav
+              key={column.heading}
+              aria-label={column.heading}
+              className="flex flex-1 flex-col gap-2.5"
+            >
+              <p className="font-mono text-[10px] font-bold tracking-[0.12em] text-muted-foreground">
+                {column.heading.toUpperCase()}
+              </p>
+              {column.links.map(link => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
+          ))}
+
+          {/* About / meta column — real routes only (see header note). */}
+          <nav aria-label="About" className="flex flex-1 flex-col gap-2.5">
+            <p className="font-mono text-[10px] font-bold tracking-[0.12em] text-muted-foreground">
+              ABOUT
+            </p>
             <Link
               href="/privacy"
-              className="hover:text-foreground transition-colors"
+              className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               Privacy Policy
             </Link>
             <Link
               href="/terms"
-              className="hover:text-foreground transition-colors"
+              className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               Terms of Service
             </Link>
             <Link
               href="mailto:hello@psychichomily.com"
-              className="hover:text-foreground transition-colors"
+              className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               Contact
             </Link>
             <button
               type="button"
               onClick={openPreferences}
-              className="hover:text-foreground transition-colors"
+              className="text-left text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               Cookie Preferences
             </button>
+            <a
+              href="https://psychichomily.substack.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Substack ↗
+            </a>
           </nav>
+        </div>
+
+        <div className="mt-8 flex flex-col gap-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <p>&copy; {currentYear} Psychic Homily</p>
+          <p>Made by the scene, for the scene.</p>
         </div>
       </div>
     </footer>

--- a/frontend/e2e/pages/home.spec.ts
+++ b/frontend/e2e/pages/home.spec.ts
@@ -5,17 +5,23 @@ test.describe('Homepage', () => {
   test('loads and displays upcoming shows', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/')
 
-    // Page title
+    // Page title (PSY-389: global "%s | Psychic Homily" template, no
+    // "Arizona Music Community").
     await expect(page).toHaveTitle(/Psychic Homily/)
 
-    // "Upcoming Shows" section heading
+    // Discovery hero (PSY-389)
+    await expect(
+      page.getByRole('heading', { name: 'This is not a mirage.' })
+    ).toBeVisible()
+
+    // "Upcoming shows" section heading
     await expect(
       page.getByRole('heading', { name: /upcoming shows/i })
     ).toBeVisible()
 
-    // "View all" link to /shows
+    // "View all shows" link to /shows (quiet link above the list)
     await expect(
-      page.getByRole('link', { name: /view all/i }).first()
+      page.getByRole('link', { name: /view all shows/i }).first()
     ).toBeVisible()
 
     // Wait for show cards to load (client-side fetch via TanStack Query)
@@ -53,17 +59,36 @@ test.describe('Homepage', () => {
     await expect(page.getByRole('menuitem', { name: 'DJ Sets' })).toBeVisible()
   })
 
-  test('displays blog and DJ set sections', async ({ page }) => {
+  test('displays discovery sections and footer (PSY-389)', async ({ page }) => {
     await page.goto('/')
 
-    // Blog section (server-rendered from markdown files)
+    // Discover quick-links row in the hero
     await expect(
-      page.getByRole('heading', { name: /latest from the blog/i })
+      page.getByRole('link', { name: 'Shows in any city' })
     ).toBeVisible()
 
-    // DJ Set section (server-rendered from markdown files)
+    // Latest radio shows section + cards that link to /radio
     await expect(
-      page.getByRole('heading', { name: /latest dj set/i })
+      page.getByRole('heading', { name: /latest radio shows/i })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /KEXP.*Variety Mix/i })
+    ).toHaveAttribute('href', '/radio')
+
+    // Across the scene — reserved activity-feed placeholder
+    await expect(
+      page.getByRole('heading', { name: /across the scene/i })
+    ).toBeVisible()
+    await expect(
+      page.getByText('Reserved for the Activity feed')
+    ).toBeVisible()
+
+    // Editorial footer columns (PSY-389)
+    await expect(
+      page.getByRole('navigation', { name: 'Discover' })
+    ).toBeVisible()
+    await expect(
+      page.getByText('Made by the scene, for the scene.')
     ).toBeVisible()
   })
 })

--- a/frontend/features/home/components/ActivityFeedPlaceholder.test.tsx
+++ b/frontend/features/home/components/ActivityFeedPlaceholder.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ActivityFeedPlaceholder } from './ActivityFeedPlaceholder'
+
+describe('ActivityFeedPlaceholder', () => {
+  it('renders the "Across the scene" section heading', () => {
+    render(<ActivityFeedPlaceholder />)
+    expect(
+      screen.getByRole('heading', { name: /across the scene/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the reserved-slot label (placeholder, not a live feed)', () => {
+    render(<ActivityFeedPlaceholder />)
+    expect(
+      screen.getByText('Reserved for the Activity feed')
+    ).toBeInTheDocument()
+  })
+
+  it('credits the Following Feed project that owns the real feed', () => {
+    render(<ActivityFeedPlaceholder />)
+    expect(screen.getByText(/PSY-988/)).toBeInTheDocument()
+  })
+
+  it('does not render any interactive links (it is a static placeholder)', () => {
+    const { container } = render(<ActivityFeedPlaceholder />)
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+  })
+})

--- a/frontend/features/home/components/ActivityFeedPlaceholder.tsx
+++ b/frontend/features/home/components/ActivityFeedPlaceholder.tsx
@@ -1,0 +1,73 @@
+/**
+ * ActivityFeedPlaceholder (PSY-389) — the reserved "Across the scene" slot on
+ * the logged-out homepage (Figma `491:29`, section "Across the scene").
+ *
+ * Per the PSY-389 decision this is a tasteful RESERVED placeholder for v1, NOT
+ * a live feed. The real activity feed is owned by the separate "Following Feed
+ * — Personalized Activity" project (PSY-988–991): logged-out will show a public
+ * "across the scene" pulse, logged-in shows activity from who/what you follow,
+ * powered by the `activity_events` spine. That project's feed-surface ticket
+ * delivers this placement; here we ship only the reserved dashed slot so the
+ * page layout is final and the cross-project dependency is visible.
+ *
+ * The sample rows are illustrative of the eventual feed shape — they are static
+ * examples inside the placeholder, deliberately not wired to any data source.
+ */
+
+const SAMPLE_ITEMS: ReadonlyArray<{ text: string; age: string }> = [
+  { text: '@scenekid added 3 shows in Phoenix', age: '2h' },
+  { text: 'New collection — “Pacific NW Post-Hardcore” by @oly92', age: '5h' },
+  { text: 'Field note on Bikini Kill @ The Rebel Lounge by @riotfan', age: '6h' },
+  { text: 'Unwound · “Repetition” linked to Kill Rock Stars', age: '1d' },
+]
+
+export function ActivityFeedPlaceholder() {
+  return (
+    <section
+      aria-labelledby="home-activity-heading"
+      className="flex w-full flex-col gap-4"
+    >
+      <div className="flex items-center justify-between">
+        <h2
+          id="home-activity-heading"
+          className="text-2xl font-semibold tracking-tight text-foreground"
+        >
+          Across the scene
+        </h2>
+        <span className="font-mono text-xs text-muted-foreground">
+          Following Feed · in design →
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-[13px] rounded-xl border-[1.5px] border-dashed border-border px-[22px] py-5">
+        <p className="text-[15px] font-semibold text-foreground">
+          Reserved for the Activity feed
+        </p>
+        <p className="text-[13px] text-muted-foreground">
+          Logged-out: a public &ldquo;across the scene&rdquo; pulse. Logged-in:
+          activity from the artists, labels, venues, radio shows &amp; people you
+          follow. Powered by the <code>activity_events</code> spine.
+        </p>
+
+        <ul className="flex flex-col gap-[9px] py-1" aria-hidden>
+          {SAMPLE_ITEMS.map(item => (
+            <li key={item.text} className="flex items-center gap-[9px]">
+              <span className="text-[8px] text-primary">●</span>
+              <span className="flex-1 text-[13px] font-medium text-muted-foreground">
+                {item.text}
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground">
+                {item.age}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <p className="font-mono text-[11px] text-muted-foreground">
+          ↳ Designed in the &ldquo;Following Feed — Personalized Activity&rdquo;
+          Linear project (PSY-988&ndash;991).
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/frontend/features/home/components/HomeHero.test.tsx
+++ b/frontend/features/home/components/HomeHero.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HomeHero } from './HomeHero'
+
+const mockOpenCommandPalette = vi.fn()
+
+vi.mock('@/lib/hooks/common/useCommandPalette', () => ({
+  openCommandPalette: () => mockOpenCommandPalette(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+describe('HomeHero', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the "This is not a mirage." headline as the page h1', () => {
+    render(<HomeHero />)
+    const heading = screen.getByRole('heading', { name: 'This is not a mirage.' })
+    expect(heading.tagName).toBe('H1')
+  })
+
+  it('opens the command palette when the hero search is clicked', async () => {
+    const user = userEvent.setup()
+    render(<HomeHero />)
+    await user.click(
+      screen.getByRole('button', { name: /search shows, artists, labels/i })
+    )
+    expect(mockOpenCommandPalette).toHaveBeenCalledOnce()
+  })
+
+  it('renders "Find a show" as a primary CTA linking to /shows (value-before-contribution)', () => {
+    render(<HomeHero />)
+    const cta = screen.getByRole('link', { name: 'Find a show' })
+    expect(cta).toHaveAttribute('href', '/shows')
+  })
+
+  it('renders the Discover quick-links to their canonical destinations', () => {
+    render(<HomeHero />)
+    const expected: Array<[string, string]> = [
+      ['Shows in any city', '/shows'],
+      ['Artists', '/artists'],
+      ['Freeform Radio', '/radio'],
+      ['Record Labels', '/labels'],
+      ['and more', '/explore'],
+    ]
+    for (const [label, href] of expected) {
+      expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+        'href',
+        href
+      )
+    }
+  })
+
+  it('renders a quiet Sign up nudge to /auth (not a contribution CTA)', () => {
+    render(<HomeHero />)
+    expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute(
+      'href',
+      '/auth'
+    )
+  })
+})

--- a/frontend/features/home/components/HomeHero.tsx
+++ b/frontend/features/home/components/HomeHero.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import Link from 'next/link'
+import { Search } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { openCommandPalette } from '@/lib/hooks/common/useCommandPalette'
+
+/**
+ * HomeHero (PSY-389) — the centered discovery-landing hero for the logged-out
+ * homepage (Figma `491:29`).
+ *
+ * Pure mystique by design: an oblique What.cd call-back headline + evocative
+ * two-line subtext, then a dominant search field and a "Find a show" primary
+ * CTA. The concrete "what is this" work rests on the search placeholder, the
+ * Discover quick-links row, and the sections below — never a contribution CTA
+ * (value-before-contribution).
+ *
+ * The search field reuses the existing command-palette mechanism
+ * (`openCommandPalette`, same as the nav `SearchTrigger`); it is presented
+ * wider here as the page's dominant action.
+ */
+
+/** Discover quick-links — acclimation row helping a newcomer find an entry. */
+const DISCOVER_LINKS: ReadonlyArray<{ href: string; label: string }> = [
+  { href: '/shows', label: 'Shows in any city' },
+  { href: '/artists', label: 'Artists' },
+  { href: '/radio', label: 'Freeform Radio' },
+  { href: '/labels', label: 'Record Labels' },
+  { href: '/explore', label: 'and more' },
+]
+
+export function HomeHero() {
+  return (
+    <section
+      aria-labelledby="home-hero-heading"
+      className="flex w-full flex-col items-center gap-4 pb-3.5 pt-6"
+    >
+      <h1
+        id="home-hero-heading"
+        className="text-center text-4xl font-bold tracking-tight text-foreground sm:text-5xl"
+      >
+        This is not a mirage.
+      </h1>
+
+      <div className="max-w-[720px] text-center text-base leading-relaxed text-muted-foreground sm:text-lg">
+        <p>You&rsquo;ve stumbled upon a door where your imagination is the limit.</p>
+        <p>Bring your true self without compromise, and you&rsquo;ll find your answers.</p>
+      </div>
+
+      {/* Dominant action: search + Find a show */}
+      <div className="flex w-full max-w-[600px] flex-col items-stretch gap-2.5 pt-1.5 sm:flex-row sm:items-center sm:justify-center">
+        <button
+          type="button"
+          onClick={() => openCommandPalette()}
+          aria-label="Search shows, artists, labels"
+          aria-keyshortcuts="Meta+K Control+K"
+          className="flex h-[52px] flex-1 items-center gap-2.5 rounded-[10px] border border-input bg-muted px-4 text-left text-base text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 sm:w-[480px] sm:flex-none"
+        >
+          <Search className="size-5 shrink-0" aria-hidden />
+          <span className="flex-1 truncate">Search shows, artists, labels…</span>
+          <kbd className="pointer-events-none hidden shrink-0 items-center rounded border border-input bg-background px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground sm:inline-flex">
+            ⌘K
+          </kbd>
+        </button>
+        <Button asChild size="lg" className="h-[52px] shrink-0 text-base">
+          <Link href="/shows">Find a show</Link>
+        </Button>
+      </div>
+
+      {/* Discover quick-links row */}
+      <nav
+        aria-label="Discover"
+        className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 pt-0.5 text-sm"
+      >
+        <span className="font-medium text-muted-foreground">Discover:</span>
+        {DISCOVER_LINKS.map((link, i) => (
+          <span key={link.href} className="inline-flex items-center">
+            <Link
+              href={link.href}
+              className="font-medium text-foreground transition-colors hover:text-primary hover:underline underline-offset-4"
+            >
+              {link.label}
+            </Link>
+            {i < DISCOVER_LINKS.length - 1 && (
+              <span className="ml-1.5 text-muted-foreground/60" aria-hidden>
+                ·
+              </span>
+            )}
+          </span>
+        ))}
+      </nav>
+
+      {/* Quiet sign-up nudge */}
+      <p className="flex items-center gap-2 pt-1 text-sm">
+        <span className="text-muted-foreground">New here?</span>
+        <Link
+          href="/auth"
+          className="font-semibold text-primary transition-colors hover:underline underline-offset-4"
+        >
+          Sign up
+        </Link>
+      </p>
+    </section>
+  )
+}

--- a/frontend/features/home/components/LatestRadioShows.test.tsx
+++ b/frontend/features/home/components/LatestRadioShows.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LatestRadioShows } from './LatestRadioShows'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+describe('LatestRadioShows', () => {
+  it('renders the section heading and a "Browse all stations" link to /radio', () => {
+    render(<LatestRadioShows />)
+    expect(
+      screen.getByRole('heading', { name: /latest radio shows/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /browse all stations/i })
+    ).toHaveAttribute('href', '/radio')
+  })
+
+  it('renders three station preview cards (KEXP / WFMU / NTS)', () => {
+    render(<LatestRadioShows />)
+    expect(screen.getByText('KEXP')).toBeInTheDocument()
+    expect(screen.getByText('WFMU')).toBeInTheDocument()
+    expect(screen.getByText('NTS')).toBeInTheDocument()
+  })
+
+  it('links every station card to /radio (PSY-389 decision: no D2-panel coupling)', () => {
+    render(<LatestRadioShows />)
+    const cardLinks = screen
+      .getAllByRole('link')
+      .filter(a => a.getAttribute('aria-label')?.includes('Browse radio'))
+    expect(cardLinks).toHaveLength(3)
+    for (const link of cardLinks) {
+      expect(link).toHaveAttribute('href', '/radio')
+    }
+  })
+})

--- a/frontend/features/home/components/LatestRadioShows.tsx
+++ b/frontend/features/home/components/LatestRadioShows.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link'
+
+/**
+ * LatestRadioShows (PSY-389) — three station preview cards on the logged-out
+ * homepage (Figma `491:29`, section "Latest radio shows").
+ *
+ * Per the PSY-389 decision these cards LINK to `/radio` and DO NOT depend on
+ * the Radio D2 station panel (PSY-1016, built in parallel) — coupling to that
+ * in-flight component would conflict. Each card is a static newcomer-facing
+ * teaser of one of the three real stations (KEXP / WFMU / NTS) that introduces
+ * the station to someone who's never heard of it, then sends them to the full
+ * `/radio` page to go deeper.
+ *
+ * The full live now-playing / vibe / recent-artists experience is the `/radio`
+ * page itself; these cards are the lobby's invitation into it.
+ */
+
+interface StationPreview {
+  /** Station call sign (KEXP / WFMU / NTS). */
+  station: string
+  /** Home city, shown next to the call sign. */
+  city: string
+  /** A representative show name. */
+  showName: string
+  /** One-line "what it's like" for a newcomer. */
+  vibe: string
+  /** A few representative artists, as a single middot-joined line. */
+  artists: string
+  /** Whether to flag the station as currently on air. */
+  live?: boolean
+}
+
+const STATIONS: ReadonlyArray<StationPreview> = [
+  {
+    station: 'KEXP',
+    city: 'Seattle',
+    showName: 'Variety Mix',
+    vibe: 'Eclectic host’s-choice',
+    artists: 'Sleater-Kinney · Wipers · Unwound',
+    live: true,
+  },
+  {
+    station: 'WFMU',
+    city: 'Jersey City',
+    showName: 'Wake and Bake',
+    vibe: 'Freeform, anything-goes',
+    artists: 'Stereolab · Broadcast · Pram',
+  },
+  {
+    station: 'NTS',
+    city: 'London',
+    showName: 'Charlie Bones',
+    vibe: 'Global morning show',
+    artists: 'Sun Ra · Alice Coltrane · Pharoah',
+  },
+]
+
+function StationCard({ preview }: { preview: StationPreview }) {
+  return (
+    <Link
+      href="/radio"
+      aria-label={`${preview.station} · ${preview.city} — ${preview.showName}. Browse radio.`}
+      className="flex flex-1 flex-col gap-[7px] rounded-xl border border-border bg-card p-[18px] transition-colors hover:border-foreground/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-[7px]">
+          <span className="font-mono text-sm font-bold text-foreground">
+            {preview.station}
+          </span>
+          <span className="text-xs text-muted-foreground">{preview.city}</span>
+        </div>
+        {preview.live && (
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="text-[8px] text-primary" aria-hidden>
+              ●
+            </span>
+            live
+          </span>
+        )}
+      </div>
+      <p className="text-[15px] font-semibold text-foreground">{preview.showName}</p>
+      <p className="text-xs text-muted-foreground">{preview.vibe}</p>
+      <p className="text-[13px] font-medium text-foreground">{preview.artists}</p>
+    </Link>
+  )
+}
+
+export function LatestRadioShows() {
+  return (
+    <section aria-labelledby="home-radio-heading" className="flex w-full flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2
+          id="home-radio-heading"
+          className="text-2xl font-semibold tracking-tight text-foreground"
+        >
+          Latest radio shows
+        </h2>
+        <Link
+          href="/radio"
+          className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary hover:underline underline-offset-4"
+        >
+          Browse all stations →
+        </Link>
+      </div>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-stretch">
+        {STATIONS.map(preview => (
+          <StationCard key={preview.station} preview={preview} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/features/home/index.ts
+++ b/frontend/features/home/index.ts
@@ -1,0 +1,5 @@
+// Public API for the home (logged-out discovery landing) feature module — PSY-389.
+
+export { HomeHero } from './components/HomeHero'
+export { LatestRadioShows } from './components/LatestRadioShows'
+export { ActivityFeedPlaceholder } from './components/ActivityFeedPlaceholder'


### PR DESCRIPTION
## Summary

Replaces the Arizona-framed blog/DJ-set logged-out homepage with the editorial discovery landing from the Navigation & Discovery Redesign (Figma `491:29`, file `XakQQ0nYGqnt77PrHKO9IE`). Logged-out only — the logged-in customizable dashboard is a separate project.

Section stack (top → bottom):
- **Hero** (`HomeHero`) — centered "This is not a mirage." headline + two-line evocative subtext + dominant search (reuses `openCommandPalette`, same mechanism as the nav `SearchTrigger`) + "Find a show" primary CTA + Discover quick-links row (Shows in any city → `/shows` · Artists → `/artists` · Freeform Radio → `/radio` · Record Labels → `/labels` · and more → `/explore`) + quiet "New here? Sign up". Value-before-contribution: no contribution CTA on the hero.
- **Upcoming shows** — reuses `HomeShowList` as-is (city filter + geo default via `/api/geo` + popular-cities row — shared filter/geo components consumed unchanged) with a quiet "View all shows →" above and a prominent "View more shows →" primary CTA below.
- **Latest radio shows** (`LatestRadioShows`) — 3 static station preview cards (KEXP/WFMU/NTS) that LINK to `/radio`. Deliberately NOT coupled to the in-flight Radio D2 panel (PSY-1016).
- **Across the scene** (`ActivityFeedPlaceholder`) — reserved dashed placeholder for v1; the real feed is owned by the Following Feed project (PSY-988–991).
- **Footer** — replaces the minimal global footer with the editorial brand + Discover/Browse/Community/About columns + sign-off (rendered globally via `layout.tsx`). Legal/cookie affordances preserved (Privacy, Terms, Contact, Cookie Preferences trigger, Substack).

Title: dropped "Arizona Music Community". Next.js does NOT apply a layout's `title.template` to a page in the same route segment as that layout — and the root `page.tsx` shares the root `layout.tsx` segment — so the global "%s | Psychic Homily" template can't decorate this page; set via `title.absolute` → "Discover live music | Psychic Homily" (matches the template output). Stale blog/DJ-set hero removed.

Deferred (NOT in v1, per ticket): Trending & newly added, Featured collections, From the blog & DJ sets.

## Test plan
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors (pre-existing warnings only, none in new files)
- [x] `cd frontend && bun run test:run components/layout/Footer.test.tsx features/home` — 27 passed (15 Footer + 12 home-component)
- [x] `cd frontend && bun run test:run app` — 338 passed; 1 unrelated flake (`app/admin/page.test.tsx` lazy-load `waitFor` timeout under full-suite parallel load — passes in isolation, untouched by this PR)

## Manual repro
Brought up the dispatch stack (`stack-up.sh --mode`), loaded the homepage LOGGED OUT in an isolated agent-browser Chrome, and verified:
- Title renders "Discover live music | Psychic Homily" (in-browser + server HTML).
- Hero: headline, subtext, search field (opens command palette), "Find a show" → `/shows`, Discover row (all 5 links → correct hrefs), "Sign up" → `/auth`.
- Upcoming shows: city filter defaulted to the derived city (Phoenix); clicking the Tucson popular-city button switched the selection; "View all shows →" + "View more shows →" both present.
- Latest radio shows: 3 cards (KEXP/WFMU/NTS) all link to `/radio` (verified hrefs).
- Across the scene: reserved dashed placeholder rendered.
- Footer: Discover/Browse/Community/About columns + "Made by the scene, for the scene." sign-off.

## Screenshots
**Hero**
![hero](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-389-screenshots/hero.png)

**Full page**
![full page](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-389-screenshots/full-page.png)

## Code review
`/code-review` (inline, sub-agent worktree — 9 finder angles across reuse/quality/efficiency/correctness). **No correctness bugs found.** Notable: the old `page.tsx` rendered its own `<main>` nested inside the layout's `<main id="main-content">` (duplicate landmark) — the new page removes it (a11y improvement). Server/client split is optimal (only `HomeHero` ships client JS; radio cards + activity placeholder are static server components). Footer About column intentionally links real routes only (Figma's About/FAQ/Vision reference unbuilt pages) — documented in-code.

## Adversarial review
`/adversarial-review` — CLEAN (no findings, no fixes commit).
- **Saboteur:** CLEAN — static content + reused components handle their own empty/error/loading states; no new breakable inputs/state.
- **Future-Maintainer:** CLEAN — clear names; WHY-comments on the `title.absolute` quirk, the no-D2-coupling decision, and the footer route-reality gap.
- **Security:** CLEAN — no input/auth/injection surface; Substack external link uses `rel="noopener noreferrer"`.
- **Completeness:** CLEAN — all AC met. The activity-header "Following Feed · in design →" is a non-interactive label (correct: the real feed is unbuilt; the existing `/following` route is a different, logged-in follow-management feature).

Panel ran inline against the branch diff (dispatched sub-agent — no Agent tool in worktree).

Closes PSY-389
