### PR TITLE
PSY-1023: tick age confirmation in E2E register spec

### DIFF
--- a/frontend/e2e/auth/register.spec.ts
+++ b/frontend/e2e/auth/register.spec.ts
@@ -20,6 +20,7 @@ test.describe('Registration', () => {
     await page.locator('#signup-email').fill(REGISTER_USER.email)
     await page.locator('#signup-password').fill(REGISTER_USER.password)
     await page.locator('#terms').check()
+    await page.locator('#age-confirmation').check()
 
     // Submit
     await page.getByRole('button', { name: 'Create account' }).click()
@@ -68,6 +69,7 @@ test.describe('Registration', () => {
     await page.locator('#signup-email').fill('breach-test@test.local')
     await page.locator('#signup-password').fill('TestPassword123!')
     await page.locator('#terms').check()
+    await page.locator('#age-confirmation').check()
 
     // Submit — server will reject the breached password
     await page.getByRole('button', { name: 'Create account' }).click()


### PR DESCRIPTION
## Summary

Follow-up to PSY-1023 (#1056) — restores E2E register coverage broken by the age gate.

PSY-1023 added a **required** "I am at least 16 years old" confirmation (`#age-confirmation`) to the signup form. `ageConfirmed` is in the form's Zod schema and gates `canSubmit`, so the "Create account" button stays **disabled** until the age box is checked. The merge did not update the E2E spec, so `frontend/e2e/auth/register.spec.ts` ticked only `#terms` → button disabled → form never submitted → `waitForURL` timed out. (The #1056 E2E run failed on an unrelated 504 infra flake that masked this; it would surface on the next run.)

This ticks `#age-confirmation` right after the existing `#terms` tick in the two tests that submit / reach the server:
- `@smoke` "registers a new account and redirects to home"
- "shows error for breached password" (must submit to hit the server breach check)

The "shows password strength requirements" test is left unchanged — it only asserts the button is **disabled** with a short password, which holds regardless of the age box.

## Test plan

- [x] **Register E2E spec run locally** — `cd frontend && bun run test:e2e -- e2e/auth/register.spec.ts` → **3 passed (31.5s)**. Backend logs confirmed both server-reaching paths: `register_success user_id=10` (smoke) and `register_validation_failed … password has been exposed in a data breach` (breach test).
- [x] **Lint** — `cd frontend && bun run lint` → exit 0 (0 errors; 156 pre-existing warnings, none in `register.spec.ts`).

## Manual repro

E2E spec run locally — 3/3 register tests pass; the `@smoke` registration now submits with the age box ticked (previously the disabled Create-account button blocked submission and `waitForURL` timed out).

## Other signup-via-UI flows

Confirmed `register.spec.ts` is the only E2E flow that registers via the signup UI. `e2e/global-setup.ts` logs in seeded users via the **login** form (`#email` / `#password` / "Sign in") — no terms/age checkbox — so no other flow needed the fix.

## Code review

`/code-review` (xhigh, inline — no Agent tool in worktree) — CLEAN, no findings. The 2-line addition mirrors the adjacent `#terms` tick exactly; `#age-confirmation` confirmed present in the same form at `frontend/app/auth/page.tsx:539`.

## Adversarial review

`/adversarial-review` — CLEAN, no findings (no fix commit needed). 4 lenses run inline (no Agent tool in worktree):
- **Saboteur** — `.check()` is idempotent + auto-waits; single-match locator (no strict-mode ambiguity); real E2E run confirms both paths submit. CLEAN.
- **Future Maintainer** — placed beside the analogous `#terms` tick, mirroring intra-test convention; id matches the production attribute. CLEAN.
- **Security** — test-only `e2e/` change; breach test still asserts server rejection, so security coverage is preserved. CLEAN.
- **Completeness** — all acceptance criteria met (age tick added to the 2 submitting tests, strength test unchanged, spec passes, lint passes, no other flow affected). CLEAN.

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran against the branch diff.
