### PR TITLE
PSY-1034: cap venue grid track to stop ResizeObserver balloon

### DIFF
--- a/frontend/features/venues/components/VenueBillNetwork.tsx
+++ b/frontend/features/venues/components/VenueBillNetwork.tsx
@@ -243,8 +243,13 @@ export function VenueBillNetwork({ venueIdOrSlug, venueName }: VenueBillNetworkP
         // PSY-366: `id="graph"` enables Cmd+K deep-links from the command
         // palette (`/venues/{slug}#graph`). `scroll-mt-20` accounts for the
         // sticky header on the entity layout.
+        // PSY-1034/PSY-949: `min-w-0` is load-bearing — the ResizeObserver
+        // below feeds this element's measured width to the graph as an explicit
+        // pixel width. Without `min-w-0` the canvas's min-content width can push
+        // this container wider than its grid track, which re-fires the RO with a
+        // larger width and balloons the layout. Do NOT remove it.
         id="graph"
-        className="mt-8 px-4 md:px-0 scroll-mt-20"
+        className="mt-8 px-4 md:px-0 scroll-mt-20 min-w-0"
         // Hide inline copy from assistive tech while the overlay is open —
         // the overlay's own header is the single source of truth in that mode.
         aria-hidden={isFullscreen || undefined}

--- a/frontend/features/venues/components/VenueDetail.test.tsx
+++ b/frontend/features/venues/components/VenueDetail.test.tsx
@@ -331,6 +331,22 @@ describe('VenueDetail', () => {
       expect(screen.getByTestId('location-card')).toBeInTheDocument()
     })
 
+    // PSY-1034 regression guard: the two-column grid track must stay
+    // min-width-capped so the ResizeObserver-measured VenueBillNetwork graph
+    // can't balloon the layout rightward. A plain `1fr` track has an implicit
+    // `min-width: auto` and reintroduces the bug; `minmax(0,1fr)` + `min-w-0`
+    // on the main column are the two independent caps. Assert both are present.
+    it('keeps the two-column grid track min-width-capped (no RO balloon)', () => {
+      const { container } = render(<VenueDetail venueId="1" />)
+      const grid = container.querySelector(
+        '.lg\\:grid-cols-\\[minmax\\(0\\,1fr\\)_400px\\]',
+      )
+      expect(grid).not.toBeNull()
+      // The main (graph-bearing) column carries the belt-and-suspenders cap.
+      const mainColumn = grid?.querySelector('.min-w-0')
+      expect(mainColumn).not.toBeNull()
+    })
+
     it('does not render a favorite venue button', () => {
       render(<VenueDetail venueId="1" />)
       expect(screen.queryByTestId('favorite-button')).not.toBeInTheDocument()

--- a/frontend/features/venues/components/VenueDetail.test.tsx
+++ b/frontend/features/venues/components/VenueDetail.test.tsx
@@ -342,9 +342,12 @@ describe('VenueDetail', () => {
         '.lg\\:grid-cols-\\[minmax\\(0\\,1fr\\)_400px\\]',
       )
       expect(grid).not.toBeNull()
-      // The main (graph-bearing) column carries the belt-and-suspenders cap.
-      const mainColumn = grid?.querySelector('.min-w-0')
-      expect(mainColumn).not.toBeNull()
+      // The main (graph-bearing) column is the grid's FIRST child and must
+      // itself carry the belt-and-suspenders `min-w-0` cap. Asserting on the
+      // direct child (not any descendant) keeps the guard precise — it can't be
+      // satisfied by some unrelated nested `min-w-0` element.
+      const mainColumn = grid?.firstElementChild
+      expect(mainColumn?.className).toContain('min-w-0')
     })
 
     it('does not render a favorite venue button', () => {

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -175,9 +175,15 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
       />
 
       {/* Main Content - Two Column Layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-8">
+      {/* PSY-1034: `minmax(0,1fr)` (not `1fr`) caps the main track's implicit
+          `min-width: auto`. Without it, the ResizeObserver-measured graph in
+          VenueBillNetwork grows the track, which re-fires the RO with a larger
+          width, ballooning the layout rightward each cycle. Same class as
+          PSY-949's Dialog fix; `min-w-0` on the main column is the
+          belt-and-suspenders sibling. */}
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_400px] gap-8">
         {/* Main Column - Header + Shows */}
-        <div className="order-2 lg:order-1">
+        <div className="order-2 lg:order-1 min-w-0">
           {/* Header */}
           <header className="mb-8">
             <EntityHeader


### PR DESCRIPTION
## Summary

The venue detail page (`/venues/[slug]`) progressively drifted rightward — a horizontal overflow that grew over time, pushing the 400px Location sidebar off-viewport. Signature of a **ResizeObserver width-balloon feedback loop**.

Root cause (confirmed in code + browser): `VenueDetail`'s hand-rolled two-column grid used `lg:grid-cols-[1fr_400px]`. CSS `1fr` is `minmax(auto, 1fr)`, whose implicit `min-width: auto` lets a child grow the track. `VenueBillNetwork` ResizeObserver-measures its container (`#graph`) and feeds that width to the graph canvas — so each cycle the measured width grew the track, the RO re-fired with a larger width, and the layout ballooned right. Same class as **PSY-949** (graph-in-Dialog RO balloon), but that fix was Dialog-only; this in-page grid case was unguarded.

**Fix (CSS min-width capping — no refactor):**
- `VenueDetail.tsx`: `lg:grid-cols-[1fr_400px]` → `lg:grid-cols-[minmax(0,1fr)_400px]` caps the main track's min-width; `min-w-0` added to the main column as the belt-and-suspenders sibling. Either alone breaks the loop; both is cheap + idiomatic.
- `VenueBillNetwork.tsx`: `min-w-0` on the ResizeObserver-observed `#graph` div so the canvas can't push its own container wider (mirrors PSY-949 on the measured element itself).

**Sweep of the other RO-measuring graphs — all already safe, none over-edited:**
| Component | Page | Why it's safe |
| --- | --- | --- |
| `SceneGraph` | /scenes | single-column block container (`space-y-6`), not a growable track |
| `InlineGraph` | /explore | single-column `max-w-6xl` block inside `<section>` |
| `BillComposition` | /artists | renders inside `EntityDetailLayout`'s `flex-1 min-w-0` main column |
| `RelatedArtists` | /artists | already carries the PSY-949 `min-w-0` on its measured div |
| `CollectionGraph` | /collections | single-column `container max-w-6xl` block, not a growable track |

The venue page was the only one with a hand-rolled `1fr` grid track wrapping a RO graph. `EntityDetailLayout` (which every other entity page uses) already does the correct `flex-1 min-w-0`; the venue page was the outlier.

## Test plan
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors (156 pre-existing warnings, none in touched files)
- [x] `cd frontend && bun run test:run features/venues` — 149 passed (incl. new regression guard)

Regression guard: `VenueDetail.test.tsx` asserts the grid track stays min-width-capped (`minmax(0,1fr)`) and that the grid's direct first child (the graph-bearing main column) carries `min-w-0`.

## Manual repro
Ran against the dispatch stack (`--mode=shared`, auto-upgraded to isolated), venue `the-rebel-lounge-phoenix-az` at 1440×900. Numeric proof via Chrome DevTools `evaluate_script`:

- **No overflow:** `document.documentElement.scrollWidth` = `clientWidth` = **1425px**, overflow = **0px**. Confirmed my fix is live in the DOM: grid class `grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_400px] gap-8`, main column has `min-w-0`.
- **Stable over time / resizes:** sampled across 6 RO/resize cycles and OS-window resizes at 1024/1280/1440/1600 — `scrollWidth === clientWidth` every time, **maxOverflow = 0px, scrollWidth grew by 0px** (no accumulation).
- **A/B cap proof (live page):** injecting an intrinsically 3000px-wide child into the graph column — the exact balloon trigger — left the **FIXED** track pinned at **688px**, while temporarily reverting to `1fr` + no `min-w-0` ballooned the same track to **1120px**. The RO now always measures a stable 688px → the feedback loop is broken at the source, not masked.

## Screenshots
Fixed venue detail page — sidebar in-viewport, no right-drift:
- Light: https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1034-screenshots-1780899901/venue-detail-light.png
- Dark: https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1034-screenshots-1780899901/venue-detail-dark.png

## Code review
`/code-review` (inline lenses, sub-agent in worktree) — one finding applied in commit `d6837369`: tightened the regression guard to assert `min-w-0` on the grid's direct first child (the main column) rather than any descendant, so the guard can't be satisfied by an unrelated nested element. Verified the `whitespace-nowrap` shows table is not a regression — `min-w-0` confines any overflow to the column instead of ballooning the page.

## Adversarial review
`/adversarial-review` — **CLEAN**, no findings. Panel: Saboteur · Future-Maintainer · Security · Completeness, run inline (dispatched sub-agent has no Agent tool — expected fallback) with no prior-session context against the branch diff. Probed: does `min-w-0` clip content (no — `w-full` table compresses; browser overflow=0); does the fix stop vs mask the balloon (stops — A/B proof); mobile path (untouched — `grid-cols-1`); all ticket acceptance criteria met.

Closes PSY-1034
