### PR TITLE
PSY-1046: public profile list endpoints (following / attended / field-notes)

### DIFF
--- a/backend/internal/api/handlers/community/contributor_profile.go
+++ b/backend/internal/api/handlers/community/contributor_profile.go
@@ -11,23 +11,36 @@ import (
 	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
+	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
 // ContributorProfileHandler handles contributor profile HTTP requests.
 type ContributorProfileHandler struct {
-	profileService contracts.ContributorProfileServiceInterface
-	userService    contracts.UserServiceInterface
+	profileService    contracts.ContributorProfileServiceInterface
+	userService       contracts.UserServiceInterface
+	followService     contracts.FollowServiceInterface
+	attendanceService contracts.AttendanceServiceInterface
+	fieldNoteService  contracts.FieldNoteServiceInterface
 }
 
 // NewContributorProfileHandler creates a new contributor profile handler.
+// followService / attendanceService / fieldNoteService back the public
+// profile list endpoints (PSY-1046); tests that don't exercise those
+// handlers may pass nil for them.
 func NewContributorProfileHandler(
 	profileService contracts.ContributorProfileServiceInterface,
 	userService contracts.UserServiceInterface,
+	followService contracts.FollowServiceInterface,
+	attendanceService contracts.AttendanceServiceInterface,
+	fieldNoteService contracts.FieldNoteServiceInterface,
 ) *ContributorProfileHandler {
 	return &ContributorProfileHandler{
-		profileService: profileService,
-		userService:    userService,
+		profileService:    profileService,
+		userService:       userService,
+		followService:     followService,
+		attendanceService: attendanceService,
+		fieldNoteService:  fieldNoteService,
 	}
 }
 
@@ -169,7 +182,98 @@ type GetPercentileRankingsResponse struct {
 	Body *contracts.PercentileRankings
 }
 
+type GetUserFollowingRequest struct {
+	Username string `path:"username" doc:"Username of the contributor"`
+	Type     string `query:"type" default:"all" doc:"Entity type filter: artist, venue, label, festival, or all"`
+	Limit    int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of items per page (max 100)"`
+	Offset   int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+}
+
+type GetUserFollowingResponse struct {
+	Body struct {
+		Following []*contracts.FollowingEntityResponse `json:"following"`
+		Total     int64                                `json:"total"`
+		Limit     int                                  `json:"limit"`
+		Offset    int                                  `json:"offset"`
+	}
+}
+
+type GetUserAttendedShowsRequest struct {
+	Username string `path:"username" doc:"Username of the contributor"`
+	Limit    int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of shows per page (max 100)"`
+	Offset   int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+}
+
+type GetUserAttendedShowsResponse struct {
+	Body struct {
+		Shows  []*contracts.AttendingShowResponse `json:"shows"`
+		Total  int64                              `json:"total"`
+		Limit  int                                `json:"limit"`
+		Offset int                                `json:"offset"`
+	}
+}
+
+type GetUserFieldNotesRequest struct {
+	Username string `path:"username" doc:"Username of the contributor"`
+	Limit    int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Number of field notes per page (max 100)"`
+	Offset   int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+}
+
+type GetUserFieldNotesResponse struct {
+	Body struct {
+		FieldNotes []*contracts.AuthoredFieldNote `json:"field_notes"`
+		Total      int64                          `json:"total"`
+		Limit      int                            `json:"limit"`
+		Offset     int                            `json:"offset"`
+	}
+}
+
 // --- Handlers ---
+
+// resolveProfileTarget looks up the profile owner by username and applies the
+// master profile-visibility gate shared by every public profile endpoint.
+// Returns the target user and whether the viewer is the owner. A private
+// profile (or missing user) resolves to 404 so hidden profiles are
+// indistinguishable from nonexistent ones.
+func (h *ContributorProfileHandler) resolveProfileTarget(ctx context.Context, username string) (*authm.User, bool, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	targetUser, err := h.userService.GetUserByUsername(username)
+	if err != nil {
+		logger.FromContext(ctx).Error("profile_target_lookup_failed",
+			"username", username,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, false, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to look up user (request_id: %s)", requestID),
+		)
+	}
+	if targetUser == nil {
+		return nil, false, huma.Error404NotFound("User not found")
+	}
+
+	viewer := middleware.GetUserFromContext(ctx)
+	isOwner := viewer != nil && viewer.ID == targetUser.ID
+
+	// Master privacy check
+	if targetUser.ProfileVisibility == "private" && !isOwner {
+		return nil, false, huma.Error404NotFound("User not found")
+	}
+
+	return targetUser, isOwner, nil
+}
+
+// granularPrivacy unmarshals the user's stored privacy settings over the
+// defaults. Unmarshal failures fall back to the defaults (the same lenient
+// posture the profile service takes for this column).
+func granularPrivacy(targetUser *authm.User) contracts.PrivacySettings {
+	privacy := contracts.DefaultPrivacySettings()
+	if targetUser.PrivacySettings != nil {
+		_ = json.Unmarshal(*targetUser.PrivacySettings, &privacy)
+	}
+	return privacy
+}
 
 // GetPublicProfileHandler handles GET /users/{username}.
 func (h *ContributorProfileHandler) GetPublicProfileHandler(ctx context.Context, req *GetPublicProfileRequest) (*GetPublicProfileResponse, error) {
@@ -204,37 +308,14 @@ func (h *ContributorProfileHandler) GetPublicProfileHandler(ctx context.Context,
 func (h *ContributorProfileHandler) GetContributionHistoryHandler(ctx context.Context, req *GetContributionHistoryRequest) (*GetContributionHistoryResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	targetUser, err := h.userService.GetUserByUsername(req.Username)
+	targetUser, isOwner, err := h.resolveProfileTarget(ctx, req.Username)
 	if err != nil {
-		logger.FromContext(ctx).Error("get_contribution_history_user_lookup_failed",
-			"username", req.Username,
-			"error", err.Error(),
-			"request_id", requestID,
-		)
-		return nil, huma.Error500InternalServerError(
-			fmt.Sprintf("Failed to look up user (request_id: %s)", requestID),
-		)
-	}
-	if targetUser == nil {
-		return nil, huma.Error404NotFound("User not found")
-	}
-
-	viewer := middleware.GetUserFromContext(ctx)
-	isOwner := viewer != nil && viewer.ID == targetUser.ID
-
-	// Master privacy check
-	if targetUser.ProfileVisibility == "private" && !isOwner {
-		return nil, huma.Error404NotFound("User not found")
+		return nil, err
 	}
 
 	// Granular privacy check for contributions
 	if !isOwner {
-		privacy := contracts.DefaultPrivacySettings()
-		if targetUser.PrivacySettings != nil {
-			_ = json.Unmarshal(*targetUser.PrivacySettings, &privacy)
-		}
-
-		switch privacy.Contributions {
+		switch granularPrivacy(targetUser).Contributions {
 		case contracts.PrivacyHidden:
 			return nil, huma.Error404NotFound("User not found")
 		case contracts.PrivacyCountOnly:
@@ -791,4 +872,186 @@ func (h *ContributorProfileHandler) GetPercentileRankingsHandler(ctx context.Con
 	}
 
 	return &GetPercentileRankingsResponse{Body: rankings}, nil
+}
+
+// GetUserFollowingHandler handles GET /users/{username}/following (PSY-1046).
+// Lists the artists / venues / labels / festivals a user follows, gated by
+// the profile's `following` privacy setting (default count_only).
+func (h *ContributorProfileHandler) GetUserFollowingHandler(ctx context.Context, req *GetUserFollowingRequest) (*GetUserFollowingResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	targetUser, isOwner, err := h.resolveProfileTarget(ctx, req.Username)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate type filter (mirrors GetMyFollowingHandler); "all"/"" mean no filter.
+	entityType := req.Type
+	if entityType == "all" {
+		entityType = ""
+	}
+	switch entityType {
+	case "", "artist", "venue", "label", "festival":
+	default:
+		return nil, huma.Error400BadRequest("Type must be 'artist', 'venue', 'label', 'festival', or 'all'")
+	}
+
+	emptyBody := func(total int64) *GetUserFollowingResponse {
+		return &GetUserFollowingResponse{
+			Body: struct {
+				Following []*contracts.FollowingEntityResponse `json:"following"`
+				Total     int64                                `json:"total"`
+				Limit     int                                  `json:"limit"`
+				Offset    int                                  `json:"offset"`
+			}{
+				Following: []*contracts.FollowingEntityResponse{},
+				Total:     total,
+				Limit:     req.Limit,
+				Offset:    req.Offset,
+			},
+		}
+	}
+
+	if !isOwner {
+		switch granularPrivacy(targetUser).Following {
+		case contracts.PrivacyHidden:
+			return nil, huma.Error404NotFound("User not found")
+		case contracts.PrivacyCountOnly:
+			// Total only, no items. limit=1 keeps the page fetch trivial; the
+			// service's count query is what we're after.
+			_, total, err := h.followService.GetUserFollowing(targetUser.ID, entityType, 1, 0)
+			if err != nil {
+				logger.FromContext(ctx).Error("get_user_following_count_failed",
+					"user_id", targetUser.ID,
+					"error", err.Error(),
+					"request_id", requestID,
+				)
+				return nil, huma.Error500InternalServerError(
+					fmt.Sprintf("Failed to get following (request_id: %s)", requestID),
+				)
+			}
+			return emptyBody(total), nil
+		}
+	}
+
+	following, total, err := h.followService.GetUserFollowing(targetUser.ID, entityType, req.Limit, req.Offset)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_user_following_failed",
+			"user_id", targetUser.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get following (request_id: %s)", requestID),
+		)
+	}
+
+	resp := emptyBody(total)
+	resp.Body.Following = following
+	return resp, nil
+}
+
+// GetUserAttendedShowsHandler handles GET /users/{username}/attended-shows
+// (PSY-1046). The concert diary: past approved shows the user marked "going",
+// most recent first, gated by the profile's `attendance` privacy setting
+// (default hidden).
+func (h *ContributorProfileHandler) GetUserAttendedShowsHandler(ctx context.Context, req *GetUserAttendedShowsRequest) (*GetUserAttendedShowsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	targetUser, isOwner, err := h.resolveProfileTarget(ctx, req.Username)
+	if err != nil {
+		return nil, err
+	}
+
+	emptyBody := func(total int64) *GetUserAttendedShowsResponse {
+		return &GetUserAttendedShowsResponse{
+			Body: struct {
+				Shows  []*contracts.AttendingShowResponse `json:"shows"`
+				Total  int64                              `json:"total"`
+				Limit  int                                `json:"limit"`
+				Offset int                                `json:"offset"`
+			}{
+				Shows:  []*contracts.AttendingShowResponse{},
+				Total:  total,
+				Limit:  req.Limit,
+				Offset: req.Offset,
+			},
+		}
+	}
+
+	if !isOwner {
+		switch granularPrivacy(targetUser).Attendance {
+		case contracts.PrivacyHidden:
+			return nil, huma.Error404NotFound("User not found")
+		case contracts.PrivacyCountOnly:
+			_, total, err := h.attendanceService.GetUserAttendedShows(targetUser.ID, 1, 0)
+			if err != nil {
+				logger.FromContext(ctx).Error("get_user_attended_shows_count_failed",
+					"user_id", targetUser.ID,
+					"error", err.Error(),
+					"request_id", requestID,
+				)
+				return nil, huma.Error500InternalServerError(
+					fmt.Sprintf("Failed to get attended shows (request_id: %s)", requestID),
+				)
+			}
+			return emptyBody(total), nil
+		}
+	}
+
+	shows, total, err := h.attendanceService.GetUserAttendedShows(targetUser.ID, req.Limit, req.Offset)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_user_attended_shows_failed",
+			"user_id", targetUser.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get attended shows (request_id: %s)", requestID),
+		)
+	}
+
+	resp := emptyBody(total)
+	resp.Body.Shows = shows
+	return resp, nil
+}
+
+// GetUserFieldNotesHandler handles GET /users/{username}/field-notes
+// (PSY-1046). Lists the visible field notes a user has written, newest
+// first. No granular privacy field gates field notes: they are already
+// public on each show page, so this listing is just a different index over
+// already-public content — only the master profile-visibility gate applies.
+func (h *ContributorProfileHandler) GetUserFieldNotesHandler(ctx context.Context, req *GetUserFieldNotesRequest) (*GetUserFieldNotesResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	targetUser, _, err := h.resolveProfileTarget(ctx, req.Username)
+	if err != nil {
+		return nil, err
+	}
+
+	notes, total, err := h.fieldNoteService.ListFieldNotesByAuthor(targetUser.ID, req.Limit, req.Offset)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_user_field_notes_failed",
+			"user_id", targetUser.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get field notes (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetUserFieldNotesResponse{
+		Body: struct {
+			FieldNotes []*contracts.AuthoredFieldNote `json:"field_notes"`
+			Total      int64                          `json:"total"`
+			Limit      int                            `json:"limit"`
+			Offset     int                            `json:"offset"`
+		}{
+			FieldNotes: notes,
+			Total:      total,
+			Limit:      req.Limit,
+			Offset:     req.Offset,
+		},
+	}, nil
 }

--- a/backend/internal/api/handlers/community/contributor_profile_integration_test.go
+++ b/backend/internal/api/handlers/community/contributor_profile_integration_test.go
@@ -5,13 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
 	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/engagement"
 	usersvc "psychic-homily-backend/internal/services/user"
+	"psychic-homily-backend/internal/utils"
 )
 
 type ContributorProfileHandlerIntegrationSuite struct {
@@ -24,12 +29,20 @@ type ContributorProfileHandlerIntegrationSuite struct {
 func (s *ContributorProfileHandlerIntegrationSuite) SetupSuite() {
 	s.deps = testhelpers.SetupIntegrationDeps(s.T())
 	s.profileService = usersvc.NewContributorProfileService(s.deps.DB)
-	s.handler = NewContributorProfileHandler(s.profileService, s.deps.UserService)
+	s.handler = NewContributorProfileHandler(
+		s.profileService, s.deps.UserService,
+		engagement.NewFollowService(s.deps.DB),
+		engagement.NewAttendanceService(s.deps.DB),
+		engagement.NewCommentService(s.deps.DB, utils.NewMarkdownRenderer()),
+	)
 }
 
 func (s *ContributorProfileHandlerIntegrationSuite) TearDownTest() {
 	sqlDB, _ := s.deps.DB.DB()
 	_, _ = sqlDB.Exec("DELETE FROM user_profile_sections")
+	// comments is not covered by CleanupTables; the PSY-1046 field-note
+	// tests seed it directly.
+	_, _ = sqlDB.Exec("DELETE FROM comments")
 	testhelpers.CleanupTables(s.deps.DB)
 }
 
@@ -948,4 +961,325 @@ func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_NoAct
 	s.NoError(err)
 	s.NotNil(resp)
 	s.Empty(resp.Body.Days)
+}
+
+// =============================================================================
+// PSY-1046: public profile list endpoints
+// (following / attended-shows / field-notes)
+// =============================================================================
+
+// --- Seed helpers ---
+
+func (s *ContributorProfileHandlerIntegrationSuite) createArtistEntity(name, slug string) *catalogm.Artist {
+	artist := &catalogm.Artist{Name: name, Slug: testhelpers.StringPtr(slug)}
+	s.deps.DB.Create(artist)
+	return artist
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) createVenueEntity(name, slug string) *catalogm.Venue {
+	venue := &catalogm.Venue{Name: name, Slug: testhelpers.StringPtr(slug), City: "Phoenix", State: "AZ"}
+	s.deps.DB.Create(venue)
+	return venue
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) createShowAt(title string, eventDate time.Time, venue *catalogm.Venue) *catalogm.Show {
+	show := &catalogm.Show{
+		Title:     title,
+		EventDate: eventDate,
+		City:      testhelpers.StringPtr("Phoenix"),
+		State:     testhelpers.StringPtr("AZ"),
+		Status:    catalogm.ShowStatusApproved,
+	}
+	s.deps.DB.Create(show)
+	// Slug is auto-set in CreateShow but raw inserts skip that.
+	s.deps.DB.Model(show).Update("slug", fmt.Sprintf("show-%d", show.ID))
+	if venue != nil {
+		s.Require().NoError(s.deps.DB.Model(show).Association("Venues").Append(venue))
+	}
+	return show
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) bookmark(userID uint, entityType engagementm.BookmarkEntityType, entityID uint, action engagementm.BookmarkAction) {
+	s.deps.DB.Create(&engagementm.UserBookmark{
+		UserID:     userID,
+		EntityType: entityType,
+		EntityID:   entityID,
+		Action:     action,
+	})
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) createFieldNote(userID, showID uint, body string, visibility engagementm.CommentVisibility, createdAt time.Time) *engagementm.Comment {
+	note := &engagementm.Comment{
+		EntityType: engagementm.CommentEntityShow,
+		EntityID:   showID,
+		Kind:       engagementm.CommentKindFieldNote,
+		UserID:     userID,
+		Body:       body,
+		BodyHTML:   "<p>" + body + "</p>",
+		Visibility: visibility,
+		CreatedAt:  createdAt,
+		UpdatedAt:  createdAt,
+	}
+	s.deps.DB.Create(note)
+	return note
+}
+
+// =============================================================================
+// GetUserFollowingHandler
+// =============================================================================
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFollowing_VisibleList() {
+	target := s.createUserWithUsername("followpublic")
+	settings := contracts.DefaultPrivacySettings()
+	settings.Following = contracts.PrivacyVisible
+	s.setPrivacySettings(target, settings)
+
+	a1 := s.createArtistEntity("Just Mustard", "just-mustard")
+	a2 := s.createArtistEntity("Wisp", "wisp")
+	v1 := s.createVenueEntity("Valley Bar", "valley-bar")
+	s.bookmark(target.ID, engagementm.BookmarkEntityArtist, a1.ID, engagementm.BookmarkActionFollow)
+	s.bookmark(target.ID, engagementm.BookmarkEntityArtist, a2.ID, engagementm.BookmarkActionFollow)
+	s.bookmark(target.ID, engagementm.BookmarkEntityVenue, v1.ID, engagementm.BookmarkActionFollow)
+
+	// Anonymous viewer, type=all: full enriched list.
+	resp, err := s.handler.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "followpublic", Type: "all", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(3), resp.Body.Total)
+	s.Require().Len(resp.Body.Following, 3)
+
+	slugsByName := map[string]string{}
+	for _, f := range resp.Body.Following {
+		slugsByName[f.Name] = f.Slug
+	}
+	s.Equal("just-mustard", slugsByName["Just Mustard"])
+	s.Equal("valley-bar", slugsByName["Valley Bar"])
+
+	// Type filter narrows to artists only.
+	resp, err = s.handler.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "followpublic", Type: "artist", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(2), resp.Body.Total)
+	s.Require().Len(resp.Body.Following, 2)
+	for _, f := range resp.Body.Following {
+		s.Equal("artist", f.EntityType)
+	}
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFollowing_DefaultCountOnly() {
+	// No stored privacy settings: the default for `following` is count_only,
+	// so anonymous viewers get a total but no items. Guarding the default
+	// matters — flipping it is an explicit open question on PSY-1045.
+	target := s.createUserWithUsername("followdefault")
+	a1 := s.createArtistEntity("Crows", "crows")
+	s.bookmark(target.ID, engagementm.BookmarkEntityArtist, a1.ID, engagementm.BookmarkActionFollow)
+
+	resp, err := s.handler.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "followdefault", Type: "all", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(1), resp.Body.Total)
+	s.Empty(resp.Body.Following)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFollowing_Hidden() {
+	target := s.createUserWithUsername("followhidden")
+	settings := contracts.DefaultPrivacySettings()
+	settings.Following = contracts.PrivacyHidden
+	s.setPrivacySettings(target, settings)
+
+	_, err := s.handler.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "followhidden", Type: "all", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(s.T(), err, 404)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFollowing_OwnerSeesFullDespiteHidden() {
+	target := s.createUserWithUsername("followowner")
+	settings := contracts.DefaultPrivacySettings()
+	settings.Following = contracts.PrivacyHidden
+	s.setPrivacySettings(target, settings)
+	a1 := s.createArtistEntity("Squid", "squid")
+	s.bookmark(target.ID, engagementm.BookmarkEntityArtist, a1.ID, engagementm.BookmarkActionFollow)
+
+	resp, err := s.handler.GetUserFollowingHandler(testhelpers.CtxWithUser(target), &GetUserFollowingRequest{
+		Username: "followowner", Type: "all", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(1), resp.Body.Total)
+	s.Require().Len(resp.Body.Following, 1)
+	s.Equal("Squid", resp.Body.Following[0].Name)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFollowing_PrivateProfile() {
+	target := s.createPrivateUser("followprivate")
+
+	// Anonymous viewer: master gate hides the profile entirely.
+	_, err := s.handler.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "followprivate", Type: "all", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(s.T(), err, 404)
+
+	// Owner still passes the master gate.
+	_, err = s.handler.GetUserFollowingHandler(testhelpers.CtxWithUser(target), &GetUserFollowingRequest{
+		Username: "followprivate", Type: "all", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFollowing_InvalidType() {
+	s.createUserWithUsername("followbadtype")
+	_, err := s.handler.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "followbadtype", Type: "banana", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(s.T(), err, 400)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFollowing_UserNotFound() {
+	_, err := s.handler.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "ghost-user", Type: "all", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(s.T(), err, 404)
+}
+
+// =============================================================================
+// GetUserAttendedShowsHandler
+// =============================================================================
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserAttendedShows_VisiblePastOnlyDesc() {
+	target := s.createUserWithUsername("diaryuser")
+	settings := contracts.DefaultPrivacySettings()
+	settings.Attendance = contracts.PrivacyVisible
+	s.setPrivacySettings(target, settings)
+
+	venue := s.createVenueEntity("Rebel Lounge", "rebel-lounge")
+	now := time.Now().UTC()
+	older := s.createShowAt("Older Past Show", now.AddDate(0, -2, 0), venue)
+	recent := s.createShowAt("Recent Past Show", now.AddDate(0, -1, 0), venue)
+	future := s.createShowAt("Future Show", now.AddDate(0, 1, 0), venue)
+	pastInterested := s.createShowAt("Interested Past Show", now.AddDate(0, -3, 0), venue)
+
+	s.bookmark(target.ID, engagementm.BookmarkEntityShow, older.ID, engagementm.BookmarkActionGoing)
+	s.bookmark(target.ID, engagementm.BookmarkEntityShow, recent.ID, engagementm.BookmarkActionGoing)
+	s.bookmark(target.ID, engagementm.BookmarkEntityShow, future.ID, engagementm.BookmarkActionGoing)
+	s.bookmark(target.ID, engagementm.BookmarkEntityShow, pastInterested.ID, engagementm.BookmarkActionInterested)
+
+	resp, err := s.handler.GetUserAttendedShowsHandler(context.Background(), &GetUserAttendedShowsRequest{
+		Username: "diaryuser", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	// Future "going" and past "interested" are both excluded from the diary.
+	s.Equal(int64(2), resp.Body.Total)
+	s.Require().Len(resp.Body.Shows, 2)
+	// Most recent first.
+	s.Equal("Recent Past Show", resp.Body.Shows[0].Title)
+	s.Equal("Older Past Show", resp.Body.Shows[1].Title)
+	s.Equal("going", resp.Body.Shows[0].Status)
+	// Venue enrichment survives the join.
+	s.Require().NotNil(resp.Body.Shows[0].VenueName)
+	s.Equal("Rebel Lounge", *resp.Body.Shows[0].VenueName)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserAttendedShows_DefaultHidden() {
+	// No stored privacy settings: the default for `attendance` is hidden —
+	// anonymous viewers must get a 404, while the owner still sees the diary.
+	target := s.createUserWithUsername("diaryhidden")
+	show := s.createShowAt("Past Hidden Show", time.Now().UTC().AddDate(0, -1, 0), nil)
+	s.bookmark(target.ID, engagementm.BookmarkEntityShow, show.ID, engagementm.BookmarkActionGoing)
+
+	_, err := s.handler.GetUserAttendedShowsHandler(context.Background(), &GetUserAttendedShowsRequest{
+		Username: "diaryhidden", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(s.T(), err, 404)
+
+	resp, err := s.handler.GetUserAttendedShowsHandler(testhelpers.CtxWithUser(target), &GetUserAttendedShowsRequest{
+		Username: "diaryhidden", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(1), resp.Body.Total)
+	s.Require().Len(resp.Body.Shows, 1)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserAttendedShows_CountOnly() {
+	target := s.createUserWithUsername("diarycount")
+	settings := contracts.DefaultPrivacySettings()
+	settings.Attendance = contracts.PrivacyCountOnly
+	s.setPrivacySettings(target, settings)
+	show := s.createShowAt("Past Counted Show", time.Now().UTC().AddDate(0, -1, 0), nil)
+	s.bookmark(target.ID, engagementm.BookmarkEntityShow, show.ID, engagementm.BookmarkActionGoing)
+
+	resp, err := s.handler.GetUserAttendedShowsHandler(context.Background(), &GetUserAttendedShowsRequest{
+		Username: "diarycount", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(1), resp.Body.Total)
+	s.Empty(resp.Body.Shows)
+}
+
+// =============================================================================
+// GetUserFieldNotesHandler
+// =============================================================================
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFieldNotes_List() {
+	author := s.createUserWithUsername("noteauthor")
+	now := time.Now().UTC()
+	show1 := s.createShowAt("Wall of Sound Night", now.AddDate(0, -1, 0), nil)
+	show2 := s.createShowAt("Reverent Room", now.AddDate(0, -2, 0), nil)
+
+	s.createFieldNote(author.ID, show1.ID, "older note", engagementm.CommentVisibilityVisible, now.Add(-48*time.Hour))
+	s.createFieldNote(author.ID, show2.ID, "newer note", engagementm.CommentVisibilityVisible, now.Add(-24*time.Hour))
+	// Hidden notes and plain comments must never appear on the profile.
+	s.createFieldNote(author.ID, show1.ID, "hidden note", engagementm.CommentVisibilityHiddenByMod, now.Add(-12*time.Hour))
+	plain := &engagementm.Comment{
+		EntityType: engagementm.CommentEntityShow,
+		EntityID:   show1.ID,
+		Kind:       engagementm.CommentKindComment,
+		UserID:     author.ID,
+		Body:       "plain comment",
+		BodyHTML:   "<p>plain comment</p>",
+		Visibility: engagementm.CommentVisibilityVisible,
+	}
+	s.deps.DB.Create(plain)
+
+	resp, err := s.handler.GetUserFieldNotesHandler(context.Background(), &GetUserFieldNotesRequest{
+		Username: "noteauthor", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(2), resp.Body.Total)
+	s.Require().Len(resp.Body.FieldNotes, 2)
+	// Newest first, with show title/slug enrichment.
+	s.Equal("newer note", resp.Body.FieldNotes[0].Body)
+	s.Equal("Reverent Room", resp.Body.FieldNotes[0].ShowTitle)
+	s.Equal(fmt.Sprintf("show-%d", show2.ID), resp.Body.FieldNotes[0].ShowSlug)
+	s.Equal("older note", resp.Body.FieldNotes[1].Body)
+	s.Equal("Wall of Sound Night", resp.Body.FieldNotes[1].ShowTitle)
+	// Author attribution resolves (PSY-353 chain).
+	s.Equal("noteauthor", resp.Body.FieldNotes[0].AuthorName)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFieldNotes_PrivateProfile() {
+	target := s.createPrivateUser("noteprivate")
+
+	_, err := s.handler.GetUserFieldNotesHandler(context.Background(), &GetUserFieldNotesRequest{
+		Username: "noteprivate", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(s.T(), err, 404)
+
+	// Owner still passes the master gate.
+	_, err = s.handler.GetUserFieldNotesHandler(testhelpers.CtxWithUser(target), &GetUserFieldNotesRequest{
+		Username: "noteprivate", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserFieldNotes_Empty() {
+	s.createUserWithUsername("notenone")
+	resp, err := s.handler.GetUserFieldNotesHandler(context.Background(), &GetUserFieldNotesRequest{
+		Username: "notenone", Limit: 20, Offset: 0,
+	})
+	s.Require().NoError(err)
+	s.Equal(int64(0), resp.Body.Total)
+	s.Empty(resp.Body.FieldNotes)
 }

--- a/backend/internal/api/handlers/community/contributor_profile_lists_test.go
+++ b/backend/internal/api/handlers/community/contributor_profile_lists_test.go
@@ -1,0 +1,189 @@
+package community
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// PSY-1046 public profile list handlers
+// (GetUserFollowingHandler / GetUserAttendedShowsHandler /
+//  GetUserFieldNotesHandler)
+//
+// The full privacy matrix (stored defaults, hidden, count_only, owner
+// bypass, private-profile master gate, SQL semantics) is exercised against a
+// real database by the integration suite. These unit tests cover the
+// handler-level branches integration can't reach without forcing a live
+// service to fail — the service-error → 500 mappings — plus the exact
+// service arguments the count-only path sends.
+// ============================================================================
+
+// listsMockUserService returns a MockUserService whose lookup resolves to a
+// public-profile user with the given (optional) stored privacy settings.
+// settings == nil leaves PrivacySettings NULL, so granularPrivacy falls back
+// to the defaults (following=count_only, attendance=hidden).
+func listsMockUserService(t *testing.T, id uint, settings *contracts.PrivacySettings) *testhelpers.MockUserService {
+	t.Helper()
+	return &testhelpers.MockUserService{
+		GetUserByUsernameFn: func(string) (*authm.User, error) {
+			u := &authm.User{ID: id, ProfileVisibility: "public"}
+			if settings != nil {
+				raw, err := json.Marshal(settings)
+				if err != nil {
+					t.Fatalf("marshal privacy settings: %v", err)
+				}
+				rawMsg := json.RawMessage(raw)
+				u.PrivacySettings = &rawMsg
+			}
+			return u, nil
+		},
+	}
+}
+
+// listsVisibleSettings returns stored settings with the two list-relevant
+// fields opened up so the handlers fall through to the full-list path.
+func listsVisibleSettings() *contracts.PrivacySettings {
+	s := contracts.DefaultPrivacySettings()
+	s.Following = contracts.PrivacyVisible
+	s.Attendance = contracts.PrivacyVisible
+	return &s
+}
+
+// --- GetUserFollowingHandler ---
+
+func TestGetUserFollowing_LookupError(t *testing.T) {
+	mockUsers := &testhelpers.MockUserService{
+		GetUserByUsernameFn: func(string) (*authm.User, error) {
+			return nil, errors.New("db down")
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, nil, nil, nil)
+
+	_, err := h.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "anyone", Type: "all", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+func TestGetUserFollowing_ServiceError(t *testing.T) {
+	mockUsers := listsMockUserService(t, 7, listsVisibleSettings())
+	mockFollow := &testhelpers.MockFollowService{
+		GetUserFollowingFn: func(uint, string, int, int) ([]*contracts.FollowingEntityResponse, int64, error) {
+			return nil, 0, errors.New("query failed")
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, mockFollow, nil, nil)
+
+	_, err := h.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "publicuser", Type: "all", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+func TestGetUserFollowing_CountOnlyArgsAndShape(t *testing.T) {
+	// NULL stored settings → default following=count_only for non-owners.
+	mockUsers := listsMockUserService(t, 7, nil)
+	var gotType string
+	var gotLimit, gotOffset int
+	mockFollow := &testhelpers.MockFollowService{
+		GetUserFollowingFn: func(_ uint, entityType string, limit, offset int) ([]*contracts.FollowingEntityResponse, int64, error) {
+			gotType, gotLimit, gotOffset = entityType, limit, offset
+			return []*contracts.FollowingEntityResponse{{Name: "must not leak"}}, 42, nil
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, mockFollow, nil, nil)
+
+	resp, err := h.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "publicuser", Type: "all", Limit: 20, Offset: 5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Count-only fetches a minimal page ("all" maps to the unfiltered "").
+	if gotType != "" || gotLimit != 1 || gotOffset != 0 {
+		t.Errorf("expected count-only service call (\"\", 1, 0), got (%q, %d, %d)", gotType, gotLimit, gotOffset)
+	}
+	// The total survives; any fetched items must NOT leak; the response
+	// echoes the request's pagination, not the internal count-call's.
+	if resp.Body.Total != 42 {
+		t.Errorf("expected total=42, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Following) != 0 {
+		t.Errorf("count_only must return no items, got %d", len(resp.Body.Following))
+	}
+	if resp.Body.Limit != 20 || resp.Body.Offset != 5 {
+		t.Errorf("expected echoed pagination (20, 5), got (%d, %d)", resp.Body.Limit, resp.Body.Offset)
+	}
+}
+
+func TestGetUserFollowing_CountOnlyServiceError(t *testing.T) {
+	mockUsers := listsMockUserService(t, 7, nil) // defaults → count_only
+	mockFollow := &testhelpers.MockFollowService{
+		GetUserFollowingFn: func(uint, string, int, int) ([]*contracts.FollowingEntityResponse, int64, error) {
+			return nil, 0, errors.New("count failed")
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, mockFollow, nil, nil)
+
+	_, err := h.GetUserFollowingHandler(context.Background(), &GetUserFollowingRequest{
+		Username: "publicuser", Type: "all", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// --- GetUserAttendedShowsHandler ---
+
+func TestGetUserAttendedShows_ServiceError(t *testing.T) {
+	mockUsers := listsMockUserService(t, 7, listsVisibleSettings())
+	mockAttendance := &testhelpers.MockAttendanceService{
+		GetUserAttendedShowsFn: func(uint, int, int) ([]*contracts.AttendingShowResponse, int64, error) {
+			return nil, 0, errors.New("query failed")
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, nil, mockAttendance, nil)
+
+	_, err := h.GetUserAttendedShowsHandler(context.Background(), &GetUserAttendedShowsRequest{
+		Username: "publicuser", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+func TestGetUserAttendedShows_CountOnlyServiceError(t *testing.T) {
+	settings := contracts.DefaultPrivacySettings()
+	settings.Attendance = contracts.PrivacyCountOnly
+	mockUsers := listsMockUserService(t, 7, &settings)
+	mockAttendance := &testhelpers.MockAttendanceService{
+		GetUserAttendedShowsFn: func(uint, int, int) ([]*contracts.AttendingShowResponse, int64, error) {
+			return nil, 0, errors.New("count failed")
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, nil, mockAttendance, nil)
+
+	_, err := h.GetUserAttendedShowsHandler(context.Background(), &GetUserAttendedShowsRequest{
+		Username: "publicuser", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// --- GetUserFieldNotesHandler ---
+
+func TestGetUserFieldNotes_ServiceError(t *testing.T) {
+	mockUsers := listsMockUserService(t, 7, nil) // field-notes has no granular gate
+	mockFieldNotes := &testhelpers.MockFieldNoteService{
+		ListFieldNotesByAuthorFn: func(uint, int, int) ([]*contracts.AuthoredFieldNote, int64, error) {
+			return nil, 0, errors.New("query failed")
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, nil, nil, mockFieldNotes)
+
+	_, err := h.GetUserFieldNotesHandler(context.Background(), &GetUserFieldNotesRequest{
+		Username: "publicuser", Limit: 20, Offset: 0,
+	})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/community/contributor_profile_rankings_test.go
+++ b/backend/internal/api/handlers/community/contributor_profile_rankings_test.go
@@ -36,7 +36,7 @@ func TestGetPercentileRankings_PublicSuccess(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewContributorProfileHandler(mockProfile, mockUsers)
+	h := NewContributorProfileHandler(mockProfile, mockUsers, nil, nil, nil)
 
 	// Anonymous viewer — public profile falls through to full rankings.
 	resp, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "johndoe"})
@@ -54,7 +54,7 @@ func TestGetPercentileRankings_UserNotFound(t *testing.T) {
 			return nil, nil // not found → handler returns 404
 		},
 	}
-	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers)
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, nil, nil, nil)
 
 	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "ghost"})
 	testhelpers.AssertHumaError(t, err, 404)
@@ -66,7 +66,7 @@ func TestGetPercentileRankings_PrivateProfileHiddenFromOthers(t *testing.T) {
 			return &authm.User{ID: 5, ProfileVisibility: "private"}, nil
 		},
 	}
-	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers)
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, nil, nil, nil)
 
 	// Anonymous (non-owner) viewer → private profile masked as 404.
 	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "private-user"})
@@ -79,7 +79,7 @@ func TestGetPercentileRankings_UserLookupError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers)
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers, nil, nil, nil)
 
 	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "johndoe"})
 	testhelpers.AssertHumaError(t, err, 500)
@@ -96,7 +96,7 @@ func TestGetPercentileRankings_RankingsServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewContributorProfileHandler(mockProfile, mockUsers)
+	h := NewContributorProfileHandler(mockProfile, mockUsers, nil, nil, nil)
 
 	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "johndoe"})
 	testhelpers.AssertHumaError(t, err, 500)

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -442,6 +442,7 @@ type MockAttendanceService struct {
 	GetBatchAttendanceCountsFn func([]uint) (map[uint]*contracts.AttendanceCountsResponse, error)
 	GetBatchUserAttendanceFn   func(uint, []uint) (map[uint]string, error)
 	GetUserAttendingShowsFn    func(uint, string, int, int) ([]*contracts.AttendingShowResponse, int64, error)
+	GetUserAttendedShowsFn     func(uint, int, int) ([]*contracts.AttendingShowResponse, int64, error)
 }
 
 func (m *MockAttendanceService) SetAttendance(userID uint, showID uint, status string) error {
@@ -487,6 +488,12 @@ func (m *MockAttendanceService) GetBatchUserAttendance(userID uint, showIDs []ui
 func (m *MockAttendanceService) GetUserAttendingShows(userID uint, status string, limit int, offset int) ([]*contracts.AttendingShowResponse, int64, error) {
 	if m.GetUserAttendingShowsFn != nil {
 		return m.GetUserAttendingShowsFn(userID, status, limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *MockAttendanceService) GetUserAttendedShows(userID uint, limit int, offset int) ([]*contracts.AttendingShowResponse, int64, error) {
+	if m.GetUserAttendedShowsFn != nil {
+		return m.GetUserAttendedShowsFn(userID, limit, offset)
 	}
 	return nil, 0, nil
 }
@@ -1899,8 +1906,9 @@ func (m *MockFestivalService) GetFestivalsForArtist(artistID uint) ([]*contracts
 // ============================================================================
 
 type MockFieldNoteService struct {
-	CreateFieldNoteFn       func(uint, *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error)
-	ListFieldNotesForShowFn func(uint, int, int) (*contracts.CommentListResponse, error)
+	CreateFieldNoteFn        func(uint, *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error)
+	ListFieldNotesForShowFn  func(uint, int, int) (*contracts.CommentListResponse, error)
+	ListFieldNotesByAuthorFn func(uint, int, int) ([]*contracts.AuthoredFieldNote, int64, error)
 }
 
 func (m *MockFieldNoteService) CreateFieldNote(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
@@ -1914,6 +1922,12 @@ func (m *MockFieldNoteService) ListFieldNotesForShow(showID uint, limit int, off
 		return m.ListFieldNotesForShowFn(showID, limit, offset)
 	}
 	return nil, nil
+}
+func (m *MockFieldNoteService) ListFieldNotesByAuthor(userID uint, limit int, offset int) ([]*contracts.AuthoredFieldNote, int64, error) {
+	if m.ListFieldNotesByAuthorFn != nil {
+		return m.ListFieldNotesByAuthorFn(userID, limit, offset)
+	}
+	return nil, 0, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/routes/contributor.go
+++ b/backend/internal/api/routes/contributor.go
@@ -9,7 +9,10 @@ import (
 
 // setupContributorProfileRoutes configures contributor profile endpoints
 func setupContributorProfileRoutes(rc RouteContext) {
-	profileHandler := communityh.NewContributorProfileHandler(rc.SC.ContributorProfile, rc.SC.User)
+	profileHandler := communityh.NewContributorProfileHandler(
+		rc.SC.ContributorProfile, rc.SC.User,
+		rc.SC.Follow, rc.SC.Attendance, rc.SC.Comment,
+	)
 
 	// Public profile endpoints with optional auth (so profile owner can see their own private profile)
 	optionalAuthGroup := huma.NewGroup(rc.API, "")
@@ -19,6 +22,10 @@ func setupContributorProfileRoutes(rc RouteContext) {
 	huma.Get(optionalAuthGroup, "/users/{username}/sections", profileHandler.GetUserSectionsHandler)
 	huma.Get(optionalAuthGroup, "/users/{username}/activity-heatmap", profileHandler.GetActivityHeatmapHandler)
 	huma.Get(optionalAuthGroup, "/users/{username}/rankings", profileHandler.GetPercentileRankingsHandler)
+	// PSY-1046: public profile list surfaces (privacy-gated per field)
+	huma.Get(optionalAuthGroup, "/users/{username}/following", profileHandler.GetUserFollowingHandler)
+	huma.Get(optionalAuthGroup, "/users/{username}/attended-shows", profileHandler.GetUserAttendedShowsHandler)
+	huma.Get(optionalAuthGroup, "/users/{username}/field-notes", profileHandler.GetUserFieldNotesHandler)
 
 	// Protected endpoints for authenticated user's own profile
 	huma.Get(rc.Protected, "/auth/profile/contributor", profileHandler.GetOwnProfileHandler)

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -119,6 +119,15 @@ type CommentListResponse struct {
 	HasMore  bool               `json:"has_more"`
 }
 
+// AuthoredFieldNote is a field note listed on its author's public profile
+// (PSY-1046). Show title/slug are enriched so the frontend can render a
+// linked "note on <show>" line without re-fetching each show.
+type AuthoredFieldNote struct {
+	CommentResponse
+	ShowTitle string `json:"show_title"`
+	ShowSlug  string `json:"show_slug,omitempty"`
+}
+
 // ──────────────────────────────────────────────
 // Comment service interface
 // ──────────────────────────────────────────────
@@ -138,6 +147,7 @@ type CommentServiceInterface interface {
 type FieldNoteServiceInterface interface {
 	CreateFieldNote(userID uint, req *CreateFieldNoteRequest) (*CommentResponse, error)
 	ListFieldNotesForShow(showID uint, limit, offset int) (*CommentListResponse, error)
+	ListFieldNotesByAuthor(userID uint, limit, offset int) ([]*AuthoredFieldNote, int64, error)
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/contracts/engagement.go
+++ b/backend/internal/services/contracts/engagement.go
@@ -178,6 +178,7 @@ type AttendanceServiceInterface interface {
 	GetBatchAttendanceCounts(showIDs []uint) (map[uint]*AttendanceCountsResponse, error)
 	GetBatchUserAttendance(userID uint, showIDs []uint) (map[uint]string, error)
 	GetUserAttendingShows(userID uint, status string, limit, offset int) ([]*AttendingShowResponse, int64, error)
+	GetUserAttendedShows(userID uint, limit, offset int) ([]*AttendingShowResponse, int64, error)
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/engagement/attendance.go
+++ b/backend/internal/services/engagement/attendance.go
@@ -267,10 +267,6 @@ func (s *AttendanceService) GetBatchUserAttendance(userID uint, showIDs []uint) 
 // status filter: "going", "interested", or "all" (default).
 // Only returns upcoming approved shows, ordered by event_date ASC.
 func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, limit, offset int) ([]*contracts.AttendingShowResponse, int64, error) {
-	if s.db == nil {
-		return nil, 0, fmt.Errorf("database not initialized")
-	}
-
 	// Build the bookmark filter
 	actions := []engagementm.BookmarkAction{engagementm.BookmarkActionGoing, engagementm.BookmarkActionInterested}
 	if status == string(engagementm.BookmarkActionGoing) {
@@ -279,7 +275,33 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 		actions = []engagementm.BookmarkAction{engagementm.BookmarkActionInterested}
 	}
 
+	return s.listUserShowsByAttendance(userID, actions, false, limit, offset)
+}
+
+// GetUserAttendedShows returns the user's concert diary: approved shows with
+// a past event_date that the user marked "going", most recent first
+// (PSY-1046). GetUserAttendingShows is the upcoming-RSVP surface; this is its
+// past-direction sibling.
+func (s *AttendanceService) GetUserAttendedShows(userID uint, limit, offset int) ([]*contracts.AttendingShowResponse, int64, error) {
+	return s.listUserShowsByAttendance(userID, []engagementm.BookmarkAction{engagementm.BookmarkActionGoing}, true, limit, offset)
+}
+
+// listUserShowsByAttendance is the shared core behind the attending/attended
+// surfaces. past=false keeps upcoming shows (event_date >= now) soonest-first;
+// past=true keeps past shows (event_date < now) most-recent-first. Only
+// approved shows are returned either way.
+func (s *AttendanceService) listUserShowsByAttendance(userID uint, actions []engagementm.BookmarkAction, past bool, limit, offset int) ([]*contracts.AttendingShowResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
 	now := time.Now().UTC()
+	dateCond := "shows.event_date >= ?"
+	order := "shows.event_date ASC, shows.id ASC"
+	if past {
+		dateCond = "shows.event_date < ?"
+		order = "shows.event_date DESC, shows.id DESC"
+	}
 
 	// Count total matching shows
 	var total int64
@@ -287,7 +309,8 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 		Joins("JOIN shows ON shows.id = user_bookmarks.entity_id").
 		Where("user_bookmarks.user_id = ? AND user_bookmarks.entity_type = ? AND user_bookmarks.action IN ?",
 			userID, engagementm.BookmarkEntityShow, actions).
-		Where("shows.status = ? AND shows.event_date >= ?", catalogm.ShowStatusApproved, now).
+		Where("shows.status = ?", catalogm.ShowStatusApproved).
+		Where(dateCond, now).
 		Count(&total).Error
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to count attending shows: %w", err)
@@ -310,8 +333,9 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 		Joins("JOIN shows ON shows.id = user_bookmarks.entity_id").
 		Where("user_bookmarks.user_id = ? AND user_bookmarks.entity_type = ? AND user_bookmarks.action IN ?",
 			userID, engagementm.BookmarkEntityShow, actions).
-		Where("shows.status = ? AND shows.event_date >= ?", catalogm.ShowStatusApproved, now).
-		Order("shows.event_date ASC, shows.id ASC").
+		Where("shows.status = ?", catalogm.ShowStatusApproved).
+		Where(dateCond, now).
+		Order(order).
 		Limit(limit).
 		Offset(offset).
 		Pluck("shows.id", &showIDs).Error
@@ -356,9 +380,10 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 		Joins("LEFT JOIN venues ON venues.id = show_venues.venue_id").
 		Where("user_bookmarks.user_id = ? AND user_bookmarks.entity_type = ? AND user_bookmarks.action IN ?",
 			userID, engagementm.BookmarkEntityShow, actions).
-		Where("shows.status = ? AND shows.event_date >= ?", catalogm.ShowStatusApproved, now).
+		Where("shows.status = ?", catalogm.ShowStatusApproved).
+		Where(dateCond, now).
 		Where("shows.id IN ?", showIDs).
-		Order("shows.event_date ASC, shows.id ASC").
+		Order(order).
 		Find(&rows).Error
 
 	if err != nil {

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -1082,6 +1082,82 @@ func (s *CommentService) ListFieldNotesForShow(showID uint, limit, offset int) (
 	}, nil
 }
 
+// ListFieldNotesByAuthor returns the visible field notes a user has written,
+// newest first, with show title/slug enriched for profile display (PSY-1046).
+// Only visibility=visible notes are listed — hidden/pending notes never leak
+// onto a public profile.
+func (s *CommentService) ListFieldNotesByAuthor(userID uint, limit, offset int) ([]*contracts.AuthoredFieldNote, int64, error) {
+	if s.db == nil {
+		return nil, 0, errors.New("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	query := s.db.Model(&engagementm.Comment{}).
+		Where("user_id = ? AND entity_type = ? AND kind = ? AND visibility = ?",
+			userID, engagementm.CommentEntityShow, engagementm.CommentKindFieldNote, engagementm.CommentVisibilityVisible)
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count authored field notes: %w", err)
+	}
+	if total == 0 {
+		return []*contracts.AuthoredFieldNote{}, 0, nil
+	}
+
+	var comments []engagementm.Comment
+	if err := query.Preload("User").
+		Order("created_at DESC, id DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&comments).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch authored field notes: %w", err)
+	}
+
+	// Batch-enrich show titles/slugs for this page of notes.
+	showIDs := make([]uint, 0, len(comments))
+	seenShows := make(map[uint]bool)
+	for i := range comments {
+		id := comments[i].EntityID
+		if !seenShows[id] {
+			seenShows[id] = true
+			showIDs = append(showIDs, id)
+		}
+	}
+	type showRow struct {
+		ID    uint
+		Title string
+		Slug  *string
+	}
+	showsByID := make(map[uint]showRow, len(showIDs))
+	if len(showIDs) > 0 {
+		var rows []showRow
+		s.db.Table("shows").Select("id, title, slug").Where("id IN ?", showIDs).Scan(&rows)
+		for _, r := range rows {
+			showsByID[r.ID] = r
+		}
+	}
+
+	notes := make([]*contracts.AuthoredFieldNote, len(comments))
+	for i := range comments {
+		note := &contracts.AuthoredFieldNote{CommentResponse: *commentToResponse(&comments[i])}
+		if row, ok := showsByID[comments[i].EntityID]; ok {
+			note.ShowTitle = row.Title
+			if row.Slug != nil {
+				note.ShowSlug = *row.Slug
+			}
+		}
+		notes[i] = note
+	}
+
+	return notes, total, nil
+}
+
 // ============================================================================
 // Admin moderation methods
 // ============================================================================


### PR DESCRIPTION
Closes PSY-1046.

## Summary

Three privacy-gated public GET endpoints under `/users/{username}`, unblocking the showcase sections of the PSY-1045 content-first profile redesign:

- **`/following?type=all|artist|venue|label|festival`** — the entities a user follows, name/slug-enriched. Thin gated wrapper over the **existing** `FollowService.GetUserFollowing` (the Following-Feed project had already built the service layer + `/me/following`; the ticket's "needs building" premise was stale). Gate: `privacy.following` (default `count_only`).
- **`/attended-shows`** — the concert diary: **past** approved shows marked `going`, most recent first. New `AttendanceService.GetUserAttendedShows`, the past-direction sibling of the upcoming-only `GetUserAttendingShows` — both now delegate to one shared core (`listUserShowsByAttendance`), preserving the page-on-distinct-IDs-before-venue-join behavior. Gate: `privacy.attendance` (default `hidden`).
- **`/field-notes`** — visible field notes by author, newest first, show title/slug enriched (new `CommentService.ListFieldNotesByAuthor`). Gate: **master profile visibility only** — field notes are already public on each show page, so a by-author listing is a different index over already-public content (documented in the handler).

All three mirror the existing contributions-endpoint conventions: `{items, total, limit, offset}` offset pagination; `hidden` → 404; `count_only` → total + empty list; owner always sees the full list; private profile → 404 for non-owners.

Also extracted `resolveProfileTarget` + `granularPrivacy` handler helpers and refactored `GetContributionHistoryHandler` onto them (semantics unchanged — all pre-existing tests pass untouched).

## Notable scope facts

- **Tag-following does not exist** anywhere in the backend (no bookmark type, no model) — the `type` param covers the four real followable types. The profile-redesign Figma's "TAGS" row is aspirational; flagged in `docs/features/profile-redesign.md` and PSY-1045 will need to drop or re-scope it.
- **No migration needed**: `user_bookmarks(user_id, entity_type, action)` and `comments(user_id)` indexes cover the new query paths.
- **No committed OpenAPI artifact** in this repo; the only spec snapshot test (festival_intelligence) is untouched.

## Self-review disposition (multi-agent review skipped per user instruction)

Six review angles ran; no code changes warranted. Disclosed trade-offs:

- **Count-only paths call the list method with `limit=1`** instead of a bare COUNT (2–3 small indexed queries on a rare path). A dedicated count method would grow two service interfaces for marginal gain; "all-types" following count has no existing cheap counter anyway.
- **Show-enrichment `Scan()` errors are intentionally ignored** in `ListFieldNotesByAuthor` — matches the best-effort enrichment convention in `enrichEntityNames` and `GetUserFollowing` (degrades to missing titles, never fails the list).
- **Pre-existing peer gap, not expanded**: `GetUserSectionsHandler` / `GetActivityHeatmapHandler` / `GetPercentileRankingsHandler` still do the lookup+master-gate inline; migrating them onto `resolveProfileTarget` is a mechanical follow-up.
- **`type` validation mirrors `GetMyFollowingHandler`'s inline check** (needed for a 400; the service's own validation surfaces as a wrapped error).

## Test plan

- [x] `go build ./...` + `go generate ./...` (mocks regenerated) — clean
- [x] `go vet` on touched packages — clean
- [x] Full backend suite `go test ./...` — **36 packages, 0 failures**
- [x] New unit tests (7) in `contributor_profile_lists_test.go` (commit `b36c97ce`): service-error → 500 mappings on all three handlers (incl. both count-only paths) + lookup-error 500 + count-only args/shape assertion (`("", 1, 0)`, no item leak, request pagination echoed) — the branches integration can't reach without forcing a live service to fail
- [x] New integration tests (13) in `contributor_profile_integration_test.go`: visible-list + enrichment, **default-privacy contracts** (following=count_only, attendance=hidden — guarding the PSY-1045 open question), hidden→404, owner-sees-despite-hidden, private-profile master gate, past-only/DESC diary semantics (future `going` + past `interested` excluded), hidden/plain-comment exclusion from field notes, invalid type→400, not-found→404
- [x] Pre-existing `TestGetContributionHistory_*` suite passes against the refactored gating helpers (semantics preserved)
- [x] Attendance refactor regression: `internal/services/engagement` + `internal/api/handlers/engagement` suites pass (upcoming-RSVP surface unchanged)
- [ ] Manual repro vs local dev stack — deferred: no UI surface yet (frontend consumption lands with PSY-1045); endpoint behavior is covered by the integration suite above

## Coverage gaps

- No UI surface — screenshots N/A (backend-only; PSY-1045 consumes these endpoints).
- `count_only` + `type` filter interaction returns the count **for the requested type filter** (not the all-types total) — matches the request semantics, noting it here since the frontend may prefer the unfiltered total for the "(42)" chip.
- The diary intentionally diverges from `ContributionStats.shows_attended` (which counts ALL `going` bookmarks incl. future RSVPs); sidebar count vs list length may differ until PSY-1045 decides which number to show.
