### PR TITLE
PSY-1051: rebuild radio show + playlist pages (archive + track table)

### DIFF
--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeDateDetail.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeDateDetail.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import Link from 'next/link'
-import {
-  ArrowLeft,
-  Loader2,
-  Calendar,
-  Clock,
-  Music,
-  ExternalLink,
-  Headphones,
-} from 'lucide-react'
+import { ArrowLeft, ArrowUpRight, Loader2, Play } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { useRadioEpisode, RadioPlayRow } from '@/features/radio'
+import {
+  useRadioEpisode,
+  useEpisodeNeighbors,
+  computeArtistMatchStats,
+  formatDurationMinutes,
+  formatTimeOfDay,
+} from '@/features/radio'
+import { EpisodeNav } from './EpisodeNav'
+import { PlaylistTable } from './PlaylistTable'
 
 interface EpisodeDateDetailProps {
   stationSlug: string
@@ -20,32 +19,24 @@ interface EpisodeDateDetailProps {
   date: string
 }
 
-function formatDate(dateStr: string): string {
+function formatLongDate(dateStr: string): string {
   const date = new Date(dateStr + 'T00:00:00')
   return date.toLocaleDateString('en-US', {
-    weekday: 'long',
     month: 'long',
     day: 'numeric',
     year: 'numeric',
   })
 }
 
-/**
- * Format a time string like "06:00:00" or "21:30:00" into "6:00 AM" or "9:30 PM".
- */
-function formatAirTime(timeStr: string): string {
-  const [hoursStr, minutesStr] = timeStr.split(':')
-  const hours = parseInt(hoursStr, 10)
-  const minutes = parseInt(minutesStr, 10)
-  if (isNaN(hours) || isNaN(minutes)) return timeStr
-  const period = hours >= 12 ? 'PM' : 'AM'
-  const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
-  const displayMinutes = minutes.toString().padStart(2, '0')
-  return `${displayHours}:${displayMinutes} ${period}`
+function formatWeekday(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  if (isNaN(date.getTime())) return ''
+  return date.toLocaleDateString('en-US', { weekday: 'short' })
 }
 
 export default function EpisodeDateDetail({ stationSlug, showSlug, date }: EpisodeDateDetailProps) {
   const { data: episode, isLoading, error } = useRadioEpisode(showSlug, date)
+  const { data: neighbors } = useEpisodeNeighbors(showSlug, date)
 
   if (isLoading) {
     return (
@@ -74,169 +65,95 @@ export default function EpisodeDateDetail({ stationSlug, showSlug, date }: Episo
     )
   }
 
-  const hasTitle = !!episode.title
   const plays = episode.plays ?? []
-  const genreTags = episode.genre_tags ?? []
-  const moodTags = episode.mood_tags ?? []
+  const showUrl = `/radio/${stationSlug}/${showSlug}`
+
+  const matchStats = computeArtistMatchStats(plays)
+  const duration = formatDurationMinutes(episode.duration_minutes)
+  const airTime = formatTimeOfDay(episode.air_time)
+  const airedLine = `aired ${formatWeekday(episode.air_date)}${airTime ? ` ${airTime}` : ''}`
+
+  const metaParts = [
+    `${episode.play_count} ${episode.play_count === 1 ? 'track' : 'tracks'}`,
+    duration,
+    airedLine,
+    matchStats.total > 0
+      ? `${matchStats.matched} of ${matchStats.total} artists matched to the graph`
+      : null,
+  ].filter(Boolean) as string[]
 
   return (
     <div className="flex min-h-screen items-start justify-center">
-      <main className="w-full max-w-4xl px-4 py-8 md:px-8">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
         {/* Breadcrumb */}
-        <div className="mb-6 flex items-center gap-1.5 text-sm text-muted-foreground">
-          <Link
-            href="/radio"
-            className="hover:text-foreground transition-colors"
-          >
-            Radio
-          </Link>
-          <span>/</span>
-          <Link
-            href={`/radio/${stationSlug}`}
-            className="hover:text-foreground transition-colors"
-          >
-            {episode.station_name}
-          </Link>
-          <span>/</span>
-          <Link
-            href={`/radio/${stationSlug}/${showSlug}`}
-            className="hover:text-foreground transition-colors"
-          >
-            {episode.show_name}
+        <div className="mb-6 font-mono text-xs text-muted-foreground">
+          <Link href={showUrl} className="hover:text-foreground transition-colors">
+            ← {episode.show_name}
           </Link>
         </div>
 
         {/* Episode header */}
-        <div className="mb-8">
-          {hasTitle ? (
-            <>
-              <h1 className="text-2xl font-bold">{episode.title}</h1>
-              <p className="text-base text-muted-foreground mt-1 flex items-center gap-1.5">
-                <Calendar className="h-4 w-4 shrink-0" />
-                {formatDate(episode.air_date)}
-                {episode.air_time && (
-                  <span className="flex items-center gap-1 ml-1">
-                    <Clock className="h-3.5 w-3.5 shrink-0" />
-                    {formatAirTime(episode.air_time)}
-                  </span>
-                )}
-              </p>
-            </>
-          ) : (
-            <h1 className="text-2xl font-bold flex items-center gap-2">
-              <Calendar className="h-6 w-6 shrink-0" />
-              {formatDate(episode.air_date)}
-              {episode.air_time && (
-                <span className="text-lg font-normal text-muted-foreground flex items-center gap-1 ml-1">
-                  <Clock className="h-4 w-4 shrink-0" />
-                  {formatAirTime(episode.air_time)}
+        <header className="mb-6">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <h1 className="text-2xl font-bold min-w-0">
+              {formatLongDate(episode.air_date)}
+              {episode.title && (
+                <span className="ml-2 text-base font-normal text-muted-foreground">
+                  — {episode.title}
                 </span>
               )}
             </h1>
-          )}
-          <p className="text-sm text-muted-foreground mt-1">
-            <Link
-              href={`/radio/${stationSlug}/${showSlug}`}
-              className="hover:text-foreground transition-colors"
-            >
-              {episode.show_name}
-            </Link>
-            {' on '}
-            <Link
-              href={`/radio/${stationSlug}`}
-              className="hover:text-foreground transition-colors"
-            >
-              {episode.station_name}
-            </Link>
-          </p>
-
-          <div className="flex items-center gap-3 flex-wrap mt-3">
-            {episode.duration_minutes && (
-              <span className="text-sm text-muted-foreground">
-                {episode.duration_minutes} min
-              </span>
-            )}
-            <span className="flex items-center gap-1 text-sm text-muted-foreground">
-              <Music className="h-3.5 w-3.5" />
-              {episode.play_count} tracks
-            </span>
+            <div className="flex items-center gap-2 shrink-0">
+              {episode.archive_url && (
+                <Button asChild size="sm">
+                  <a
+                    href={episode.archive_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Play className="h-3.5 w-3.5 mr-1.5" />
+                    Play archive
+                  </a>
+                </Button>
+              )}
+              {episode.mixcloud_url && (
+                <Button asChild variant="outline" size="sm">
+                  <a
+                    href={episode.mixcloud_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Mixcloud
+                    <ArrowUpRight className="h-3.5 w-3.5 ml-1" />
+                  </a>
+                </Button>
+              )}
+            </div>
           </div>
 
-          {/* Tags */}
-          {(genreTags.length > 0 || moodTags.length > 0) && (
-            <div className="flex items-center gap-1.5 flex-wrap mt-3">
-              {genreTags.map(tag => (
-                <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
-                  {tag}
-                </Badge>
-              ))}
-              {moodTags.map(tag => (
-                <Badge key={tag} variant="outline" className="text-[10px] px-1.5 py-0">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          )}
+          <p className="mt-1 font-mono text-xs text-muted-foreground">
+            {metaParts.join(' · ')}
+          </p>
 
-          {/* External links */}
-          <div className="flex items-center gap-2 mt-4">
-            {episode.archive_url && (
-              <Button asChild variant="outline" size="sm">
-                <a
-                  href={episode.archive_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Headphones className="h-4 w-4 mr-2" />
-                  Listen to Archive
-                  <ExternalLink className="h-3 w-3 ml-1" />
-                </a>
-              </Button>
-            )}
-            {episode.mixcloud_url && (
-              <Button asChild variant="outline" size="sm">
-                <a
-                  href={episode.mixcloud_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Headphones className="h-4 w-4 mr-2" />
-                  Mixcloud
-                  <ExternalLink className="h-3 w-3 ml-1" />
-                </a>
-              </Button>
-            )}
+          <div className="mt-3">
+            <EpisodeNav neighbors={neighbors} showUrl={showUrl} />
           </div>
 
           {episode.description && (
-            <p className="text-sm text-muted-foreground leading-relaxed mt-4">
+            <p className="mt-3 text-sm text-muted-foreground leading-relaxed max-w-3xl">
               {episode.description}
             </p>
           )}
-        </div>
+        </header>
 
-        {/* Playlist */}
-        <section>
-          <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
-            <Music className="h-5 w-5" />
-            Playlist
-            <span className="text-sm font-normal text-muted-foreground">
-              ({plays.length} {plays.length === 1 ? 'track' : 'tracks'})
-            </span>
-          </h2>
-
-          {plays.length > 0 ? (
-            <div className="space-y-0.5 border border-border/50 rounded-lg p-2">
-              {plays.map(play => (
-                <RadioPlayRow key={play.id} play={play} />
-              ))}
-            </div>
-          ) : (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              No playlist data available for this episode
-            </div>
-          )}
-        </section>
+        {/* Track table */}
+        {plays.length > 0 ? (
+          <PlaylistTable plays={plays} />
+        ) : (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No playlist data available for this episode
+          </div>
+        )}
       </main>
     </div>
   )

--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeNav.test.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeNav.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EpisodeNav } from './EpisodeNav'
+import type { EpisodeNeighbors, RadioEpisodeListItem } from '@/features/radio'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makeEpisode(id: number, airDate: string): RadioEpisodeListItem {
+  return {
+    id,
+    show_id: 1,
+    title: null,
+    air_date: airDate,
+    air_time: null,
+    duration_minutes: null,
+    archive_url: null,
+    play_count: 10,
+    created_at: '2026-01-01T00:00:00Z',
+    artist_preview: [],
+  }
+}
+
+const SHOW_URL = '/radio/wfmu/the-night-owl-show'
+
+describe('EpisodeNav', () => {
+  it('links both neighbors when present', () => {
+    const neighbors: EpisodeNeighbors = {
+      older: makeEpisode(1, '2026-05-26'),
+      newer: makeEpisode(3, '2026-06-09'),
+    }
+    render(<EpisodeNav neighbors={neighbors} showUrl={SHOW_URL} />)
+
+    expect(
+      screen.getByRole('link', { name: 'Previous episode, May 26' })
+    ).toHaveAttribute('href', `${SHOW_URL}/2026-05-26`)
+    expect(
+      screen.getByRole('link', { name: 'Next episode, Jun 9' })
+    ).toHaveAttribute('href', `${SHOW_URL}/2026-06-09`)
+  })
+
+  it('disables the newer bracket at the newest episode', () => {
+    const neighbors: EpisodeNeighbors = {
+      older: makeEpisode(1, '2026-05-26'),
+      newer: null,
+    }
+    render(<EpisodeNav neighbors={neighbors} showUrl={SHOW_URL} />)
+
+    expect(
+      screen.getByRole('button', { name: 'No newer episode' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('link', { name: 'Previous episode, May 26' })
+    ).toBeInTheDocument()
+  })
+
+  it('disables the older bracket at the oldest episode', () => {
+    const neighbors: EpisodeNeighbors = {
+      older: null,
+      newer: makeEpisode(3, '2026-06-09'),
+    }
+    render(<EpisodeNav neighbors={neighbors} showUrl={SHOW_URL} />)
+
+    expect(
+      screen.getByRole('button', { name: 'No older episode' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('link', { name: 'Next episode, Jun 9' })
+    ).toBeInTheDocument()
+  })
+
+  it('disables both brackets while neighbors are loading', () => {
+    render(<EpisodeNav neighbors={undefined} showUrl={SHOW_URL} />)
+
+    expect(screen.getByRole('button', { name: 'No older episode' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'No newer episode' })).toBeDisabled()
+  })
+
+  it('always links back to the full archive', () => {
+    render(<EpisodeNav neighbors={undefined} showUrl={SHOW_URL} />)
+    expect(screen.getByRole('link', { name: 'all episodes' })).toHaveAttribute(
+      'href',
+      SHOW_URL
+    )
+  })
+})

--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeNav.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeNav.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { BracketLink } from '@/components/shared/BracketLink'
+import { formatShortNavDate } from '@/features/radio'
+import type { EpisodeNeighbors } from '@/features/radio'
+
+interface EpisodeNavProps {
+  /** Prev/next neighbors; undefined while the neighbor walk is in flight. */
+  neighbors: EpisodeNeighbors | undefined
+  /** Base /radio/{station}/{show} URL; episode URLs append /{air_date}. */
+  showUrl: string
+}
+
+/**
+ * Prev/next episode navigation for the playlist page (PSY-1051): an older
+ * bracket on the left, a newer bracket on the right, and an [all episodes]
+ * hop back to the show's archive. At the oldest/newest episode (or while the
+ * neighbor walk is loading) the corresponding bracket renders disabled
+ * rather than disappearing, so the row doesn't jump.
+ */
+export function EpisodeNav({ neighbors, showUrl }: EpisodeNavProps) {
+  const older = neighbors?.older ?? null
+  const newer = neighbors?.newer ?? null
+
+  return (
+    <nav
+      aria-label="Episode navigation"
+      className="flex items-center gap-3 font-mono text-xs"
+    >
+      <BracketLink
+        label={older ? `◀ ${formatShortNavDate(older.air_date)}` : '◀ older'}
+        href={older ? `${showUrl}/${older.air_date}` : undefined}
+        disabled={!older}
+        ariaLabel={
+          older ? `Previous episode, ${formatShortNavDate(older.air_date)}` : 'No older episode'
+        }
+        className="text-xs"
+      />
+      <BracketLink
+        label={newer ? `${formatShortNavDate(newer.air_date)} ▶` : 'newer ▶'}
+        href={newer ? `${showUrl}/${newer.air_date}` : undefined}
+        disabled={!newer}
+        ariaLabel={
+          newer ? `Next episode, ${formatShortNavDate(newer.air_date)}` : 'No newer episode'
+        }
+        className="text-xs"
+      />
+      <BracketLink label="all episodes" href={showUrl} className="text-xs" />
+    </nav>
+  )
+}

--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/PlaylistTable.test.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/PlaylistTable.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PlaylistTable } from './PlaylistTable'
+import type { RadioPlay } from '@/features/radio'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makePlay(overrides: Partial<RadioPlay> = {}): RadioPlay {
+  return {
+    id: 1,
+    episode_id: 10,
+    position: 1,
+    artist_name: 'CAN',
+    track_title: 'Mother Sky',
+    album_title: 'Soundtracks',
+    label_name: 'United Artists',
+    release_year: 1970,
+    is_new: false,
+    rotation_status: null,
+    dj_comment: null,
+    is_live_performance: false,
+    is_request: false,
+    artist_id: null,
+    artist_slug: null,
+    release_id: null,
+    release_slug: null,
+    label_id: null,
+    label_slug: null,
+    musicbrainz_artist_id: null,
+    musicbrainz_recording_id: null,
+    musicbrainz_release_id: null,
+    air_timestamp: null,
+    ...overrides,
+  }
+}
+
+describe('PlaylistTable', () => {
+  it('renders a matched artist as a link with the filled dot', () => {
+    render(
+      <PlaylistTable
+        plays={[makePlay({ artist_id: 5, artist_slug: 'can' })]}
+      />
+    )
+    expect(screen.getByRole('link', { name: 'CAN' })).toHaveAttribute(
+      'href',
+      '/artists/can'
+    )
+    // One ● in the row + one in the legend
+    expect(screen.getAllByText('●')).toHaveLength(2)
+  })
+
+  it('renders an unmatched artist as plain text with the open dot', () => {
+    render(<PlaylistTable plays={[makePlay({ artist_name: 'The Tweeters' })]} />)
+    const artist = screen.getByText('The Tweeters')
+    expect(artist.closest('a')).toBeNull()
+    // One ○ in the row + one in the legend
+    expect(screen.getAllByText('○')).toHaveLength(2)
+  })
+
+  it('renders track, album, label, and year', () => {
+    render(<PlaylistTable plays={[makePlay()]} />)
+    expect(screen.getByText('Mother Sky')).toBeInTheDocument()
+    expect(screen.getByText('Soundtracks')).toBeInTheDocument()
+    expect(screen.getByText('United Artists')).toBeInTheDocument()
+    expect(screen.getByText('1970')).toBeInTheDocument()
+  })
+
+  it('links the label when label_slug is present', () => {
+    render(
+      <PlaylistTable
+        plays={[makePlay({ label_id: 3, label_slug: 'united-artists' })]}
+      />
+    )
+    expect(screen.getByRole('link', { name: 'United Artists' })).toHaveAttribute(
+      'href',
+      '/labels/united-artists'
+    )
+  })
+
+  it('renders the TIME cell from air_timestamp and leaves it blank when null', () => {
+    render(
+      <PlaylistTable
+        plays={[
+          makePlay({ id: 1, air_timestamp: '2026-06-02T21:02:00' }),
+          makePlay({ id: 2, artist_name: 'Neu!', air_timestamp: null }),
+        ]}
+      />
+    )
+    expect(screen.getByText('9:02 PM')).toBeInTheDocument()
+    // Only one populated TIME cell across both rows
+    const timeCells = document.querySelectorAll('tbody td:first-child')
+    expect(timeCells).toHaveLength(2)
+    expect(timeCells[1].textContent).toBe('')
+  })
+
+  it('keeps rows in playlist order', () => {
+    render(
+      <PlaylistTable
+        plays={[
+          makePlay({ id: 1, position: 1, artist_name: 'CAN' }),
+          makePlay({ id: 2, position: 2, artist_name: 'Neu!' }),
+          makePlay({ id: 3, position: 3, artist_name: 'Harmonia' }),
+        ]}
+      />
+    )
+    const rows = screen.getAllByRole('row').slice(1) // skip thead
+    expect(rows[0]).toHaveTextContent('CAN')
+    expect(rows[1]).toHaveTextContent('Neu!')
+    expect(rows[2]).toHaveTextContent('Harmonia')
+  })
+
+  it('renders LIVE, NEW, rotation, and REQ badges in the NOTES column', () => {
+    render(
+      <PlaylistTable
+        plays={[
+          makePlay({
+            is_live_performance: true,
+            is_new: true,
+            rotation_status: 'recommended_new',
+            is_request: true,
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText('LIVE')).toBeInTheDocument()
+    expect(screen.getByText('NEW')).toBeInTheDocument()
+    expect(screen.getByText('REC NEW')).toBeInTheDocument()
+    expect(screen.getByText('REQ')).toBeInTheDocument()
+  })
+
+  it('does not render a rotation tag for library rotation', () => {
+    render(<PlaylistTable plays={[makePlay({ rotation_status: 'library' })]} />)
+    expect(screen.queryByText('LIBRARY')).not.toBeInTheDocument()
+  })
+
+  it('renders a dj_comment as an indented sub-row under its track', () => {
+    render(
+      <PlaylistTable
+        plays={[makePlay({ dj_comment: 'recorded in Forst — RIP Michael Rother' })]}
+      />
+    )
+    const comment = screen.getByText('recorded in Forst — RIP Michael Rother')
+    expect(comment).toBeInTheDocument()
+    // The comment lives in its own row, not the track row
+    const commentRow = comment.closest('tr')
+    expect(commentRow).not.toBeNull()
+    expect(commentRow).not.toHaveTextContent('Mother Sky')
+  })
+
+  it('does not render a comment sub-row when there is no dj_comment', () => {
+    render(<PlaylistTable plays={[makePlay()]} />)
+    // 1 header row + 1 track row only
+    expect(screen.getAllByRole('row')).toHaveLength(2)
+  })
+
+  it('renders the matched/unmatched legend without a suggest-a-match action', () => {
+    render(<PlaylistTable plays={[makePlay()]} />)
+    expect(screen.getByText('linked to artist page')).toBeInTheDocument()
+    expect(screen.getByText('not matched yet')).toBeInTheDocument()
+    expect(screen.queryByText(/suggest a match/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/PlaylistTable.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/PlaylistTable.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { Fragment } from 'react'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { DenseTable } from '@/components/shared/DenseTable'
+import { formatPlayTime, getRotationStatusColor } from '@/features/radio'
+import type { RadioPlay } from '@/features/radio'
+
+interface PlaylistTableProps {
+  plays: RadioPlay[]
+}
+
+/**
+ * Short mono-tag labels for rotation_status in the NOTES column (the long
+ * "Heavy Rotation" labels don't fit the dense register). Unknown statuses
+ * fall back to the raw value, uppercased.
+ */
+const ROTATION_TAG_LABELS: Record<string, string> = {
+  heavy: 'HEAVY',
+  medium: 'MEDIUM',
+  light: 'LIGHT',
+  recommended_new: 'REC NEW',
+}
+
+function rotationTagLabel(status: string): string {
+  return ROTATION_TAG_LABELS[status] ?? status.replace(/_/g, ' ').toUpperCase()
+}
+
+const BADGE_CLASSES = 'font-mono text-[10px] px-1.5 py-0'
+
+/**
+ * The playlist page's full-width record-collector track table (PSY-1051,
+ * locked PSY-1049 decision 5): TIME · ARTIST · TRACK · ALBUM · LABEL · YEAR ·
+ * NOTES. Matched artists (artist_id) render as an orange link with a ● dot;
+ * unmatched as plain text with ○ — explained by the legend row underneath.
+ * TIME comes from air_timestamp where the feed carries one and is otherwise
+ * blank (never fabricated); position keeps the row order. dj_comment renders
+ * as an indented full-width sub-row under its track.
+ *
+ * Explicitly NOT here in v1 (locked): airbreak divider rows (no play_type
+ * data), [suggest a match] on unmatched rows (PSY-1052 spike), TIME
+ * deep-links into a seekable player.
+ */
+export function PlaylistTable({ plays }: PlaylistTableProps) {
+  return (
+    <div>
+      <DenseTable>
+        <thead>
+          <tr>
+            <th className="w-20">Time</th>
+            <th className="w-[22%]">Artist</th>
+            <th>Track</th>
+            <th className="w-[18%]">Album</th>
+            <th className="w-[15%]">Label</th>
+            <th className="w-14">Year</th>
+            <th className="w-28">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {plays.map(play => {
+            const time = formatPlayTime(play.air_timestamp)
+            const matched = play.artist_id != null
+
+            return (
+              <Fragment key={play.id}>
+                <tr className={play.dj_comment ? 'border-b-0!' : undefined}>
+                  <td className="whitespace-nowrap font-mono text-xs text-primary/90 tabular-nums">
+                    {time ?? ''}
+                  </td>
+                  <td>
+                    <span className="inline-flex items-baseline gap-1.5">
+                      <span
+                        className={matched ? 'text-primary' : 'text-muted-foreground/60'}
+                        aria-hidden="true"
+                      >
+                        {matched ? '●' : '○'}
+                      </span>
+                      {play.artist_slug ? (
+                        <Link
+                          href={`/artists/${play.artist_slug}`}
+                          className="font-medium text-primary hover:text-primary/80 transition-colors"
+                        >
+                          {play.artist_name}
+                        </Link>
+                      ) : (
+                        <span className="font-medium text-foreground">
+                          {play.artist_name}
+                        </span>
+                      )}
+                    </span>
+                  </td>
+                  <td className="text-foreground">{play.track_title}</td>
+                  <td>
+                    {play.album_title &&
+                      (play.release_slug ? (
+                        <Link
+                          href={`/releases/${play.release_slug}`}
+                          className="text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          {play.album_title}
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground">{play.album_title}</span>
+                      ))}
+                  </td>
+                  <td>
+                    {play.label_name &&
+                      (play.label_slug ? (
+                        <Link
+                          href={`/labels/${play.label_slug}`}
+                          className="text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          {play.label_name}
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground">{play.label_name}</span>
+                      ))}
+                  </td>
+                  <td className="tabular-nums text-muted-foreground">
+                    {play.release_year}
+                  </td>
+                  <td>
+                    <span className="inline-flex flex-wrap items-center gap-1">
+                      {play.is_live_performance && (
+                        <Badge
+                          variant="outline"
+                          className={`${BADGE_CLASSES} border-primary/40 text-primary`}
+                        >
+                          LIVE
+                        </Badge>
+                      )}
+                      {play.is_new && (
+                        <Badge variant="accent" className={BADGE_CLASSES}>
+                          NEW
+                        </Badge>
+                      )}
+                      {play.rotation_status && play.rotation_status !== 'library' && (
+                        <Badge
+                          className={`${BADGE_CLASSES} ${getRotationStatusColor(play.rotation_status)}`}
+                        >
+                          {rotationTagLabel(play.rotation_status)}
+                        </Badge>
+                      )}
+                      {play.is_request && (
+                        <Badge variant="outline" className={BADGE_CLASSES}>
+                          REQ
+                        </Badge>
+                      )}
+                    </span>
+                  </td>
+                </tr>
+                {play.dj_comment && (
+                  <tr>
+                    <td aria-hidden="true" />
+                    <td colSpan={6} className="pt-0!">
+                      <span className="font-mono text-xs text-muted-foreground">
+                        <span aria-hidden="true">└ </span>
+                        {play.dj_comment}
+                      </span>
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
+        </tbody>
+      </DenseTable>
+
+      {/* Legend (the [suggest a match] action is the PSY-1052 spike — v1 is legend-only) */}
+      <p className="mt-3 font-mono text-xs text-muted-foreground">
+        <span className="text-primary" aria-hidden="true">
+          ●
+        </span>{' '}
+        <span>linked to artist page</span>
+        <span className="mx-2" aria-hidden="true">
+          ·
+        </span>
+        <span aria-hidden="true">○</span> <span>not matched yet</span>
+      </p>
+    </div>
+  )
+}

--- a/frontend/app/radio/[station-slug]/[show-slug]/_components/EpisodeArchiveTable.test.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/_components/EpisodeArchiveTable.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EpisodeArchiveTable } from './EpisodeArchiveTable'
+import type { RadioEpisodeListItem } from '@/features/radio'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makeEpisode(overrides: Partial<RadioEpisodeListItem> = {}): RadioEpisodeListItem {
+  return {
+    id: 1,
+    show_id: 1,
+    title: null,
+    air_date: '2026-06-02',
+    air_time: null,
+    duration_minutes: null,
+    archive_url: null,
+    play_count: 24,
+    created_at: '2026-06-02T00:00:00Z',
+    artist_preview: [],
+    ...overrides,
+  }
+}
+
+function localToday(): string {
+  const now = new Date()
+  return [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+  ].join('-')
+}
+
+const defaultProps = {
+  stationSlug: 'wfmu',
+  showSlug: 'the-night-owl-show',
+}
+
+describe('EpisodeArchiveTable', () => {
+  it('links the date cell to the episode playlist page', () => {
+    render(<EpisodeArchiveTable {...defaultProps} episodes={[makeEpisode()]} />)
+    const dateLink = screen.getByRole('link', { name: 'Jun 2 2026' })
+    expect(dateLink).toHaveAttribute(
+      'href',
+      '/radio/wfmu/the-night-owl-show/2026-06-02'
+    )
+  })
+
+  it('renders the episode title as a link when present', () => {
+    render(
+      <EpisodeArchiveTable
+        {...defaultProps}
+        episodes={[makeEpisode({ title: 'with guest Alabaster DePlume' })]}
+      />
+    )
+    expect(
+      screen.getByRole('link', { name: 'with guest Alabaster DePlume' })
+    ).toHaveAttribute('href', '/radio/wfmu/the-night-owl-show/2026-06-02')
+  })
+
+  it('renders an em dash when the episode has no title', () => {
+    render(<EpisodeArchiveTable {...defaultProps} episodes={[makeEpisode()]} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders matched preview artists as links and unmatched as plain text', () => {
+    render(
+      <EpisodeArchiveTable
+        {...defaultProps}
+        episodes={[
+          makeEpisode({
+            artist_preview: [
+              { artist_name: 'CAN', artist_id: 5, artist_slug: 'can' },
+              { artist_name: 'The Tweeters', artist_id: null, artist_slug: null },
+            ],
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByRole('link', { name: 'CAN' })).toHaveAttribute(
+      'href',
+      '/artists/can'
+    )
+    const unmatched = screen.getByText('The Tweeters')
+    expect(unmatched.closest('a')).toBeNull()
+  })
+
+  it('renders the track count', () => {
+    render(<EpisodeArchiveTable {...defaultProps} episodes={[makeEpisode({ play_count: 41 })]} />)
+    expect(screen.getByText('41')).toBeInTheDocument()
+  })
+
+  it('renders an [mp3] link when the episode has an archive_url', () => {
+    render(
+      <EpisodeArchiveTable
+        {...defaultProps}
+        episodes={[makeEpisode({ archive_url: 'https://example.com/ep.mp3' })]}
+      />
+    )
+    const mp3 = screen.getByRole('link', {
+      name: 'Listen to the Jun 2 2026 archive',
+    })
+    expect(mp3).toHaveAttribute('href', 'https://example.com/ep.mp3')
+    expect(mp3).toHaveAttribute('target', '_blank')
+  })
+
+  it('omits the [mp3] link when there is no archive_url', () => {
+    render(<EpisodeArchiveTable {...defaultProps} episodes={[makeEpisode()]} />)
+    expect(screen.queryByText('[ mp3 ]')).not.toBeInTheDocument()
+  })
+
+  it("marks today's episode as live instead of showing an [mp3] link", () => {
+    render(
+      <EpisodeArchiveTable
+        {...defaultProps}
+        episodes={[
+          makeEpisode({
+            air_date: localToday(),
+            archive_url: 'https://example.com/ep.mp3',
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText('live')).toBeInTheDocument()
+    expect(screen.queryByText('[ mp3 ]')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/[station-slug]/[show-slug]/_components/EpisodeArchiveTable.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/_components/EpisodeArchiveTable.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import Link from 'next/link'
+import { DenseTable } from '@/components/shared/DenseTable'
+import {
+  ArtistHops,
+  formatArchiveDate,
+  isAirDateToday,
+  previewToHops,
+} from '@/features/radio'
+import type { RadioEpisodeListItem } from '@/features/radio'
+
+interface EpisodeArchiveTableProps {
+  episodes: RadioEpisodeListItem[]
+  stationSlug: string
+  showSlug: string
+}
+
+/**
+ * The show page's playlist archive (PSY-1051): one reverse-chron episode
+ * table — date · episode title · played preview · tracks · [mp3]. The show
+ * page IS its archive (WFMU model, locked PSY-1049 decision 4); there is no
+ * separate episodes sub-page. Episode previews come from the PSY-1048
+ * artist_preview extension on the episodes list — no per-row detail fetch.
+ */
+export function EpisodeArchiveTable({
+  episodes,
+  stationSlug,
+  showSlug,
+}: EpisodeArchiveTableProps) {
+  return (
+    <DenseTable>
+      <thead>
+        <tr>
+          <th className="w-28">Date</th>
+          <th className="w-48">Episode</th>
+          <th>Played</th>
+          <th className="w-16 text-right">Tracks</th>
+          <th className="w-20 text-right">
+            <span className="sr-only">Archive</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {episodes.map(episode => {
+          const episodeUrl = `/radio/${stationSlug}/${showSlug}/${episode.air_date}`
+          const isToday = isAirDateToday(episode.air_date)
+          const hops = previewToHops(episode.artist_preview)
+
+          return (
+            <tr key={episode.id} className="group">
+              <td className="whitespace-nowrap">
+                <Link
+                  href={episodeUrl}
+                  className="font-mono text-xs uppercase text-primary hover:text-primary/80 transition-colors"
+                >
+                  {formatArchiveDate(episode.air_date)}
+                </Link>
+              </td>
+              <td>
+                {episode.title ? (
+                  <Link
+                    href={episodeUrl}
+                    className="text-primary hover:text-primary/80 transition-colors"
+                  >
+                    {episode.title}
+                  </Link>
+                ) : (
+                  <span className="text-muted-foreground/50" aria-hidden="true">
+                    —
+                  </span>
+                )}
+              </td>
+              <td className="max-w-0">
+                <div className="truncate">
+                  {hops.length > 0 ? (
+                    <ArtistHops
+                      hops={hops}
+                      className="text-muted-foreground [&_a]:hover:text-primary"
+                    />
+                  ) : (
+                    <span className="text-muted-foreground/50">&nbsp;</span>
+                  )}
+                </div>
+              </td>
+              <td className="text-right tabular-nums text-muted-foreground">
+                {episode.play_count}
+              </td>
+              <td className="text-right whitespace-nowrap font-mono text-xs">
+                {isToday ? (
+                  <span className="text-primary">
+                    <span aria-hidden="true">●</span> live
+                  </span>
+                ) : episode.archive_url ? (
+                  <a
+                    href={episode.archive_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:text-primary/80 transition-colors"
+                    aria-label={`Listen to the ${formatArchiveDate(episode.air_date)} archive`}
+                  >
+                    [ mp3 ]
+                  </a>
+                ) : null}
+              </td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </DenseTable>
+  )
+}

--- a/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
@@ -2,30 +2,27 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import {
-  ArrowLeft,
-  Loader2,
-  Mic2,
-  Calendar,
-  Tag,
-  Music,
-  ChevronLeft,
-  ChevronRight,
-} from 'lucide-react'
+import { ArrowLeft, ArrowUpRight, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { BracketLink } from '@/components/shared/BracketLink'
+import { SectionHeader } from '@/components/shared/SectionHeader'
 import {
   useRadioShow,
   useRadioEpisodes,
   useRadioTopArtists,
   useRadioTopLabels,
-  RadioEpisodeRow,
+  isAirDateToday,
 } from '@/features/radio'
 import type { RadioTopArtist, RadioTopLabel } from '@/features/radio'
+import { EpisodeArchiveTable } from './EpisodeArchiveTable'
 
 interface RadioShowDetailProps {
   stationSlug: string
   showSlug: string
+}
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`
 }
 
 function TopArtistsSidebar({ showSlug }: { showSlug: string }) {
@@ -34,35 +31,34 @@ function TopArtistsSidebar({ showSlug }: { showSlug: string }) {
   if (isLoading || !data?.artists || data.artists.length === 0) return null
 
   return (
-    <div>
-      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-        Top Artists (90d)
-      </h3>
+    <section className="rounded-md border border-border/60 px-3 py-2.5">
+      <SectionHeader title="Top artists — last 90 days" />
       <div className="space-y-1">
         {data.artists.map((artist: RadioTopArtist) => (
           <div
             key={artist.artist_name}
-            className="flex items-center justify-between py-0.5"
+            className="flex items-baseline justify-between gap-2 py-0.5"
           >
             {artist.artist_slug ? (
               <Link
                 href={`/artists/${artist.artist_slug}`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate mr-2"
+                className="text-sm text-primary hover:text-primary/80 transition-colors truncate"
               >
                 {artist.artist_name}
               </Link>
             ) : (
-              <span className="text-sm text-muted-foreground truncate mr-2">
+              <span className="text-sm text-foreground truncate">
                 {artist.artist_name}
               </span>
             )}
-            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
-              {artist.play_count}
+            <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap shrink-0">
+              {pluralize(artist.play_count, 'play')} ·{' '}
+              {pluralize(artist.episode_count, 'episode')}
             </span>
           </div>
         ))}
       </div>
-    </div>
+    </section>
   )
 }
 
@@ -72,39 +68,37 @@ function TopLabelsSidebar({ showSlug }: { showSlug: string }) {
   if (isLoading || !data?.labels || data.labels.length === 0) return null
 
   return (
-    <div>
-      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-        Top Labels (90d)
-      </h3>
+    <section className="rounded-md border border-border/60 px-3 py-2.5">
+      <SectionHeader title="Top labels — last 90 days" />
       <div className="space-y-1">
         {data.labels.map((label: RadioTopLabel) => (
           <div
             key={label.label_name}
-            className="flex items-center justify-between py-0.5"
+            className="flex items-baseline justify-between gap-2 py-0.5"
           >
             {label.label_slug ? (
               <Link
                 href={`/labels/${label.label_slug}`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate mr-2"
+                className="text-sm text-primary hover:text-primary/80 transition-colors truncate"
               >
                 {label.label_name}
               </Link>
             ) : (
-              <span className="text-sm text-muted-foreground truncate mr-2">
+              <span className="text-sm text-foreground truncate">
                 {label.label_name}
               </span>
             )}
-            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
-              {label.play_count}
+            <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap shrink-0">
+              {pluralize(label.play_count, 'play')}
             </span>
           </div>
         ))}
       </div>
-    </div>
+    </section>
   )
 }
 
-const PAGE_SIZE = 20
+const PAGE_SIZE = 25
 
 export default function RadioShowDetail({ stationSlug, showSlug }: RadioShowDetailProps) {
   const { data: show, isLoading, error } = useRadioShow(showSlug)
@@ -113,6 +107,13 @@ export default function RadioShowDetail({ stationSlug, showSlug }: RadioShowDeta
     showSlug,
     limit: PAGE_SIZE,
     offset,
+    enabled: !!show,
+  })
+  // Separate limit-1 query (cheap, cached) so the ON AIR strip always derives
+  // from the LATEST episode regardless of which archive page is in view.
+  const { data: latestData } = useRadioEpisodes({
+    showSlug,
+    limit: 1,
     enabled: !!show,
   })
 
@@ -147,161 +148,146 @@ export default function RadioShowDetail({ stationSlug, showSlug }: RadioShowDeta
   const total = episodesData?.total ?? 0
   const hasNextPage = offset + PAGE_SIZE < total
   const hasPrevPage = offset > 0
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  // v1 "on air" heuristic (PSY-1051): live when the latest episode aired
+  // today. Swaps to PSY-1022's live now-playing endpoint without layout change.
+  const latestEpisode = latestData?.episodes?.[0]
+  const isOnAir = isAirDateToday(latestEpisode?.air_date)
+  const livePlaylistUrl = latestEpisode
+    ? `/radio/${stationSlug}/${showSlug}/${latestEpisode.air_date}`
+    : null
+
+  const metaParts = [
+    show.schedule_display,
+    show.station_name,
+    ...genreTags,
+  ].filter(Boolean) as string[]
 
   return (
     <div className="flex min-h-screen items-start justify-center">
       <main className="w-full max-w-6xl px-4 py-8 md:px-8">
         {/* Breadcrumb */}
-        <div className="mb-6 flex items-center gap-1.5 text-sm text-muted-foreground">
-          <Link
-            href="/radio"
-            className="hover:text-foreground transition-colors"
-          >
-            Radio
-          </Link>
-          <span>/</span>
+        <div className="mb-6 font-mono text-xs text-muted-foreground">
           <Link
             href={`/radio/${stationSlug}`}
             className="hover:text-foreground transition-colors"
           >
-            {show.station_name}
+            ← {show.station_name}
           </Link>
         </div>
 
+        {/* Show header */}
+        <header className="mb-4">
+          <div className="flex items-start justify-between gap-4">
+            <h1 className="text-2xl font-bold min-w-0">
+              {show.name}
+              {show.host_name && (
+                <span className="ml-2 text-base font-normal text-muted-foreground">
+                  w/ {show.host_name}
+                </span>
+              )}
+            </h1>
+            {show.archive_url && (
+              <Button asChild variant="outline" size="sm" className="shrink-0">
+                <a
+                  href={show.archive_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Archive
+                  <ArrowUpRight className="h-3.5 w-3.5 ml-1" />
+                </a>
+              </Button>
+            )}
+          </div>
+
+          {metaParts.length > 0 && (
+            <p className="mt-1 font-mono text-xs text-muted-foreground">
+              {metaParts.join(' · ')}
+            </p>
+          )}
+
+          {show.description && (
+            <p className="mt-2 text-sm text-muted-foreground leading-relaxed max-w-3xl">
+              {show.description}
+            </p>
+          )}
+        </header>
+
+        {/* ON AIR strip (v1 heuristic until PSY-1022) */}
+        {isOnAir && livePlaylistUrl && (
+          <div className="mb-6 flex items-center justify-between gap-3 rounded-md border border-primary/40 bg-primary/5 px-4 py-2.5">
+            <span className="font-mono text-xs text-foreground">
+              <span className="text-primary" aria-hidden="true">
+                ●
+              </span>{' '}
+              ON AIR NOW — tonight&apos;s playlist is updating live
+            </span>
+            <BracketLink
+              label="open live playlist →"
+              href={livePlaylistUrl}
+              className="font-mono text-xs text-primary hover:text-primary/80"
+            />
+          </div>
+        )}
+
         <div className="flex flex-col lg:flex-row gap-8">
-          {/* Main content */}
+          {/* Playlist archive */}
           <div className="flex-1 min-w-0">
-            {/* Show header */}
-            <div className="flex items-start gap-4 mb-6">
-              <div className="shrink-0 rounded-xl bg-muted/50 flex items-center justify-center overflow-hidden h-20 w-20">
-                {show.image_url ? (
-                  <img
-                    src={show.image_url}
-                    alt={show.name}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <Mic2 className="h-10 w-10 text-muted-foreground/40" />
-                )}
+            <SectionHeader
+              as="h2"
+              size="md"
+              title={`Playlists — ${pluralize(total, 'episode')}`}
+            />
+
+            {episodesLoading && (
+              <div className="flex justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
               </div>
-
-              <div className="flex-1 min-w-0">
-                <h1 className="text-2xl font-bold">{show.name}</h1>
-                <p className="text-sm text-muted-foreground mt-0.5">
-                  on{' '}
-                  <Link
-                    href={`/radio/${stationSlug}`}
-                    className="hover:text-foreground transition-colors"
-                  >
-                    {show.station_name}
-                  </Link>
-                </p>
-
-                {show.host_name && (
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Hosted by {show.host_name}
-                  </p>
-                )}
-
-                <div className="flex items-center gap-2 flex-wrap mt-2">
-                  {show.schedule_display && (
-                    <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                      <Calendar className="h-3.5 w-3.5" />
-                      {show.schedule_display}
-                    </span>
-                  )}
-                  {genreTags.length > 0 && (
-                    <div className="flex items-center gap-1">
-                      <Tag className="h-3.5 w-3.5 text-muted-foreground" />
-                      {genreTags.map(tag => (
-                        <Badge
-                          key={tag}
-                          variant="secondary"
-                          className="text-[10px] px-1.5 py-0"
-                        >
-                          {tag}
-                        </Badge>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {show.description && (
-              <p className="text-sm text-muted-foreground leading-relaxed mb-6">
-                {show.description}
-              </p>
             )}
 
-            {/* Episodes */}
-            <section>
-              <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
-                <Music className="h-5 w-5" />
-                Recent Episodes
-                {total > 0 && (
-                  <span className="text-sm font-normal text-muted-foreground">
-                    ({total})
-                  </span>
-                )}
-              </h2>
+            {!episodesLoading && episodesData?.episodes && episodesData.episodes.length > 0 ? (
+              <>
+                <EpisodeArchiveTable
+                  episodes={episodesData.episodes}
+                  stationSlug={stationSlug}
+                  showSlug={showSlug}
+                />
 
-              {episodesLoading && (
-                <div className="flex justify-center py-8">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                </div>
-              )}
-
-              {!episodesLoading && episodesData?.episodes && episodesData.episodes.length > 0 ? (
-                <>
-                  <div className="space-y-0.5">
-                    {episodesData.episodes.map(episode => (
-                      <RadioEpisodeRow
-                        key={episode.id}
-                        episode={episode}
-                        stationSlug={stationSlug}
-                        showSlug={showSlug}
-                      />
-                    ))}
-                  </div>
-
-                  {/* Pagination */}
-                  {(hasNextPage || hasPrevPage) && (
-                    <div className="flex items-center justify-between mt-4 pt-4 border-t border-border/50">
-                      <Button
-                        variant="outline"
-                        size="sm"
+                {/* Pagination */}
+                {(hasNextPage || hasPrevPage) && (
+                  <div className="mt-3 flex items-center gap-3 font-mono text-xs text-muted-foreground">
+                    <span>
+                      page {currentPage} of {totalPages}
+                    </span>
+                    {hasPrevPage && (
+                      <BracketLink
+                        label="← newer"
                         onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                        disabled={!hasPrevPage}
-                      >
-                        <ChevronLeft className="h-4 w-4 mr-1" />
-                        Newer
-                      </Button>
-                      <span className="text-xs text-muted-foreground">
-                        {offset + 1}-{Math.min(offset + PAGE_SIZE, total)} of {total}
-                      </span>
-                      <Button
-                        variant="outline"
-                        size="sm"
+                        className="text-xs"
+                      />
+                    )}
+                    {hasNextPage && (
+                      <BracketLink
+                        label="older →"
                         onClick={() => setOffset(offset + PAGE_SIZE)}
-                        disabled={!hasNextPage}
-                      >
-                        Older
-                        <ChevronRight className="h-4 w-4 ml-1" />
-                      </Button>
-                    </div>
-                  )}
-                </>
-              ) : !episodesLoading ? (
-                <div className="py-8 text-center text-sm text-muted-foreground">
-                  No episodes yet
-                </div>
-              ) : null}
-            </section>
+                        className="text-xs"
+                      />
+                    )}
+                  </div>
+                )}
+              </>
+            ) : !episodesLoading ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                No episodes yet
+              </div>
+            ) : null}
           </div>
 
           {/* Sidebar */}
-          <aside className="w-full lg:w-64 shrink-0 space-y-6">
+          <aside className="w-full lg:w-72 shrink-0 space-y-4">
             <TopArtistsSidebar showSlug={showSlug} />
             <TopLabelsSidebar showSlug={showSlug} />
           </aside>

--- a/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
@@ -111,11 +111,15 @@ export default function RadioShowDetail({ stationSlug, showSlug }: RadioShowDeta
   })
   // Separate limit-1 query (cheap, cached) so the ON AIR strip always derives
   // from the LATEST episode regardless of which archive page is in view.
-  const { data: latestData } = useRadioEpisodes({
+  const latestQuery = useRadioEpisodes({
     showSlug,
     limit: 1,
     enabled: !!show,
   })
+  // useRadioEpisodes keeps previous data across slug changes; ignore the
+  // placeholder so the strip never links the PREVIOUS show's air_date under
+  // the new show's URL (same guard as useShowLatestEpisode).
+  const latestData = latestQuery.isPlaceholderData ? undefined : latestQuery.data
 
   if (isLoading) {
     return (

--- a/frontend/features/radio/api.ts
+++ b/frontend/features/radio/api.ts
@@ -49,6 +49,9 @@ export const radioQueryKeys = {
     ['radio-shows', showSlug, 'episodes', params] as const,
   episode: (showSlug: string, date: string) =>
     ['radio-shows', showSlug, 'episodes', date] as const,
+  // PSY-1051: prev/next neighbors derived from the episodes list
+  episodeNeighbors: (showSlug: string, date: string) =>
+    ['radio-shows', showSlug, 'episode-neighbors', date] as const,
   topArtists: (showSlug: string, params?: object) =>
     ['radio-shows', showSlug, 'top-artists', params] as const,
   topLabels: (showSlug: string, params?: object) =>

--- a/frontend/features/radio/components/RadioEpisodeRow.test.tsx
+++ b/frontend/features/radio/components/RadioEpisodeRow.test.tsx
@@ -20,6 +20,7 @@ function makeEpisode(overrides: Partial<RadioEpisodeListItem> = {}): RadioEpisod
     archive_url: null,
     play_count: 18,
     created_at: '2026-05-01T00:00:00Z',
+    artist_preview: [],
     ...overrides,
   }
 }

--- a/frontend/features/radio/hooks/index.ts
+++ b/frontend/features/radio/hooks/index.ts
@@ -15,3 +15,5 @@ export { useShowLatestEpisode } from './useShowLatestEpisode'
 export { useStationOverview } from './useStationOverview'
 // PSY-1049: The Dial hub
 export { useRecentRadioEpisodes } from './useRecentRadioEpisodes'
+// PSY-1051: show + playlist page rebuild
+export { useEpisodeNeighbors } from './useEpisodeNeighbors' 

--- a/frontend/features/radio/hooks/useEpisodeNeighbors.test.tsx
+++ b/frontend/features/radio/hooks/useEpisodeNeighbors.test.tsx
@@ -77,4 +77,13 @@ describe('useEpisodeNeighbors', () => {
     expect(noSlug.current.fetchStatus).toBe('idle')
     expect(noDate.current.fetchStatus).toBe('idle')
   })
+
+  it('does not walk the archive for a garbage date route param', () => {
+    const { result } = renderHook(
+      () => useEpisodeNeighbors('drummer', 'not-a-date'),
+      { wrapper: createWrapper() }
+    )
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
 })

--- a/frontend/features/radio/hooks/useEpisodeNeighbors.test.tsx
+++ b/frontend/features/radio/hooks/useEpisodeNeighbors.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useEpisodeNeighbors } from './useEpisodeNeighbors'
+
+const BASE = 'http://localhost:8080'
+
+function episode(id: number, airDate: string) {
+  return {
+    id,
+    show_id: 1,
+    title: null,
+    air_date: airDate,
+    air_time: null,
+    duration_minutes: null,
+    archive_url: null,
+    play_count: 10,
+    created_at: '2026-01-01T00:00:00Z',
+    artist_preview: [],
+  }
+}
+
+describe('useEpisodeNeighbors', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('keys the query per show + date', () => {
+    expect(radioQueryKeys.episodeNeighbors('drummer', '2026-06-02')).toEqual([
+      'radio-shows',
+      'drummer',
+      'episode-neighbors',
+      '2026-06-02',
+    ])
+  })
+
+  it('walks the episodes list and returns neighbors', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      episodes: [
+        episode(3, '2026-06-09'),
+        episode(2, '2026-06-02'),
+        episode(1, '2026-05-26'),
+      ],
+      total: 3,
+    })
+
+    const { result } = renderHook(
+      () => useEpisodeNeighbors('drummer', '2026-06-02'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/radio-shows/drummer/episodes?limit=100`,
+      { method: 'GET' }
+    )
+    expect(result.current.data?.newer?.air_date).toBe('2026-06-09')
+    expect(result.current.data?.older?.air_date).toBe('2026-05-26')
+  })
+
+  it('does not fetch when slug or date is empty', () => {
+    const { result: noSlug } = renderHook(() => useEpisodeNeighbors('', '2026-06-02'), {
+      wrapper: createWrapper(),
+    })
+    const { result: noDate } = renderHook(() => useEpisodeNeighbors('drummer', ''), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(noSlug.current.fetchStatus).toBe('idle')
+    expect(noDate.current.fetchStatus).toBe('idle')
+  })
+})

--- a/frontend/features/radio/hooks/useEpisodeNeighbors.ts
+++ b/frontend/features/radio/hooks/useEpisodeNeighbors.ts
@@ -7,12 +7,16 @@ import { walkEpisodeNeighbors } from '../lib/episodeArchive'
 import type { EpisodeNeighbors } from '../lib/episodeArchive'
 import type { RadioEpisodesListResponse } from '../types'
 
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
 /**
  * Prev/next episode neighbors for the playlist page nav (PSY-1051).
  *
  * Derived from the show's episodes list (air_date DESC) — there is no
  * dedicated neighbors endpoint. The page walk lives in walkEpisodeNeighbors;
- * this hook just wires it to the API and caches per (show, date).
+ * this hook just wires it to the API and caches per (show, date). The date
+ * must look like YYYY-MM-DD before any request fires — garbage route params
+ * shouldn't trigger an archive walk.
  */
 export function useEpisodeNeighbors(showSlug: string, date: string) {
   return useQuery<EpisodeNeighbors>({
@@ -26,7 +30,7 @@ export function useEpisodeNeighbors(showSlug: string, date: string) {
           { method: 'GET' }
         )
       }),
-    enabled: showSlug.length > 0 && date.length > 0,
+    enabled: showSlug.length > 0 && ISO_DATE.test(date),
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/frontend/features/radio/hooks/useEpisodeNeighbors.ts
+++ b/frontend/features/radio/hooks/useEpisodeNeighbors.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest } from '@/lib/api'
+import { radioEndpoints, radioQueryKeys } from '../api'
+import { walkEpisodeNeighbors } from '../lib/episodeArchive'
+import type { EpisodeNeighbors } from '../lib/episodeArchive'
+import type { RadioEpisodesListResponse } from '../types'
+
+/**
+ * Prev/next episode neighbors for the playlist page nav (PSY-1051).
+ *
+ * Derived from the show's episodes list (air_date DESC) — there is no
+ * dedicated neighbors endpoint. The page walk lives in walkEpisodeNeighbors;
+ * this hook just wires it to the API and caches per (show, date).
+ */
+export function useEpisodeNeighbors(showSlug: string, date: string) {
+  return useQuery<EpisodeNeighbors>({
+    queryKey: radioQueryKeys.episodeNeighbors(showSlug, date),
+    queryFn: () =>
+      walkEpisodeNeighbors(date, (offset, limit) => {
+        const params = new URLSearchParams({ limit: String(limit) })
+        if (offset > 0) params.set('offset', String(offset))
+        return apiRequest<RadioEpisodesListResponse>(
+          `${radioEndpoints.SHOW_EPISODES(showSlug)}?${params.toString()}`,
+          { method: 'GET' }
+        )
+      }),
+    enabled: showSlug.length > 0 && date.length > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/features/radio/index.ts
+++ b/frontend/features/radio/index.ts
@@ -90,3 +90,19 @@ export {
   formatStationLocation,
 } from './lib/stationOverview'
 export type { ArtistHop, NowPlaying } from './lib/stationOverview'
+
+// PSY-1051: episode-archive derivation helpers + neighbors hook
+export type { RadioEpisodePreviewArtist } from './types'
+export { useEpisodeNeighbors } from './hooks'
+export {
+  isAirDateToday,
+  previewToHops,
+  computeArtistMatchStats,
+  formatPlayTime,
+  formatTimeOfDay,
+  formatDurationMinutes,
+  formatArchiveDate,
+  formatShortNavDate,
+  walkEpisodeNeighbors,
+} from './lib/episodeArchive'
+export type { ArtistMatchStats, EpisodeNeighbors } from './lib/episodeArchive'

--- a/frontend/features/radio/index.ts
+++ b/frontend/features/radio/index.ts
@@ -92,7 +92,7 @@ export {
 export type { ArtistHop, NowPlaying } from './lib/stationOverview'
 
 // PSY-1051: episode-archive derivation helpers + neighbors hook
-export type { RadioEpisodePreviewArtist } from './types'
+// (RadioEpisodePreviewArtist is re-exported in the types block above)
 export { useEpisodeNeighbors } from './hooks'
 export {
   isAirDateToday,

--- a/frontend/features/radio/lib/episodeArchive.test.ts
+++ b/frontend/features/radio/lib/episodeArchive.test.ts
@@ -271,6 +271,36 @@ describe('walkEpisodeNeighbors', () => {
     expect(fetchPage).toHaveBeenCalledTimes(1)
   })
 
+  it('stops after one page when the date sorts newer than the page tail (DESC early exit)', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) =>
+      makeEpisode(500 - i, `2020-01-${String((i % 28) + 1).padStart(2, '0')}`)
+    )
+    const fetchPage = vi.fn().mockResolvedValue(page(fullPage, 5000))
+
+    // 2026 sorts newer than everything in the 2020 page — it can't be on an
+    // older page, so the walk must stop without paging the whole archive.
+    const result = await walkEpisodeNeighbors('2026-06-02', fetchPage)
+
+    expect(result).toEqual({ newer: null, older: null })
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('never returns a same-date sibling as a neighbor', async () => {
+    // Two episodes share an air_date (distinct external_ids upstream).
+    const episodes = [
+      makeEpisode(4, '2026-06-09'),
+      makeEpisode(3, '2026-06-02'),
+      makeEpisode(2, '2026-06-02'),
+      makeEpisode(1, '2026-05-26'),
+    ]
+    const fetchPage = vi.fn().mockResolvedValue(page(episodes, 4))
+
+    const result = await walkEpisodeNeighbors('2026-06-02', fetchPage)
+
+    expect(result.newer?.air_date).toBe('2026-06-09')
+    expect(result.older?.air_date).toBe('2026-05-26')
+  })
+
   it('caps the walk instead of paging forever', async () => {
     const fullPage = Array.from({ length: 100 }, (_, i) => makeEpisode(i + 1, '2026-01-01'))
     const fetchPage = vi.fn().mockResolvedValue(page(fullPage, 1_000_000))

--- a/frontend/features/radio/lib/episodeArchive.test.ts
+++ b/frontend/features/radio/lib/episodeArchive.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  isAirDateToday,
+  previewToHops,
+  computeArtistMatchStats,
+  formatPlayTime,
+  formatTimeOfDay,
+  formatDurationMinutes,
+  formatArchiveDate,
+  formatShortNavDate,
+  walkEpisodeNeighbors,
+} from './episodeArchive'
+import type { RadioEpisodeListItem, RadioEpisodesListResponse, RadioPlay } from '../types'
+
+function makeEpisode(
+  id: number,
+  airDate: string,
+  overrides: Partial<RadioEpisodeListItem> = {}
+): RadioEpisodeListItem {
+  return {
+    id,
+    show_id: 1,
+    title: null,
+    air_date: airDate,
+    air_time: null,
+    duration_minutes: null,
+    archive_url: null,
+    play_count: 10,
+    created_at: '2026-01-01T00:00:00Z',
+    artist_preview: [],
+    ...overrides,
+  }
+}
+
+function makePlay(overrides: Partial<RadioPlay> = {}): RadioPlay {
+  return {
+    id: 1,
+    episode_id: 10,
+    position: 1,
+    artist_name: 'CAN',
+    track_title: 'Mother Sky',
+    album_title: 'Soundtracks',
+    label_name: 'United Artists',
+    release_year: 1970,
+    is_new: false,
+    rotation_status: null,
+    dj_comment: null,
+    is_live_performance: false,
+    is_request: false,
+    artist_id: null,
+    artist_slug: null,
+    release_id: null,
+    release_slug: null,
+    label_id: null,
+    label_slug: null,
+    musicbrainz_artist_id: null,
+    musicbrainz_recording_id: null,
+    musicbrainz_release_id: null,
+    air_timestamp: null,
+    ...overrides,
+  }
+}
+
+describe('isAirDateToday', () => {
+  const now = new Date(2026, 5, 9, 21, 30) // June 9 2026, local
+
+  it('is true when the air date matches the local date of now', () => {
+    expect(isAirDateToday('2026-06-09', now)).toBe(true)
+  })
+
+  it('is false for a past date', () => {
+    expect(isAirDateToday('2026-06-02', now)).toBe(false)
+  })
+
+  it('is false for null / undefined / empty', () => {
+    expect(isAirDateToday(null, now)).toBe(false)
+    expect(isAirDateToday(undefined, now)).toBe(false)
+    expect(isAirDateToday('', now)).toBe(false)
+  })
+
+  it('zero-pads month and day when comparing', () => {
+    expect(isAirDateToday('2026-01-05', new Date(2026, 0, 5))).toBe(true)
+  })
+})
+
+describe('previewToHops', () => {
+  it('maps preview artists onto hops, preserving matched slugs', () => {
+    expect(
+      previewToHops([
+        { artist_name: 'CAN', artist_id: 5, artist_slug: 'can' },
+        { artist_name: 'The Tweeters', artist_id: null, artist_slug: null },
+      ])
+    ).toEqual([
+      { name: 'CAN', slug: 'can' },
+      { name: 'The Tweeters', slug: null },
+    ])
+  })
+
+  it('returns an empty array for null / undefined', () => {
+    expect(previewToHops(null)).toEqual([])
+    expect(previewToHops(undefined)).toEqual([])
+  })
+})
+
+describe('computeArtistMatchStats', () => {
+  it('counts distinct artists and how many are matched', () => {
+    const plays = [
+      makePlay({ id: 1, artist_name: 'CAN', artist_id: 5 }),
+      makePlay({ id: 2, artist_name: 'Neu!', artist_id: 6 }),
+      makePlay({ id: 3, artist_name: 'The Tweeters', artist_id: null }),
+    ]
+    expect(computeArtistMatchStats(plays)).toEqual({ matched: 2, total: 3 })
+  })
+
+  it('dedups artist names case-insensitively across plays', () => {
+    const plays = [
+      makePlay({ id: 1, artist_name: 'CAN', artist_id: 5 }),
+      makePlay({ id: 2, artist_name: 'can', artist_id: null }),
+    ]
+    expect(computeArtistMatchStats(plays)).toEqual({ matched: 1, total: 1 })
+  })
+
+  it('counts a name as matched when ANY of its plays carries an artist_id', () => {
+    const plays = [
+      makePlay({ id: 1, artist_name: 'Faust', artist_id: null }),
+      makePlay({ id: 2, artist_name: 'Faust', artist_id: 9 }),
+    ]
+    expect(computeArtistMatchStats(plays)).toEqual({ matched: 1, total: 1 })
+  })
+
+  it('handles empty / missing plays', () => {
+    expect(computeArtistMatchStats([])).toEqual({ matched: 0, total: 0 })
+    expect(computeArtistMatchStats(undefined)).toEqual({ matched: 0, total: 0 })
+  })
+})
+
+describe('formatPlayTime', () => {
+  it('formats an ISO timestamp as a local clock time', () => {
+    expect(formatPlayTime('2026-06-02T21:02:00')).toBe('9:02 PM')
+  })
+
+  it('returns null for missing or unparseable input (blank TIME cell)', () => {
+    expect(formatPlayTime(null)).toBeNull()
+    expect(formatPlayTime(undefined)).toBeNull()
+    expect(formatPlayTime('not-a-date')).toBeNull()
+  })
+})
+
+describe('formatTimeOfDay', () => {
+  it('formats HH:MM:SS strings', () => {
+    expect(formatTimeOfDay('21:00:00')).toBe('9:00 PM')
+    expect(formatTimeOfDay('00:30:00')).toBe('12:30 AM')
+    expect(formatTimeOfDay('09:05')).toBe('9:05 AM')
+  })
+
+  it('returns null for missing or unparseable input', () => {
+    expect(formatTimeOfDay(null)).toBeNull()
+    expect(formatTimeOfDay(undefined)).toBeNull()
+    expect(formatTimeOfDay('bogus')).toBeNull()
+  })
+})
+
+describe('formatDurationMinutes', () => {
+  it('formats hours and minutes', () => {
+    expect(formatDurationMinutes(178)).toBe('2h 58m')
+    expect(formatDurationMinutes(120)).toBe('2h')
+    expect(formatDurationMinutes(45)).toBe('45m')
+  })
+
+  it('returns null for unknown or non-positive durations', () => {
+    expect(formatDurationMinutes(null)).toBeNull()
+    expect(formatDurationMinutes(undefined)).toBeNull()
+    expect(formatDurationMinutes(0)).toBeNull()
+  })
+})
+
+describe('formatArchiveDate / formatShortNavDate', () => {
+  it('formats archive dates without a comma', () => {
+    expect(formatArchiveDate('2026-06-09')).toBe('Jun 9 2026')
+  })
+
+  it('formats short nav dates as month + day', () => {
+    expect(formatShortNavDate('2026-05-26')).toBe('May 26')
+  })
+
+  it('passes through unparseable input', () => {
+    expect(formatArchiveDate('bogus')).toBe('bogus')
+    expect(formatShortNavDate('bogus')).toBe('bogus')
+  })
+})
+
+describe('walkEpisodeNeighbors', () => {
+  const page = (episodes: RadioEpisodeListItem[], total: number): RadioEpisodesListResponse => ({
+    episodes,
+    total,
+  })
+
+  it('returns both neighbors when the date sits mid-page', async () => {
+    const episodes = [
+      makeEpisode(3, '2026-06-09'),
+      makeEpisode(2, '2026-06-02'),
+      makeEpisode(1, '2026-05-26'),
+    ]
+    const fetchPage = vi.fn().mockResolvedValue(page(episodes, 3))
+
+    const result = await walkEpisodeNeighbors('2026-06-02', fetchPage)
+
+    expect(result.newer?.air_date).toBe('2026-06-09')
+    expect(result.older?.air_date).toBe('2026-05-26')
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+    expect(fetchPage).toHaveBeenCalledWith(0, 100)
+  })
+
+  it('returns null newer at the newest episode', async () => {
+    const episodes = [makeEpisode(2, '2026-06-09'), makeEpisode(1, '2026-06-02')]
+    const fetchPage = vi.fn().mockResolvedValue(page(episodes, 2))
+
+    const result = await walkEpisodeNeighbors('2026-06-09', fetchPage)
+
+    expect(result.newer).toBeNull()
+    expect(result.older?.air_date).toBe('2026-06-02')
+  })
+
+  it('returns null older at the oldest episode', async () => {
+    const episodes = [makeEpisode(2, '2026-06-09'), makeEpisode(1, '2026-06-02')]
+    const fetchPage = vi.fn().mockResolvedValue(page(episodes, 2))
+
+    const result = await walkEpisodeNeighbors('2026-06-02', fetchPage)
+
+    expect(result.newer?.air_date).toBe('2026-06-09')
+    expect(result.older).toBeNull()
+  })
+
+  it('fetches one extra row when the date sits at the bottom of a full page', async () => {
+    const pageOne = Array.from({ length: 100 }, (_, i) =>
+      makeEpisode(200 - i, `2025-0${(i % 9) + 1}-01`)
+    )
+    pageOne[99] = makeEpisode(101, '2026-06-02')
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page(pageOne, 150))
+      .mockResolvedValueOnce(page([makeEpisode(100, '2026-05-26')], 150))
+
+    const result = await walkEpisodeNeighbors('2026-06-02', fetchPage)
+
+    expect(result.older?.air_date).toBe('2026-05-26')
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 100, 1)
+  })
+
+  it('takes the newer neighbor from the previous page tail across a boundary', async () => {
+    const pageOne = Array.from({ length: 100 }, (_, i) => makeEpisode(300 - i, '2026-01-01'))
+    pageOne[99] = makeEpisode(201, '2026-06-09')
+    const pageTwo = [makeEpisode(200, '2026-06-02'), makeEpisode(199, '2026-05-26')]
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page(pageOne, 102))
+      .mockResolvedValueOnce(page(pageTwo, 102))
+
+    const result = await walkEpisodeNeighbors('2026-06-02', fetchPage)
+
+    expect(result.newer?.air_date).toBe('2026-06-09')
+    expect(result.older?.air_date).toBe('2026-05-26')
+  })
+
+  it('returns nulls when the date is not in the archive', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(page([makeEpisode(1, '2026-06-09')], 1))
+
+    const result = await walkEpisodeNeighbors('1999-01-01', fetchPage)
+
+    expect(result).toEqual({ newer: null, older: null })
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps the walk instead of paging forever', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => makeEpisode(i + 1, '2026-01-01'))
+    const fetchPage = vi.fn().mockResolvedValue(page(fullPage, 1_000_000))
+
+    const result = await walkEpisodeNeighbors('1999-01-01', fetchPage)
+
+    expect(result).toEqual({ newer: null, older: null })
+    expect(fetchPage).toHaveBeenCalledTimes(20)
+  })
+})

--- a/frontend/features/radio/lib/episodeArchive.ts
+++ b/frontend/features/radio/lib/episodeArchive.ts
@@ -1,0 +1,194 @@
+/**
+ * Episode-archive derivation helpers (PSY-1051, radio show + playlist pages).
+ *
+ * Pure, hook-free transforms for the show page's playlist-archive table and
+ * the playlist page's dense track table. Kept out of the components so the
+ * ON AIR heuristic, the matched-artist stats, and the prev/next neighbor
+ * walk are each unit-testable seams.
+ */
+
+import type {
+  RadioEpisodeListItem,
+  RadioEpisodePreviewArtist,
+  RadioEpisodesListResponse,
+  RadioPlay,
+} from '../types'
+import type { ArtistHop } from './stationOverview'
+
+/**
+ * v1 "on air" heuristic for a single show (PSY-1051, same register as the
+ * PSY-1016 station-overview fallback): the show is treated as live when its
+ * most-recent episode aired TODAY in the viewer's local date. Honest enough
+ * until PSY-1022 ships a real live now-playing signal — the ON AIR strip is
+ * built to swap to that endpoint without layout change.
+ */
+export function isAirDateToday(
+  airDate: string | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!airDate) return false
+  const today = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+  ].join('-')
+  return airDate === today
+}
+
+/**
+ * Map an episode row's artist preview (PSY-1048) onto the ArtistHops shape so
+ * matched artists render as graph links and unmatched names as plain text.
+ */
+export function previewToHops(
+  preview: RadioEpisodePreviewArtist[] | null | undefined
+): ArtistHop[] {
+  return (preview ?? []).map(p => ({ name: p.artist_name, slug: p.artist_slug }))
+}
+
+export interface ArtistMatchStats {
+  /** Distinct artist names with a knowledge-graph match (artist_id). */
+  matched: number
+  /** Total distinct artist names in the playlist. */
+  total: number
+}
+
+/**
+ * "N of M artists matched to the graph" for a playlist's meta line. Distinct
+ * by artist name (case-insensitive, trimmed — same dedup rule as
+ * recentArtistsFromEpisode); a name counts as matched when any of its plays
+ * carries an artist_id.
+ */
+export function computeArtistMatchStats(
+  plays: RadioPlay[] | null | undefined
+): ArtistMatchStats {
+  const matchedByName = new Map<string, boolean>()
+  for (const play of plays ?? []) {
+    if (!play.artist_name) continue
+    const key = play.artist_name.trim().toLowerCase()
+    matchedByName.set(key, (matchedByName.get(key) ?? false) || play.artist_id != null)
+  }
+  let matched = 0
+  for (const isMatched of matchedByName.values()) {
+    if (isMatched) matched++
+  }
+  return { matched, total: matchedByName.size }
+}
+
+/**
+ * TIME cell for the playlist table: "9:02 PM" from an ISO air_timestamp,
+ * or null when the feed didn't carry one (NTS/WFMU) — the cell renders
+ * blank rather than fabricating a time; position keeps the row order.
+ */
+export function formatPlayTime(isoString: string | null | undefined): string | null {
+  if (!isoString) return null
+  const date = new Date(isoString)
+  if (isNaN(date.getTime())) return null
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
+/**
+ * "9:00 PM" from an HH:MM[:SS] air_time string (episode-level scheduled
+ * time); null when missing or unparseable.
+ */
+export function formatTimeOfDay(timeStr: string | null | undefined): string | null {
+  if (!timeStr) return null
+  const [hoursStr, minutesStr] = timeStr.split(':')
+  const hours = parseInt(hoursStr, 10)
+  const minutes = parseInt(minutesStr, 10)
+  if (isNaN(hours) || isNaN(minutes)) return null
+  const period = hours >= 12 ? 'PM' : 'AM'
+  const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
+  return `${displayHours}:${String(minutes).padStart(2, '0')} ${period}`
+}
+
+/** "2h 58m" / "45m" for the playlist meta line; null when unknown. */
+export function formatDurationMinutes(
+  minutes: number | null | undefined
+): string | null {
+  if (minutes == null || minutes <= 0) return null
+  const hours = Math.floor(minutes / 60)
+  const mins = minutes % 60
+  if (hours === 0) return `${mins}m`
+  if (mins === 0) return `${hours}h`
+  return `${hours}h ${mins}m`
+}
+
+/**
+ * Archive-table date: "Jun 9 2026" (mock register, no comma). Parses at local
+ * midnight so a date-only string doesn't shift a day in negative-offset zones.
+ */
+export function formatArchiveDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  if (isNaN(date.getTime())) return dateStr
+  const monthDay = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return `${monthDay} ${date.getFullYear()}`
+}
+
+/** Short "Jun 2" label for the prev/next episode nav brackets. */
+export function formatShortNavDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  if (isNaN(date.getTime())) return dateStr
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+// ---------------------------------------------------------------------------
+// Prev/next episode neighbors
+// ---------------------------------------------------------------------------
+
+export interface EpisodeNeighbors {
+  /** The next-more-recent episode (rendered on the right, "Jun 9 ▶"). */
+  newer: RadioEpisodeListItem | null
+  /** The next-older episode (rendered on the left, "◀ May 26"). */
+  older: RadioEpisodeListItem | null
+}
+
+export type EpisodePageFetcher = (
+  offset: number,
+  limit: number
+) => Promise<RadioEpisodesListResponse>
+
+const NEIGHBOR_PAGE_SIZE = 100
+/** Bounds the walk (2,000 episodes) so a bad date can't page forever. */
+const NEIGHBOR_MAX_PAGES = 20
+
+/**
+ * Find the prev/next neighbors of the episode airing on `date` by walking the
+ * show's episodes list (air_date DESC) page by page. Handles page boundaries:
+ * a hit at the top of a page takes its newer neighbor from the previous
+ * page's tail, and a hit at the bottom fetches one more row for the older
+ * neighbor. Returns nulls at the newest/oldest ends and when the date isn't
+ * found within the walk cap.
+ */
+export async function walkEpisodeNeighbors(
+  date: string,
+  fetchPage: EpisodePageFetcher
+): Promise<EpisodeNeighbors> {
+  let prevPageTail: RadioEpisodeListItem | null = null
+
+  for (let page = 0; page < NEIGHBOR_MAX_PAGES; page++) {
+    const offset = page * NEIGHBOR_PAGE_SIZE
+    const response = await fetchPage(offset, NEIGHBOR_PAGE_SIZE)
+    const episodes = response.episodes ?? []
+    const index = episodes.findIndex(e => e.air_date === date)
+
+    if (index >= 0) {
+      const newer = index > 0 ? episodes[index - 1] : prevPageTail
+      let older = index < episodes.length - 1 ? episodes[index + 1] : null
+      const moreBeyondPage = offset + episodes.length < response.total
+      if (older === null && moreBeyondPage) {
+        const next = await fetchPage(offset + episodes.length, 1)
+        older = next.episodes?.[0] ?? null
+      }
+      return { newer, older }
+    }
+
+    if (episodes.length < NEIGHBOR_PAGE_SIZE) break
+    prevPageTail = episodes[episodes.length - 1]
+  }
+
+  return { newer: null, older: null }
+}

--- a/frontend/features/radio/lib/episodeArchive.ts
+++ b/frontend/features/radio/lib/episodeArchive.ts
@@ -162,6 +162,15 @@ const NEIGHBOR_MAX_PAGES = 20
  * page's tail, and a hit at the bottom fetches one more row for the older
  * neighbor. Returns nulls at the newest/oldest ends and when the date isn't
  * found within the walk cap.
+ *
+ * Two hardenings (adversarial review):
+ * - DESC-order early exit: if the page didn't contain the date but the date
+ *   sorts AFTER the page tail, it can't be on a later (older) page — stop
+ *   instead of walking the whole archive for a bogus URL date.
+ * - Same-date siblings (the unique index allows two episodes on one date via
+ *   distinct external_ids) are never returned as neighbors — the by-date
+ *   route can only show one episode per date, so such a link would point at
+ *   the current page itself.
  */
 export async function walkEpisodeNeighbors(
   date: string,
@@ -172,21 +181,30 @@ export async function walkEpisodeNeighbors(
   for (let page = 0; page < NEIGHBOR_MAX_PAGES; page++) {
     const offset = page * NEIGHBOR_PAGE_SIZE
     const response = await fetchPage(offset, NEIGHBOR_PAGE_SIZE)
-    const episodes = response.episodes ?? []
+    const all = response.episodes ?? []
+    // Collapse same-date siblings so a neighbor never self-links.
+    const episodes = all.filter(
+      (e, i) => i === 0 || e.air_date !== all[i - 1].air_date
+    )
     const index = episodes.findIndex(e => e.air_date === date)
 
     if (index >= 0) {
-      const newer = index > 0 ? episodes[index - 1] : prevPageTail
+      const tailIsSameDate = prevPageTail?.air_date === date
+      const newer = index > 0 ? episodes[index - 1] : tailIsSameDate ? null : prevPageTail
       let older = index < episodes.length - 1 ? episodes[index + 1] : null
-      const moreBeyondPage = offset + episodes.length < response.total
+      const moreBeyondPage = offset + all.length < response.total
       if (older === null && moreBeyondPage) {
-        const next = await fetchPage(offset + episodes.length, 1)
-        older = next.episodes?.[0] ?? null
+        const next = await fetchPage(offset + all.length, 1)
+        const candidate = next.episodes?.[0] ?? null
+        older = candidate && candidate.air_date !== date ? candidate : null
       }
       return { newer, older }
     }
 
-    if (episodes.length < NEIGHBOR_PAGE_SIZE) break
+    if (all.length < NEIGHBOR_PAGE_SIZE) break
+    // ISO dates compare lexicographically: list is DESC, so a date newer
+    // than this page's tail can't appear on any later page.
+    if (date > all[all.length - 1].air_date) break
     prevPageTail = episodes[episodes.length - 1]
   }
 

--- a/frontend/features/radio/types.ts
+++ b/frontend/features/radio/types.ts
@@ -351,11 +351,10 @@ export function getRotationStatusColor(status: string): string {
 }
 
 // ============================================================================
-// PSY-1048 aggregation shapes (PSY-1049)
+// PSY-1048 aggregation shapes (PSY-1049 + PSY-1051)
 //
-// Mirrors backend/internal/services/contracts/radio.go. Parallel radio
-// redesign PRs (PSY-1050/1051) may add identical definitions — dedupe by
-// keeping one copy at rebase time.
+// Mirrors backend/internal/services/contracts/radio.go. PSY-1050 may add
+// further definitions here — dedupe identical ones at rebase time.
 // ============================================================================
 
 /**
@@ -392,4 +391,10 @@ export interface RadioStationEpisodeRow {
 export interface RadioRecentEpisodesResponse {
   episodes: RadioStationEpisodeRow[]
   total: number
+}
+
+// Declaration-merges into RadioEpisodeListItem above: episode list rows now
+// carry the first few distinct playlist artists (PSY-1048).
+export interface RadioEpisodeListItem {
+  artist_preview: RadioEpisodePreviewArtist[]
 }


### PR DESCRIPTION
## Summary

Rebuilds the radio show + playlist pages per the locked Option A direction (PSY-1049 decisions 4–5):

**Show page** (`RadioShowDetail`) is now its playlist archive — one reverse-chron `DenseTable` (DATE · EPISODE · PLAYED · TRACKS · [mp3]) fed by PSY-1048's `artist_preview` on `GET /radio-shows/{slug}/episodes` (retires the per-row episode-detail fetch pattern on this surface). Header carries name + host + `schedule_display` + genre tags + description + [Archive ↗]; an ON AIR strip (v1 heuristic: latest episode aired today, built to swap to PSY-1022's live endpoint without layout change) links to the live playlist; sidebar has bordered TOP ARTISTS / TOP LABELS (90d) boxes.

**Playlist page** (`EpisodeDateDetail`) is the full-width record-collector table: TIME · ARTIST · TRACK · ALBUM · LABEL · YEAR · NOTES. Matched artists = orange link + ● dot, unmatched = plain + ○, with a legend row; LIVE / NEW / rotation (mono tag) / REQ badges; `dj_comment` as an indented full-width sub-row. TIME comes from `air_timestamp` and renders blank when absent (never fabricated; position keeps order). Header gains prev/next episode nav (derived by walking the episodes list with page-boundary handling), [▶ Play archive] + [Mixcloud ↗], and an "N of M artists matched to the graph" meta line.

**Explicitly NOT in v1 (locked):** airbreak divider rows (no `play_type` data), [suggest a match] (PSY-1052 spike — legend ships without the action), TIME deep-links into a player, "Listeners also dig" box.

New seams: `features/radio/lib/episodeArchive.ts` (pure helpers + neighbor walk), `useEpisodeNeighbors` hook. `RadioEpisodeListItem` gains `artist_preview` via an end-of-`types.ts` block per the PSY-1049/1050 cross-PR coordination (declaration merge so nothing touches shared lines).

Disclosures:
- TIME and the playlist meta render in the **viewer's local timezone** (pre-existing `RadioPlayRow` convention for `air_timestamp`).
- `formatTimeOfDay` duplicates `RadioEpisodeRow`'s local `formatAirTime`; that component now has no page usage but is left exported — the hub/station tickets (PSY-1049/1050) own its surfaces, so cleanup is deferred to after the wave merges (same for `RadioPlayRow`).
- Show image, "Radio /" root breadcrumb crumb, and episode genre/mood tag badges are dropped from these two pages — absent from the locked mocks.

## Test plan

- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors (153 pre-existing warnings, none in touched files)
- [x] `cd frontend && bun run test:run features/radio app/radio` — 31 files / 254 tests passed
- [x] New tests: `episodeArchive.test.ts` (28: ON AIR heuristic, match stats, time/duration/date formatting, neighbor walk incl. page boundaries, newest/oldest edges, DESC early exit, same-date siblings, walk cap), `EpisodeArchiveTable.test.tsx` (8: date/title links, matched/unmatched preview, [mp3], live row), `PlaylistTable.test.tsx` (11: ●/○ + links, badges, library suppression, comment sub-rows, blank TIME, row order, legend without suggest-a-match), `EpisodeNav.test.tsx` (5: both neighbors, newest/oldest/loading disabled states, all-episodes link), `useEpisodeNeighbors.test.tsx` (4: key shape, walk wiring, empty + garbage-date guards)

## Manual repro

Isolated dispatch stack (`stack-up.sh --mode=shared` auto-escalated to isolated; backend built from this worktree, confirmed `artist_preview` present on `GET /radio-shows/{slug}/episodes`). Seeded the isolated DB with 3 extra episodes for KEXP's The Morning Show (one dated today, rich plays with comments/badges/timestamps, one with no timestamps). Verified with agent-browser:

- Show page: archive table with previews (matched = links), [mp3] anchors, live row marker, ON AIR strip → click-through lands on tonight's playlist
- Playlist page: dense table, ● matched links (Calexico → `/artists/calexico` verified), ○ unmatched, HEAVY/REQ/NEW/LIVE/REC NEW badges, DJ-comment sub-rows, "4 of 6 artists matched" meta
- Prev/next nav: mid-archive (both enabled), newest (newer disabled), oldest (older disabled)
- TIME fallback: episode with no `air_timestamp` renders blank TIME column in position order
- Dark mode: both pages token-clean

## Screenshots

| | |
|---|---|
| Show page (light) | ![show page](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1051-screenshots/01-show-page.png) |
| Playlist page (light) | ![playlist page](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1051-screenshots/02-playlist-page.png) |
| Newest-edge nav (tonight, live) | ![newest edge](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1051-screenshots/03-playlist-newest-edge.png) |
| Oldest-edge nav | ![oldest edge](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1051-screenshots/04-playlist-oldest-edge.png) |
| TIME fallback (no timestamps) | ![no timestamps](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1051-screenshots/05-playlist-no-timestamps.png) |
| Playlist (dark) | ![playlist dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1051-screenshots/06-playlist-dark.png) |
| Show page (dark) | ![show dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1051-screenshots/07-show-page-dark.png) |

## Code review

`/code-review` (inline lenses — sub-agent worktree, no Agent tool): 1 confirmed finding, fixed in `03068cde` — the limit-1 latest-episode query's `keepPreviousData` placeholder could briefly render the ON AIR strip with the previous show's `air_date` under the new show's URL during navigation; now guarded with `isPlaceholderData` (same guard `useShowLatestEpisode` documents). Reuse/simplification/efficiency lenses: no further findings.

## Adversarial review

`/adversarial-review` — CONCERNS; 2 findings addressed in commit `160295f2`.
- [MEDIUM] neighbor-walk amplification on bogus episode URLs (up to 20 list calls per crawler hit) → ISO-date enable guard + DESC-order early exit
- [MEDIUM→LOW] same-date sibling episodes could surface as a self-linking neighbor → same-date collapse + cross-page tail guard
- [LOW, disclosed] viewer-local TIME rendering; `formatTimeOfDay` duplication; raw `archive_url` anchors (same trust boundary as existing episode/station external links)

Panel: Saboteur · Future-Maintainer · Security · Completeness, run inline (dispatched sub-agents have no Agent tool; expected fallback per repo convention).

Closes PSY-1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
