### PR TITLE
PSY-1049: rebuild /radio hub as The Dial (Option A)

### DIFF
--- a/frontend/app/radio/_components/DialSidebarBoxes.test.tsx
+++ b/frontend/app/radio/_components/DialSidebarBoxes.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NewReleaseRadarBox, DialStatsBox } from './DialSidebarBoxes'
+import type { RadioNewReleaseRadarEntry, RadioStats } from '@/features/radio'
+
+function makeEntry(
+  overrides: Partial<RadioNewReleaseRadarEntry> = {}
+): RadioNewReleaseRadarEntry {
+  return {
+    artist_name: 'Wet Leg',
+    artist_id: 4,
+    artist_slug: 'wet-leg',
+    album_title: 'Moisturizer',
+    label_name: 'Domino',
+    release_id: 8,
+    release_slug: 'wet-leg-moisturizer',
+    label_id: 2,
+    label_slug: 'domino',
+    play_count: 24,
+    station_count: 2,
+    ...overrides,
+  }
+}
+
+describe('NewReleaseRadarBox', () => {
+  it('renders nothing when there are no releases', () => {
+    const { container } = render(
+      <NewReleaseRadarBox releases={[]} isLoading={false} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('links a matched release to its release page with a mono subline', () => {
+    render(<NewReleaseRadarBox releases={[makeEntry()]} isLoading={false} />)
+
+    expect(screen.getByText('New release radar')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Wet Leg — Moisturizer' })
+    ).toHaveAttribute('href', '/releases/wet-leg-moisturizer')
+    expect(screen.getByText('Domino · 24 plays · 2 stations')).toBeInTheDocument()
+  })
+
+  it('falls back to the artist page, then plain text (no dead links)', () => {
+    render(
+      <NewReleaseRadarBox
+        releases={[
+          makeEntry({ release_slug: null }),
+          makeEntry({
+            artist_name: 'Florry',
+            album_title: 'Sounds Like...',
+            artist_slug: null,
+            release_slug: null,
+          }),
+        ]}
+        isLoading={false}
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Wet Leg — Moisturizer' })
+    ).toHaveAttribute('href', '/artists/wet-leg')
+
+    expect(screen.getByText('Florry — Sounds Like...')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Florry — Sounds Like...' })
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe('DialStatsBox', () => {
+  const stats: RadioStats = {
+    total_stations: 6,
+    total_shows: 2341,
+    total_episodes: 1725,
+    total_plays: 19071,
+    matched_plays: 8210,
+    unique_artists: 1148,
+  }
+
+  it('renders nothing without stats', () => {
+    const { container } = render(<DialStatsBox stats={undefined} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders lifetime stats with honest all-time labels', () => {
+    render(<DialStatsBox stats={stats} />)
+
+    expect(screen.getByText('On the dial — all time')).toBeInTheDocument()
+    expect(screen.getByText('playlists tracked')).toBeInTheDocument()
+    expect(screen.getByText('1,725')).toBeInTheDocument()
+    expect(screen.getByText('plays logged')).toBeInTheDocument()
+    expect(screen.getByText('19,071')).toBeInTheDocument()
+    expect(screen.getByText('plays matched')).toBeInTheDocument()
+    expect(screen.getByText('unique artists')).toBeInTheDocument()
+    // No "this week" claims — weekly windowed stats were not built.
+    expect(screen.queryByText(/this week/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/_components/DialSidebarBoxes.tsx
+++ b/frontend/app/radio/_components/DialSidebarBoxes.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import Link from 'next/link'
+import { Loader2 } from 'lucide-react'
+import { StatsList } from '@/components/shared/StatsList'
+import type { RadioNewReleaseRadarEntry, RadioStats } from '@/features/radio'
+
+/**
+ * Sidebar boxes for The Dial hub (PSY-1049): hairline-bordered Gazelle-style
+ * stat boxes with mono headers. Presentational — the hub owns the fetches.
+ */
+
+function SidebarBox({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="rounded-md border border-border">
+      <h2 className="border-b border-border bg-muted/40 px-3.5 py-2 font-mono text-[11px] uppercase tracking-[1.2px] text-muted-foreground">
+        {title}
+      </h2>
+      <div className="px-3.5 py-3">{children}</div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// New Release Radar
+// ---------------------------------------------------------------------------
+
+export function NewReleaseRadarBox({
+  releases,
+  isLoading,
+}: {
+  releases: RadioNewReleaseRadarEntry[] | undefined
+  isLoading: boolean
+}) {
+  if (isLoading) {
+    return (
+      <SidebarBox title="New release radar">
+        <div className="flex justify-center py-3">
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+          <span className="sr-only">Loading new release radar</span>
+        </div>
+      </SidebarBox>
+    )
+  }
+
+  if (!releases || releases.length === 0) return null
+
+  return (
+    <SidebarBox title="New release radar">
+      <ul className="flex flex-col gap-2.5">
+        {releases.map((entry, idx) => {
+          const title = entry.album_title
+            ? `${entry.artist_name} — ${entry.album_title}`
+            : entry.artist_name
+          // Link the whole "Artist — Album" line to the release when matched,
+          // else to the artist, else plain text (no dead links).
+          const href = entry.release_slug
+            ? `/releases/${entry.release_slug}`
+            : entry.artist_slug
+              ? `/artists/${entry.artist_slug}`
+              : null
+          const subline = [
+            entry.label_name,
+            `${entry.play_count} ${entry.play_count === 1 ? 'play' : 'plays'}`,
+            `${entry.station_count} ${entry.station_count === 1 ? 'station' : 'stations'}`,
+          ]
+            .filter(Boolean)
+            .join(' · ')
+
+          return (
+            <li
+              key={`${entry.artist_name}-${entry.album_title}-${idx}`}
+              className="min-w-0"
+            >
+              {href ? (
+                <Link
+                  href={href}
+                  className="text-sm font-medium text-primary transition-colors hover:underline"
+                >
+                  {title}
+                </Link>
+              ) : (
+                <span className="text-sm font-medium text-foreground">
+                  {title}
+                </span>
+              )}
+              <p className="font-mono text-[11px] leading-4 text-muted-foreground">
+                {subline}
+              </p>
+            </li>
+          )
+        })}
+      </ul>
+    </SidebarBox>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Dial stats
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifetime dial stats. PSY-1048 did NOT ship weekly windowed stats, so the
+ * mock's "THIS WEEK ON THE DIAL" renders honestly as all-time numbers.
+ */
+export function DialStatsBox({ stats }: { stats: RadioStats | undefined }) {
+  if (!stats) return null
+
+  return (
+    <SidebarBox title="On the dial — all time">
+      <StatsList
+        items={[
+          { label: 'playlists tracked', value: stats.total_episodes },
+          { label: 'plays logged', value: stats.total_plays },
+          { label: 'plays matched', value: stats.matched_plays },
+          { label: 'unique artists', value: stats.unique_artists },
+        ]}
+      />
+    </SidebarBox>
+  )
+}

--- a/frontend/app/radio/_components/DialStationStrip.test.tsx
+++ b/frontend/app/radio/_components/DialStationStrip.test.tsx
@@ -186,7 +186,7 @@ describe('DialStationStrip', () => {
     ).toHaveAttribute('href', '/radio/wfmu-drummer/honky-tonk')
     expect(screen.getByText(/w\/ Becky/)).toBeInTheDocument()
 
-    expect(screen.getByRole('link', { name: '[ listen ]' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: '[listen]' })).toHaveAttribute(
       'href',
       'https://wfmu.org/drummer'
     )

--- a/frontend/app/radio/_components/DialStationStrip.test.tsx
+++ b/frontend/app/radio/_components/DialStationStrip.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type {
+  RadioStationListItem,
+  RadioStationDetail,
+  RadioShowDetail,
+  RadioEpisodeDetail,
+  RadioPlay,
+} from '@/features/radio'
+
+const mockUseStationOverview = vi.fn()
+const mockUseRadioShows = vi.fn()
+const mockUseRadioStation = vi.fn()
+
+vi.mock('@/features/radio', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/features/radio')>()
+  return {
+    ...actual,
+    useStationOverview: (...args: unknown[]) => mockUseStationOverview(...args),
+    useRadioShows: (...args: unknown[]) => mockUseRadioShows(...args),
+    useRadioStation: (...args: unknown[]) => mockUseRadioStation(...args),
+  }
+})
+
+import { DialStationStrip } from './DialStationStrip'
+
+function makeStation(
+  overrides: Partial<RadioStationListItem> = {}
+): RadioStationListItem {
+  return {
+    id: 2,
+    name: 'WFMU',
+    slug: 'wfmu',
+    city: 'Jersey City',
+    state: 'NJ',
+    country: 'USA',
+    broadcast_type: 'both',
+    frequency_mhz: 91.1,
+    logo_url: null,
+    is_active: true,
+    network: { slug: 'wfmu', name: 'WFMU', is_flagship: true },
+    sibling_stations: [
+      {
+        id: 5,
+        slug: 'wfmu-drummer',
+        name: 'Give the Drummer Radio',
+        broadcast_type: 'internet',
+        frequency_mhz: null,
+        is_flagship: false,
+      },
+    ],
+    show_count: 12,
+    ...overrides,
+  }
+}
+
+const stationDetail = {
+  slug: 'wfmu',
+  name: 'WFMU',
+  website: 'https://wfmu.org',
+} as RadioStationDetail
+
+const showDetail = {
+  id: 3,
+  slug: 'night-owl',
+  name: 'The Night Owl Show',
+  host_name: 'Pedro Santos',
+} as RadioShowDetail
+
+const currentPlay = {
+  id: 77,
+  artist_name: 'CAN',
+  artist_slug: 'can',
+  track_title: 'Vitamin C',
+  rotation_status: 'heavy',
+} as RadioPlay
+
+const latestEpisode = { air_date: '2026-06-09' } as RadioEpisodeDetail
+
+function overviewLoaded() {
+  return {
+    station: stationDetail,
+    nowPlayingShow: { id: 3, slug: 'night-owl' },
+    nowPlayingShowDetail: showDetail,
+    nowPlaying: {
+      current: currentPlay,
+      recentArtists: [
+        { name: 'Brentford All Stars', slug: null },
+        { name: 'Mdou Moctar', slug: 'mdou-moctar' },
+      ],
+    },
+    latestEpisode,
+    recentShows: [],
+    isLoading: false,
+    isEmpty: false,
+    error: null,
+  }
+}
+
+describe('DialStationStrip', () => {
+  beforeEach(() => {
+    mockUseStationOverview.mockReset().mockReturnValue(overviewLoaded())
+    mockUseRadioShows.mockReset().mockReturnValue({
+      data: {
+        shows: [
+          {
+            id: 9,
+            slug: 'honky-tonk',
+            name: 'Honky Tonk Radio Girl',
+            host_name: 'Becky',
+            episode_count: 40,
+          },
+        ],
+      },
+      isLoading: false,
+    })
+    mockUseRadioStation.mockReset().mockReturnValue({
+      data: { website: 'https://wfmu.org/drummer' },
+      isLoading: false,
+    })
+  })
+
+  it('renders the station name as an underlined link to the station page', () => {
+    render(<DialStationStrip station={makeStation()} />)
+    const link = screen.getByRole('link', { name: 'WFMU' })
+    expect(link).toHaveAttribute('href', '/radio/wfmu')
+    expect(link.className).toContain('underline')
+  })
+
+  it('renders frequency and identity line', () => {
+    render(<DialStationStrip station={makeStation()} />)
+    expect(screen.getByText('91.1 FM')).toBeInTheDocument()
+    expect(
+      screen.getByText('Jersey City, NJ · FM/AM + Internet · 1 channel')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the on-air show, current track, rotation tag, and earlier hops', () => {
+    render(<DialStationStrip station={makeStation()} />)
+
+    const showLink = screen.getByRole('link', { name: 'The Night Owl Show' })
+    expect(showLink).toHaveAttribute('href', '/radio/wfmu/night-owl')
+    expect(screen.getByText('w/ Pedro Santos')).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: 'CAN' })).toHaveAttribute(
+      'href',
+      '/artists/can'
+    )
+    expect(screen.getByText('— Vitamin C')).toBeInTheDocument()
+    expect(screen.getByText('Heavy Rotation')).toBeInTheDocument()
+
+    // earlier: matched artist links, unmatched stays plain text.
+    expect(screen.getByText('earlier:')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Mdou Moctar' })).toHaveAttribute(
+      'href',
+      '/artists/mdou-moctar'
+    )
+    expect(
+      screen.queryByRole('link', { name: 'Brentford All Stars' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders Listen + live playlist actions', () => {
+    render(<DialStationStrip station={makeStation()} />)
+
+    expect(screen.getByRole('link', { name: /Listen/ })).toHaveAttribute(
+      'href',
+      'https://wfmu.org'
+    )
+    expect(
+      screen.getByRole('link', { name: 'live playlist' })
+    ).toHaveAttribute('href', '/radio/wfmu/night-owl/2026-06-09')
+  })
+
+  it('renders channel sub-rows with underlined channel links and current show', () => {
+    render(<DialStationStrip station={makeStation()} />)
+
+    const channelLink = screen.getByRole('link', {
+      name: 'Give the Drummer Radio',
+    })
+    expect(channelLink).toHaveAttribute('href', '/radio/wfmu/channel/drummer')
+    expect(channelLink.className).toContain('underline')
+
+    expect(
+      screen.getByRole('link', { name: 'Honky Tonk Radio Girl' })
+    ).toHaveAttribute('href', '/radio/wfmu-drummer/honky-tonk')
+    expect(screen.getByText(/w\/ Becky/)).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: '[ listen ]' })).toHaveAttribute(
+      'href',
+      'https://wfmu.org/drummer'
+    )
+  })
+
+  it('renders the empty on-air state for a station with no shows', () => {
+    mockUseStationOverview.mockReturnValue({
+      ...overviewLoaded(),
+      nowPlayingShow: null,
+      nowPlayingShowDetail: undefined,
+      nowPlaying: { current: null, recentArtists: [] },
+      latestEpisode: undefined,
+      isEmpty: true,
+    })
+    render(<DialStationStrip station={makeStation({ sibling_stations: [] })} />)
+
+    expect(screen.getByText('No playlists tracked yet.')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'live playlist' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders a loading indicator while on-air info is in flight', () => {
+    mockUseStationOverview.mockReturnValue({
+      ...overviewLoaded(),
+      station: undefined,
+      nowPlayingShowDetail: undefined,
+      nowPlaying: { current: null, recentArtists: [] },
+      latestEpisode: undefined,
+      isLoading: true,
+      isEmpty: false,
+    })
+    render(<DialStationStrip station={makeStation({ sibling_stations: [] })} />)
+    expect(screen.getByText('Loading on-air info')).toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/_components/DialStationStrip.tsx
+++ b/frontend/app/radio/_components/DialStationStrip.tsx
@@ -1,0 +1,323 @@
+'use client'
+
+import Link from 'next/link'
+import { Loader2, Play } from 'lucide-react'
+import { BracketLink } from '@/components/shared/BracketLink'
+import {
+  useStationOverview,
+  useRadioShows,
+  useRadioStation,
+  pickNowPlayingShow,
+  formatStationLocation,
+  getBroadcastTypeLabel,
+  getRotationStatusLabel,
+  getStationDetailUrl,
+  ArtistHops,
+} from '@/features/radio'
+import type {
+  RadioStationListItem,
+  RadioSiblingStation,
+  RadioShowDetail,
+  NowPlaying,
+} from '@/features/radio'
+
+interface DialStationStripProps {
+  station: RadioStationListItem
+}
+
+/**
+ * One full-width strip on The Dial (PSY-1049): identity column (underlined
+ * station name + frequency + location), ON AIR column (current show + track +
+ * "earlier:" artist hops, via the PSY-1016 v1 heuristic), and actions
+ * ([▶ Listen] + [ live playlist ]). Network flagships also list their channel
+ * sub-rows.
+ *
+ * Underline convention (locked 2026-06-09): station/channel names are
+ * underlined foreground links — underline means "this identity is a page".
+ * Orange links remain for content (shows/playlists).
+ *
+ * "ON AIR" reflects the v1 heuristic — the most-active show's latest logged
+ * playlist, not a live signal. PSY-1022's live endpoint swaps in at the
+ * useStationOverview seam without changing this layout.
+ */
+export function DialStationStrip({ station }: DialStationStripProps) {
+  const {
+    station: detail,
+    nowPlayingShowDetail,
+    nowPlaying,
+    latestEpisode,
+    isLoading,
+    isEmpty,
+    error,
+  } = useStationOverview(station.slug)
+
+  // Non-flagship siblings = the network's channels (sibling_stations excludes
+  // self, so on a flagship every non-flagship entry is a channel sub-row).
+  const channels = station.sibling_stations.filter(s => !s.is_flagship)
+
+  const identityLine = [
+    formatStationLocation(station.city, station.state),
+    getBroadcastTypeLabel(station.broadcast_type),
+    channels.length > 0
+      ? `${channels.length} ${channels.length === 1 ? 'channel' : 'channels'}`
+      : '',
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  const livePlaylistUrl =
+    nowPlayingShowDetail && latestEpisode
+      ? `/radio/${station.slug}/${nowPlayingShowDetail.slug}/${latestEpisode.air_date}`
+      : null
+
+  return (
+    <article className="grid gap-3 border-b border-border/60 py-5 last:border-b-0 md:grid-cols-[200px_minmax(0,1fr)_auto] md:gap-6">
+      {/* Identity column */}
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <Link
+            href={`/radio/${station.slug}`}
+            className="text-xl font-bold text-foreground underline decoration-1 underline-offset-4 transition-colors hover:decoration-primary"
+          >
+            {station.name}
+          </Link>
+          {station.frequency_mhz != null && (
+            <span className="font-mono text-xs text-muted-foreground">
+              {station.frequency_mhz.toFixed(1)} FM
+            </span>
+          )}
+        </div>
+        {identityLine && (
+          <p className="mt-1 font-mono text-[11px] leading-4 text-muted-foreground">
+            {identityLine}
+          </p>
+        )}
+      </div>
+
+      {/* ON AIR column + channel sub-rows */}
+      <div className="flex min-w-0 flex-col gap-3">
+        <OnAirBlock
+          stationSlug={station.slug}
+          isLoading={isLoading}
+          isEmpty={isEmpty}
+          error={error}
+          showDetail={nowPlayingShowDetail}
+          nowPlaying={nowPlaying}
+        />
+        {channels.length > 0 && (
+          <ul className="flex flex-col gap-1.5">
+            {channels.map(channel => (
+              <DialChannelRow
+                key={channel.id}
+                networkSlug={station.network?.slug ?? station.slug}
+                channel={channel}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Actions column */}
+      <div className="flex items-center gap-4 md:flex-col md:items-end md:gap-2">
+        {detail?.website && (
+          <a
+            href={detail.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <Play className="size-3.5 fill-current" aria-hidden />
+            Listen
+          </a>
+        )}
+        {livePlaylistUrl && (
+          <BracketLink
+            label="live playlist"
+            href={livePlaylistUrl}
+            className="font-mono text-xs text-primary hover:text-primary/80"
+          />
+        )}
+      </div>
+    </article>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ON AIR block (v1 heuristic)
+// ---------------------------------------------------------------------------
+
+function OnAirBlock({
+  stationSlug,
+  isLoading,
+  isEmpty,
+  error,
+  showDetail,
+  nowPlaying,
+}: {
+  stationSlug: string
+  isLoading: boolean
+  isEmpty: boolean
+  error: unknown
+  showDetail: RadioShowDetail | undefined
+  nowPlaying: NowPlaying
+}) {
+  if (isLoading && !showDetail) {
+    return (
+      <div className="flex items-center gap-2 py-1 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" aria-hidden />
+        <span className="sr-only">Loading on-air info</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Couldn&apos;t load on-air info.
+      </p>
+    )
+  }
+
+  if (isEmpty || !showDetail) {
+    return (
+      <p className="text-sm text-muted-foreground">No playlists tracked yet.</p>
+    )
+  }
+
+  const { current, recentArtists } = nowPlaying
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      {/* ● ON AIR  Show name  w/ host */}
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <span className="inline-flex items-baseline gap-1.5 font-mono text-[11px] uppercase tracking-[1.2px] text-muted-foreground">
+          <span
+            className="size-2 self-center rounded-full bg-primary"
+            aria-hidden
+          />
+          On air
+        </span>
+        <Link
+          href={`/radio/${stationSlug}/${showDetail.slug}`}
+          className="text-[15px] font-semibold text-foreground transition-colors hover:text-primary"
+        >
+          {showDetail.name}
+        </Link>
+        {showDetail.host_name && (
+          <span className="text-[13px] text-muted-foreground">
+            w/ {showDetail.host_name}
+          </span>
+        )}
+      </div>
+
+      {/* ♪ current track + rotation tag */}
+      {current && (
+        <div className="flex flex-wrap items-baseline gap-x-1.5">
+          <span className="text-primary" aria-hidden>
+            ♪
+          </span>
+          {current.artist_slug ? (
+            <Link
+              href={`/artists/${current.artist_slug}`}
+              className="text-sm font-medium text-foreground transition-colors hover:text-primary"
+            >
+              {current.artist_name}
+            </Link>
+          ) : (
+            <span className="text-sm font-medium text-foreground">
+              {current.artist_name}
+            </span>
+          )}
+          {current.track_title && (
+            <span className="text-sm text-muted-foreground">
+              — {current.track_title}
+            </span>
+          )}
+          {current.rotation_status && (
+            <span className="font-mono text-[11px] lowercase text-primary">
+              {getRotationStatusLabel(current.rotation_status)}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* earlier: artist hops */}
+      {recentArtists.length > 0 && (
+        <div className="flex items-baseline gap-1.5">
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">
+            earlier:
+          </span>
+          <ArtistHops
+            hops={recentArtists}
+            className="font-mono text-xs text-foreground"
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Network channel sub-row
+// ---------------------------------------------------------------------------
+
+/**
+ * One channel sub-row under a network flagship: underlined channel name +
+ * its current show (v1 heuristic: most-active show) + [ listen ]. Fetches its
+ * own shows + detail (bounded N — networks have a handful of channels), the
+ * same per-row pattern as PSY-1016's RecentShowRow.
+ */
+function DialChannelRow({
+  networkSlug,
+  channel,
+}: {
+  networkSlug: string
+  channel: RadioSiblingStation
+}) {
+  const showsQuery = useRadioShows(channel.id)
+  const currentShow = pickNowPlayingShow(showsQuery.data?.shows)
+  // Channel detail is only needed for the external listen URL.
+  const { data: channelDetail } = useRadioStation(channel.slug)
+
+  const channelUrl = getStationDetailUrl(channel.slug, {
+    slug: networkSlug,
+    is_flagship: false,
+  })
+
+  return (
+    <li className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+      <span
+        className="size-1.5 self-center rounded-full bg-primary/60"
+        aria-hidden
+      />
+      <Link
+        href={channelUrl}
+        className="text-sm font-semibold text-foreground underline decoration-1 underline-offset-4 transition-colors hover:decoration-primary"
+      >
+        {channel.name}
+      </Link>
+      {currentShow && (
+        <span className="text-[13px] text-muted-foreground">
+          —{' '}
+          <Link
+            href={`/radio/${channel.slug}/${currentShow.slug}`}
+            className="transition-colors hover:text-primary"
+          >
+            {currentShow.name}
+          </Link>
+          {currentShow.host_name && ` w/ ${currentShow.host_name}`}
+        </span>
+      )}
+      {channelDetail?.website && (
+        <a
+          href={channelDetail.website}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono text-xs text-primary transition-colors hover:text-primary/80"
+        >
+          [ listen ]
+        </a>
+      )}
+    </li>
+  )
+}

--- a/frontend/app/radio/_components/DialStationStrip.tsx
+++ b/frontend/app/radio/_components/DialStationStrip.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { Loader2, Play } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { BracketLink } from '@/components/shared/BracketLink'
 import {
   useStationOverview,
@@ -120,15 +121,12 @@ export function DialStationStrip({ station }: DialStationStripProps) {
       {/* Actions column */}
       <div className="flex items-center gap-4 md:flex-col md:items-end md:gap-2">
         {detail?.website && (
-          <a
-            href={detail.website}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            <Play className="size-3.5 fill-current" aria-hidden />
-            Listen
-          </a>
+          <Button asChild size="sm">
+            <a href={detail.website} target="_blank" rel="noopener noreferrer">
+              <Play className="size-3.5 fill-current" aria-hidden />
+              Listen
+            </a>
+          </Button>
         )}
         {livePlaylistUrl && (
           <BracketLink
@@ -309,13 +307,16 @@ function DialChannelRow({
         </span>
       )}
       {channelDetail?.website && (
+        // Hand-rolled bracket link (not BracketLink) because the target is an
+        // external stream URL needing target="_blank"; text matches
+        // BracketLink's tight [label] idiom.
         <a
           href={channelDetail.website}
           target="_blank"
           rel="noopener noreferrer"
           className="font-mono text-xs text-primary transition-colors hover:text-primary/80"
         >
-          [ listen ]
+          [listen]
         </a>
       )}
     </li>

--- a/frontend/app/radio/_components/LatestPlaylistsTable.test.tsx
+++ b/frontend/app/radio/_components/LatestPlaylistsTable.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LatestPlaylistsTable } from './LatestPlaylistsTable'
+import type { RadioStationEpisodeRow } from '@/features/radio'
+
+function makeRow(
+  overrides: Partial<RadioStationEpisodeRow> = {}
+): RadioStationEpisodeRow {
+  return {
+    id: 1,
+    title: null,
+    air_date: '2026-06-09',
+    play_count: 24,
+    archive_url: null,
+    show_id: 3,
+    show_name: 'The Night Owl Show',
+    show_slug: 'night-owl',
+    station_id: 2,
+    station_name: 'WFMU',
+    station_slug: 'wfmu',
+    artist_preview: [
+      { artist_name: 'CAN', artist_id: 9, artist_slug: 'can' },
+      { artist_name: "it's all meat", artist_id: null, artist_slug: null },
+    ],
+    ...overrides,
+  }
+}
+
+describe('LatestPlaylistsTable', () => {
+  it('renders a loading spinner while the feed is in flight', () => {
+    render(<LatestPlaylistsTable rows={undefined} isLoading error={null} />)
+    expect(screen.getByText('Loading latest playlists')).toBeInTheDocument()
+  })
+
+  it('renders an error message when the feed fails', () => {
+    render(
+      <LatestPlaylistsTable
+        rows={undefined}
+        isLoading={false}
+        error={new Error('boom')}
+      />
+    )
+    expect(
+      screen.getByText("Couldn't load the latest playlists.")
+    ).toBeInTheDocument()
+  })
+
+  it('renders an empty state when there are no episodes', () => {
+    render(<LatestPlaylistsTable rows={[]} isLoading={false} error={null} />)
+    expect(screen.getByText('No playlists tracked yet.')).toBeInTheDocument()
+  })
+
+  it('renders date, station, show link, and track count for each row', () => {
+    render(
+      <LatestPlaylistsTable rows={[makeRow()]} isLoading={false} error={null} />
+    )
+
+    expect(screen.getByText('Jun 9')).toBeInTheDocument()
+    expect(screen.getByText('WFMU')).toBeInTheDocument()
+    expect(screen.getByText('24')).toBeInTheDocument()
+
+    const showLink = screen.getByRole('link', { name: 'The Night Owl Show' })
+    expect(showLink).toHaveAttribute('href', '/radio/wfmu/night-owl')
+  })
+
+  it('links matched preview artists and renders unmatched ones as plain text', () => {
+    render(
+      <LatestPlaylistsTable rows={[makeRow()]} isLoading={false} error={null} />
+    )
+
+    const matched = screen.getByRole('link', { name: 'CAN' })
+    expect(matched).toHaveAttribute('href', '/artists/can')
+
+    // Unmatched artist: visible, but NOT a link (no dead links).
+    expect(screen.getByText("it's all meat")).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: "it's all meat" })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders a dash for rows with an empty artist preview', () => {
+    render(
+      <LatestPlaylistsTable
+        rows={[makeRow({ artist_preview: [] })]}
+        isLoading={false}
+        error={null}
+      />
+    )
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/_components/LatestPlaylistsTable.tsx
+++ b/frontend/app/radio/_components/LatestPlaylistsTable.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import Link from 'next/link'
+import { Loader2 } from 'lucide-react'
+import { DenseTable } from '@/components/shared/DenseTable'
+import { ArtistHops, formatShortAirDate } from '@/features/radio'
+import type { RadioStationEpisodeRow } from '@/features/radio'
+
+interface LatestPlaylistsTableProps {
+  rows: RadioStationEpisodeRow[] | undefined
+  isLoading: boolean
+  error: unknown
+}
+
+/**
+ * "LATEST PLAYLISTS — ACROSS THE DIAL" (PSY-1049): the dial-wide recent feed
+ * (PSY-1048) as a dense table — date · station · show · played preview ·
+ * track count. Show names are orange content links; preview artists link into
+ * the graph only when matched (ArtistHops rule — no dead links).
+ *
+ * Presentational: the hub owns the fetch (useRecentRadioEpisodes).
+ */
+export function LatestPlaylistsTable({
+  rows,
+  isLoading,
+  error,
+}: LatestPlaylistsTableProps) {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        <span className="sr-only">Loading latest playlists</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="py-6 text-sm text-muted-foreground">
+        Couldn&apos;t load the latest playlists.
+      </p>
+    )
+  }
+
+  if (!rows || rows.length === 0) {
+    return (
+      <p className="py-6 text-sm text-muted-foreground">
+        No playlists tracked yet.
+      </p>
+    )
+  }
+
+  return (
+    <DenseTable variant="standard">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Station</th>
+          <th>Show</th>
+          <th>Played</th>
+          <th className="text-right">Tracks</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(row => (
+          <tr key={row.id}>
+            <td className="whitespace-nowrap font-mono text-xs uppercase text-muted-foreground">
+              {formatShortAirDate(row.air_date)}
+            </td>
+            <td className="max-w-[8rem] truncate font-mono text-xs uppercase text-muted-foreground">
+              {row.station_name}
+            </td>
+            <td>
+              <Link
+                href={`/radio/${row.station_slug}/${row.show_slug}`}
+                className="font-medium text-primary transition-colors hover:underline"
+              >
+                {row.show_name}
+              </Link>
+            </td>
+            <td className="text-muted-foreground">
+              {row.artist_preview.length > 0 ? (
+                <ArtistHops
+                  hops={row.artist_preview.map(a => ({
+                    name: a.artist_name,
+                    slug: a.artist_slug,
+                  }))}
+                  className="text-sm text-muted-foreground [&_a]:text-foreground"
+                />
+              ) : (
+                <span aria-hidden>—</span>
+              )}
+            </td>
+            <td className="text-right text-muted-foreground">
+              {row.play_count}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </DenseTable>
+  )
+}

--- a/frontend/app/radio/_components/RadioHub.test.tsx
+++ b/frontend/app/radio/_components/RadioHub.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const mockUseRadioStats = vi.fn()
+const mockUseRadioStations = vi.fn()
+const mockUseRecentRadioEpisodes = vi.fn()
+const mockUseNewReleaseRadar = vi.fn()
+
+vi.mock('@/features/radio', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/features/radio')>()
+  return {
+    ...actual,
+    useRadioStats: () => mockUseRadioStats(),
+    useRadioStations: () => mockUseRadioStations(),
+    useRecentRadioEpisodes: (...args: unknown[]) =>
+      mockUseRecentRadioEpisodes(...args),
+    useNewReleaseRadar: (...args: unknown[]) => mockUseNewReleaseRadar(...args),
+  }
+})
+
+// The strip fetches per-station data; stub it so the hub test stays focused
+// on page structure (the strip has its own test file).
+vi.mock('./DialStationStrip', () => ({
+  DialStationStrip: ({ station }: { station: { name: string } }) => (
+    <div data-testid="dial-strip">{station.name}</div>
+  ),
+}))
+
+import RadioHub from './RadioHub'
+
+const stats = {
+  total_stations: 6,
+  total_shows: 2341,
+  total_episodes: 1725,
+  total_plays: 19071,
+  matched_plays: 8210,
+  unique_artists: 1148,
+}
+
+function makeStation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    name: 'KEXP',
+    slug: 'kexp',
+    city: 'Seattle',
+    state: 'WA',
+    country: 'USA',
+    broadcast_type: 'both',
+    frequency_mhz: 90.3,
+    logo_url: null,
+    is_active: true,
+    network: null,
+    sibling_stations: [],
+    show_count: 40,
+    ...overrides,
+  }
+}
+
+describe('RadioHub', () => {
+  beforeEach(() => {
+    mockUseRadioStats.mockReset().mockReturnValue({ data: stats })
+    mockUseRadioStations.mockReset().mockReturnValue({
+      data: {
+        stations: [
+          makeStation(),
+          makeStation({ id: 2, name: 'WFMU', slug: 'wfmu' }),
+          // Non-flagship network sibling must NOT get its own strip.
+          makeStation({
+            id: 5,
+            name: 'Give the Drummer Radio',
+            slug: 'wfmu-drummer',
+            network: { slug: 'wfmu', name: 'WFMU', is_flagship: false },
+          }),
+        ],
+        count: 3,
+      },
+      isLoading: false,
+      error: null,
+    })
+    mockUseRecentRadioEpisodes.mockReset().mockReturnValue({
+      data: { episodes: [], total: 0 },
+      isLoading: false,
+      error: null,
+    })
+    mockUseNewReleaseRadar.mockReset().mockReturnValue({
+      data: { releases: [], count: 0 },
+      isLoading: false,
+    })
+  })
+
+  it('renders the page head with mission and mono stats line', () => {
+    render(<RadioHub />)
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Radio' })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/wired into the knowledge graph/)).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        '6 stations · 2,341 shows · 1,725 playlists · 19,071 plays tracked'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('renders one dial strip per visible station, excluding non-flagship channels', () => {
+    render(<RadioHub />)
+
+    const strips = screen.getAllByTestId('dial-strip')
+    expect(strips.map(s => s.textContent)).toEqual(['KEXP', 'WFMU'])
+  })
+
+  it('renders the dial and latest-playlists section headings', () => {
+    render(<RadioHub />)
+
+    expect(screen.getByText('The dial — live now')).toBeInTheDocument()
+    expect(
+      screen.getByText('Latest playlists — across the dial')
+    ).toBeInTheDocument()
+  })
+
+  it('renders an error state when stations fail to load', () => {
+    mockUseRadioStations.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    })
+    render(<RadioHub />)
+    expect(screen.getByText("Couldn't load radio stations.")).toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/_components/RadioHub.tsx
+++ b/frontend/app/radio/_components/RadioHub.tsx
@@ -1,173 +1,124 @@
 'use client'
 
-import Link from 'next/link'
-import { Radio, Loader2, Disc3 } from 'lucide-react'
-import { useRadioStats, useNewReleaseRadar, RadioPanel } from '@/features/radio'
-import type { RadioNewReleaseRadarEntry } from '@/features/radio'
+import { Loader2, Radio } from 'lucide-react'
+import {
+  useRadioStats,
+  useRadioStations,
+  useNewReleaseRadar,
+  useRecentRadioEpisodes,
+  isStationVisibleOnIndex,
+} from '@/features/radio'
+import { DialStationStrip } from './DialStationStrip'
+import { LatestPlaylistsTable } from './LatestPlaylistsTable'
+import { NewReleaseRadarBox, DialStatsBox } from './DialSidebarBoxes'
 
-// PSY-1016: the /radio page now leads with the same Option-D2 station-overview
-// layout as the Radio nav panel (RadioPanel), rendered full-width/expanded
-// instead of inside a popover. The page keeps the stats header and New Release
-// Radar below it as the existing radio-feature context.
+/**
+ * The Dial — /radio hub (PSY-1049, Option A, locked 2026-06-09).
+ *
+ * Every station and channel is visible as a full-width strip with on-air info
+ * inline (zero clicks to see the whole dial), followed by the dial-wide
+ * latest-playlists feed (PSY-1048) with New Release Radar + lifetime stats in
+ * the sidebar. The nav Radio popover keeps the D2 panel (PSY-1016) — this
+ * page no longer uses RadioPanel.
+ */
 export default function RadioHub() {
   const { data: stats } = useRadioStats()
-  const { data: radarData, isLoading: radarLoading } = useNewReleaseRadar({ limit: 10 })
+  const stationsQuery = useRadioStations()
+  const { data: recentData, isLoading: recentLoading, error: recentError } =
+    useRecentRadioEpisodes({ limit: 12 })
+  const { data: radarData, isLoading: radarLoading } = useNewReleaseRadar({
+    limit: 5,
+  })
+
+  const stations = (stationsQuery.data?.stations ?? []).filter(
+    isStationVisibleOnIndex
+  )
 
   return (
     <div className="flex min-h-screen items-start justify-center">
       <main className="w-full max-w-6xl px-4 py-8 md:px-8">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold flex items-center justify-center gap-3">
-            <Radio className="h-8 w-8" />
-            Radio
-          </h1>
-          <p className="text-muted-foreground mt-2">
-            Explore radio stations, shows, and playlists
+        {/* Page head */}
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold">Radio</h1>
+          <p className="mt-1.5 text-muted-foreground">
+            Independent radio, wired into the knowledge graph — every playlist
+            links into artists, releases, and labels.
           </p>
-
           {stats && (
-            <div className="flex items-center justify-center gap-6 mt-4 text-sm text-muted-foreground">
-              <span>{stats.total_stations} {stats.total_stations === 1 ? 'station' : 'stations'}</span>
-              <span>{stats.total_shows} {stats.total_shows === 1 ? 'show' : 'shows'}</span>
-              <span>{stats.total_episodes.toLocaleString()} {stats.total_episodes === 1 ? 'episode' : 'episodes'}</span>
-              <span>{stats.total_plays.toLocaleString()} {stats.total_plays === 1 ? 'play' : 'plays'} tracked</span>
+            <p className="mt-2 font-mono text-xs text-muted-foreground">
+              {stats.total_stations.toLocaleString()}{' '}
+              {stats.total_stations === 1 ? 'station' : 'stations'}
+              {' · '}
+              {stats.total_shows.toLocaleString()}{' '}
+              {stats.total_shows === 1 ? 'show' : 'shows'}
+              {' · '}
+              {stats.total_episodes.toLocaleString()}{' '}
+              {stats.total_episodes === 1 ? 'playlist' : 'playlists'}
+              {' · '}
+              {stats.total_plays.toLocaleString()}{' '}
+              {stats.total_plays === 1 ? 'play' : 'plays'} tracked
+            </p>
+          )}
+        </header>
+
+        {/* THE DIAL */}
+        <section className="mb-10" aria-label="The dial">
+          <DialSectionHeading title="The dial — live now" />
+          {stationsQuery.isLoading && (
+            <div className="flex justify-center py-12">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+              <span className="sr-only">Loading stations</span>
             </div>
           )}
-        </div>
+          {!stationsQuery.isLoading &&
+            (stationsQuery.error || stations.length === 0) && (
+              <div className="flex flex-col items-center gap-1 py-12 text-center">
+                <Radio className="size-7 text-muted-foreground/30" />
+                <p className="text-sm text-muted-foreground">
+                  {stationsQuery.error
+                    ? "Couldn't load radio stations."
+                    : 'No radio stations yet.'}
+                </p>
+              </div>
+            )}
+          {stations.map(station => (
+            <DialStationStrip key={station.id} station={station} />
+          ))}
+        </section>
 
-        {/* Option-D2 station overview (expanded). Reuses the same layout as the
-            Radio nav panel. RadioPanel owns its own loading / empty / error
-            states. */}
-        <div className="mb-10 overflow-hidden rounded-xl border border-border bg-popover">
-          <RadioPanel className="min-h-[360px]" />
-        </div>
+        {/* Latest playlists + sidebar */}
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <section aria-label="Latest playlists">
+            <DialSectionHeading title="Latest playlists — across the dial" />
+            <LatestPlaylistsTable
+              rows={recentData?.episodes}
+              isLoading={recentLoading}
+              error={recentError}
+            />
+          </section>
 
-        {/* New Release Radar */}
-        <NewReleaseRadarSection releases={radarData?.releases} isLoading={radarLoading} />
+          <aside className="flex flex-col gap-5">
+            <NewReleaseRadarBox
+              releases={radarData?.releases}
+              isLoading={radarLoading}
+            />
+            <DialStatsBox stats={stats} />
+          </aside>
+        </div>
       </main>
     </div>
   )
 }
 
-// ---------------------------------------------------------------------------
-// New Release Radar sub-component
-// ---------------------------------------------------------------------------
-
-function NewReleaseRadarSection({
-  releases,
-  isLoading,
-}: {
-  releases: RadioNewReleaseRadarEntry[] | undefined
-  isLoading: boolean
-}) {
-  // Don't render the section at all while loading or if there's no data
-  if (isLoading) {
-    return (
-      <section className="mb-10">
-        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
-          <Disc3 className="h-5 w-5" />
-          New Release Radar
-        </h2>
-        <div className="rounded-lg border border-border/50 bg-card p-6">
-          <div className="flex justify-center py-4">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-          </div>
-        </div>
-      </section>
-    )
-  }
-
-  if (!releases || releases.length === 0) {
-    return null
-  }
-
+/**
+ * Mono section heading in the radio register (matches PSY-1016's panel
+ * headers; the shared SectionHeader primitive uses the sans entity-page
+ * register, which isn't this surface's idiom).
+ */
+function DialSectionHeading({ title }: { title: string }) {
   return (
-    <section className="mb-10">
-      <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
-        <Disc3 className="h-5 w-5" />
-        New Release Radar
-      </h2>
-
-      <div className="rounded-lg border border-border/50 bg-card overflow-hidden">
-        {/* Header row */}
-        <div className="hidden sm:grid sm:grid-cols-[1fr_1fr_1fr_4.5rem_4.5rem] gap-3 px-4 py-2 border-b border-border/30 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-          <span>Artist</span>
-          <span>Album</span>
-          <span>Label</span>
-          <span className="text-right">Plays</span>
-          <span className="text-right">Stations</span>
-        </div>
-
-        {/* Rows */}
-        {releases.map((entry, idx) => (
-          <div
-            key={`${entry.artist_name}-${entry.album_title}-${idx}`}
-            className="sm:grid sm:grid-cols-[1fr_1fr_1fr_4.5rem_4.5rem] gap-3 px-4 py-2.5 hover:bg-muted/30 transition-colors border-b border-border/10 last:border-b-0"
-          >
-            {/* Artist */}
-            <div className="truncate">
-              {entry.artist_slug ? (
-                <Link
-                  href={`/artists/${entry.artist_slug}`}
-                  className="text-sm font-medium hover:text-primary transition-colors"
-                >
-                  {entry.artist_name}
-                </Link>
-              ) : (
-                <span className="text-sm font-medium">{entry.artist_name}</span>
-              )}
-            </div>
-
-            {/* Album */}
-            <div className="truncate">
-              {entry.album_title ? (
-                entry.release_slug ? (
-                  <Link
-                    href={`/releases/${entry.release_slug}`}
-                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {entry.album_title}
-                  </Link>
-                ) : (
-                  <span className="text-sm text-muted-foreground">{entry.album_title}</span>
-                )
-              ) : (
-                <span className="text-sm text-muted-foreground/40">--</span>
-              )}
-            </div>
-
-            {/* Label */}
-            <div className="truncate">
-              {entry.label_name ? (
-                entry.label_slug ? (
-                  <Link
-                    href={`/labels/${entry.label_slug}`}
-                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {entry.label_name}
-                  </Link>
-                ) : (
-                  <span className="text-sm text-muted-foreground">{entry.label_name}</span>
-                )
-              ) : (
-                <span className="text-sm text-muted-foreground/40">--</span>
-              )}
-            </div>
-
-            {/* Play count */}
-            <div className="text-sm text-muted-foreground tabular-nums text-right sm:block inline">
-              <span className="sm:hidden text-xs text-muted-foreground/50 mr-1">plays:</span>
-              {entry.play_count}
-            </div>
-
-            {/* Station count */}
-            <div className="text-sm text-muted-foreground tabular-nums text-right sm:block inline ml-3 sm:ml-0">
-              <span className="sm:hidden text-xs text-muted-foreground/50 mr-1">stations:</span>
-              {entry.station_count}
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
+    <h2 className="mb-1 border-b border-border pb-1.5 font-mono text-[11px] uppercase tracking-[1.2px] text-muted-foreground">
+      {title}
+    </h2>
   )
 }

--- a/frontend/e2e/pages/radio.spec.ts
+++ b/frontend/e2e/pages/radio.spec.ts
@@ -64,17 +64,23 @@ test.describe('Radio browse flow', () => {
       main.getByRole('heading', { name: 'Radio', level: 1 })
     ).toBeVisible({ timeout: 10_000 })
 
-    // PSY-1016: the /radio index now leads with the Option-D2 station-overview
-    // panel — the station list is a selectable button group (left pane), not
-    // link cards. KEXP / WFMU / NTS are the three index-visible stations (the 3
-    // WFMU sub-channels are hidden by isStationVisibleOnIndex per PSY-673). The
-    // selected station's full detail page stays reachable via the right-pane
-    // station link (exercised by the next test).
+    // PSY-1049: the /radio index is The Dial — every index-visible station
+    // renders as a full-width strip whose underlined station name is a link
+    // to the station page (no clicks needed to see the whole dial). KEXP /
+    // WFMU / NTS are the three index-visible stations (the 3 WFMU
+    // sub-channels are hidden by isStationVisibleOnIndex per PSY-673; they
+    // appear as channel sub-rows under the WFMU strip instead).
     await expect(
-      main.getByRole('button', { name: KEXP_STATION_NAME })
+      main.getByRole('link', { name: KEXP_STATION_NAME })
     ).toBeVisible({ timeout: 10_000 })
-    await expect(main.getByRole('button', { name: 'WFMU' })).toBeVisible()
-    await expect(main.getByRole('button', { name: 'NTS Radio' })).toBeVisible()
+    await expect(main.getByRole('link', { name: 'WFMU' })).toBeVisible()
+    await expect(main.getByRole('link', { name: 'NTS Radio' })).toBeVisible()
+
+    // WFMU's channels surface as underlined sub-row links on the flagship
+    // strip (seed has 3 wfmu sub-channels; assert one stable example).
+    await expect(
+      main.getByRole('link', { name: 'Give the Drummer Radio' })
+    ).toBeVisible()
   })
 
   test('clicking a station opens station detail and lists its shows', async ({

--- a/frontend/features/radio/api.ts
+++ b/frontend/features/radio/api.ts
@@ -32,6 +32,8 @@ export const radioEndpoints = {
   // Aggregation
   NEW_RELEASES: `${API_BASE_URL}/radio/new-releases`,
   STATS: `${API_BASE_URL}/radio/stats`,
+  // PSY-1048: dial-wide latest-playlists feed
+  RECENT_EPISODES: `${API_BASE_URL}/radio/episodes/recent`,
 } as const
 
 // ============================================================================
@@ -55,4 +57,5 @@ export const radioQueryKeys = {
   releasePlays: (releaseSlug: string) => ['releases', releaseSlug, 'radio-plays'] as const,
   newReleases: (params?: object) => ['radio', 'new-releases', params] as const,
   stats: () => ['radio', 'stats'] as const,
+  recentEpisodes: (params?: object) => ['radio', 'episodes', 'recent', params] as const,
 } as const

--- a/frontend/features/radio/components/RadioStationOverview.test.tsx
+++ b/frontend/features/radio/components/RadioStationOverview.test.tsx
@@ -140,6 +140,7 @@ function baseOverview(overrides: Partial<StationOverview> = {}): StationOverview
         { name: 'Unwound', slug: null },
       ],
     },
+    latestEpisode: undefined,
     recentShows: [makeShowListItem({ id: 2, name: 'Audioasis', slug: 'audioasis' })],
     isLoading: false,
     isEmpty: false,

--- a/frontend/features/radio/hooks/index.ts
+++ b/frontend/features/radio/hooks/index.ts
@@ -13,3 +13,5 @@ export { useRadioStats } from './useRadioStats'
 // PSY-1016: Radio D2 station-overview panel
 export { useShowLatestEpisode } from './useShowLatestEpisode'
 export { useStationOverview } from './useStationOverview'
+// PSY-1049: The Dial hub
+export { useRecentRadioEpisodes } from './useRecentRadioEpisodes'

--- a/frontend/features/radio/hooks/useRecentRadioEpisodes.test.tsx
+++ b/frontend/features/radio/hooks/useRecentRadioEpisodes.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRecentRadioEpisodes } from './useRecentRadioEpisodes'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRecentRadioEpisodes', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('carries limit/offset in the recentEpisodes() query key', () => {
+    expect(radioQueryKeys.recentEpisodes({ limit: 12, offset: 0 })).toEqual([
+      'radio',
+      'episodes',
+      'recent',
+      { limit: 12, offset: 0 },
+    ])
+  })
+
+  it('fetches the dial-wide feed with the default limit', async () => {
+    const mockResponse = {
+      episodes: [
+        {
+          id: 1,
+          title: null,
+          air_date: '2026-06-09',
+          play_count: 24,
+          archive_url: null,
+          show_id: 3,
+          show_name: 'The Night Owl Show',
+          show_slug: 'night-owl',
+          station_id: 2,
+          station_name: 'WFMU',
+          station_slug: 'wfmu',
+          artist_preview: [],
+        },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRecentRadioEpisodes(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/radio/episodes/recent?limit=20`,
+      { method: 'GET' }
+    )
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('includes offset when paginating', async () => {
+    mockApiRequest.mockResolvedValueOnce({ episodes: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useRecentRadioEpisodes({ limit: 12, offset: 24 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('limit=12')
+    expect(calledUrl).toContain('offset=24')
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const { result } = renderHook(
+      () => useRecentRadioEpisodes({ enabled: false }),
+      { wrapper: createWrapper() }
+    )
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRecentRadioEpisodes(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useRecentRadioEpisodes.ts
+++ b/frontend/features/radio/hooks/useRecentRadioEpisodes.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest } from '@/lib/api'
+import { radioEndpoints, radioQueryKeys } from '../api'
+import type { RadioRecentEpisodesResponse } from '../types'
+
+interface UseRecentRadioEpisodesOptions {
+  limit?: number
+  offset?: number
+  enabled?: boolean
+}
+
+/**
+ * Fetch the dial-wide latest-playlists feed (PSY-1048): the newest episodes
+ * across every active station, with show/station attribution and a short
+ * artist preview per row. Drives the "Latest playlists — across the dial"
+ * table on the /radio hub (PSY-1049).
+ */
+export function useRecentRadioEpisodes({
+  limit = 20,
+  offset = 0,
+  enabled = true,
+}: UseRecentRadioEpisodesOptions = {}) {
+  const params = new URLSearchParams()
+  if (limit) params.set('limit', limit.toString())
+  if (offset) params.set('offset', offset.toString())
+
+  const queryString = params.toString()
+  const endpoint = queryString
+    ? `${radioEndpoints.RECENT_EPISODES}?${queryString}`
+    : radioEndpoints.RECENT_EPISODES
+
+  return useQuery({
+    queryKey: radioQueryKeys.recentEpisodes({ limit, offset }),
+    queryFn: () =>
+      apiRequest<RadioRecentEpisodesResponse>(endpoint, {
+        method: 'GET',
+      }),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/features/radio/hooks/useStationOverview.ts
+++ b/frontend/features/radio/hooks/useStationOverview.ts
@@ -15,6 +15,7 @@ import type {
   RadioStationDetail,
   RadioShowListItem,
   RadioShowDetail,
+  RadioEpisodeDetail,
 } from '../types'
 
 export interface StationOverview {
@@ -25,6 +26,12 @@ export interface StationOverview {
   nowPlayingShowDetail: RadioShowDetail | undefined
   /** Derived now-playing surface (current track + recent artists). */
   nowPlaying: NowPlaying
+  /**
+   * nowPlayingShow's most-recent episode (the playlist behind `nowPlaying`).
+   * Exposed so surfaces can deep-link to the live playlist page
+   * (/radio/{station}/{show}/{air_date}) — PSY-1049's [ live playlist ].
+   */
+  latestEpisode: RadioEpisodeDetail | undefined
   /** Shows to list under "Recent shows" (excludes nowPlayingShow). */
   recentShows: RadioShowListItem[]
   isLoading: boolean
@@ -81,6 +88,7 @@ export function useStationOverview(stationSlug: string): StationOverview {
     nowPlayingShow,
     nowPlayingShowDetail: nowPlayingShowDetailQuery.data,
     nowPlaying,
+    latestEpisode: latest.episode,
     recentShows,
     isLoading,
     isEmpty,

--- a/frontend/features/radio/index.ts
+++ b/frontend/features/radio/index.ts
@@ -26,6 +26,10 @@ export type {
   RadioTopLabelsResponse,
   RadioAsHeardOnResponse,
   RadioNewReleasesResponse,
+  // PSY-1048 aggregation shapes (PSY-1049)
+  RadioEpisodePreviewArtist,
+  RadioStationEpisodeRow,
+  RadioRecentEpisodesResponse,
 } from './types'
 
 export {
@@ -56,6 +60,8 @@ export {
   // PSY-1016
   useShowLatestEpisode,
   useStationOverview,
+  // PSY-1049
+  useRecentRadioEpisodes,
 } from './hooks'
 
 // Components

--- a/frontend/features/radio/types.ts
+++ b/frontend/features/radio/types.ts
@@ -349,3 +349,47 @@ export function getRotationStatusLabel(status: string): string {
 export function getRotationStatusColor(status: string): string {
   return ROTATION_STATUS_COLORS[status] ?? 'bg-muted text-muted-foreground border-border'
 }
+
+// ============================================================================
+// PSY-1048 aggregation shapes (PSY-1049)
+//
+// Mirrors backend/internal/services/contracts/radio.go. Parallel radio
+// redesign PRs (PSY-1050/1051) may add identical definitions — dedupe by
+// keeping one copy at rebase time.
+// ============================================================================
+
+/**
+ * One artist in an episode row's short "played" preview: the raw playlist
+ * name plus a knowledge-graph link when the matching engine resolved it.
+ * Unmatched artists (null id/slug) render as plain text — never a dead link.
+ */
+export interface RadioEpisodePreviewArtist {
+  artist_name: string
+  artist_id: number | null
+  artist_slug: string | null
+}
+
+/**
+ * An episode row in the station-scoped and dial-wide latest-playlists feeds:
+ * episode fields plus show and channel (station) attribution.
+ */
+export interface RadioStationEpisodeRow {
+  id: number
+  title: string | null
+  air_date: string
+  play_count: number
+  archive_url: string | null
+  show_id: number
+  show_name: string
+  show_slug: string
+  station_id: number
+  station_name: string
+  station_slug: string
+  artist_preview: RadioEpisodePreviewArtist[]
+}
+
+/** Response shape for GET /radio/episodes/recent (and station episode feeds). */
+export interface RadioRecentEpisodesResponse {
+  episodes: RadioStationEpisodeRow[]
+  total: number
+}


### PR DESCRIPTION
## Summary

Rebuilds the /radio hub as **The Dial** (Option A, locked 2026-06-09 — see the canonical-decisions comment on PSY-1049). The two-pane `RadioPanel` page-mode usage is gone; the nav Radio popover keeps the D2 panel (PSY-1016) untouched.

- **Page head** — title, mission line, mono lifetime stats from `GET /radio/stats`.
- **THE DIAL** — every index-visible station as a full-width strip: identity column (station name as **underlined** foreground link — underline = identity navigation, per the locked convention — + frequency + location), ON AIR column (dot + show + host, ♪ current track + rotation tag, "earlier:" artist hops via `ArtistHops`), actions ([▶ Listen] + `[live playlist]` deep link to the latest playlist page). Network flagships (WFMU) render underlined channel sub-rows with each channel's current show + [listen].
- **LATEST PLAYLISTS — across the dial** — `DenseTable` over the new `GET /radio/episodes/recent` feed (PSY-1048): date · station · show (orange link) · played preview (matched artists link, unmatched render as plain text — no dead links) · track count.
- **Sidebar** — New Release Radar box (`GET /radio/new-releases`) + honest all-time stats box (weekly windowed stats were not built, so the mock's "this week" box renders lifetime numbers labeled "all time").

On-air content uses the existing PSY-1016 v1 heuristic (`useStationOverview` / `lib/stationOverview.ts`); PSY-1022's live endpoint swaps in at that seam without layout change. New TS mirrors of the PSY-1048 contracts (`RadioStationEpisodeRow`, `RadioEpisodePreviewArtist`) live in a commented block at the end of `types.ts` for easy dedupe against the parallel PSY-1050/1051 PRs. `useStationOverview` gains an additive `latestEpisode` field (drives the live-playlist deep link).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (156 pre-existing warnings, none in touched files)
- [x] `bun run test:run features/radio app/radio` — 31 files / 225 tests passed (includes new tests: dial strip underline + link targets + empty/loading states, feed table matched/unmatched preview links + empty `artist_preview`, sidebar boxes, hub structure + non-flagship filtering, `useRecentRadioEpisodes`)
- [x] `bunx eslint e2e/pages/radio.spec.ts` — clean (spec updated for The Dial; see Adversarial review)

## Manual repro

Per-worktree dispatch stack (isolated mode — backend from this branch, so `GET /radio/episodes/recent` was live; verified with curl before browsing). Exercised with agent-browser:

- Full dial visible with zero clicks: KEXP / NTS / WFMU strips with on-air lines; WFMU shows 3 underlined channel sub-rows
- Station name → `/radio/kexp`; channel name → `/radio/wfmu/channel/drummer`
- `[live playlist]` → `/radio/kexp/the-morning-show/2025-01-15`
- Table show link → `/radio/kexp/the-morning-show`; matched preview artist → `/artists/calexico`; unmatched preview artist renders as plain text
- Sidebar stats box renders lifetime numbers; NRR box hides when the feed is empty (seed data)
- Nav Radio popover unchanged (D2 panel, screenshot below)
- Dark mode renders with theme tokens (no hardcoded light-mode colors)

## Screenshots

| Light (full hub) | Dark |
| --- | --- |
| ![hub light](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1049-screenshots/radio-hub-full.png) | ![hub dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1049-screenshots/radio-hub-dark.png) |

| Table + sidebar | Nav popover (unchanged D2) |
| --- | --- |
| ![table sidebar](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1049-screenshots/radio-hub-table-sidebar.png) | ![popover](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1049-screenshots/radio-popover-d2.png) |

## Code review

`/code-review` (run inline — no Agent tool in worktree): reuse `Button` for the Listen action, align the external `[listen]` link with BracketLink's tight `[label]` idiom; verified the backend always serializes `sibling_stations` / `artist_preview` as arrays (no null guards needed). Fixed in `17ce0e4b`.

## Adversarial review

`/adversarial-review` — verdict **CONCERNS** (after 1 HIGH fixed in `90935475`).

- [HIGH] `e2e/pages/radio.spec.ts` asserted the D2 panel's station **buttons** on /radio — would fail on CI's full E2E run against The Dial → fixed in `90935475` (stations asserted as links + a channel sub-row link; selectors verified against the rendered DOM via agent-browser). Spec not executed locally (Playwright harness needs the standard :3000/:8080 dev stack); CI E2E is the runner.
- [MEDIUM, disclosed] The mock's `[ all playlists → ]` and `[ full radar → ]` footer links are intentionally omitted — no target pages exist yet, and shipping them would violate the no-dead-links rule.
- [MEDIUM, disclosed] Per-channel rows fetch station detail solely for the listen URL (bounded N, mirrors PSY-1016's per-row pattern; consolidates when PSY-1022 lands).
- [MEDIUM, rejected] "Same show linked twice on one page (strip + table)" — the one-link strict-mode rule applies to nested links within a single card, not page-level repetition; no spec queries show links on /radio.

Panel: Saboteur · Future-Maintainer · Security · Completeness — run inline.

Closes PSY-1049
