### PR TITLE
PSY-1031: raise venue/artist shows limit cap from 50 to 200

### DIFF
--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -214,7 +214,7 @@ func (h *ArtistHandler) GetArtistHandler(ctx context.Context, req *GetArtistRequ
 type GetArtistShowsRequest struct {
 	ArtistID   string `path:"artist_id" doc:"Artist ID or slug" example:"the-national"`
 	Timezone   string `query:"timezone" doc:"Timezone for date filtering" example:"America/Phoenix"`
-	Limit      int    `query:"limit" default:"20" minimum:"1" maximum:"50" doc:"Maximum number of shows to return"`
+	Limit      int    `query:"limit" default:"20" minimum:"1" maximum:"200" doc:"Maximum number of shows to return (max 200)"`
 	TimeFilter string `query:"time_filter" doc:"Filter shows by time: upcoming, past, or all" example:"upcoming" enum:"upcoming,past,all"`
 }
 

--- a/backend/internal/api/handlers/catalog/shows_limit_tags_test.go
+++ b/backend/internal/api/handlers/catalog/shows_limit_tags_test.go
@@ -1,0 +1,38 @@
+package catalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestEntityShowsLimitTagsAllow200 locks the per-entity shows endpoints
+// (GET /venues/{id}/shows and GET /artists/{id}/shows) to a 200 limit cap so it
+// isn't silently lowered again. These endpoints list a single entity's shows and
+// can legitimately exceed 50 (e.g. a venue with 60+ upcoming shows). They are
+// limit/time_filter paged (no offset), so they don't belong in the admin
+// offset-pagination guard. See PSY-1031.
+func TestEntityShowsLimitTagsAllow200(t *testing.T) {
+	// Both endpoints share one limit contract — lock them to it together so the
+	// cap can't be silently lowered or drift apart between the two.
+	const expectedTag = `query:"limit" default:"20" minimum:"1" maximum:"200" doc:"Maximum number of shows to return (max 200)"`
+
+	for _, tc := range []struct {
+		name    string
+		request any
+	}{
+		{"venue shows", GetVenueShowsRequest{}},
+		{"artist shows", GetArtistShowsRequest{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requestType := reflect.TypeOf(tc.request)
+
+			limitField, ok := requestType.FieldByName("Limit")
+			if !ok {
+				t.Fatalf("%s is missing Limit field", requestType.Name())
+			}
+			if got := string(limitField.Tag); got != expectedTag {
+				t.Fatalf("Limit tag mismatch:\ngot:  %s\nwant: %s", got, expectedTag)
+			}
+		})
+	}
+}

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -167,7 +167,7 @@ func (h *VenueHandler) GetVenueHandler(ctx context.Context, req *GetVenueRequest
 type GetVenueShowsRequest struct {
 	VenueID    string `path:"venue_id" doc:"Venue ID or slug" example:"valley-bar-phoenix-az"`
 	Timezone   string `query:"timezone" doc:"Timezone for date filtering" example:"America/Phoenix"`
-	Limit      int    `query:"limit" default:"20" minimum:"1" maximum:"50" doc:"Maximum number of shows to return"`
+	Limit      int    `query:"limit" default:"20" minimum:"1" maximum:"200" doc:"Maximum number of shows to return (max 200)"`
 	TimeFilter string `query:"time_filter" doc:"Filter shows by time: upcoming, past, or all" example:"upcoming" enum:"upcoming,past,all"`
 }
 


### PR DESCRIPTION
## Summary

Raises the `limit` query-param cap from **50 → 200** on the two per-entity shows endpoints:

- `GET /venues/{id}/shows` (`GetVenueShowsRequest`)
- `GET /artists/{id}/shows` (`GetArtistShowsRequest`)

These list a single entity's shows but have no `offset`/cursor to page past the cap, so a venue/artist with >50 upcoming shows couldn't be retrieved in one call. Surfaced while ingesting **Thalia Hall** (63 upcoming shows) — `?limit=100` returned HTTP 422.

## Why 200

`200` is already the established ceiling for show listings here — the public `GET /shows` (`catalog/show.go`) and several admin show/artist/venue listings use `maximum:"200"`. This brings the two per-entity endpoints in line.

## Notes

- **Default unchanged (20)** — no behavior change for existing callers.
- **No service change** — `GetShowsForVenue` / `GetShowsForArtist` already pass `limit` straight to a query `LIMIT` with no secondary cap, and batch-load associations (no N+1 at 200; verified in review).
- Added a reflection tag-guard test (`shows_limit_tags_test.go`) locking both endpoints to the 200 contract — mirrors the existing admin `pagination_tags_test.go` pattern (kept separate because these endpoints are limit/time_filter paged, no `Offset` field).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/api/handlers/catalog/...` (incl. integration suites) — pass
- [x] New `TestEntityShowsLimitTagsAllow200` passes
- [x] `go vet ./internal/api/handlers/catalog/` clean
- [x] `/simplify` run (4-agent pass); applied the one in-scope cleanup (collapse duplicated tag literal to a shared `expectedTag` const)

Closes PSY-1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
