### PR TITLE
PSY-1035: assert D2 station buttons in /radio E2E (not stale link cards)

### DIFF
--- a/frontend/e2e/pages/radio.spec.ts
+++ b/frontend/e2e/pages/radio.spec.ts
@@ -64,14 +64,17 @@ test.describe('Radio browse flow', () => {
       main.getByRole('heading', { name: 'Radio', level: 1 })
     ).toBeVisible({ timeout: 10_000 })
 
-    // Station cards render as links. KEXP / WFMU / NTS are the three
-    // index-visible stations (the 3 WFMU sub-channels are hidden by
-    // isStationVisibleOnIndex per PSY-673).
+    // PSY-1016: the /radio index now leads with the Option-D2 station-overview
+    // panel — the station list is a selectable button group (left pane), not
+    // link cards. KEXP / WFMU / NTS are the three index-visible stations (the 3
+    // WFMU sub-channels are hidden by isStationVisibleOnIndex per PSY-673). The
+    // selected station's full detail page stays reachable via the right-pane
+    // station link (exercised by the next test).
     await expect(
-      main.getByRole('link', { name: KEXP_STATION_NAME })
+      main.getByRole('button', { name: KEXP_STATION_NAME })
     ).toBeVisible({ timeout: 10_000 })
-    await expect(main.getByRole('link', { name: 'WFMU' })).toBeVisible()
-    await expect(main.getByRole('link', { name: 'NTS Radio' })).toBeVisible()
+    await expect(main.getByRole('button', { name: 'WFMU' })).toBeVisible()
+    await expect(main.getByRole('button', { name: 'NTS Radio' })).toBeVisible()
   })
 
   test('clicking a station opens station detail and lists its shows', async ({


### PR DESCRIPTION
## Summary

Second full-E2E-on-main restoration (after PSY-1033/home.spec). PSY-1016's D2 `/radio` index renders the station list as a **button group** (`RadioStationList`, `aria-pressed`), not link cards — so `radio.spec.ts:58 "/radio loads and lists seeded stations"` (which asserted station **links**) failed with element-not-found on `E2E Tests (shard …)`. Non-`@smoke`, so PSY-1016's PR smoke never ran it.

Assert the station **buttons** (KEXP / WFMU / NTS) instead. **No app change.** Not a navigation regression — the D2 right pane still links to `/radio/{slug}` (`RadioStationOverview.tsx:122`) and `/radio/{slug}/{show}`, so the other 3 `radio.spec` tests (station detail, show detail, breadcrumb) are unaffected.

## Test plan
- [x] `bun run typecheck` — passed
- [x] `eslint e2e/pages/radio.spec.ts` — passed
- [x] `bun run test:e2e e2e/pages/radio.spec.ts` — `:58` **passed** (link→button verified)

## Manual repro
Ran `radio.spec.ts` locally (docker stack via global-setup): the rewritten `:58` passes against the merged D2 `/radio`. (`:114` flaked on a `waitForURL` timeout — a pre-existing navigation-timing flake, PSY-1006 territory, unrelated to this change.)

## Out of scope (pre-existing flakes)
`radio.spec.ts:114`, `artist-detail.spec.ts:5`, `city-filter.spec.ts:11/:78`, `add-to-collection.spec.ts:19` — navigation/timing flakes (PSY-1006), not addressed here.

Closes PSY-1035
