### PR TITLE
PSY-1023: require + record a 16+ age confirmation at signup

### DIFF
--- a/backend/db/migrations/20260607120000_add_user_age_confirmation.down.sql
+++ b/backend/db/migrations/20260607120000_add_user_age_confirmation.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+  DROP COLUMN IF EXISTS min_age_attested,
+  DROP COLUMN IF EXISTS age_confirmed_at;

--- a/backend/db/migrations/20260607120000_add_user_age_confirmation.up.sql
+++ b/backend/db/migrations/20260607120000_add_user_age_confirmation.up.sql
@@ -1,0 +1,8 @@
+-- PSY-1023: record an explicit "I am at least N years old" confirmation at
+-- signup. Mirrors the terms-acceptance evidence columns added in 000031.
+-- age_confirmed_at is the acceptance timestamp; min_age_attested records the
+-- minimum age the user attested to (e.g. 16) so the value survives a future
+-- change to the minimum.
+ALTER TABLE users
+  ADD COLUMN age_confirmed_at TIMESTAMPTZ,
+  ADD COLUMN min_age_attested INTEGER;

--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -17,6 +17,30 @@ import (
 	"psychic-homily-backend/internal/services/contracts"
 )
 
+// MinSignupAge is the minimum age (in years) a user must confirm at signup.
+// Locked at 16 (PSY-1023) to match the /terms and /privacy minimum-age clauses.
+// The backend is the authoritative gate: every account-creation path requires an
+// age confirmation of at least this value, independent of the frontend checkbox.
+const MinSignupAge = 16
+
+// validateSignupAgeConfirmation enforces the required minimum-age confirmation
+// shared by every account-creation handler (PSY-1023). It mirrors the terms
+// guard: the confirmation flag must be set, and the attested minimum age must be
+// at least MinSignupAge. The frontend always sends MinSignupAge, but the server
+// re-checks so a tampered/absent value can never bypass the gate. Returns the
+// error code + user-facing message and ok=false on failure.
+func validateSignupAgeConfirmation(ageConfirmed bool, minAgeAttested int) (code, message string, ok bool) {
+	if !ageConfirmed {
+		err := autherrors.ErrAgeConfirmationRequired("age confirmation not provided")
+		return autherrors.CodeAgeConfirmationRequired, err.Message, false
+	}
+	if minAgeAttested < MinSignupAge {
+		err := autherrors.ErrAgeConfirmationRequired("attested age below minimum")
+		return autherrors.CodeAgeConfirmationRequired, err.Message, false
+	}
+	return "", "", true
+}
+
 // AuthHandler handles authentication requests
 type AuthHandler struct {
 	authService       contracts.AuthServiceInterface
@@ -505,6 +529,8 @@ type RegisterRequest struct {
 		TermsAccepted  bool    `json:"terms_accepted" doc:"Whether user accepted Terms of Service"`
 		TermsVersion   string  `json:"terms_version,omitempty" doc:"Accepted terms version identifier"`
 		PrivacyVersion string  `json:"privacy_version,omitempty" doc:"Accepted privacy policy version identifier"`
+		AgeConfirmed   bool    `json:"age_confirmed" doc:"Whether user confirmed they meet the minimum age"`
+		MinAgeAttested int     `json:"min_age_attested,omitempty" doc:"Minimum age the user attested to"`
 	}
 }
 
@@ -561,6 +587,15 @@ func (h *AuthHandler) RegisterHandler(ctx context.Context, input *RegisterReques
 		resp.Body.ErrorCode = autherrors.CodeValidationFailed
 		return resp, nil
 	}
