### PR TITLE
PSY-1048: radio aggregation endpoints for The Dial browse surfaces

### DIFF
--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -25,6 +25,7 @@ import (
 type RadioStationReader interface {
 	GetStation(stationID uint) (*contracts.RadioStationDetailResponse, error)
 	GetStationBySlug(slug string) (*contracts.RadioStationDetailResponse, error)
+	ResolveStationIDBySlug(slug string) (uint, error)
 	ListStations(filters map[string]interface{}) ([]*contracts.RadioStationListResponse, error)
 }
 
@@ -32,19 +33,23 @@ type RadioStationReader interface {
 type RadioShowReader interface {
 	GetShow(showID uint) (*contracts.RadioShowDetailResponse, error)
 	GetShowBySlug(slug string) (*contracts.RadioShowDetailResponse, error)
-	ListShows(stationID uint) ([]*contracts.RadioShowListResponse, error)
+	ListShows(stationID uint, sortBy string) ([]*contracts.RadioShowListResponse, error)
 }
 
 // RadioEpisodeReader reads radio episodes (public endpoints).
 type RadioEpisodeReader interface {
 	GetEpisodes(showID uint, limit, offset int) ([]*contracts.RadioEpisodeResponse, int64, error)
 	GetEpisodeByShowAndDate(showID uint, airDate string) (*contracts.RadioEpisodeDetailResponse, error)
+	GetStationEpisodes(stationID uint, limit, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error)
+	GetRecentEpisodes(limit, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error)
 }
 
 // RadioAggregationReader reads radio aggregation/stats data (public endpoints).
 type RadioAggregationReader interface {
 	GetTopArtistsForShow(showID uint, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error)
 	GetTopLabelsForShow(showID uint, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error)
+	GetTopArtistsForStation(stationID uint, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error)
+	GetTopLabelsForStation(stationID uint, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error)
 	GetAsHeardOnForArtist(artistID uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetAsHeardOnForRelease(releaseID uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetNewReleaseRadar(stationID uint, limit int) ([]*contracts.RadioNewReleaseRadarEntry, error)
@@ -210,12 +215,189 @@ func (h *RadioHandler) GetRadioStationHandler(ctx context.Context, req *GetRadio
 }
 
 // ============================================================================
+// Public: Station Latest Playlists (PSY-1048)
+// ============================================================================
+
+// GetRadioStationEpisodesRequest lists a station's latest playlists across
+// all of its shows (and network channels, for a flagship).
+type GetRadioStationEpisodesRequest struct {
+	Slug   string `path:"slug" doc:"Radio station slug or numeric ID" example:"wfmu"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" default:"20" doc:"Max results (default 20)" example:"20"`
+	Offset int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
+}
+
+// GetRadioStationEpisodesResponse is the station latest-playlists feed.
+type GetRadioStationEpisodesResponse struct {
+	Body struct {
+		Episodes []*contracts.RadioStationEpisodeRow `json:"episodes" doc:"Latest episodes across the station's shows, newest first, with channel attribution"`
+		Total    int64                               `json:"total" doc:"Total number of episodes"`
+	}
+}
+
+// GetRadioStationEpisodesHandler handles GET /radio-stations/{slug}/episodes
+func (h *RadioHandler) GetRadioStationEpisodesHandler(ctx context.Context, req *GetRadioStationEpisodesRequest) (*GetRadioStationEpisodesResponse, error) {
+	stationID, err := h.resolveStationID(req.Slug)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	episodes, total, err := h.episodeReader.GetStationEpisodes(stationID, limit, offset)
+	if err != nil {
+		return nil, mapRadioStationErrorMsg(err, "Failed to fetch station episodes")
+	}
+
+	resp := &GetRadioStationEpisodesResponse{}
+	resp.Body.Episodes = episodes
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
+// Public: Dial-wide Recent Playlists (PSY-1048)
+// ============================================================================
+
+// GetRecentRadioEpisodesRequest lists the newest playlists across every
+// active station.
+type GetRecentRadioEpisodesRequest struct {
+	Limit  int `query:"limit" required:"false" minimum:"1" maximum:"100" default:"20" doc:"Max results (default 20)" example:"20"`
+	Offset int `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
+}
+
+// GetRecentRadioEpisodesResponse is the dial-wide latest-playlists feed.
+type GetRecentRadioEpisodesResponse struct {
+	Body struct {
+		Episodes []*contracts.RadioStationEpisodeRow `json:"episodes" doc:"Latest episodes across all active stations, newest first"`
+		Total    int64                               `json:"total" doc:"Total number of episodes"`
+	}
+}
+
+// GetRecentRadioEpisodesHandler handles GET /radio/episodes/recent
+func (h *RadioHandler) GetRecentRadioEpisodesHandler(ctx context.Context, req *GetRecentRadioEpisodesRequest) (*GetRecentRadioEpisodesResponse, error) {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	episodes, total, err := h.episodeReader.GetRecentEpisodes(limit, offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch recent episodes", err)
+	}
+
+	resp := &GetRecentRadioEpisodesResponse{}
+	resp.Body.Episodes = episodes
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
+// Public: Station Top Artists / Top Labels (PSY-1048)
+// ============================================================================
+
+// GetRadioStationTopArtistsRequest asks for a station's most-played artists.
+type GetRadioStationTopArtistsRequest struct {
+	Slug   string `path:"slug" doc:"Radio station slug or numeric ID" example:"wfmu"`
+	Period int    `query:"period" required:"false" default:"90" doc:"Period in days (default 90)" example:"90"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" default:"20" doc:"Max results (default 20)" example:"20"`
+}
+
+// GetRadioStationTopArtistsResponse carries a station's top artists.
+type GetRadioStationTopArtistsResponse struct {
+	Body struct {
+		Artists []*contracts.RadioTopArtistResponse `json:"artists" doc:"Top artists across the station's shows"`
+		Count   int                                 `json:"count" doc:"Number of results"`
+	}
+}
+
+// GetRadioStationTopArtistsHandler handles GET /radio-stations/{slug}/top-artists
+func (h *RadioHandler) GetRadioStationTopArtistsHandler(ctx context.Context, req *GetRadioStationTopArtistsRequest) (*GetRadioStationTopArtistsResponse, error) {
+	stationID, err := h.resolveStationID(req.Slug)
+	if err != nil {
+		return nil, err
+	}
+
+	period := req.Period
+	if period <= 0 {
+		period = 90
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	artists, err := h.aggregationReader.GetTopArtistsForStation(stationID, period, limit)
+	if err != nil {
+		return nil, mapRadioStationErrorMsg(err, "Failed to fetch top artists")
+	}
+
+	resp := &GetRadioStationTopArtistsResponse{}
+	resp.Body.Artists = artists
+	resp.Body.Count = len(artists)
+	return resp, nil
+}
+
+// GetRadioStationTopLabelsRequest asks for a station's most-featured labels.
+type GetRadioStationTopLabelsRequest struct {
+	Slug   string `path:"slug" doc:"Radio station slug or numeric ID" example:"wfmu"`
+	Period int    `query:"period" required:"false" default:"90" doc:"Period in days (default 90)" example:"90"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" default:"20" doc:"Max results (default 20)" example:"20"`
+}
+
+// GetRadioStationTopLabelsResponse carries a station's top labels.
+type GetRadioStationTopLabelsResponse struct {
+	Body struct {
+		Labels []*contracts.RadioTopLabelResponse `json:"labels" doc:"Top labels across the station's shows"`
+		Count  int                                `json:"count" doc:"Number of results"`
+	}
+}
+
+// GetRadioStationTopLabelsHandler handles GET /radio-stations/{slug}/top-labels
+func (h *RadioHandler) GetRadioStationTopLabelsHandler(ctx context.Context, req *GetRadioStationTopLabelsRequest) (*GetRadioStationTopLabelsResponse, error) {
+	stationID, err := h.resolveStationID(req.Slug)
+	if err != nil {
+		return nil, err
+	}
+
+	period := req.Period
+	if period <= 0 {
+		period = 90
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	labels, err := h.aggregationReader.GetTopLabelsForStation(stationID, period, limit)
+	if err != nil {
+		return nil, mapRadioStationErrorMsg(err, "Failed to fetch top labels")
+	}
+
+	resp := &GetRadioStationTopLabelsResponse{}
+	resp.Body.Labels = labels
+	resp.Body.Count = len(labels)
+	return resp, nil
+}
+
+// ============================================================================
 // Public: List Radio Shows
 // ============================================================================
 
 // ListRadioShowsRequest represents the request for listing radio shows.
 type ListRadioShowsRequest struct {
-	StationID uint `query:"station_id" doc:"Station ID (required)" example:"1"`
+	StationID uint   `query:"station_id" doc:"Station ID (required)" example:"1"`
+	Sort      string `query:"sort" required:"false" enum:"name,latest" doc:"Sort order: name (alphabetical, default) or latest (active shows first, most recent playlist first)" example:"latest"`
 }
 
 // ListRadioShowsResponse represents the response for listing radio shows.
@@ -232,7 +414,7 @@ func (h *RadioHandler) ListRadioShowsHandler(ctx context.Context, req *ListRadio
 		return nil, huma.Error422UnprocessableEntity("station_id query parameter is required")
 	}
 
-	shows, err := h.showReader.ListShows(req.StationID)
+	shows, err := h.showReader.ListShows(req.StationID, req.Sort)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to fetch radio shows", err)
 	}
@@ -1467,6 +1649,22 @@ func (h *RadioHandler) resolveStation(slugOrID string) (*contracts.RadioStationD
 	return station, nil
 }
 
+// resolveStationID resolves a station slug or numeric ID to just the ID,
+// skipping the full detail build (network preload, show count, siblings)
+// that resolveStation pays for — for station-scoped reads that only need
+// the ID (PSY-1048). Numeric IDs pass through unverified; the service 404s
+// on a missing station and mapRadioStationError surfaces it.
+func (h *RadioHandler) resolveStationID(slugOrID string) (uint, error) {
+	if id, parseErr := strconv.ParseUint(slugOrID, 10, 32); parseErr == nil {
+		return uint(id), nil
+	}
+	id, err := h.stationReader.ResolveStationIDBySlug(slugOrID)
+	if err != nil {
+		return 0, mapRadioStationError(err)
+	}
+	return id, nil
+}
+
 // resolveShow resolves a radio show by slug or numeric ID.
 func (h *RadioHandler) resolveShow(slugOrID string) (*contracts.RadioShowDetailResponse, error) {
 	if id, parseErr := strconv.ParseUint(slugOrID, 10, 32); parseErr == nil {
@@ -1512,11 +1710,18 @@ func (h *RadioHandler) resolveReleaseID(slugOrID string) (uint, error) {
 
 // mapRadioStationError maps a radio service error to a Huma HTTP error.
 func mapRadioStationError(err error) error {
+	return mapRadioStationErrorMsg(err, "Failed to fetch radio station")
+}
+
+// mapRadioStationErrorMsg is mapRadioStationError with an operation-specific
+// 500 message, for station-scoped endpoints whose failures are not station
+// fetches (episode feeds, aggregations).
+func mapRadioStationErrorMsg(err error, msg500 string) error {
 	var radioErr *apperrors.RadioError
 	if errors.As(err, &radioErr) && radioErr.Code == apperrors.CodeRadioStationNotFound {
 		return huma.Error404NotFound("Radio station not found")
 	}
-	return huma.Error500InternalServerError("Failed to fetch radio station", err)
+	return huma.Error500InternalServerError(msg500, err)
 }
 
 // mapRadioShowError maps a radio service error to a Huma HTTP error.

--- a/backend/internal/api/handlers/catalog/radio_test.go
+++ b/backend/internal/api/handlers/catalog/radio_test.go
@@ -157,7 +157,7 @@ func TestGetRadioStation_NotFound(t *testing.T) {
 
 func TestListRadioShows_Success(t *testing.T) {
 	mock := &testhelpers.MockRadioService{
-		ListShowsFn: func(stationID uint) ([]*contracts.RadioShowListResponse, error) {
+		ListShowsFn: func(stationID uint, sortBy string) ([]*contracts.RadioShowListResponse, error) {
 			return []*contracts.RadioShowListResponse{
 				{ID: 1, StationID: stationID, Name: "Morning Show", Slug: "morning-show"},
 			}, nil

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -2406,20 +2406,25 @@ type MockRadioService struct {
 	CreateStationFn               func(*contracts.CreateRadioStationRequest) (*contracts.RadioStationDetailResponse, error)
 	GetStationFn                  func(uint) (*contracts.RadioStationDetailResponse, error)
 	GetStationBySlugFn            func(string) (*contracts.RadioStationDetailResponse, error)
+	ResolveStationIDBySlugFn      func(string) (uint, error)
 	ListStationsFn                func(map[string]interface{}) ([]*contracts.RadioStationListResponse, error)
 	UpdateStationFn               func(uint, *contracts.UpdateRadioStationRequest) (*contracts.RadioStationDetailResponse, error)
 	DeleteStationFn               func(uint) error
 	CreateShowFn                  func(uint, *contracts.CreateRadioShowRequest) (*contracts.RadioShowDetailResponse, error)
 	GetShowFn                     func(uint) (*contracts.RadioShowDetailResponse, error)
 	GetShowBySlugFn               func(string) (*contracts.RadioShowDetailResponse, error)
-	ListShowsFn                   func(uint) ([]*contracts.RadioShowListResponse, error)
+	ListShowsFn                   func(uint, string) ([]*contracts.RadioShowListResponse, error)
 	UpdateShowFn                  func(uint, *contracts.UpdateRadioShowRequest) (*contracts.RadioShowDetailResponse, error)
 	DeleteShowFn                  func(uint) error
 	GetEpisodesFn                 func(uint, int, int) ([]*contracts.RadioEpisodeResponse, int64, error)
 	GetEpisodeByShowAndDateFn     func(uint, string) (*contracts.RadioEpisodeDetailResponse, error)
 	GetEpisodeDetailFn            func(uint) (*contracts.RadioEpisodeDetailResponse, error)
+	GetStationEpisodesFn          func(uint, int, int) ([]*contracts.RadioStationEpisodeRow, int64, error)
+	GetRecentEpisodesFn           func(int, int) ([]*contracts.RadioStationEpisodeRow, int64, error)
 	GetTopArtistsForShowFn        func(uint, int, int) ([]*contracts.RadioTopArtistResponse, error)
 	GetTopLabelsForShowFn         func(uint, int, int) ([]*contracts.RadioTopLabelResponse, error)
+	GetTopArtistsForStationFn     func(uint, int, int) ([]*contracts.RadioTopArtistResponse, error)
+	GetTopLabelsForStationFn      func(uint, int, int) ([]*contracts.RadioTopLabelResponse, error)
 	GetAsHeardOnForArtistFn       func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetAsHeardOnForReleaseFn      func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetNewReleaseRadarFn          func(uint, int) ([]*contracts.RadioNewReleaseRadarEntry, error)
@@ -2461,6 +2466,12 @@ func (m *MockRadioService) GetStationBySlug(slug string) (*contracts.RadioStatio
 	}
 	return nil, nil
 }
+func (m *MockRadioService) ResolveStationIDBySlug(slug string) (uint, error) {
+	if m.ResolveStationIDBySlugFn != nil {
+		return m.ResolveStationIDBySlugFn(slug)
+	}
+	return 0, nil
+}
 func (m *MockRadioService) ListStations(filters map[string]interface{}) ([]*contracts.RadioStationListResponse, error) {
 	if m.ListStationsFn != nil {
 		return m.ListStationsFn(filters)
@@ -2497,9 +2508,9 @@ func (m *MockRadioService) GetShowBySlug(slug string) (*contracts.RadioShowDetai
 	}
 	return nil, nil
 }
-func (m *MockRadioService) ListShows(stationID uint) ([]*contracts.RadioShowListResponse, error) {
+func (m *MockRadioService) ListShows(stationID uint, sortBy string) ([]*contracts.RadioShowListResponse, error) {
 	if m.ListShowsFn != nil {
-		return m.ListShowsFn(stationID)
+		return m.ListShowsFn(stationID, sortBy)
 	}
 	return nil, nil
 }
@@ -2533,6 +2544,18 @@ func (m *MockRadioService) GetEpisodeDetail(episodeID uint) (*contracts.RadioEpi
 	}
 	return nil, nil
 }
+func (m *MockRadioService) GetStationEpisodes(stationID uint, limit int, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error) {
+	if m.GetStationEpisodesFn != nil {
+		return m.GetStationEpisodesFn(stationID, limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *MockRadioService) GetRecentEpisodes(limit int, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error) {
+	if m.GetRecentEpisodesFn != nil {
+		return m.GetRecentEpisodesFn(limit, offset)
+	}
+	return nil, 0, nil
+}
 func (m *MockRadioService) GetTopArtistsForShow(showID uint, periodDays int, limit int) ([]*contracts.RadioTopArtistResponse, error) {
 	if m.GetTopArtistsForShowFn != nil {
 		return m.GetTopArtistsForShowFn(showID, periodDays, limit)
@@ -2542,6 +2565,18 @@ func (m *MockRadioService) GetTopArtistsForShow(showID uint, periodDays int, lim
 func (m *MockRadioService) GetTopLabelsForShow(showID uint, periodDays int, limit int) ([]*contracts.RadioTopLabelResponse, error) {
 	if m.GetTopLabelsForShowFn != nil {
 		return m.GetTopLabelsForShowFn(showID, periodDays, limit)
+	}
+	return nil, nil
+}
+func (m *MockRadioService) GetTopArtistsForStation(stationID uint, periodDays int, limit int) ([]*contracts.RadioTopArtistResponse, error) {
+	if m.GetTopArtistsForStationFn != nil {
+		return m.GetTopArtistsForStationFn(stationID, periodDays, limit)
+	}
+	return nil, nil
+}
+func (m *MockRadioService) GetTopLabelsForStation(stationID uint, periodDays int, limit int) ([]*contracts.RadioTopLabelResponse, error) {
+	if m.GetTopLabelsForStationFn != nil {
+		return m.GetTopLabelsForStationFn(stationID, periodDays, limit)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/routes/radio.go
+++ b/backend/internal/api/routes/radio.go
@@ -13,6 +13,9 @@ func setupRadioRoutes(rc RouteContext) {
 	// Public radio station endpoints
 	huma.Get(rc.API, "/radio-stations", radioHandler.ListRadioStationsHandler)
 	huma.Get(rc.API, "/radio-stations/{slug}", radioHandler.GetRadioStationHandler)
+	huma.Get(rc.API, "/radio-stations/{slug}/episodes", radioHandler.GetRadioStationEpisodesHandler)
+	huma.Get(rc.API, "/radio-stations/{slug}/top-artists", radioHandler.GetRadioStationTopArtistsHandler)
+	huma.Get(rc.API, "/radio-stations/{slug}/top-labels", radioHandler.GetRadioStationTopLabelsHandler)
 
 	// Public radio show endpoints
 	huma.Get(rc.API, "/radio-shows", radioHandler.ListRadioShowsHandler)
@@ -27,6 +30,7 @@ func setupRadioRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/releases/{slug}/radio-plays", radioHandler.GetReleaseRadioPlaysHandler)
 
 	// Public radio aggregation endpoints
+	huma.Get(rc.API, "/radio/episodes/recent", radioHandler.GetRecentRadioEpisodesHandler)
 	huma.Get(rc.API, "/radio/new-releases", radioHandler.GetRadioNewReleaseRadarHandler)
 	huma.Get(rc.API, "/radio/stats", radioHandler.GetRadioStatsHandler)
 

--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"gorm.io/gorm"
@@ -409,8 +410,14 @@ func (s *RadioService) GetShowBySlug(slug string) (*contracts.RadioShowDetailRes
 	return s.buildShowDetailResponse(&show)
 }
 
+// RadioShowSortLatest orders shows active-first, most-recent playlist first
+// (PSY-1048, for the station-page shows directory). Any other sortBy value
+// (the handler's enum allows "name" or empty) keeps the original
+// alphabetical order.
+const RadioShowSortLatest = "latest"
+
 // ListShows retrieves all shows for a station
-func (s *RadioService) ListShows(stationID uint) ([]*contracts.RadioShowListResponse, error) {
+func (s *RadioService) ListShows(stationID uint, sortBy string) ([]*contracts.RadioShowListResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -424,44 +431,80 @@ func (s *RadioService) ListShows(stationID uint) ([]*contracts.RadioShowListResp
 		return nil, fmt.Errorf("failed to list radio shows: %w", err)
 	}
 
-	// Batch-load episode counts
+	// Batch-load episode counts + latest air dates (one query each)
 	showIDs := make([]uint, len(shows))
 	for i, sh := range shows {
 		showIDs[i] = sh.ID
 	}
 
 	episodeCounts := make(map[uint]int64)
+	latestAirDates := make(map[uint]string)
 	if len(showIDs) > 0 {
 		type countResult struct {
 			ShowID uint
 			Count  int64
+			Latest *string
 		}
 		var counts []countResult
-		s.db.Model(&catalogm.RadioEpisode{}).
-			Select("show_id, COUNT(*) as count").
+		if err := s.db.Model(&catalogm.RadioEpisode{}).
+			Select("show_id, COUNT(*) as count, MAX(air_date) as latest").
 			Where("show_id IN ?", showIDs).
 			Group("show_id").
-			Find(&counts)
+			Find(&counts).Error; err != nil {
+			return nil, fmt.Errorf("failed to load episode counts: %w", err)
+		}
 
 		for _, c := range counts {
 			episodeCounts[c.ShowID] = c.Count
+			if c.Latest != nil {
+				latestAirDates[c.ShowID] = normalizeDate(*c.Latest)
+			}
 		}
 	}
 
 	responses := make([]*contracts.RadioShowListResponse, len(shows))
 	for i, sh := range shows {
-		responses[i] = &contracts.RadioShowListResponse{
-			ID:           sh.ID,
-			StationID:    sh.StationID,
-			StationName:  sh.Station.Name,
-			Name:         sh.Name,
-			Slug:         sh.Slug,
-			HostName:     sh.HostName,
-			GenreTags:    sh.GenreTags,
-			ImageURL:     sh.ImageURL,
-			IsActive:     sh.IsActive,
-			EpisodeCount: episodeCounts[sh.ID],
+		var latest *string
+		if d, ok := latestAirDates[sh.ID]; ok {
+			latest = &d
 		}
+		responses[i] = &contracts.RadioShowListResponse{
+			ID:            sh.ID,
+			StationID:     sh.StationID,
+			StationName:   sh.Station.Name,
+			Name:          sh.Name,
+			Slug:          sh.Slug,
+			HostName:      sh.HostName,
+			GenreTags:     sh.GenreTags,
+			ImageURL:      sh.ImageURL,
+			IsActive:      sh.IsActive,
+			EpisodeCount:  episodeCounts[sh.ID],
+			LatestAirDate: latest,
+		}
+	}
+
+	// In-memory sort is safe because this endpoint always returns every show
+	// for the station (no pagination) and LatestAirDate is already computed.
+	if sortBy == RadioShowSortLatest {
+		sort.SliceStable(responses, func(i, j int) bool {
+			a, b := responses[i], responses[j]
+			if a.IsActive != b.IsActive {
+				return a.IsActive
+			}
+			// Shows with episodes before shows without; later dates first.
+			// YYYY-MM-DD strings compare correctly lexicographically.
+			ad, bd := "", ""
+			if a.LatestAirDate != nil {
+				ad = *a.LatestAirDate
+			}
+			if b.LatestAirDate != nil {
+				bd = *b.LatestAirDate
+			}
+			if ad != bd {
+				return ad > bd
+			}
+			return a.Name < b.Name
+		})
 	}
 
 	return responses, nil
@@ -546,7 +589,9 @@ func (s *RadioService) GetEpisodes(showID uint, limit, offset int) ([]*contracts
 	}
 
 	var total int64
-	s.db.Model(&catalogm.RadioEpisode{}).Where("show_id = ?", showID).Count(&total)
+	if err := s.db.Model(&catalogm.RadioEpisode{}).Where("show_id = ?", showID).Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count episodes: %w", err)
+	}
 
 	var episodes []catalogm.RadioEpisode
 	err := s.db.Where("show_id = ?", showID).
@@ -556,6 +601,15 @@ func (s *RadioService) GetEpisodes(showID uint, limit, offset int) ([]*contracts
 		Find(&episodes).Error
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get episodes: %w", err)
+	}
+
+	episodeIDs := make([]uint, len(episodes))
+	for i, ep := range episodes {
+		episodeIDs[i] = ep.ID
+	}
+	previews, err := s.episodeArtistPreviews(episodeIDs)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	responses := make([]*contracts.RadioEpisodeResponse, len(episodes))
@@ -570,6 +624,7 @@ func (s *RadioService) GetEpisodes(showID uint, limit, offset int) ([]*contracts
 			ArchiveURL:      ep.ArchiveURL,
 			PlayCount:       ep.PlayCount,
 			CreatedAt:       ep.CreatedAt,
+			ArtistPreview:   previewOrEmpty(previews, ep.ID),
 		}
 	}
 
@@ -618,8 +673,41 @@ func (s *RadioService) GetEpisodeDetail(episodeID uint) (*contracts.RadioEpisode
 // Aggregation queries
 // =============================================================================
 
+// playsScope narrows a top-artists/labels aggregation query (radio_plays rp
+// joined to radio_episodes re) to a show or a station family, applied with
+// .Scopes(). The episode feeds use the separate episodeFeedScope type — see
+// its comment for why the two are not interchangeable.
+type playsScope func(*gorm.DB) *gorm.DB
+
+func showScope(showID uint) playsScope {
+	return func(q *gorm.DB) *gorm.DB {
+		return q.Where("re.show_id = ?", showID)
+	}
+}
+
+func stationFamilyScope(stationIDs []uint) playsScope {
+	return func(q *gorm.DB) *gorm.DB {
+		return q.Joins("JOIN radio_shows rsh ON rsh.id = re.show_id").
+			Where("rsh.station_id IN ?", stationIDs)
+	}
+}
+
 // GetTopArtistsForShow returns the most-played artists for a show over a time period
 func (s *RadioService) GetTopArtistsForShow(showID uint, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error) {
+	return s.topArtists(showScope(showID), periodDays, limit)
+}
+
+// GetTopArtistsForStation returns the most-played artists across a station's
+// shows — for a network flagship, across the whole network (PSY-1048).
+func (s *RadioService) GetTopArtistsForStation(stationID uint, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error) {
+	ids, err := s.stationFamilyIDs(stationID)
+	if err != nil {
+		return nil, err
+	}
+	return s.topArtists(stationFamilyScope(ids), periodDays, limit)
+}
+
+func (s *RadioService) topArtists(scope playsScope, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -634,7 +722,7 @@ func (s *RadioService) GetTopArtistsForShow(showID uint, periodDays, limit int) 
 		`).
 		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
 		Joins("LEFT JOIN artists a ON a.id = rp.artist_id").
-		Where("re.show_id = ?", showID).
+		Scopes(scope).
 		Group("rp.artist_name, rp.artist_id, a.slug").
 		Order("play_count DESC").
 		Limit(limit)
@@ -673,6 +761,20 @@ func (s *RadioService) GetTopArtistsForShow(showID uint, periodDays, limit int) 
 
 // GetTopLabelsForShow returns the most-featured labels for a show over a time period
 func (s *RadioService) GetTopLabelsForShow(showID uint, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error) {
+	return s.topLabels(showScope(showID), periodDays, limit)
+}
+
+// GetTopLabelsForStation returns the most-featured labels across a station's
+// shows — for a network flagship, across the whole network (PSY-1048).
+func (s *RadioService) GetTopLabelsForStation(stationID uint, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error) {
+	ids, err := s.stationFamilyIDs(stationID)
+	if err != nil {
+		return nil, err
+	}
+	return s.topLabels(stationFamilyScope(ids), periodDays, limit)
+}
+
+func (s *RadioService) topLabels(scope playsScope, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -686,7 +788,8 @@ func (s *RadioService) GetTopLabelsForShow(showID uint, periodDays, limit int) (
 		`).
 		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
 		Joins("LEFT JOIN labels l ON l.id = rp.label_id").
-		Where("re.show_id = ? AND rp.label_name IS NOT NULL AND rp.label_name != ''", showID).
+		Scopes(scope).
+		Where("rp.label_name IS NOT NULL AND rp.label_name != ''").
 		Group("rp.label_name, rp.label_id, l.slug").
 		Order("play_count DESC").
 		Limit(limit)
@@ -719,6 +822,228 @@ func (s *RadioService) GetTopLabelsForShow(showID uint, periodDays, limit int) (
 	}
 
 	return responses, nil
+}
+
+// =============================================================================
+// Latest-playlists feeds (PSY-1048)
+// =============================================================================
+
+// episodePreviewArtistCount is how many distinct artists an episode row's
+// preview carries, in play order.
+const episodePreviewArtistCount = 3
+
+// previewOrEmpty guarantees a JSON [] (never null) for episodes whose
+// playlist has no usable artists yet.
+func previewOrEmpty(previews map[uint][]contracts.RadioEpisodePreviewArtist, episodeID uint) []contracts.RadioEpisodePreviewArtist {
+	if p, ok := previews[episodeID]; ok {
+		return p
+	}
+	return []contracts.RadioEpisodePreviewArtist{}
+}
+
+// ResolveStationIDBySlug returns just the station ID for a slug — a cheap
+// resolver for station-scoped reads that don't need the full detail build
+// (network preload, show count, siblings) that GetStationBySlug performs.
+func (s *RadioService) ResolveStationIDBySlug(slug string) (uint, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("database not initialized")
+	}
+	var station catalogm.RadioStation
+	if err := s.db.Select("id").Where("slug = ?", slug).First(&station).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, apperrors.ErrRadioStationNotFound(0)
+		}
+		return 0, fmt.Errorf("failed to resolve radio station: %w", err)
+	}
+	return station.ID, nil
+}
+
+// stationFamilyIDs returns the station IDs a station page aggregates over:
+// the station itself, plus — when the station is a network flagship — every
+// station in its network. Non-flagship channels and standalone stations
+// aggregate only themselves.
+//
+// Two deliberate policy notes (PSY-1048):
+//   - The family includes INACTIVE sibling channels: a flagship page is the
+//     network's archive, so retired channels' playlists stay reachable. The
+//     dial-wide feed (GetRecentEpisodes) separately filters to active
+//     stations — hub policy, not archive policy.
+//   - GetNewReleaseRadar keeps its pre-existing single-station semantics
+//     (rs.id = ?) and does NOT expand to the family; reconciling that is a
+//     product call deferred to PSY-1050.
+func (s *RadioService) stationFamilyIDs(stationID uint) ([]uint, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	var station catalogm.RadioStation
+	if err := s.db.Select("id", "is_flagship", "network_id").
+		First(&station, stationID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrRadioStationNotFound(stationID)
+		}
+		return nil, fmt.Errorf("failed to get radio station: %w", err)
+	}
+	if !station.IsFlagship || station.NetworkID == nil {
+		return []uint{station.ID}, nil
+	}
+	var ids []uint
+	if err := s.db.Model(&catalogm.RadioStation{}).
+		Where("network_id = ?", *station.NetworkID).
+		Pluck("id", &ids).Error; err != nil {
+		return nil, fmt.Errorf("failed to list network stations: %w", err)
+	}
+	return ids, nil
+}
+
+// episodeArtistPreviews returns up to episodePreviewArtistCount distinct
+// artists per episode, in play order, with knowledge-graph links where
+// matched — one query for the whole page of episodes, never per-row.
+//
+// The inner query groups by name (so a name that is matched on some plays
+// and unmatched on others appears once, and MAX(artist_id) keeps its
+// knowledge-graph link) and caps each episode's rows in SQL via
+// ROW_NUMBER, so the transfer scales with the preview size rather than
+// with playlist length.
+func (s *RadioService) episodeArtistPreviews(episodeIDs []uint) (map[uint][]contracts.RadioEpisodePreviewArtist, error) {
+	previews := make(map[uint][]contracts.RadioEpisodePreviewArtist, len(episodeIDs))
+	if len(episodeIDs) == 0 {
+		return previews, nil
+	}
+
+	type row struct {
+		EpisodeID  uint    `gorm:"column:episode_id"`
+		ArtistName string  `gorm:"column:artist_name"`
+		ArtistID   *uint   `gorm:"column:artist_id"`
+		ArtistSlug *string `gorm:"column:artist_slug"`
+	}
+	var rows []row
+	err := s.db.Raw(`
+		SELECT g.episode_id, g.artist_name, g.artist_id, a.slug AS artist_slug
+		FROM (
+			SELECT rp.episode_id, rp.artist_name, MAX(rp.artist_id) AS artist_id,
+			       MIN(rp.position) AS first_pos,
+			       ROW_NUMBER() OVER (PARTITION BY rp.episode_id ORDER BY MIN(rp.position)) AS rn
+			FROM radio_plays rp
+			WHERE rp.episode_id IN ? AND rp.artist_name != ''
+			GROUP BY rp.episode_id, rp.artist_name
+		) g
+		LEFT JOIN artists a ON a.id = g.artist_id
+		WHERE g.rn <= ?
+		ORDER BY g.episode_id, g.first_pos`,
+		episodeIDs, episodePreviewArtistCount).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to load episode artist previews: %w", err)
+	}
+
+	for _, r := range rows {
+		previews[r.EpisodeID] = append(previews[r.EpisodeID], contracts.RadioEpisodePreviewArtist{
+			ArtistName: r.ArtistName,
+			ArtistID:   r.ArtistID,
+			ArtistSlug: r.ArtistSlug,
+		})
+	}
+	return previews, nil
+}
+
+// GetStationEpisodes returns the station's latest playlists across all of
+// its shows — for a network flagship, across all network channels — newest
+// first, with channel attribution per row.
+func (s *RadioService) GetStationEpisodes(stationID uint, limit, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error) {
+	ids, err := s.stationFamilyIDs(stationID)
+	if err != nil {
+		return nil, 0, err
+	}
+	return s.episodeRows(func(q *gorm.DB) *gorm.DB {
+		return q.Where("rsh.station_id IN ?", ids)
+	}, limit, offset)
+}
+
+// GetRecentEpisodes returns the newest playlists across every active
+// station — the dial-wide "latest playlists" feed. (Active-filtering is hub
+// policy; station pages serve inactive stations' archives directly.)
+func (s *RadioService) GetRecentEpisodes(limit, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error) {
+	return s.episodeRows(func(q *gorm.DB) *gorm.DB {
+		return q.Where("rst.is_active = ?", true)
+	}, limit, offset)
+}
+
+// episodeFeedScope narrows the episode-feed base query (radio_episodes re
+// joined to radio_shows rsh and radio_stations rst). Distinct from
+// playsScope: stationFamilyScope embeds its own rsh join and would produce
+// a duplicate alias here.
+type episodeFeedScope func(*gorm.DB) *gorm.DB
+
+// episodeRows is the shared core of the station-scoped and dial-wide feeds.
+func (s *RadioService) episodeRows(scope episodeFeedScope, limit, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+	base := func() *gorm.DB {
+		return s.db.Table("radio_episodes re").
+			Joins("JOIN radio_shows rsh ON rsh.id = re.show_id").
+			Joins("JOIN radio_stations rst ON rst.id = rsh.station_id").
+			Scopes(scope)
+	}
+
+	var total int64
+	if err := base().Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count episodes: %w", err)
+	}
+
+	type row struct {
+		ID          uint    `gorm:"column:id"`
+		Title       *string `gorm:"column:title"`
+		AirDate     string  `gorm:"column:air_date"`
+		PlayCount   int     `gorm:"column:play_count"`
+		ArchiveURL  *string `gorm:"column:archive_url"`
+		ShowID      uint    `gorm:"column:show_id"`
+		ShowName    string  `gorm:"column:show_name"`
+		ShowSlug    string  `gorm:"column:show_slug"`
+		StationID   uint    `gorm:"column:station_id"`
+		StationName string  `gorm:"column:station_name"`
+		StationSlug string  `gorm:"column:station_slug"`
+	}
+	var rows []row
+	err := base().
+		Select(`re.id, re.title, re.air_date, re.play_count, re.archive_url,
+			rsh.id as show_id, rsh.name as show_name, rsh.slug as show_slug,
+			rst.id as station_id, rst.name as station_name, rst.slug as station_slug`).
+		Order("re.air_date DESC, re.id DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&rows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list episodes: %w", err)
+	}
+
+	episodeIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		episodeIDs[i] = r.ID
+	}
+	previews, err := s.episodeArtistPreviews(episodeIDs)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	out := make([]*contracts.RadioStationEpisodeRow, len(rows))
+	for i, r := range rows {
+		out[i] = &contracts.RadioStationEpisodeRow{
+			ID:            r.ID,
+			Title:         r.Title,
+			AirDate:       normalizeDate(r.AirDate),
+			PlayCount:     r.PlayCount,
+			ArchiveURL:    r.ArchiveURL,
+			ShowID:        r.ShowID,
+			ShowName:      r.ShowName,
+			ShowSlug:      r.ShowSlug,
+			StationID:     r.StationID,
+			StationName:   r.StationName,
+			StationSlug:   r.StationSlug,
+			ArtistPreview: previewOrEmpty(previews, r.ID),
+		}
+	}
+	return out, total, nil
 }
 
 // GetAsHeardOnForArtist returns stations/shows where an artist has been played

--- a/backend/internal/services/catalog/radio_test.go
+++ b/backend/internal/services/catalog/radio_test.go
@@ -53,7 +53,7 @@ func TestRadioService_NilDB_Show(t *testing.T) {
 	})
 	assertNilDBError(t, func() error { _, err := svc.GetShow(1); return err })
 	assertNilDBError(t, func() error { _, err := svc.GetShowBySlug("x"); return err })
-	assertNilDBError(t, func() error { _, err := svc.ListShows(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.ListShows(1, ""); return err })
 	assertNilDBError(t, func() error {
 		_, err := svc.UpdateShow(1, &contracts.UpdateRadioShowRequest{})
 		return err
@@ -462,7 +462,7 @@ func (suite *RadioServiceIntegrationTestSuite) TestListShows_WithEpisodeCounts()
 	suite.createEpisode(show.ID, "2026-01-02")
 	suite.createShow(station.ID, "Afternoon Show") // no episodes
 
-	resp, err := suite.radioService.ListShows(station.ID)
+	resp, err := suite.radioService.ListShows(station.ID, "")
 
 	suite.Require().NoError(err)
 	suite.Len(resp, 2)
@@ -1149,4 +1149,232 @@ func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_ListStations_Pop
 	suite.Nil(k.Network)
 	suite.NotNil(k.SiblingStations)
 	suite.Empty(k.SiblingStations)
+}
+
+// =============================================================================
+// LATEST-PLAYLISTS FEEDS + STATION AGGREGATIONS (PSY-1048)
+// =============================================================================
+
+func TestRadioService_NilDB_Feeds(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error { _, _, err := svc.GetStationEpisodes(1, 10, 0); return err })
+	assertNilDBError(t, func() error { _, _, err := svc.GetRecentEpisodes(10, 0); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetTopArtistsForStation(1, 90, 10); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetTopLabelsForStation(1, 90, 10); return err })
+}
+
+// createNetworkFamily seeds a network with a flagship + one sibling channel,
+// plus one standalone station outside the network. Returns (flagship,
+// sibling, standalone).
+func (suite *RadioServiceIntegrationTestSuite) createNetworkFamily() (*catalogm.RadioStation, *catalogm.RadioStation, *catalogm.RadioStation) {
+	suite.Require().NoError(suite.db.Exec(`INSERT INTO radio_networks (slug, name) VALUES ('fam-net', 'Family Net')`).Error)
+	var network catalogm.RadioNetwork
+	suite.Require().NoError(suite.db.Where("slug = ?", "fam-net").First(&network).Error)
+
+	flagship := &catalogm.RadioStation{Name: "Flagship", Slug: "flagship", BroadcastType: "both", NetworkID: &network.ID, IsFlagship: true}
+	suite.Require().NoError(suite.db.Create(flagship).Error)
+	sibling := &catalogm.RadioStation{Name: "Channel Two", Slug: "channel-two", BroadcastType: "internet", NetworkID: &network.ID}
+	suite.Require().NoError(suite.db.Create(sibling).Error)
+	standalone := &catalogm.RadioStation{Name: "Standalone", Slug: "standalone", BroadcastType: "both"}
+	suite.Require().NoError(suite.db.Create(standalone).Error)
+	return flagship, sibling, standalone
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestListShows_LatestAirDateAndSort() {
+	station := suite.createStation("KSRT")
+	older := suite.createShow(station.ID, "Alpha Show")
+	suite.createEpisode(older.ID, "2026-06-01")
+	suite.createEpisode(older.ID, "2026-06-05")
+	fresh := suite.createShow(station.ID, "Zulu Show")
+	suite.createEpisode(fresh.ID, "2026-06-09")
+	suite.createShow(station.ID, "Mid Show")
+	retired := suite.createShow(station.ID, "Beta Retired")
+	suite.createEpisode(retired.ID, "2026-06-08")
+	suite.Require().NoError(suite.db.Model(&catalogm.RadioShow{}).Where("id = ?", retired.ID).Update("is_active", false).Error)
+
+	// Default sort stays alphabetical (existing behavior).
+	byName, err := suite.radioService.ListShows(station.ID, "")
+	suite.Require().NoError(err)
+	suite.Require().Len(byName, 4)
+	suite.Equal("Alpha Show", byName[0].Name)
+	suite.Require().NotNil(byName[0].LatestAirDate)
+	suite.Equal("2026-06-05", *byName[0].LatestAirDate)
+
+	// sort=latest: active shows first, newest playlist first, episode-less
+	// actives after dated actives, inactive shows last.
+	byLatest, err := suite.radioService.ListShows(station.ID, RadioShowSortLatest)
+	suite.Require().NoError(err)
+	suite.Require().Len(byLatest, 4)
+	suite.Equal("Zulu Show", byLatest[0].Name)
+	suite.Equal("Alpha Show", byLatest[1].Name)
+	suite.Equal("Mid Show", byLatest[2].Name)
+	suite.Nil(byLatest[2].LatestAirDate)
+	suite.Equal("Beta Retired", byLatest[3].Name)
+	suite.False(byLatest[3].IsActive)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetEpisodes_ArtistPreview() {
+	station := suite.createStation("KPRV")
+	show := suite.createShow(station.ID, "Preview Show")
+	ep := suite.createEpisode(show.ID, "2026-06-09")
+
+	matched := suite.createArtist("Matched Artist")
+	first := suite.createArtist("First Artist")
+	plays := []catalogm.RadioPlay{
+		// "First Artist" plays unmatched at position 1 and matched at 3 —
+		// the preview must keep the knowledge-graph link (MAX(artist_id)).
+		{EpisodeID: ep.ID, Position: 1, ArtistName: "First Artist"},
+		{EpisodeID: ep.ID, Position: 2, ArtistName: "Matched Artist", ArtistID: &matched.ID},
+		{EpisodeID: ep.ID, Position: 3, ArtistName: "First Artist", ArtistID: &first.ID},
+		{EpisodeID: ep.ID, Position: 4, ArtistName: "Third Artist"},
+		{EpisodeID: ep.ID, Position: 5, ArtistName: "Fourth Artist"}, // beyond preview cap
+	}
+	for i := range plays {
+		suite.Require().NoError(suite.db.Create(&plays[i]).Error)
+	}
+
+	episodes, total, err := suite.radioService.GetEpisodes(show.ID, 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(episodes, 1)
+
+	preview := episodes[0].ArtistPreview
+	suite.Require().Len(preview, episodePreviewArtistCount)
+	suite.Equal("First Artist", preview[0].ArtistName)
+	suite.Require().NotNil(preview[0].ArtistID, "partially-matched artist must keep its graph link")
+	suite.Equal(first.ID, *preview[0].ArtistID)
+	suite.Equal("Matched Artist", preview[1].ArtistName)
+	suite.Require().NotNil(preview[1].ArtistID)
+	suite.Equal(matched.ID, *preview[1].ArtistID)
+	suite.Require().NotNil(preview[1].ArtistSlug)
+	suite.Equal("Third Artist", preview[2].ArtistName)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetStationEpisodes_FlagshipIncludesNetwork() {
+	flagship, sibling, standalone := suite.createNetworkFamily()
+
+	flagShow := suite.createShow(flagship.ID, "Flag Show")
+	sibShow := suite.createShow(sibling.ID, "Sib Show")
+	aloneShow := suite.createShow(standalone.ID, "Alone Show")
+	suite.createEpisode(flagShow.ID, "2026-06-08")
+	suite.createEpisode(sibShow.ID, "2026-06-09")
+	suite.createEpisode(aloneShow.ID, "2026-06-07")
+
+	// Flagship aggregates the whole network, newest first, with channel attribution.
+	rows, total, err := suite.radioService.GetStationEpisodes(flagship.ID, 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total)
+	suite.Require().Len(rows, 2)
+	suite.Equal("Sib Show", rows[0].ShowName)
+	suite.Equal("Channel Two", rows[0].StationName)
+	suite.Equal("channel-two", rows[0].StationSlug)
+	suite.Equal("2026-06-09", rows[0].AirDate)
+	suite.Equal("Flag Show", rows[1].ShowName)
+	suite.Equal("Flagship", rows[1].StationName)
+	suite.Require().NotNil(rows[1].ArtistPreview, "episodes without plays must serialize artist_preview as [], not null")
+	suite.Empty(rows[1].ArtistPreview)
+
+	// A non-flagship channel aggregates only itself.
+	sibRows, sibTotal, err := suite.radioService.GetStationEpisodes(sibling.ID, 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), sibTotal)
+	suite.Require().Len(sibRows, 1)
+	suite.Equal("Sib Show", sibRows[0].ShowName)
+
+	// Unknown station -> not found error.
+	_, _, err = suite.radioService.GetStationEpisodes(99999, 10, 0)
+	suite.Require().Error(err)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetRecentEpisodes_ActiveStationsOnly() {
+	active := suite.createStation("Active FM")
+	dormant := suite.createStation("Dormant FM")
+	suite.Require().NoError(suite.db.Model(&catalogm.RadioStation{}).Where("id = ?", dormant.ID).Update("is_active", false).Error)
+
+	activeShow := suite.createShow(active.ID, "Active Show")
+	dormantShow := suite.createShow(dormant.ID, "Dormant Show")
+	suite.createEpisode(activeShow.ID, "2026-06-08")
+	suite.createEpisode(activeShow.ID, "2026-06-09")
+	suite.createEpisode(dormantShow.ID, "2026-06-09")
+
+	rows, total, err := suite.radioService.GetRecentEpisodes(10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total)
+	suite.Require().Len(rows, 2)
+	suite.Equal("2026-06-09", rows[0].AirDate)
+	suite.Equal("2026-06-08", rows[1].AirDate)
+	for _, r := range rows {
+		suite.Equal("Active Show", r.ShowName)
+	}
+
+	// Pagination: second page carries the remaining row.
+	page2, total2, err := suite.radioService.GetRecentEpisodes(1, 1)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total2)
+	suite.Require().Len(page2, 1)
+	suite.Equal("2026-06-08", page2[0].AirDate)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetTopArtistsForStation_AggregatesNetwork() {
+	flagship, sibling, standalone := suite.createNetworkFamily()
+	flagShow := suite.createShow(flagship.ID, "Flag Show")
+	sibShow := suite.createShow(sibling.ID, "Sib Show")
+	aloneShow := suite.createShow(standalone.ID, "Alone Show")
+	flagEp := suite.createEpisode(flagShow.ID, "2026-06-08")
+	sibEp := suite.createEpisode(sibShow.ID, "2026-06-09")
+	aloneEp := suite.createEpisode(aloneShow.ID, "2026-06-07")
+
+	suite.createPlay(flagEp.ID, 1, "Shared Artist")
+	suite.createPlay(sibEp.ID, 1, "Shared Artist")
+	suite.createPlay(sibEp.ID, 2, "Channel Artist")
+	suite.createPlay(aloneEp.ID, 1, "Outsider Artist")
+
+	artists, err := suite.radioService.GetTopArtistsForStation(flagship.ID, 90, 10)
+	suite.Require().NoError(err)
+	suite.Require().Len(artists, 2)
+	suite.Equal("Shared Artist", artists[0].ArtistName)
+	suite.Equal(2, artists[0].PlayCount)
+	suite.Equal(2, artists[0].EpisodeCount)
+	suite.Equal("Channel Artist", artists[1].ArtistName)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetTopLabelsForStation_AggregatesNetwork() {
+	flagship, sibling, _ := suite.createNetworkFamily()
+	flagShow := suite.createShow(flagship.ID, "Flag Show")
+	sibShow := suite.createShow(sibling.ID, "Sib Show")
+	flagEp := suite.createEpisode(flagShow.ID, "2026-06-08")
+	sibEp := suite.createEpisode(sibShow.ID, "2026-06-09")
+
+	label := "Family Label"
+	other := "Channel Label"
+	plays := []catalogm.RadioPlay{
+		{EpisodeID: flagEp.ID, Position: 1, ArtistName: "A", LabelName: &label},
+		{EpisodeID: sibEp.ID, Position: 1, ArtistName: "B", LabelName: &label},
+		{EpisodeID: sibEp.ID, Position: 2, ArtistName: "C", LabelName: &other},
+	}
+	for i := range plays {
+		suite.Require().NoError(suite.db.Create(&plays[i]).Error)
+	}
+
+	labels, err := suite.radioService.GetTopLabelsForStation(flagship.ID, 90, 10)
+	suite.Require().NoError(err)
+	suite.Require().Len(labels, 2)
+	suite.Equal("Family Label", labels[0].LabelName)
+	suite.Equal(2, labels[0].PlayCount)
+}
+
+func TestRadioService_NilDB_ResolveStationID(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error { _, err := svc.ResolveStationIDBySlug("x"); return err })
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestResolveStationIDBySlug() {
+	station := suite.createStation("Resolve FM")
+
+	id, err := suite.radioService.ResolveStationIDBySlug(station.Slug)
+	suite.Require().NoError(err)
+	suite.Equal(station.ID, id)
+
+	_, err = suite.radioService.ResolveStationIDBySlug("no-such-station")
+	suite.Require().Error(err)
 }

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -193,11 +193,22 @@ type RadioShowListResponse struct {
 	ImageURL     *string          `json:"image_url"`
 	IsActive     bool             `json:"is_active"`
 	EpisodeCount int64            `json:"episode_count"`
+	// LatestAirDate is the air date (YYYY-MM-DD) of the show's most recent
+	// episode, nil when the show has no episodes (PSY-1048).
+	LatestAirDate *string `json:"latest_air_date"`
 }
 
 // ──────────────────────────────────────────────
 // Radio Episode types
 // ──────────────────────────────────────────────
+
+// RadioEpisodePreviewArtist is one artist in an episode row's short
+// "played" preview — raw name plus knowledge-graph link when matched (PSY-1048).
+type RadioEpisodePreviewArtist struct {
+	ArtistName string  `json:"artist_name"`
+	ArtistID   *uint   `json:"artist_id"`
+	ArtistSlug *string `json:"artist_slug"`
+}
 
 // RadioEpisodeResponse represents a radio episode in list views
 type RadioEpisodeResponse struct {
@@ -210,6 +221,27 @@ type RadioEpisodeResponse struct {
 	ArchiveURL      *string   `json:"archive_url"`
 	PlayCount       int       `json:"play_count"`
 	CreatedAt       time.Time `json:"created_at"`
+	// ArtistPreview holds the first few distinct artists from the episode's
+	// playlist, in play order (PSY-1048).
+	ArtistPreview []RadioEpisodePreviewArtist `json:"artist_preview"`
+}
+
+// RadioStationEpisodeRow is an episode row in the station-scoped and
+// dial-wide latest-playlists feeds: episode fields plus show and channel
+// (station) attribution (PSY-1048).
+type RadioStationEpisodeRow struct {
+	ID            uint                        `json:"id"`
+	Title         *string                     `json:"title"`
+	AirDate       string                      `json:"air_date"`
+	PlayCount     int                         `json:"play_count"`
+	ArchiveURL    *string                     `json:"archive_url"`
+	ShowID        uint                        `json:"show_id"`
+	ShowName      string                      `json:"show_name"`
+	ShowSlug      string                      `json:"show_slug"`
+	StationID     uint                        `json:"station_id"`
+	StationName   string                      `json:"station_name"`
+	StationSlug   string                      `json:"station_slug"`
+	ArtistPreview []RadioEpisodePreviewArtist `json:"artist_preview"`
 }
 
 // RadioEpisodeDetailResponse represents the full radio episode data
@@ -457,6 +489,7 @@ type RadioServiceInterface interface {
 	CreateStation(req *CreateRadioStationRequest) (*RadioStationDetailResponse, error)
 	GetStation(stationID uint) (*RadioStationDetailResponse, error)
 	GetStationBySlug(slug string) (*RadioStationDetailResponse, error)
+	ResolveStationIDBySlug(slug string) (uint, error)
 	ListStations(filters map[string]interface{}) ([]*RadioStationListResponse, error)
 	UpdateStation(stationID uint, req *UpdateRadioStationRequest) (*RadioStationDetailResponse, error)
 	DeleteStation(stationID uint) error
@@ -465,7 +498,7 @@ type RadioServiceInterface interface {
 	CreateShow(stationID uint, req *CreateRadioShowRequest) (*RadioShowDetailResponse, error)
 	GetShow(showID uint) (*RadioShowDetailResponse, error)
 	GetShowBySlug(slug string) (*RadioShowDetailResponse, error)
-	ListShows(stationID uint) ([]*RadioShowListResponse, error)
+	ListShows(stationID uint, sortBy string) ([]*RadioShowListResponse, error)
 	UpdateShow(showID uint, req *UpdateRadioShowRequest) (*RadioShowDetailResponse, error)
 	DeleteShow(showID uint) error
 
@@ -473,10 +506,14 @@ type RadioServiceInterface interface {
 	GetEpisodes(showID uint, limit, offset int) ([]*RadioEpisodeResponse, int64, error)
 	GetEpisodeByShowAndDate(showID uint, airDate string) (*RadioEpisodeDetailResponse, error)
 	GetEpisodeDetail(episodeID uint) (*RadioEpisodeDetailResponse, error)
+	GetStationEpisodes(stationID uint, limit, offset int) ([]*RadioStationEpisodeRow, int64, error)
+	GetRecentEpisodes(limit, offset int) ([]*RadioStationEpisodeRow, int64, error)
 
 	// Aggregation queries
 	GetTopArtistsForShow(showID uint, periodDays, limit int) ([]*RadioTopArtistResponse, error)
 	GetTopLabelsForShow(showID uint, periodDays, limit int) ([]*RadioTopLabelResponse, error)
+	GetTopArtistsForStation(stationID uint, periodDays, limit int) ([]*RadioTopArtistResponse, error)
+	GetTopLabelsForStation(stationID uint, periodDays, limit int) ([]*RadioTopLabelResponse, error)
 	GetAsHeardOnForArtist(artistID uint) ([]*RadioAsHeardOnResponse, error)
 	GetAsHeardOnForRelease(releaseID uint) ([]*RadioAsHeardOnResponse, error)
 	GetNewReleaseRadar(stationID uint, limit int) ([]*RadioNewReleaseRadarEntry, error)


### PR DESCRIPTION
Closes PSY-1048

Backend keystone for the locked Radio redesign (Option A — "The Dial", decisions: [PSY-1049 comment](https://linear.app/psychic-homily/issue/PSY-1049#comment-67819c6f)). Unblocks PSY-1049 (/radio hub) and PSY-1050 (station page); PSY-1051's show-page table consumes the episode artist previews.

## What's new

**Endpoints**
- `GET /radio-stations/{slug}/episodes?limit&offset` — station latest-playlists feed across all of the station's shows; a **network flagship aggregates its whole network**, each row carries channel (station) attribution. Non-flagship channels and standalone stations aggregate only themselves (`stationFamilyIDs`).
- `GET /radio/episodes/recent?limit&offset` — dial-wide feed, **active stations only** (hub policy; station pages still serve inactive stations' archives directly).
- `GET /radio-stations/{slug}/top-artists` + `/top-labels` (`period`, `limit`) — station-level aggregations; same response shapes as the show-level endpoints, implemented by refactoring the show-level queries onto shared cores (`topArtists`/`topLabels` + `playsScope`).

**Contract extensions (additive)**
- `RadioShowListResponse.latest_air_date` (nullable) + `GET /radio-shows?sort=latest` (active-first, newest playlist first; **default alphabetical order unchanged**).
- `RadioEpisodeResponse.artist_preview` + new `RadioStationEpisodeRow` rows: first 3 distinct artists in play order, matched names carry `artist_id`/`artist_slug`. One batched query per page (ROW_NUMBER-capped in SQL, `MAX(artist_id)` so a partially-matched name keeps its graph link). Always `[]`, never `null`.
- Cheap `ResolveStationIDBySlug` resolver so the three new station handlers skip the full detail build (network preload + show count + siblings) that `resolveStation` pays for.

## Deliberate decisions (flagged for review)

- **Family scope includes inactive sibling channels** — a flagship page is the network's archive; the dial feed separately filters to active stations. Documented on `stationFamilyIDs`.
- **`GET /radio/new-releases` keeps its pre-existing single-station semantics** (does not expand to the network family) — reconciling is a product call deferred to PSY-1050.
- **Previews are a hard dependency of the episode list**: if the preview query fails, the endpoint fails (fail-loud over silently dropping the field).
- Open questions from the ticket resolved implementer-side: preview size fixed at 3 (`episodePreviewArtistCount`); flagship network inclusion is implicit (no `include_network` param); weekly windowed stats stretch item **not** built — hub falls back to lifetime `/radio/stats`.

## Notes

- OpenAPI: Huma reflects the spec at runtime; the routes registration test (`routes_test.go`) exercises the full route graph + `/openapi.json` — no committed spec file exists to regenerate (ticket AC adjusted accordingly).
- Indexes verified existing for all new query paths (`idx_radio_plays_episode(episode_id, position)`, `idx_radio_episodes_show(show_id, air_date DESC)`, `idx_radio_shows_station`); no migration needed.
- `/simplify` + `/code-review` (7 finder agents) ran; fixes applied include the SQL-side preview cap, matched-variant link preservation, count-query error propagation, `[]`-not-`null` previews, operation-specific 500 messages, and a scope-type split preventing a future duplicate-join footgun.

## Test plan

- [x] `go build ./...` clean; `go generate ./...` (mocks) committed
- [x] Full `go test ./...` green
- [x] New integration tests (real Postgres container): flagship-aggregates-network + channel attribution + unknown-station 404, active-stations-only dial feed + pagination, station top artists/labels across network, `latest_air_date` + `sort=latest` ordering (incl. inactive-last and no-episodes cases), artist previews (play order, name dedupe, partially-matched link preservation, cap, `[]`-not-`null`), slug resolver, nil-DB guards for all new methods
- [x] Route registration + OpenAPI exercised by existing `routes_test.go`
- [ ] Not run: live dev-stack curl — backend-only diff (dispatch-stack mode `none` per convention); behavior covered by the container-backed integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
