### PR TITLE
PSY-1056: remove Rising/Steady trend indicator from artist trajectory

### DIFF
--- a/backend/internal/services/catalog/festival_intelligence.go
+++ b/backend/internal/services/catalog/festival_intelligence.go
@@ -523,7 +523,6 @@ func (s *FestivalIntelligenceService) GetArtistFestivalTrajectory(artistID uint)
 			Appearances:      []contracts.TrajectoryEntry{},
 			BestTier:         "",
 			TotalAppearances: 0,
-			BreakoutScore:    0,
 		}, nil
 	}
 
@@ -542,32 +541,11 @@ func (s *FestivalIntelligenceService) GetArtistFestivalTrajectory(artistID uint)
 		}
 	}
 
-	// Compute breakout score
-	var totalImprovement int
-	for i := 1; i < len(history); i++ {
-		prevRank := tierRank(history[i-1].BillingTier)
-		currRank := tierRank(history[i].BillingTier)
-		if currRank < prevRank {
-			totalImprovement += prevRank - currRank
-		}
-	}
-
-	yearsSpan := history[len(history)-1].EditionYear - history[0].EditionYear
-	if yearsSpan < 1 {
-		yearsSpan = 1
-	}
-
-	breakoutScore := 0.0
-	if totalImprovement > 0 {
-		breakoutScore = math.Round(float64(totalImprovement)/float64(yearsSpan)*100) / 100
-	}
-
 	return &contracts.ArtistTrajectory{
 		Artist:           contracts.ArtistSummary{ID: artist.ID, Name: artist.Name, Slug: artistSlug},
 		Appearances:      appearances,
 		BestTier:         rankToTier(bestRank),
 		TotalAppearances: len(history),
-		BreakoutScore:    breakoutScore,
 	}, nil
 }
 

--- a/backend/internal/services/catalog/festival_intelligence_test.go
+++ b/backend/internal/services/catalog/festival_intelligence_test.go
@@ -323,7 +323,6 @@ func (suite *FestivalIntelligenceTestSuite) TestGetArtistFestivalTrajectory_Mult
 	suite.Len(traj.Appearances, 3)
 	suite.Equal("sub_headliner", traj.BestTier)
 	suite.Equal(3, traj.TotalAppearances)
-	suite.Greater(traj.BreakoutScore, 0.0)
 
 	// Verify chronological order
 	suite.Equal(2024, traj.Appearances[0].Year)
@@ -339,7 +338,6 @@ func (suite *FestivalIntelligenceTestSuite) TestGetArtistFestivalTrajectory_NoAp
 	suite.Require().NoError(err)
 	suite.Empty(traj.Appearances)
 	suite.Equal(0, traj.TotalAppearances)
-	suite.Equal(0.0, traj.BreakoutScore)
 }
 
 func (suite *FestivalIntelligenceTestSuite) TestGetArtistFestivalTrajectory_NotFound() {

--- a/backend/internal/services/contracts/festival_intelligence.go
+++ b/backend/internal/services/contracts/festival_intelligence.go
@@ -65,7 +65,6 @@ type ArtistTrajectory struct {
 	Appearances      []TrajectoryEntry `json:"appearances"`
 	BestTier         string            `json:"best_tier"`
 	TotalAppearances int               `json:"total_appearances"`
-	BreakoutScore    float64           `json:"breakout_score"`
 }
 
 // SeriesComparison shows year-over-year analysis for a recurring festival series.

--- a/frontend/features/festivals/components/ArtistTrajectoryChart.test.tsx
+++ b/frontend/features/festivals/components/ArtistTrajectoryChart.test.tsx
@@ -20,7 +20,6 @@ function makeTrajectory(overrides: Partial<ArtistTrajectory> = {}): ArtistTrajec
     ],
     best_tier: 'mid_card',
     total_appearances: 2,
-    breakout_score: 0.5,
     ...overrides,
   }
 }

--- a/frontend/features/festivals/components/ArtistTrajectoryChart.tsx
+++ b/frontend/features/festivals/components/ArtistTrajectoryChart.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { Loader2, TrendingUp, Minus } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import { BracketLink } from '@/components/shared/BracketLink'
 import { useArtistFestivalTrajectory } from '../hooks/useFestivals'
 import { getBillingTierLabel, getTierBarWidth } from '../types'
@@ -22,7 +22,6 @@ interface ArtistTrajectoryChartProps {
 }
 
 function ChartBody({ data }: { data: ArtistTrajectory }) {
-  const isRising = data.breakout_score > 0
   return (
     <>
       <div className="space-y-2">
@@ -54,20 +53,11 @@ function ChartBody({ data }: { data: ArtistTrajectory }) {
         ))}
       </div>
       {data.total_appearances > 1 && (
-        <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
-          {isRising ? (
-            <>
-              <TrendingUp className="h-3.5 w-3.5 text-green-500" />
-              <span>
-                Rising — {data.breakout_score.toFixed(1)} tier improvements/year
-              </span>
-            </>
-          ) : (
-            <>
-              <Minus className="h-3.5 w-3.5" />
-              <span>Steady — {data.total_appearances} festival appearances</span>
-            </>
-          )}
+        <div className="mt-3 text-xs text-muted-foreground">
+          {/* Factual count only — Rising/Steady trend judgments were removed
+              (PSY-1056): our lineup history is incomplete, so any trend read
+              off it is a guess. */}
+          <span>{data.total_appearances} festival appearances</span>
         </div>
       )}
     </>

--- a/frontend/features/festivals/types.ts
+++ b/frontend/features/festivals/types.ts
@@ -294,7 +294,6 @@ export interface ArtistTrajectory {
   appearances: TrajectoryEntry[]
   best_tier: string
   total_appearances: number
-  breakout_score: number
 }
 
 export interface SeriesEdition {


### PR DESCRIPTION
Closes PSY-1056.

Follow-up to #1078 (PSY-1055) — same epistemic rationale, now applied to the artist page's trajectory chart. Rebased onto main after #1078 merged.

## Summary

Removes the **"Rising — N tier improvements/year" / "Steady — N festival appearances"** trend indicator from the artist page's festival trajectory chart, completing the PSY-1055 rationale: trend judgments read off our incomplete lineup history are guesses — a single missing appearance flips the trend. (The "Steady" branch was the same inference in the other direction.)

**What stays — the facts:** the chart's bars (known appearances + billing tiers per festival), the `/artists/{id}/festival-trajectory` endpoint, and `TrajectoryEntry`. The footer becomes the plain factual **"N festival appearances"**.

**Removed end to end** (the chart was `breakout_score`'s only consumer, verified):
- Frontend: the `isRising` ternary + TrendingUp/Minus icons; `breakout_score` off the `ArtistTrajectory` type; chart-test fixture updated
- Backend: `BreakoutScore` off the `ArtistTrajectory` contract + its computation block in `GetArtistFestivalTrajectory`; the two service-test assertions

## Test plan

- [x] `go build ./...` + vet — clean (`math` import still used elsewhere in the file)
- [x] Backend catalog service + handler suites — pass
- [x] `bun run typecheck` — clean
- [x] `features/festivals` + `features/artists` suites — 38 files / 405 tests pass
- [x] Zero references repo-wide: `breakout_score|BreakoutScore|isRising` grep is empty
- [ ] Manual visual check — deferred: removal-only; chart rendering covered by `ArtistTrajectoryChart.test.tsx`

## Coverage gaps

- No screenshot (footer text swap; the chart test asserts the component renders with the updated fixture).