+	if errCode, errMsg, ok := validateSignupAgeConfirmation(input.Body.AgeConfirmed, input.Body.MinAgeAttested); !ok {
+		logger.AuthWarn(ctx, "register_validation_failed",
+			"error", errMsg,
+		)
+		resp.Body.Success = false
+		resp.Body.Message = errMsg
+		resp.Body.ErrorCode = errCode
+		return resp, nil
+	}
 
 	// Validate password using the password validator (min 12, max 128, breach check, common password check)
 	if h.passwordValidator != nil {
@@ -614,6 +649,8 @@ func (h *AuthHandler) RegisterHandler(ctx context.Context, input *RegisterReques
 			TermsAcceptedAt: time.Now().UTC(),
 			TermsVersion:    input.Body.TermsVersion,
 			PrivacyVersion:  input.Body.PrivacyVersion,
+			AgeConfirmedAt:  time.Now().UTC(),
+			MinAgeAttested:  input.Body.MinAgeAttested,
 		},
 	)
 	if err != nil {

--- a/backend/internal/api/handlers/auth/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth/auth_integration_test.go
@@ -216,6 +216,8 @@ func (s *AuthHandlerIntegrationSuite) TestRegister_Success() {
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
 	input.Body.PrivacyVersion = "2026-02-15"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 	s.Require().NoError(err)
@@ -224,6 +226,31 @@ func (s *AuthHandlerIntegrationSuite) TestRegister_Success() {
 	s.NotNil(resp.Body.User)
 	s.Equal("new-user@test.com", *resp.Body.User.Email)
 	s.NotEmpty(resp.SetCookie.Name)
+
+	// PSY-1023: the age confirmation is persisted on the new user.
+	created := s.reloadUser(resp.Body.User.ID)
+	s.Require().NotNil(created.AgeConfirmedAt, "expected age_confirmed_at recorded on new user")
+	s.Require().NotNil(created.MinAgeAttested, "expected min_age_attested recorded on new user")
+	s.Equal(MinSignupAge, *created.MinAgeAttested)
+}
+
+// TestRegister_MissingAgeConfirmation asserts the integration-level register
+// path blocks signup when the age confirmation is absent (PSY-1023).
+func (s *AuthHandlerIntegrationSuite) TestRegister_MissingAgeConfirmation() {
+	h := s.newAuthHandler(false)
+
+	input := &RegisterRequest{}
+	input.Body.Email = "no-age@test.com"
+	input.Body.Password = "very-strong-password-123!"
+	input.Body.TermsAccepted = true
+	input.Body.TermsVersion = "2026-01-31"
+	input.Body.PrivacyVersion = "2026-02-15"
+	input.Body.AgeConfirmed = false
+
+	resp, err := h.RegisterHandler(context.Background(), input)
+	s.Require().NoError(err)
+	s.False(resp.Body.Success)
+	s.Equal(autherrors.CodeAgeConfirmationRequired, resp.Body.ErrorCode)
 }
 
 func (s *AuthHandlerIntegrationSuite) TestRegister_DuplicateEmail() {
@@ -236,6 +263,8 @@ func (s *AuthHandlerIntegrationSuite) TestRegister_DuplicateEmail() {
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
 	input.Body.PrivacyVersion = "2026-02-15"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 	s.Require().NoError(err)
@@ -252,6 +281,8 @@ func (s *AuthHandlerIntegrationSuite) TestRegister_WeakPassword() {
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
 	input.Body.PrivacyVersion = "2026-02-15"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 	s.Require().NoError(err)

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -333,6 +333,98 @@ func TestRegisterHandler_MissingTermsAcceptance(t *testing.T) {
 	}
 }
 
+// TestRegisterHandler_MissingAgeConfirmation mirrors the terms-rejection test
+// (PSY-1023): a signup with terms accepted but no age confirmation must be
+// rejected with the AGE_CONFIRMATION_REQUIRED code.
+func TestRegisterHandler_MissingAgeConfirmation(t *testing.T) {
+	h := testAuthHandler()
+	input := &RegisterRequest{}
+	input.Body.Email = "user@example.com"
+	input.Body.Password = "a-valid-password-123"
+	input.Body.TermsAccepted = true
+	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = false
+
+	resp, err := h.RegisterHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeAgeConfirmationRequired {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeAgeConfirmationRequired, resp.Body.ErrorCode)
+	}
+}
+
+// TestRegisterHandler_AgeBelowMinimum guards the server-side age floor: a client
+// that attests an age below MinSignupAge (e.g. tampered request) must be
+// rejected even though the age_confirmed flag is set.
+func TestRegisterHandler_AgeBelowMinimum(t *testing.T) {
+	h := testAuthHandler()
+	input := &RegisterRequest{}
+	input.Body.Email = "user@example.com"
+	input.Body.Password = "a-valid-password-123"
+	input.Body.TermsAccepted = true
+	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge - 1
+
+	resp, err := h.RegisterHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeAgeConfirmationRequired {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeAgeConfirmationRequired, resp.Body.ErrorCode)
+	}
+}
+
+// TestRegisterHandler_RecordsAgeConfirmation asserts the handler forwards the
+// age confirmation into the LegalAcceptance passed to the user service, so the
+// evidence is persisted on the new user.
+func TestRegisterHandler_RecordsAgeConfirmation(t *testing.T) {
+	var captured contracts.LegalAcceptance
+	h := authHandler(func(ah *AuthHandler) {
+		ah.userService = &testhelpers.MockUserService{
+			CreateUserWithPasswordWithLegalFn: func(email, password, firstName, lastName string, acceptance contracts.LegalAcceptance) (*authm.User, error) {
+				captured = acceptance
+				return &authm.User{ID: 11, Email: strPtr(email)}, nil
+			},
+		}
+		ah.jwtService = &testhelpers.MockJWTService{
+			CreateTokenFn: func(u *authm.User) (string, error) { return "tok", nil },
+		}
+		ah.discordService = &testhelpers.MockDiscordService{
+			NotifyNewUserFn: func(u *authm.User) {},
+		}
+	})
+
+	input := &RegisterRequest{}
+	input.Body.Email = "new@example.com"
+	input.Body.Password = "a-valid-password-123"
+	input.Body.TermsAccepted = true
+	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
+
+	resp, err := h.RegisterHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Fatalf("expected success=true, got message=%q", resp.Body.Message)
+	}
+	if captured.MinAgeAttested != MinSignupAge {
+		t.Errorf("expected MinAgeAttested=%d on LegalAcceptance, got %d", MinSignupAge, captured.MinAgeAttested)
+	}
+	if captured.AgeConfirmedAt.IsZero() {
+		t.Error("expected AgeConfirmedAt to be set on LegalAcceptance")
+	}
+}
+
 func TestRegisterHandler_NilUserService(t *testing.T) {
 	// No passwordValidator, no userService → hits userService nil check
 	h := testAuthHandler()
@@ -341,6 +433,8 @@ func TestRegisterHandler_NilUserService(t *testing.T) {
 	input.Body.Password = "a-valid-password-123"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 	input.Body.PrivacyVersion = "2026-02-15"
 
 	resp, err := h.RegisterHandler(context.Background(), input)
@@ -365,6 +459,8 @@ func TestRegisterHandler_WeakPassword(t *testing.T) {
 	input.Body.Password = "abc" // too short (min 12)
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 	input.Body.PrivacyVersion = "2026-02-15"
 
 	resp, err := h.RegisterHandler(context.Background(), input)
@@ -1117,6 +1213,8 @@ func TestRegisterHandler_Success(t *testing.T) {
 	input.Body.Password = "a-valid-password-123"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 	if err != nil {
@@ -1157,6 +1255,8 @@ func TestRegisterHandler_UserExists(t *testing.T) {
 	input.Body.Password = "a-valid-password-123"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 	// Option A: HTTP 200, so the handler returns a nil error. A non-nil error
@@ -1199,6 +1299,8 @@ func TestRegisterHandler_UnknownServiceErrorFailsClosed(t *testing.T) {
 	input.Body.Password = "a-valid-password-123"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 
@@ -1248,6 +1350,8 @@ func TestRegisterHandler_WeakPasswordMock(t *testing.T) {
 	input.Body.Password = "short"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 	if err != nil {
@@ -1283,6 +1387,8 @@ func TestRegisterHandler_TokenFails(t *testing.T) {
 	input.Body.Password = "a-valid-password-123"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "2026-01-31"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.RegisterHandler(context.Background(), input)
 	if err != nil {

--- a/backend/internal/api/handlers/auth/oauth_handlers.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"sync"
 	"time"
 
@@ -122,11 +123,23 @@ func (h *OAuthHTTPHandler) OAuthLoginHTTPHandler(w http.ResponseWriter, r *http.
 			return
 		}
 
+		// Require the minimum-age confirmation (PSY-1023), mirroring the terms
+		// gate. min_age_attested is re-checked server-side against MinSignupAge so
+		// a tampered/absent query param can never bypass the gate.
+		ageConfirmed := r.URL.Query().Get("age_confirmed") == "true"
+		minAgeAttested, _ := strconv.Atoi(r.URL.Query().Get("min_age_attested"))
+		if !ageConfirmed || minAgeAttested < MinSignupAge {
+			http.Error(w, "Age confirmation is required for account creation", http.StatusBadRequest)
+			return
+		}
+
 		encodedConsent, err := encodeOAuthSignupConsent(contracts.OAuthSignupConsent{
 			TermsAccepted:  true,
 			TermsVersion:   termsVersion,
 			PrivacyVersion: privacyVersion,
 			AcceptedAt:     time.Now().UTC(),
+			AgeConfirmed:   true,
+			MinAgeAttested: minAgeAttested,
 		})
 		if err != nil {
 			http.Error(w, "Failed to process signup consent", http.StatusInternalServerError)

--- a/backend/internal/api/handlers/auth/oauth_handlers_integration_test.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers_integration_test.go
@@ -97,6 +97,8 @@ func (s *OAuthHandlerIntegrationSuite) addSignupConsentCookie(req *http.Request)
 		TermsVersion:   "2026-01-31",
 		PrivacyVersion: "2026-02-15",
 		AcceptedAt:     time.Now().UTC(),
+		AgeConfirmed:   true,
+		MinAgeAttested: MinSignupAge,
 	})
 	s.Require().NoError(err)
 	req.AddCookie(&http.Cookie{

--- a/backend/internal/api/handlers/auth/oauth_handlers_test.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers_test.go
@@ -241,3 +241,87 @@ func TestOAuthLoginHTTPHandler_ValidProvider_GoogleQueryParam(t *testing.T) {
 	// The response will be whatever gothic writes (likely 400 or 500).
 	// The key test is that the handler didn't panic.
 }
+
+// TestOAuthLoginHTTPHandler_SignupIntent_MissingAgeConfirmation locks the
+// server-side OAuth age gate (PSY-1023): a signup-intent OAuth init with terms
+// accepted but no age confirmation must be rejected with a 400 before any OAuth
+// redirect, and no consent cookie may be set.
+func TestOAuthLoginHTTPHandler_SignupIntent_MissingAgeConfirmation(t *testing.T) {
+	handler := NewOAuthHTTPHandler(nil, nil)
+
+	req := httptest.NewRequest("GET", "/auth/login/google?signup_intent=1&terms_accepted=true&terms_version=2026-01-31", nil)
+	w := httptest.NewRecorder()
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("provider", "google")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	handler.OAuthLoginHTTPHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for signup without age confirmation, got %d", w.Code)
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == oauthSignupConsentCookieName {
+			t.Error("expected no signup-consent cookie when age confirmation is missing")
+		}
+	}
+}
+
+// TestOAuthLoginHTTPHandler_SignupIntent_AgeBelowMinimum guards the server-side
+// age floor for the OAuth init path against a tampered min_age_attested.
+func TestOAuthLoginHTTPHandler_SignupIntent_AgeBelowMinimum(t *testing.T) {
+	handler := NewOAuthHTTPHandler(nil, nil)
+
+	req := httptest.NewRequest("GET", "/auth/login/google?signup_intent=1&terms_accepted=true&terms_version=2026-01-31&age_confirmed=true&min_age_attested=10", nil)
+	w := httptest.NewRecorder()
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("provider", "google")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	handler.OAuthLoginHTTPHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for attested age below minimum, got %d", w.Code)
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == oauthSignupConsentCookieName {
+			t.Error("expected no signup-consent cookie when attested age is below minimum")
+		}
+	}
+}
+
+// TestOAuthLoginHTTPHandler_SignupIntent_RecordsAgeConsent confirms a valid
+// signup-intent init (terms + age confirmed) sets a consent cookie carrying the
+// age confirmation, so the callback path can persist it.
+func TestOAuthLoginHTTPHandler_SignupIntent_RecordsAgeConsent(t *testing.T) {
+	handler := NewOAuthHTTPHandler(nil, nil)
+
+	req := httptest.NewRequest("GET", "/auth/login/google?signup_intent=1&terms_accepted=true&terms_version=2026-01-31&age_confirmed=true&min_age_attested=16", nil)
+	w := httptest.NewRecorder()
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("provider", "google")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	handler.OAuthLoginHTTPHandler(w, req)
+
+	var consentCookie *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == oauthSignupConsentCookieName {
+			consentCookie = c
+			break
+		}
+	}
+	if consentCookie == nil {
+		t.Fatal("expected signup-consent cookie to be set for valid signup intent")
+	}
+	consent, err := decodeOAuthSignupConsent(consentCookie.Value)
+	if err != nil {
+		t.Fatalf("failed to decode consent cookie: %v", err)
+	}
+	if !consent.AgeConfirmed {
+		t.Error("expected AgeConfirmed=true in consent cookie")
+	}
+	if consent.MinAgeAttested != MinSignupAge {
+		t.Errorf("expected MinAgeAttested=%d in consent cookie, got %d", MinSignupAge, consent.MinAgeAttested)
+	}
+}

--- a/backend/internal/api/handlers/auth/passkey.go
+++ b/backend/internal/api/handlers/auth/passkey.go
@@ -592,6 +592,8 @@ type BeginSignupRequest struct {
 		TermsAccepted  bool   `json:"terms_accepted" doc:"Whether user accepted Terms of Service"`
 		TermsVersion   string `json:"terms_version,omitempty" doc:"Accepted terms version identifier"`
 		PrivacyVersion string `json:"privacy_version,omitempty" doc:"Accepted privacy policy version identifier"`
+		AgeConfirmed   bool   `json:"age_confirmed" doc:"Whether user confirmed they meet the minimum age"`
+		MinAgeAttested int    `json:"min_age_attested,omitempty" doc:"Minimum age the user attested to"`
 	}
 }
 
@@ -630,6 +632,12 @@ func (h *PasskeyHandler) BeginSignupHandler(ctx context.Context, input *BeginSig
 		resp.Body.Success = false
 		resp.Body.Message = "Terms version is required"
 		resp.Body.ErrorCode = autherrors.CodeValidationFailed
+		return resp, nil
+	}
+	if errCode, errMsg, ok := validateSignupAgeConfirmation(input.Body.AgeConfirmed, input.Body.MinAgeAttested); !ok {
+		resp.Body.Success = false
+		resp.Body.Message = errMsg
+		resp.Body.ErrorCode = errCode
 		return resp, nil
 	}
 
@@ -704,6 +712,8 @@ type FinishSignupRequest struct {
 		TermsAccepted  bool                       `json:"terms_accepted" doc:"Whether user accepted Terms of Service"`
 		TermsVersion   string                     `json:"terms_version,omitempty" doc:"Accepted terms version identifier"`
 		PrivacyVersion string                     `json:"privacy_version,omitempty" doc:"Accepted privacy policy version identifier"`
+		AgeConfirmed   bool                       `json:"age_confirmed" doc:"Whether user confirmed they meet the minimum age"`
+		MinAgeAttested int                        `json:"min_age_attested,omitempty" doc:"Minimum age the user attested to"`
 	}
 }
 
@@ -786,6 +796,12 @@ func (h *PasskeyHandler) FinishSignupHandler(ctx context.Context, input *FinishS
 		resp.Body.ErrorCode = autherrors.CodeValidationFailed
 		return resp, nil
 	}
+	if errCode, errMsg, ok := validateSignupAgeConfirmation(input.Body.AgeConfirmed, input.Body.MinAgeAttested); !ok {
+		resp.Body.Success = false
+		resp.Body.Message = errMsg
+		resp.Body.ErrorCode = errCode
+		return resp, nil
+	}
 
 	// Complete registration and create user
 	user, err := h.webauthnService.FinishSignupRegistrationWithLegal(
@@ -797,6 +813,8 @@ func (h *PasskeyHandler) FinishSignupHandler(ctx context.Context, input *FinishS
 			TermsAcceptedAt: time.Now().UTC(),
 			TermsVersion:    input.Body.TermsVersion,
 			PrivacyVersion:  input.Body.PrivacyVersion,
+			AgeConfirmedAt:  time.Now().UTC(),
+			MinAgeAttested:  input.Body.MinAgeAttested,
 		},
 	)
 	if err != nil {

--- a/backend/internal/api/handlers/auth/passkey_test.go
+++ b/backend/internal/api/handlers/auth/passkey_test.go
@@ -828,6 +828,52 @@ func TestBeginSignupHandler_MissingTermsVersion(t *testing.T) {
 	}
 }
 
+// TestBeginSignupHandler_MissingAgeConfirmation mirrors the terms-rejection
+// tests (PSY-1023): passkey signup must be blocked when the age confirmation is
+// absent, even with terms accepted.
+func TestBeginSignupHandler_MissingAgeConfirmation(t *testing.T) {
+	h := testPasskeyHandler()
+	input := &BeginSignupRequest{}
+	input.Body.Email = "test@example.com"
+	input.Body.TermsAccepted = true
+	input.Body.TermsVersion = "v1"
+	input.Body.AgeConfirmed = false
+
+	resp, err := h.BeginSignupHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeAgeConfirmationRequired {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeAgeConfirmationRequired, resp.Body.ErrorCode)
+	}
+}
+
+// TestBeginSignupHandler_AgeBelowMinimum guards the server-side age floor for
+// the passkey path.
+func TestBeginSignupHandler_AgeBelowMinimum(t *testing.T) {
+	h := testPasskeyHandler()
+	input := &BeginSignupRequest{}
+	input.Body.Email = "test@example.com"
+	input.Body.TermsAccepted = true
+	input.Body.TermsVersion = "v1"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge - 1
+
+	resp, err := h.BeginSignupHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeAgeConfirmationRequired {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeAgeConfirmationRequired, resp.Body.ErrorCode)
+	}
+}
+
 func TestBeginSignupHandler_EmailCheckFails(t *testing.T) {
 	mockUS := &testhelpers.MockUserService{
 		GetUserByEmailFn: func(email string) (*authm.User, error) {
@@ -840,6 +886,8 @@ func TestBeginSignupHandler_EmailCheckFails(t *testing.T) {
 	input.Body.Email = "new@example.com"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "v1"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.BeginSignupHandler(context.Background(), input)
 	if err != nil {
@@ -869,6 +917,8 @@ func TestBeginSignupHandler_EmailAlreadyExists(t *testing.T) {
 	input.Body.Email = email
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "v1"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.BeginSignupHandler(context.Background(), input)
 	if err != nil {
@@ -902,6 +952,8 @@ func TestBeginSignupHandler_BeginRegistrationForEmailFails(t *testing.T) {
 	input.Body.Email = "new@example.com"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "v1"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.BeginSignupHandler(context.Background(), input)
 	if err != nil {
@@ -935,6 +987,8 @@ func TestBeginSignupHandler_StoreChallengeWithEmailFails(t *testing.T) {
 	input.Body.Email = "new@example.com"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "v1"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.BeginSignupHandler(context.Background(), input)
 	if err != nil {
@@ -976,6 +1030,8 @@ func TestBeginSignupHandler_Success(t *testing.T) {
 	input.Body.Email = "new@example.com"
 	input.Body.TermsAccepted = true
 	input.Body.TermsVersion = "v1"
+	input.Body.AgeConfirmed = true
+	input.Body.MinAgeAttested = MinSignupAge
 
 	resp, err := h.BeginSignupHandler(context.Background(), input)
 	if err != nil {

--- a/backend/internal/errors/auth.go
+++ b/backend/internal/errors/auth.go
@@ -39,6 +39,9 @@ const (
 	// CodeTermsAcceptanceRequired indicates an OAuth signup arrived without the
 	// required Terms of Service / Privacy Policy consent.
 	CodeTermsAcceptanceRequired = "TERMS_ACCEPTANCE_REQUIRED"
+	// CodeAgeConfirmationRequired indicates a signup arrived without the required
+	// minimum-age confirmation (PSY-1023).
+	CodeAgeConfirmationRequired = "AGE_CONFIRMATION_REQUIRED"
 	// CodeInvalidReplyPermission indicates an unrecognized default-reply-permission value.
 	CodeInvalidReplyPermission = "INVALID_REPLY_PERMISSION"
 	// CodeUsernameTaken indicates a username unique-constraint violation on profile update.
@@ -186,6 +189,13 @@ func ErrNoPasswordSet() *AuthError {
 // so logs keep the cause without the handler string-matching the message.
 func ErrTermsAcceptanceRequired(detail string) *AuthError {
 	return NewAuthError(CodeTermsAcceptanceRequired, "Please accept the Terms of Service and Privacy Policy before creating an account.", fmt.Errorf("%s", detail))
+}
+
+// ErrAgeConfirmationRequired creates a signup age-confirmation-missing error.
+// The detail distinguishes "not confirmed" from "attested age below minimum"
+// so logs keep the cause without the handler string-matching the message.
+func ErrAgeConfirmationRequired(detail string) *AuthError {
+	return NewAuthError(CodeAgeConfirmationRequired, "You must confirm that you are at least 16 years old to create an account.", fmt.Errorf("%s", detail))
 }
 
 // ErrInvalidReplyPermission creates an invalid default-reply-permission error.

--- a/backend/internal/errors/auth.go
+++ b/backend/internal/errors/auth.go
@@ -194,6 +194,10 @@ func ErrTermsAcceptanceRequired(detail string) *AuthError {
 // ErrAgeConfirmationRequired creates a signup age-confirmation-missing error.
 // The detail distinguishes "not confirmed" from "attested age below minimum"
 // so logs keep the cause without the handler string-matching the message.
+// NOTE: the "16" in the user-facing copy is kept in sync by hand with
+// auth-handler MinSignupAge / user-service minOAuthSignupAge; if the minimum
+// changes, update this string too (the threshold is enforced by those
+// constants, not parsed from this message).
 func ErrAgeConfirmationRequired(detail string) *AuthError {
 	return NewAuthError(CodeAgeConfirmationRequired, "You must confirm that you are at least 16 years old to create an account.", fmt.Errorf("%s", detail))
 }

--- a/backend/internal/models/auth/user.go
+++ b/backend/internal/models/auth/user.go
@@ -30,6 +30,8 @@ type User struct {
 	TermsAcceptedAt     *time.Time       `json:"-" gorm:"column:terms_accepted_at"` // Legal acceptance evidence
 	TermsVersion        *string          `json:"-" gorm:"column:terms_version"`
 	PrivacyVersion      *string          `json:"-" gorm:"column:privacy_version"`
+	AgeConfirmedAt      *time.Time       `json:"-" gorm:"column:age_confirmed_at"` // Age-confirmation evidence (mirrors TermsAcceptedAt)
+	MinAgeAttested      *int             `json:"-" gorm:"column:min_age_attested"` // Minimum age the user attested to at signup (e.g. 16)
 	FailedLoginAttempts int              `json:"-" gorm:"default:0"`
 	LockedUntil         *time.Time       `json:"-" gorm:"column:locked_until"`
 	CreatedAt           time.Time        `json:"created_at"`

--- a/backend/internal/services/auth/webauthn.go
+++ b/backend/internal/services/auth/webauthn.go
@@ -462,6 +462,17 @@ func (s *WebAuthnService) FinishSignupRegistrationWithLegal(
 		user.TermsVersion = &termsVersion
 		user.PrivacyVersion = &privacyVersion
 	}
+	// Record the minimum-age confirmation alongside terms (PSY-1023). Mirrors the
+	// terms block: only applied when an age was attested.
+	if acceptance.MinAgeAttested > 0 {
+		ageConfirmedAt := acceptance.AgeConfirmedAt
+		if ageConfirmedAt.IsZero() {
+			ageConfirmedAt = time.Now().UTC()
+		}
+		minAge := acceptance.MinAgeAttested
+		user.AgeConfirmedAt = &ageConfirmedAt
+		user.MinAgeAttested = &minAge
+	}
 
 	if err := tx.Create(user).Error; err != nil {
 		tx.Rollback()

--- a/backend/internal/services/contracts/auth.go
+++ b/backend/internal/services/contracts/auth.go
@@ -73,6 +73,11 @@ type LegalAcceptance struct {
 	TermsAcceptedAt time.Time
 	TermsVersion    string
 	PrivacyVersion  string
+	// AgeConfirmedAt / MinAgeAttested mirror the terms fields for the required
+	// "I am at least N years old" confirmation (PSY-1023). A zero MinAgeAttested
+	// means the caller did not record an age confirmation.
+	AgeConfirmedAt time.Time
+	MinAgeAttested int
 }
 
 // OAuthSignupConsent carries consent details from OAuth signup initiation.
@@ -81,6 +86,10 @@ type OAuthSignupConsent struct {
 	TermsVersion   string
 	PrivacyVersion string
 	AcceptedAt     time.Time
+	// AgeConfirmed / MinAgeAttested capture the required age confirmation for
+	// OAuth signups (PSY-1023), mirroring TermsAccepted.
+	AgeConfirmed   bool
+	MinAgeAttested int
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -290,6 +290,7 @@ func (s *UserService) createUserWithPassword(
 		user.TermsAcceptedAt = &acceptedAt
 		user.TermsVersion = &termsVersion
 		user.PrivacyVersion = &privacyVersion
+		applyAgeConfirmation(user, acceptance.AgeConfirmedAt, acceptance.MinAgeAttested)
 	}
 
 	if err := tx.Create(user).Error; err != nil {
@@ -317,6 +318,23 @@ func (s *UserService) createUserWithPassword(
 	}
 
 	return user, nil
+}
+
+// applyAgeConfirmation records the "I am at least N years old" confirmation on a
+// user being created (PSY-1023). It mirrors the terms-acceptance fields: only
+// applied when a minimum age was attested (minAge > 0), defaulting the timestamp
+// to now if the caller left it zero.
+func applyAgeConfirmation(user *authm.User, confirmedAt time.Time, minAge int) {
+	if minAge <= 0 {
+		return
+	}
+	at := confirmedAt
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	minAgeCopy := minAge
+	user.AgeConfirmedAt = &at
+	user.MinAgeAttested = &minAgeCopy
 }
 
 func (s *UserService) AuthenticateUserWithPassword(email, password string) (*authm.User, error) {
@@ -441,6 +459,9 @@ func (s *UserService) createNewUserOauthWithConsent(
 		user.TermsAcceptedAt = &acceptedAt
 		user.TermsVersion = &termsVersion
 		user.PrivacyVersion = &privacyVersion
+		if consent.AgeConfirmed {
+			applyAgeConfirmation(user, acceptedAt, consent.MinAgeAttested)
+		}
 	}
 
 	if err := tx.Create(user).Error; err != nil {
@@ -493,6 +514,11 @@ func (s *UserService) createNewUserOauthWithConsent(
 	return user, nil
 }
 
+// minOAuthSignupAge is the minimum age a new OAuth user must have attested to.
+// Kept in sync with the handler-level MinSignupAge constant; duplicated here to
+// avoid a service→handler import cycle. Both enforce 16 (PSY-1023).
+const minOAuthSignupAge = 16
+
 func validateOAuthSignupConsent(consent *contracts.OAuthSignupConsent) error {
 	if consent == nil {
 		return apperrors.ErrTermsAcceptanceRequired("terms acceptance required for OAuth signup")
@@ -502,6 +528,13 @@ func validateOAuthSignupConsent(consent *contracts.OAuthSignupConsent) error {
 	}
 	if consent.TermsVersion == "" {
 		return apperrors.ErrTermsAcceptanceRequired("terms version is required for OAuth signup")
+	}
+	// Age confirmation is required for OAuth signup (PSY-1023), mirroring terms.
+	if !consent.AgeConfirmed {
+		return apperrors.ErrAgeConfirmationRequired("age confirmation required for OAuth signup")
+	}
+	if consent.MinAgeAttested < minOAuthSignupAge {
+		return apperrors.ErrAgeConfirmationRequired("attested age below minimum for OAuth signup")
 	}
 	return nil
 }

--- a/frontend/app/auth/_components/google-oauth-button.tsx
+++ b/frontend/app/auth/_components/google-oauth-button.tsx
@@ -13,6 +13,10 @@ interface GoogleOAuthButtonProps {
   termsVersion?: string
   privacyVersion?: string
   onMissingTermsAcceptance?: () => void
+  // PSY-1023: required minimum-age confirmation, mirroring terms acceptance.
+  ageConfirmed?: boolean
+  minAge?: number
+  onMissingAgeConfirmation?: () => void
 }
 
 export function GoogleOAuthButton({
@@ -22,10 +26,17 @@ export function GoogleOAuthButton({
   termsVersion,
   privacyVersion,
   onMissingTermsAcceptance,
+  ageConfirmed = false,
+  minAge,
+  onMissingAgeConfirmation,
 }: GoogleOAuthButtonProps) {
   const handleGoogleLogin = () => {
     if (variant === 'signup' && !termsAccepted) {
       onMissingTermsAcceptance?.()
+      return
+    }
+    if (variant === 'signup' && !ageConfirmed) {
+      onMissingAgeConfirmation?.()
       return
     }
 
@@ -40,6 +51,10 @@ export function GoogleOAuthButton({
       }
       if (privacyVersion) {
         loginUrl.searchParams.set('privacy_version', privacyVersion)
+      }
+      loginUrl.searchParams.set('age_confirmed', 'true')
+      if (minAge) {
+        loginUrl.searchParams.set('min_age_attested', String(minAge))
       }
     }
     window.location.href = loginUrl.toString()

--- a/frontend/app/auth/_components/passkey-signup.test.tsx
+++ b/frontend/app/auth/_components/passkey-signup.test.tsx
@@ -80,7 +80,9 @@ describe('PasskeySignupButton', () => {
 
     await user.click(screen.getByRole('button', { name: /sign up with passkey/i }))
     await user.type(screen.getByLabelText('Email'), 'signup@example.com')
-    await user.click(screen.getByRole('checkbox'))
+    // Two required checkboxes: terms + age confirmation (PSY-1023).
+    await user.click(screen.getByRole('checkbox', { name: /Terms of Service/ }))
+    await user.click(screen.getByRole('checkbox', { name: /at least 16 years old/ }))
     await user.click(
       screen.getByRole('button', { name: /continue with passkey/i })
     )
@@ -97,6 +99,16 @@ describe('PasskeySignupButton', () => {
       terms_accepted: true,
       terms_version: '2026-01-31',
       privacy_version: '2026-02-15',
+      age_confirmed: true,
+      min_age_attested: 16,
+    })
+
+    const finishSignupPayload = JSON.parse(
+      (fetchMock.mock.calls[1]?.[1] as { body: string }).body
+    )
+    expect(finishSignupPayload).toMatchObject({
+      age_confirmed: true,
+      min_age_attested: 16,
     })
 
     await waitFor(() => {
@@ -112,5 +124,23 @@ describe('PasskeySignupButton', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/library')
     })
+  })
+
+  // PSY-1023: the Continue button is disabled and no signup request fires until
+  // the age confirmation is checked, even with email + terms provided.
+  it('blocks passkey signup until age is confirmed', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<PasskeySignupButton returnTo="/library" />)
+
+    await user.click(screen.getByRole('button', { name: /sign up with passkey/i }))
+    await user.type(screen.getByLabelText('Email'), 'signup@example.com')
+    await user.click(screen.getByRole('checkbox', { name: /Terms of Service/ }))
+
+    // Age unchecked → Continue button stays disabled and no fetch fires.
+    expect(
+      screen.getByRole('button', { name: /continue with passkey/i })
+    ).toBeDisabled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/app/auth/_components/passkey-signup.tsx
+++ b/frontend/app/auth/_components/passkey-signup.tsx
@@ -19,7 +19,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { CURRENT_PRIVACY_VERSION, CURRENT_TERMS_VERSION } from '@/lib/legal'
+import { CURRENT_PRIVACY_VERSION, CURRENT_TERMS_VERSION, MIN_SIGNUP_AGE } from '@/lib/legal'
 import { BackupAuthPrompt } from './backup-auth-prompt'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
@@ -30,6 +30,7 @@ interface PasskeySignupButtonProps {
   returnTo?: string
   termsVersion?: string
   privacyVersion?: string
+  minAge?: number
 }
 
 export function PasskeySignupButton({
@@ -38,6 +39,7 @@ export function PasskeySignupButton({
   returnTo = '/',
   termsVersion = CURRENT_TERMS_VERSION,
   privacyVersion = CURRENT_PRIVACY_VERSION,
+  minAge = MIN_SIGNUP_AGE,
 }: PasskeySignupButtonProps) {
   const router = useRouter()
   const { setUser } = useAuthContext()
@@ -48,6 +50,8 @@ export function PasskeySignupButton({
   const [emailError, setEmailError] = useState<string | null>(null)
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [termsError, setTermsError] = useState<string | null>(null)
+  const [ageConfirmed, setAgeConfirmed] = useState(false)
+  const [ageError, setAgeError] = useState<string | null>(null)
 
   // Check if browser supports WebAuthn
   const supportsWebAuthn = browserSupportsWebAuthn()
@@ -69,6 +73,13 @@ export function PasskeySignupButton({
     }
     setTermsError(null)
 
+    // Validate age confirmation (PSY-1023)
+    if (!ageConfirmed) {
+      setAgeError(`You must confirm that you are at least ${minAge} years old`)
+      return
+    }
+    setAgeError(null)
+
     if (!supportsWebAuthn) {
       onError?.('Your browser does not support passkeys')
       return
@@ -87,6 +98,8 @@ export function PasskeySignupButton({
           terms_accepted: true,
           terms_version: termsVersion,
           privacy_version: privacyVersion,
+          age_confirmed: true,
+          min_age_attested: minAge,
         }),
       })
 
@@ -112,6 +125,8 @@ export function PasskeySignupButton({
           terms_accepted: true,
           terms_version: termsVersion,
           privacy_version: privacyVersion,
+          age_confirmed: true,
+          min_age_attested: minAge,
         }),
       })
 
@@ -245,10 +260,32 @@ export function PasskeySignupButton({
               <p role="alert" className="text-sm text-destructive">{termsError}</p>
             )}
           </div>
+          <div className="space-y-2">
+            <div className="flex items-start space-x-3">
+              <Checkbox
+                id="passkey-age-confirmation"
+                checked={ageConfirmed}
+                onCheckedChange={(checked) => {
+                  setAgeConfirmed(checked === true)
+                  setAgeError(null)
+                }}
+                className="mt-0.5"
+              />
+              <Label
+                htmlFor="passkey-age-confirmation"
+                className="text-sm font-normal leading-relaxed cursor-pointer"
+              >
+                I confirm that I am at least {minAge} years old
+              </Label>
+            </div>
+            {ageError && (
+              <p role="alert" className="text-sm text-destructive">{ageError}</p>
+            )}
+          </div>
           <Button
             type="button"
             onClick={handlePasskeySignup}
-            disabled={isLoading || !email || !termsAccepted}
+            disabled={isLoading || !email || !termsAccepted || !ageConfirmed}
             className="w-full"
           >
             {isLoading ? (

--- a/frontend/app/auth/page.tsx
+++ b/frontend/app/auth/page.tsx
@@ -25,7 +25,7 @@ import { PasskeyLoginButton } from '@/app/auth/_components/passkey-login'
 import { PasskeySignupButton } from '@/app/auth/_components/passkey-signup'
 import { GoogleOAuthButton } from '@/app/auth/_components/google-oauth-button'
 import { getUniqueErrors } from '@/lib/utils/formErrors'
-import { CURRENT_PRIVACY_VERSION, CURRENT_TERMS_VERSION } from '@/lib/legal'
+import { CURRENT_PRIVACY_VERSION, CURRENT_TERMS_VERSION, MIN_SIGNUP_AGE } from '@/lib/legal'
 import {
   safeDecodeQueryParam,
   sanitizeReturnTo,
@@ -51,6 +51,11 @@ const signupSchema = z.object({
     .boolean()
     .refine((val) => val === true, {
       message: 'You must agree to the Terms of Service and Privacy Policy',
+    }),
+  ageConfirmed: z
+    .boolean()
+    .refine((val) => val === true, {
+      message: `You must confirm that you are at least ${MIN_SIGNUP_AGE} years old`,
     }),
 })
 
@@ -318,6 +323,7 @@ function SignupForm({ returnTo }: { returnTo: string }) {
       email: '',
       password: '',
       termsAccepted: false,
+      ageConfirmed: false,
     } as SignupFormData,
     onSubmit: async ({ value }) => {
       registerMutation.mutate(
@@ -327,6 +333,8 @@ function SignupForm({ returnTo }: { returnTo: string }) {
           terms_accepted: value.termsAccepted,
           terms_version: CURRENT_TERMS_VERSION,
           privacy_version: CURRENT_PRIVACY_VERSION,
+          age_confirmed: value.ageConfirmed,
+          min_age_attested: MIN_SIGNUP_AGE,
         },
         {
           onSuccess: data => {
@@ -370,16 +378,21 @@ function SignupForm({ returnTo }: { returnTo: string }) {
 
       {/* OAuth and Passkey signup options */}
       <div className="space-y-3">
-        <form.Subscribe selector={state => state.values.termsAccepted}>
-          {termsAccepted => (
+        <form.Subscribe selector={state => [state.values.termsAccepted, state.values.ageConfirmed]}>
+          {([termsAccepted, ageConfirmed]) => (
             <GoogleOAuthButton
               className="w-full"
               variant="signup"
               termsAccepted={termsAccepted}
               termsVersion={CURRENT_TERMS_VERSION}
               privacyVersion={CURRENT_PRIVACY_VERSION}
+              ageConfirmed={ageConfirmed}
+              minAge={MIN_SIGNUP_AGE}
               onMissingTermsAcceptance={() => {
                 setOauthError('You must agree to the Terms of Service and Privacy Policy before continuing with Google')
+              }}
+              onMissingAgeConfirmation={() => {
+                setOauthError(`You must confirm that you are at least ${MIN_SIGNUP_AGE} years old before continuing with Google`)
               }}
             />
           )}
@@ -390,6 +403,7 @@ function SignupForm({ returnTo }: { returnTo: string }) {
           returnTo={returnTo}
           termsVersion={CURRENT_TERMS_VERSION}
           privacyVersion={CURRENT_PRIVACY_VERSION}
+          minAge={MIN_SIGNUP_AGE}
         />
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
@@ -506,6 +520,39 @@ function SignupForm({ returnTo }: { returnTo: string }) {
                 >
                   Privacy Policy
                 </Link>
+              </Label>
+            </div>
+            {field.state.meta.errors.length > 0 && (
+              <p role="alert" className="text-sm text-destructive">
+                {getUniqueErrors(field.state.meta.errors)}
+              </p>
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="ageConfirmed">
+        {field => (
+          <div className="space-y-2">
+            <div className="flex items-start space-x-3">
+              <Checkbox
+                id="age-confirmation"
+                checked={field.state.value}
+                onCheckedChange={(checked) => {
+                  const confirmed = checked === true
+                  field.handleChange(confirmed)
+                  if (confirmed) {
+                    setOauthError(null)
+                  }
+                }}
+                aria-invalid={field.state.meta.errors.length > 0}
+                className="mt-0.5"
+              />
+              <Label
+                htmlFor="age-confirmation"
+                className="text-sm font-normal leading-relaxed cursor-pointer"
+              >
+                I confirm that I am at least {MIN_SIGNUP_AGE} years old
               </Label>
             </div>
             {field.state.meta.errors.length > 0 && (

--- a/frontend/app/auth/signup-form.test.tsx
+++ b/frontend/app/auth/signup-form.test.tsx
@@ -2,8 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
-import { CURRENT_PRIVACY_VERSION, CURRENT_TERMS_VERSION } from '@/lib/legal'
+import { CURRENT_PRIVACY_VERSION, CURRENT_TERMS_VERSION, MIN_SIGNUP_AGE } from '@/lib/legal'
 import AuthPage from './page'
+
+// Accessible names for the two required signup checkboxes (PSY-1023 added age).
+const TERMS_CHECKBOX = /Terms of Service/
+const AGE_CHECKBOX = /at least 16 years old/
+// Distinct error-message text (the checkbox LABEL also contains "at least 16
+// years old", so the error matcher must key off the error-only phrasing).
+const AGE_ERROR = /You must confirm that you are at least 16 years old/
 
 // --- Mocks ---
 
@@ -77,7 +84,8 @@ describe('SignupForm deferred validation', () => {
     expect(screen.queryAllByRole('alert')).toHaveLength(0)
     expect(screen.getByLabelText('Email')).toBeInTheDocument()
     expect(screen.getByLabelText('Password')).toBeInTheDocument()
-    expect(screen.getByRole('checkbox')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: TERMS_CHECKBOX })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: AGE_CHECKBOX })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Create account' })).toBeEnabled()
   })
 
@@ -96,27 +104,30 @@ describe('SignupForm deferred validation', () => {
     await user.click(screen.getByRole('button', { name: 'Create account' }))
 
     await waitFor(() => {
-      // Email + password + terms = 3 error alerts
-      expect(screen.getAllByRole('alert')).toHaveLength(3)
+      // Email + password + terms + age = 4 error alerts (PSY-1023 added age)
+      expect(screen.getAllByRole('alert')).toHaveLength(4)
     })
     expect(screen.getByText(/Please enter a valid email address/)).toBeInTheDocument()
     expect(screen.getByText(/Password must be at least 12 characters/)).toBeInTheDocument()
     expect(screen.getByText(/You must agree to the Terms of Service/)).toBeInTheDocument()
+    expect(screen.getByText(AGE_ERROR)).toBeInTheDocument()
   })
 
   it('shows only email error when other fields are valid', async () => {
     const { user } = await renderSignupForm()
 
-    // Leave email empty, fill password and accept terms
+    // Leave email empty, fill password and accept terms + age
     await user.type(screen.getByLabelText('Password'), 'validPassword123!')
-    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('checkbox', { name: TERMS_CHECKBOX }))
+    await user.click(screen.getByRole('checkbox', { name: AGE_CHECKBOX }))
     await user.click(screen.getByRole('button', { name: 'Create account' }))
 
     await waitFor(() => {
       expect(screen.getByText(/Please enter a valid email address/)).toBeInTheDocument()
     })
-    // Only email error — no terms or password errors
+    // Only email error — no terms, age, or password errors
     expect(screen.queryByText(/You must agree to the Terms of Service/)).not.toBeInTheDocument()
+    expect(screen.queryByText(AGE_ERROR)).not.toBeInTheDocument()
     expect(mockRegisterMutate).not.toHaveBeenCalled()
   })
 
@@ -125,7 +136,8 @@ describe('SignupForm deferred validation', () => {
 
     await user.type(screen.getByLabelText('Email'), 'test@example.com')
     await user.type(screen.getByLabelText('Password'), 'short') // 5 chars
-    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('checkbox', { name: TERMS_CHECKBOX }))
+    await user.click(screen.getByRole('checkbox', { name: AGE_CHECKBOX }))
 
     const submitButton = screen.getByRole('button', { name: 'Create account' })
     expect(submitButton).toBeDisabled()
@@ -136,7 +148,8 @@ describe('SignupForm deferred validation', () => {
     const { user } = await renderSignupForm()
 
     await user.type(screen.getByLabelText('Email'), 'test@example.com')
-    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('checkbox', { name: TERMS_CHECKBOX }))
+    await user.click(screen.getByRole('checkbox', { name: AGE_CHECKBOX }))
 
     // 11 chars => still disabled
     await user.type(screen.getByLabelText('Password'), '12345678901')
@@ -159,13 +172,30 @@ describe('SignupForm deferred validation', () => {
     })
   })
 
+  // PSY-1023: submit is blocked (and the mutation never fires) when age is not
+  // confirmed, even with email, password, and terms all valid.
+  it('shows age error and blocks submit without confirming age', async () => {
+    const { user } = await renderSignupForm()
+
+    await user.type(screen.getByLabelText('Email'), 'test@example.com')
+    await user.type(screen.getByLabelText('Password'), 'validPassword123!')
+    await user.click(screen.getByRole('checkbox', { name: TERMS_CHECKBOX }))
+    // Intentionally leave the age checkbox unchecked.
+    await user.click(screen.getByRole('button', { name: 'Create account' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(AGE_ERROR)).toBeInTheDocument()
+    })
+    expect(mockRegisterMutate).not.toHaveBeenCalled()
+  })
+
   it('clears errors in real-time after failed submit', async () => {
     const { user } = await renderSignupForm()
 
-    // Submit empty form to trigger errors
+    // Submit empty form to trigger errors (email + password + terms + age)
     await user.click(screen.getByRole('button', { name: 'Create account' }))
     await waitFor(() => {
-      expect(screen.getAllByRole('alert')).toHaveLength(3)
+      expect(screen.getAllByRole('alert')).toHaveLength(4)
     })
 
     // Type valid email → email error clears
@@ -181,9 +211,15 @@ describe('SignupForm deferred validation', () => {
     })
 
     // Check terms → terms error clears
-    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('checkbox', { name: TERMS_CHECKBOX }))
     await waitFor(() => {
       expect(screen.queryByText(/You must agree to the Terms of Service/)).not.toBeInTheDocument()
+    })
+
+    // Check age → age error clears
+    await user.click(screen.getByRole('checkbox', { name: AGE_CHECKBOX }))
+    await waitFor(() => {
+      expect(screen.queryByText(AGE_ERROR)).not.toBeInTheDocument()
     })
   })
 
@@ -192,7 +228,8 @@ describe('SignupForm deferred validation', () => {
 
     await user.type(screen.getByLabelText('Email'), 'test@example.com')
     await user.type(screen.getByLabelText('Password'), 'validPassword123!')
-    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('checkbox', { name: TERMS_CHECKBOX }))
+    await user.click(screen.getByRole('checkbox', { name: AGE_CHECKBOX }))
     await user.click(screen.getByRole('button', { name: 'Create account' }))
 
     await waitFor(() => {
@@ -203,6 +240,8 @@ describe('SignupForm deferred validation', () => {
           terms_accepted: true,
           terms_version: CURRENT_TERMS_VERSION,
           privacy_version: CURRENT_PRIVACY_VERSION,
+          age_confirmed: true,
+          min_age_attested: MIN_SIGNUP_AGE,
         },
         expect.any(Object),
       )
@@ -214,7 +253,8 @@ describe('SignupForm deferred validation', () => {
 
     await user.type(screen.getByLabelText('Email'), 'not-an-email')
     await user.type(screen.getByLabelText('Password'), 'validPassword123!')
-    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('checkbox', { name: TERMS_CHECKBOX }))
+    await user.click(screen.getByRole('checkbox', { name: AGE_CHECKBOX }))
     await user.click(screen.getByRole('button', { name: 'Create account' }))
 
     await waitFor(() => {

--- a/frontend/features/auth/hooks/useAuth.test.tsx
+++ b/frontend/features/auth/hooks/useAuth.test.tsx
@@ -209,6 +209,8 @@ describe('useAuth hooks', () => {
           terms_accepted: true,
           terms_version: '2026-01-31',
           privacy_version: '2026-02-15',
+          age_confirmed: true,
+          min_age_attested: 16,
         })
       })
 
@@ -226,6 +228,8 @@ describe('useAuth hooks', () => {
             terms_accepted: true,
             terms_version: '2026-01-31',
             privacy_version: '2026-02-15',
+            age_confirmed: true,
+            min_age_attested: 16,
           }),
         })
       )
@@ -249,6 +253,8 @@ describe('useAuth hooks', () => {
           terms_accepted: true,
           terms_version: '2026-01-31',
           privacy_version: '2026-02-15',
+          age_confirmed: true,
+          min_age_attested: 16,
         })
       })
 

--- a/frontend/features/auth/hooks/useAuth.ts
+++ b/frontend/features/auth/hooks/useAuth.ts
@@ -28,6 +28,9 @@ interface RegisterCredentials {
   terms_accepted: boolean
   terms_version: string
   privacy_version: string
+  // PSY-1023: required minimum-age confirmation, mirroring terms_accepted.
+  age_confirmed: boolean
+  min_age_attested: number
 }
 
 interface AuthResponse {

--- a/frontend/lib/legal.ts
+++ b/frontend/lib/legal.ts
@@ -1,3 +1,8 @@
 // Version identifiers persisted at account creation for legal acceptance evidence.
 export const CURRENT_TERMS_VERSION = '2026-01-31'
 export const CURRENT_PRIVACY_VERSION = '2026-02-15'
+
+// Minimum age (years) a user must confirm at signup. Locked at 16 (PSY-1023) to
+// match the /terms and /privacy minimum-age clauses. The backend re-checks this
+// value, so the frontend confirmation is a UX gate, not the authoritative one.
+export const MIN_SIGNUP_AGE = 16


### PR DESCRIPTION
## Summary

Adds a required **"I am at least 16 years old"** confirmation to signup, recorded on the user (`age_confirmed_at` + `min_age_attested`), mirroring the existing terms-acceptance mechanism so it covers every live account-creation path identically. Minimum age is **16** (decided), matching the `/terms` + `/privacy` minimum-age clauses — no legal-doc rewrite.

**Backend** (Go)
- `User` gains `AgeConfirmedAt *time.Time` + `MinAgeAttested *int` (`json:"-"`), mirroring `TermsAcceptedAt` / `TermsVersion`. Additive, nullable, reversible migration adds the two columns.
- `LegalAcceptance` + `OAuthSignupConsent` carry the age fields; new `AGE_CONFIRMATION_REQUIRED` error code + `ErrAgeConfirmationRequired`.
- The **backend is the authoritative gate** (`MinSignupAge = 16`): password register, passkey begin+finish, and OAuth login-init all require the confirmation and re-check the attested age `>= 16`, so a tampered/absent client value cannot bypass it. The age is persisted on the new user in all three creation paths.

**Frontend** (Next.js)
- Required age checkbox on the password signup form, the passkey signup dialog, and gating the Google OAuth button. Submit is blocked (inline error) until checked, mirroring terms. `MIN_SIGNUP_AGE` constant in `lib/legal.ts`.

### Account-creation paths gated
| Path | Gated? | How |
| --- | --- | --- |
| Password register (`/auth/register`) | ✅ | handler guard + recorded via `CreateUserWithPasswordWithLegal` |
| Passkey (`/auth/passkey/signup/begin`+`finish`) | ✅ | guard on both; recorded via `FinishSignupRegistrationWithLegal` |
| Google OAuth (`/auth/login/google?signup_intent=1`) | ✅ | login-init guard + consent cookie; service-layer `validateOAuthSignupConsent` |
| Magic-link (`/auth/magic-link/*`) | n/a | does **not** create accounts (sends a link to existing verified users only) — verified |
| Apple Sign In (`/auth/apple/callback`) | ⚠️ disclosed | see Adversarial review below — pre-existing gap, follow-up PSY-1036 |

`/terms` + `/privacy` already state 16+ and are **consistent** — unchanged.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/api/handlers/auth/... ./internal/models/... ./internal/services/...` — pass (incl. new age-gate + age-recording tests across register/passkey/OAuth)
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors
- [x] `cd frontend && bun run test:run app/auth features/auth` — 156 pass (incl. new "submit blocked without age" tests for the form + passkey)

## Manual repro
Isolated dispatch stack (mode=isolated; migration applied — `age_confirmed_at` + `min_age_attested` columns verified present).

Backend gate (curl):
- Register **without** age confirmation → `success:false, error_code:AGE_CONFIRMATION_REQUIRED`
- Register with `min_age_attested=10` (below minimum) → `AGE_CONFIRMATION_REQUIRED`
- Register with valid age → `success:true`; DB row shows `age_confirmed=t, min_age_attested=16`
- OAuth `signup_intent=1` **without** age → HTTP 400 "Age confirmation is required for account creation"; with `min_age_attested=10` → HTTP 400

UI: signup form shows both checkboxes; checking terms only + Create account → age checkbox goes `invalid`, error "You must confirm that you are at least 16 years old", **Create account button disabled**.

## Screenshots
Signup form (both checkboxes) + blocked state (age error, disabled button), light + dark:

- Form (light): https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1023-screenshots/signup-form-light.png
- Blocked (light): https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1023-screenshots/signup-blocked-light.png
- Blocked (dark): https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1023-screenshots/signup-blocked-dark.png

## Code review
`/code-review` (9-angle inline) — no correctness bugs. Verified the legacy no-legal signup helpers (`FinishSignupRegistration`, `CreateUserWithoutPassword`, `CreateUserWithPassword`) have **zero** production callers, so no path bypasses the gate; OAuth age gate only runs for brand-new users (returning-user login untouched, mirrors terms). One maintainability note (hand-synced "16" in the error copy) documented with a comment in `992c854` (`PSY-1023: code-review pass`).

## Adversarial review
`/adversarial-review` — **CONCERNS** (1 finding disclosed, no code fix). Panel: Saboteur · Future-Maintainer · Security · Completeness, run against the branch diff with no session context.
- **[MEDIUM, disclosed] Apple Sign In (`/auth/apple/callback`) creates accounts without recording terms *or* age.** Pre-existing (it never recorded terms either) and has **no frontend affordance** — so it cannot be gated cleanly without a corresponding FE change, which is out of this PR's mirror-terms scope. Per the kickoff ("STOP + report if a signup path can't be gated cleanly") this is disclosed, not silently changed. Follow-up filed: **PSY-1036**.
- Held up well: backend is the real gate (verified via curl on all 3 live paths); age fields hidden from JSON; no injection/PII leak; magic-link confirmed non-account-creating.

Closes PSY-1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)
