### PR TITLE
PSY-1025: land Profile on the user public identity view

### DIFF
--- a/frontend/components/contributor/PublicProfile.test.tsx
+++ b/frontend/components/contributor/PublicProfile.test.tsx
@@ -175,6 +175,37 @@ describe('PublicProfile', () => {
     ).toBeInTheDocument()
   })
 
+  it('does NOT show "Edit profile" on a visitor view of a private profile', () => {
+    mockUser = { username: 'bob' }
+    mockUsePublicProfile.mockReturnValue({
+      data: makeProfile({ username: 'alice', profile_visibility: 'private' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<PublicProfile username="alice" />)
+    expect(screen.getByText('Private Profile')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /edit profile/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows owner copy + Edit affordance on the owner view of a private profile', () => {
+    // The backend returns the private profile to its owner; the owner must be
+    // able to reach settings to change visibility (PSY-1025).
+    mockUser = { username: 'alice' }
+    mockUsePublicProfile.mockReturnValue({
+      data: makeProfile({ username: 'alice', profile_visibility: 'private' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<PublicProfile username="alice" />)
+    expect(screen.getByText('Your Profile Is Private')).toBeInTheDocument()
+    const editLink = screen.getByRole('link', { name: /edit profile/i })
+    expect(editLink).toHaveAttribute('href', '/profile')
+  })
+
   it('renders null when profile data is missing', () => {
     mockUsePublicProfile.mockReturnValue({
       data: null,

--- a/frontend/components/contributor/PublicProfile.test.tsx
+++ b/frontend/components/contributor/PublicProfile.test.tsx
@@ -31,6 +31,15 @@ vi.mock('@/features/auth', () => ({
     mockUsePublicContributions(username, opts),
 }))
 
+// Owner-detection compares the logged-in user (from AuthContext) against the
+// viewed profile's username. Default to an anonymous viewer; owner tests set
+// mockUser explicitly. PSY-1025.
+let mockUser: { username?: string } | null = null
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ user: mockUser }),
+}))
+
 // Mock child components
 vi.mock('./UserTierBadge', () => ({
   UserTierBadge: ({ tier }: { tier: string }) => (
@@ -97,6 +106,7 @@ describe('PublicProfile', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-19T12:00:00Z'))
     mockUsePublicContributions.mockReturnValue({ data: null })
+    mockUser = null
   })
 
   afterEach(() => {
@@ -523,5 +533,77 @@ describe('PublicProfile', () => {
     // Should show full stats, not just count
     expect(screen.getByTestId('stats-grid')).toBeInTheDocument()
     expect(screen.queryByText(/total contributions/)).not.toBeInTheDocument()
+  })
+
+  // --- Owner-only Edit affordance (PSY-1025) ---
+
+  it('shows "Edit profile" affordance to the profile owner', () => {
+    mockUser = { username: 'alice' }
+    mockUsePublicProfile.mockReturnValue({
+      data: makeProfile({ username: 'alice' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<PublicProfile username="alice" />)
+    const editLink = screen.getByRole('link', { name: /edit profile/i })
+    expect(editLink).toBeInTheDocument()
+    expect(editLink).toHaveAttribute('href', '/profile')
+  })
+
+  it('matches owner case-insensitively (URL casing differs from stored)', () => {
+    mockUser = { username: 'Alice' }
+    mockUsePublicProfile.mockReturnValue({
+      data: makeProfile({ username: 'alice' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<PublicProfile username="alice" />)
+    expect(
+      screen.getByRole('link', { name: /edit profile/i })
+    ).toBeInTheDocument()
+  })
+
+  it('does NOT show "Edit profile" to a different logged-in user', () => {
+    mockUser = { username: 'bob' }
+    mockUsePublicProfile.mockReturnValue({
+      data: makeProfile({ username: 'alice' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<PublicProfile username="alice" />)
+    expect(
+      screen.queryByRole('link', { name: /edit profile/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does NOT show "Edit profile" to an anonymous visitor', () => {
+    mockUser = null
+    mockUsePublicProfile.mockReturnValue({
+      data: makeProfile({ username: 'alice' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<PublicProfile username="alice" />)
+    expect(
+      screen.queryByRole('link', { name: /edit profile/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does NOT match owner when the logged-in user has no username', () => {
+    mockUser = {}
+    mockUsePublicProfile.mockReturnValue({
+      data: makeProfile({ username: 'alice' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<PublicProfile username="alice" />)
+    expect(
+      screen.queryByRole('link', { name: /edit profile/i })
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontend/components/contributor/PublicProfile.tsx
+++ b/frontend/components/contributor/PublicProfile.tsx
@@ -1,8 +1,11 @@
 'use client'
 
+import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Lock, CalendarDays, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Lock, CalendarDays, Clock, Pencil } from 'lucide-react'
+import { useAuthContext } from '@/lib/context/AuthContext'
 import { ActivityHeatmap } from './ActivityHeatmap'
 import { UserTierBadge } from './UserTierBadge'
 import { ContributionStatsGrid } from './ContributionStatsGrid'
@@ -62,6 +65,8 @@ interface PublicProfileProps {
 }
 
 export function PublicProfile({ username }: PublicProfileProps) {
+  const { user } = useAuthContext()
+
   const {
     data: profile,
     isLoading,
@@ -71,6 +76,17 @@ export function PublicProfile({ username }: PublicProfileProps) {
   const {
     data: contributionsData,
   } = usePublicContributions(username, { limit: 10 })
+
+  // The viewer is the profile owner when their logged-in username matches the
+  // profile being viewed. Compared case-insensitively only to stay robust to
+  // URL casing — it gates ONLY a convenience "Edit profile" affordance and
+  // exposes no owner-only data, so a spurious match would leak nothing (the
+  // /profile edit route is itself auth-gated and scoped to the logged-in user
+  // server-side; this is a UI shortcut, not an authorization boundary). PSY-1025.
+  const isOwner = Boolean(
+    user?.username &&
+      user.username.toLowerCase() === username.toLowerCase()
+  )
 
   if (isLoading) {
     return <ProfileSkeleton />
@@ -135,6 +151,22 @@ export function PublicProfile({ username }: PublicProfileProps) {
       {/* Profile Header */}
       <div className="mb-8">
         <div className="flex items-start gap-4">
+          {/* Owner-only Edit affordance: links to the settings/edit form.
+              Rendered only for the logged-in profile owner; visitors never
+              see it. PSY-1025. */}
+          {isOwner && (
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="order-last ml-auto shrink-0"
+            >
+              <Link href="/profile">
+                <Pencil className="mr-1.5 size-3.5" />
+                Edit profile
+              </Link>
+            </Button>
+          )}
           {/* Avatar */}
           {profile.avatar_url ? (
             <img

--- a/frontend/components/contributor/PublicProfile.tsx
+++ b/frontend/components/contributor/PublicProfile.tsx
@@ -123,7 +123,12 @@ export function PublicProfile({ username }: PublicProfileProps) {
     return null
   }
 
-  // Private profile
+  // Private profile. The backend returns this page to the owner even when
+  // private (with full owner data), so without the isOwner branch an owner
+  // who clicks "Profile" (which now routes here) would hit a dead-end wall
+  // with no way to reach settings. Give the owner their own copy + the Edit
+  // affordance so they can change visibility; visitors keep the plain wall.
+  // PSY-1025.
   if (profile.profile_visibility === 'private') {
     return (
       <div className="container max-w-4xl mx-auto px-4 py-12">
@@ -131,10 +136,22 @@ export function PublicProfile({ username }: PublicProfileProps) {
           <div className="inline-flex h-16 w-16 items-center justify-center rounded-full bg-muted mb-4">
             <Lock className="h-8 w-8 text-muted-foreground" />
           </div>
-          <h1 className="text-2xl font-bold mb-2">Private Profile</h1>
+          <h1 className="text-2xl font-bold mb-2">
+            {isOwner ? 'Your Profile Is Private' : 'Private Profile'}
+          </h1>
           <p className="text-muted-foreground">
-            This user&apos;s profile is set to private.
+            {isOwner
+              ? 'Only you can see this page. Edit your profile to make it public.'
+              : "This user's profile is set to private."}
           </p>
+          {isOwner && (
+            <Button asChild variant="outline" size="sm" className="mt-6">
+              <Link href="/profile">
+                <Pencil className="mr-1.5 size-3.5" />
+                Edit profile
+              </Link>
+            </Button>
+          )}
         </div>
       </div>
     )

--- a/frontend/components/layout/TopBar.test.tsx
+++ b/frontend/components/layout/TopBar.test.tsx
@@ -29,6 +29,7 @@ const mockLogout = vi.fn()
 type MockAuthContextValue = {
   user: {
     email: string
+    username?: string
     first_name?: string
     last_name?: string
     is_admin: boolean
@@ -196,6 +197,36 @@ describe('TopBar', () => {
       await user.click(screen.getByRole('button', { name: 'User menu' }))
       expect(await screen.findByRole('menuitem', { name: 'Profile' })).toBeInTheDocument()
       expect(screen.queryByRole('menuitem', { name: 'Admin' })).not.toBeInTheDocument()
+    })
+
+    // PSY-1025: "Profile" lands the user on their OWN public identity view,
+    // not the settings form.
+    it('points "Profile" at the user public identity page when they have a username', async () => {
+      mockAuthContext.mockReturnValue({
+        user: { email: 'user@test.com', username: 'reggie', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      })
+      const user = userEvent.setup()
+      render(<TopBar />)
+      await user.click(screen.getByRole('button', { name: 'User menu' }))
+      const profileItem = await screen.findByRole('menuitem', { name: 'Profile' })
+      expect(profileItem).toHaveAttribute('href', '/users/reggie')
+    })
+
+    it('falls back "Profile" to /profile (settings) when the user has no username', async () => {
+      mockAuthContext.mockReturnValue({
+        user: { email: 'user@test.com', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      })
+      const user = userEvent.setup()
+      render(<TopBar />)
+      await user.click(screen.getByRole('button', { name: 'User menu' }))
+      const profileItem = await screen.findByRole('menuitem', { name: 'Profile' })
+      expect(profileItem).toHaveAttribute('href', '/profile')
     })
   })
 

--- a/frontend/components/layout/nav/UserMenu.tsx
+++ b/frontend/components/layout/nav/UserMenu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Loader2, LogOut, Shield, Settings, Library, Bell } from 'lucide-react'
+import { Loader2, LogOut, Shield, UserCircle, Library, Bell } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -30,6 +30,15 @@ export function UserMenu() {
   }
 
   if (isAuthenticated && user) {
+    // "Profile" lands the user on their OWN public identity view
+    // (`/users/[username]`) — the same dense page visitors see — not the
+    // settings form. The route is keyed on username, which is nullable
+    // (OAuth-only accounts; see users.username migration). When the user has
+    // no username yet, fall back to /profile (the settings form, where they
+    // can set one) so the link is never broken. Mirrors the UserAttribution
+    // linkability rule (only link when username is non-empty). PSY-1025.
+    const profileHref = user.username ? `/users/${user.username}` : '/profile'
+
     return (
       <div className="flex items-center gap-1">
         <NotificationBell />
@@ -70,8 +79,8 @@ export function UserMenu() {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <Link href="/profile">
-                  <Settings className="mr-2 size-4" />
+                <Link href={profileHref}>
+                  <UserCircle className="mr-2 size-4" />
                   Profile
                 </Link>
               </DropdownMenuItem>


### PR DESCRIPTION
## Summary

Clicking **Profile** in the account menu previously opened the account settings/edit form at `/profile`. It now lands the logged-in user on their **own public identity view** — the same dense `/users/[username]` page visitors see (contribution stats grid, activity heatmap, percentile rankings, recent activity, collections) — with an **owner-only "Edit profile"** affordance linking back to `/profile` for settings.

This closes the gap called out in `docs/research/gazelle-user-profiles.md`: *"Our current profile page is a settings form. Gazelle's was an identity hub."* No new stats backend — the public profile + dense stats already existed (`PublicProfile` / `ContributionStatsGrid`); this just re-points the entry and adds the owner affordance.

### What changed
- **`components/layout/nav/UserMenu.tsx`** — the live desktop "Profile" entry (the avatar dropdown; the only nav entry actually labeled "Profile" after the PSY-1013/1014/1015 nav rework) now routes to `/users/{username}`. Username is **nullable** (OAuth-only accounts; `users.username` is `UNIQUE` but `NULL`-able per migration `000001`), so it falls back to `/profile` when the user has no username yet — mirroring the `UserAttribution` linkability rule (only link when username is non-empty). Icon swapped `Settings` → `UserCircle` to reflect the identity destination.
- **`components/contributor/PublicProfile.tsx`** — derives `isOwner` by comparing the logged-in username (`AuthContext`) to the viewed profile (case-insensitively, to be robust to URL casing). Owner sees an "Edit profile" button → `/profile`; visitors do not. Also made the **private-profile branch owner-aware** (see Adversarial review).

`/profile` is already a tabbed settings page (Profile / Privacy / Sections / Settings), so **no settings restructure was needed** — it stays as the edit destination linked from the affordance.

### Owner-detection & the no-username case
- Owner-detection is a **UI shortcut, not an authorization boundary**: the affordance only links to `/profile`, which is itself auth-gated and user-scoped server-side. It exposes no owner-only data, so a spurious match would leak nothing.
- `/users/[username]` is keyed on username; the route param is route-guaranteed non-empty (`notFound()` on empty). When the *logged-in* user lacks a username, the nav entry falls back to `/profile` so the link is never broken.

## Test plan
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors (156 pre-existing warnings, none new in changed files)
- [x] `cd frontend && bun run test:run components/contributor components/layout app/profile` — 462 passed; the affected suites (`PublicProfile.test.tsx`, `TopBar.test.tsx`) pass with new coverage: owner-sees-Edit, case-insensitive match, different-user / anonymous / no-username do NOT see Edit, nav Profile → `/users/{username}`, no-username nav → `/profile`, owner-vs-visitor private-profile views.

## Manual repro
Ran the per-worktree dispatch stack (frontend-only, shared mode), signed in as a seeded user (`e2e-user@test.local`), set a username on it, and drove chrome-devtools:
- **Own profile**: clicking the user-menu "Profile" entry routes to `/users/{username}` (verified the menuitem href = `/users/testcontributor`); the page renders dense stats (Contributions, Shows Submitted, Activity heatmap, Recent Activity, Collections) and an **"Edit profile" → `/profile`** affordance.
- **Visitor view**: viewing another user's `/users/{username}` while logged in shows **no** Edit affordance.
- Verified light + dark. The owner-private-profile branch (added in the adversarial pass) is covered by unit tests.

## Screenshots
**Own profile, with Edit affordance (dark / light):**

![own dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1025-screenshots/01-owner-profile-with-edit-dark.png)
![own light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1025-screenshots/02-owner-profile-with-edit-light.png)

**User menu "Profile" entry points at the public identity page:**

![usermenu](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1025-screenshots/03-usermenu-profile-points-to-public-light.png)

**Visitor view, no Edit affordance (light / dark):**

![visitor light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1025-screenshots/04-visitor-view-no-edit-light.png)
![visitor dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1025-screenshots/05-visitor-view-no-edit-dark.png)

## Code review
`/code-review` (extra-high effort, 9 finder angles inline per the sub-agent fallback) — **no findings**. Verified: username path is URL-safe (server validates `[A-Za-z0-9_-]{3,30}`), empty-string username falls back correctly, `isOwner` short-circuits safely, single caller of `PublicProfile` is wrapped by the real `AuthProvider` in the root layout, and the local `isOwner` boolean follows the codebase's existing convention (comments compare by `user_id`, but the username-keyed profile API doesn't expose the profile's `user_id`, so username comparison is the appropriate local choice).

## Adversarial review
`/adversarial-review` — 1 finding addressed in commit `d31c6ac1` (4 lenses run inline: Saboteur · Future-Maintainer · Security · Completeness).
- **[MEDIUM] Owner viewing their OWN private profile hit a dead-end wall.** The backend returns a private profile to its owner (with full owner data; `contributor_profile.go:126-159`), but `PublicProfile` blanket-rendered the "Private Profile" wall for any private profile regardless of viewer — so an owner who set their profile private and then clicked "Profile" (which now routes to `/users/{username}`) would land on a wall with no path to settings. → Fixed: the private-profile branch is now owner-aware — the owner gets "Your Profile Is Private" copy + the Edit affordance → `/profile`; visitors keep the plain wall. Added tests for both.

## Scope deviation
None. The ticket allowed deferring a settings/tab restructure if it ballooned scope — but `/profile` is already a tabbed settings page, so no restructure was needed and nothing was deferred.

Closes PSY-1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
