### PR TITLE
PSY-1033: scope home.spec E2E locators around the new global footer

### DIFF
--- a/frontend/e2e/pages/home.spec.ts
+++ b/frontend/e2e/pages/home.spec.ts
@@ -39,22 +39,26 @@ test.describe('Homepage', () => {
     await page.goto('/')
 
     // Top-bar primary nav (PSY-1013): explicit links + the menu triggers,
-    // visible on the default 1280x720 viewport (>= the lg breakpoint).
-    await expect(page.getByRole('link', { name: 'Shows' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Artists' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Browse the catalog' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Contribute' })).toBeVisible()
+    // visible on the default 1280x720 viewport (>= the lg breakpoint). Scope to
+    // the Primary nav landmark — the editorial footer (PSY-389) and the hero
+    // discovery row also expose "Shows"/"Artists" links, so an unscoped
+    // getByRole would strict-mode-violate.
+    const primaryNav = page.getByRole('navigation', { name: 'Primary' })
+    await expect(primaryNav.getByRole('link', { name: 'Shows' })).toBeVisible()
+    await expect(primaryNav.getByRole('link', { name: 'Artists' })).toBeVisible()
+    await expect(primaryNav.getByRole('button', { name: 'Browse the catalog' })).toBeVisible()
+    await expect(primaryNav.getByRole('button', { name: 'Contribute' })).toBeVisible()
 
     // Login link visible when not authenticated
     await expect(page.getByRole('link', { name: /login/i })).toBeVisible()
 
     // Destinations the retired sidebar exposed directly are now reachable
     // inside the menus (no discoverability regression — PSY-1013).
-    await page.getByRole('button', { name: 'Browse the catalog' }).click()
+    await primaryNav.getByRole('button', { name: 'Browse the catalog' }).click()
     await expect(page.getByRole('menuitem', { name: 'Venues' })).toBeVisible()
     await page.keyboard.press('Escape')
 
-    await page.getByRole('button', { name: 'Contribute' }).click()
+    await primaryNav.getByRole('button', { name: 'Contribute' }).click()
     await expect(page.getByRole('menuitem', { name: 'Blog' })).toBeVisible()
     await expect(page.getByRole('menuitem', { name: 'DJ Sets' })).toBeVisible()
   })
@@ -83,9 +87,11 @@ test.describe('Homepage', () => {
       page.getByText('Reserved for the Activity feed')
     ).toBeVisible()
 
-    // Editorial footer columns (PSY-389)
+    // Editorial footer columns (PSY-389). Scope to the footer landmark — the
+    // hero also renders a "Discover" quick-links nav, so an unscoped match is
+    // a strict-mode violation (two `navigation[name="Discover"]` on the page).
     await expect(
-      page.getByRole('navigation', { name: 'Discover' })
+      page.getByRole('contentinfo').getByRole('navigation', { name: 'Discover' })
     ).toBeVisible()
     await expect(
       page.getByText('Made by the scene, for the scene.')


### PR DESCRIPTION
## Summary

Restore main's full E2E suite (shard 3/4 was red). PSY-389's new **global editorial footer** + homepage discovery row added site-wide nav links that collided with two loose `home.spec.ts` locators (strict-mode violations):
- `home:38 "displays navigation links"` — `getByRole('link', { name: 'Shows' })` matched **5** elements → scoped the nav assertions to the **`Primary`** navigation landmark.
- `home:62 "displays discovery sections and footer"` — `getByRole('navigation', { name: 'Discover' })` matched **2** (hero quick-links + footer column) → scoped the footer assertion to **`contentinfo`**.

Both tests are **non-`@smoke`**, so the PR smoke runs never executed them — only `E2E Tests (shard 3/4)` on main caught it (the "full-E2E-on-main catches what PR-smoke misses" pattern).

## Test plan
- [x] `bun run typecheck` — passed
- [x] `eslint e2e/pages/home.spec.ts` — passed
- [x] `bun run test:e2e e2e/pages/home.spec.ts` — **3 passed** (incl. both previously-failing tests)

## Manual repro
Ran the full `home.spec.ts` E2E locally (docker stack via global-setup, port 8080 free): **3/3 passed**, including "displays navigation links" and "displays discovery sections and footer (PSY-389)".

## Out of scope (pre-existing flakes)
Same shard had 3 unrelated navigation/timing flakes — `artist-detail.spec.ts:5` (`waitForURL` timeout) + `city-filter.spec.ts:11`/`:78` (`toHaveURL`). These are pre-existing E2E flakiness (PSY-1006 territory), **not** caused by PSY-389 (the footer uses `/shows`, not `/shows/<slug>`). Not addressed here.

## Note
Trivial test-locator-scoping fix (no production code); verified by running the affected E2E specs locally. A minor a11y follow-up (two `navigation[aria-label="Discover"]` landmarks on the homepage) is noted on PSY-1030.

Closes PSY-1033
