### PR TITLE
PSY-1065: move Top Tracks embed to the top of the artist sidebar

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -600,6 +600,42 @@ describe('ArtistDetail', () => {
       expect(screen.queryByTestId('music-embed')).not.toBeInTheDocument()
     })
 
+    it('renders Top tracks FIRST in the sidebar, before Statistics (PSY-1065)', () => {
+      // Listening is the fastest way to judge an unfamiliar band — the
+      // embed leads the column.
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({
+          social: {
+            instagram: null,
+            facebook: null,
+            twitter: null,
+            youtube: null,
+            spotify: 'https://open.spotify.com/artist/123',
+            soundcloud: null,
+            bandcamp: null,
+            website: null,
+          },
+          stats: {
+            releases: 2,
+            labels: 1,
+            shows_tracked: 3,
+            similar_artists: 0,
+            festival_appearances: 0,
+          },
+        }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const embed = screen.getByTestId('music-embed')
+      const statsHeader = screen.getByText('Statistics')
+      expect(
+        embed.compareDocumentPosition(statsHeader) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy()
+    })
+
     it('shows label links in sidebar when labels exist', () => {
       mockUseArtistLabels.mockReturnValue({
         data: {

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -290,6 +290,22 @@ function ArtistSidebar({
 
   return (
     <div className="space-y-6">
+      {/* Top tracks — FIRST in the column (PSY-1065): listening is the
+          fastest way to decide whether you like an unfamiliar band, so the
+          embed leads. Rendered only when a music link exists. */}
+      {hasMusicLink && (
+        <section>
+          <SectionHeader title="Top tracks" />
+          <MusicEmbed
+            bandcampAlbumUrl={artist.bandcamp_embed_url}
+            bandcampProfileUrl={artist.social?.bandcamp}
+            spotifyUrl={artist.social?.spotify}
+            artistName={artist.name}
+            compact
+          />
+        </section>
+      )}
+
       {/* Photo */}
       {artist.image_url && (
         // eslint-disable-next-line @next/next/no-img-element
@@ -363,20 +379,6 @@ function ArtistSidebar({
         <section>
           <SectionHeader title="Links" />
           <SocialLinks social={artist.social} />
-        </section>
-      )}
-
-      {/* Top tracks — compact embed, rendered only when a music link exists */}
-      {hasMusicLink && (
-        <section>
-          <SectionHeader title="Top tracks" />
-          <MusicEmbed
-            bandcampAlbumUrl={artist.bandcamp_embed_url}
-            bandcampProfileUrl={artist.social?.bandcamp}
-            spotifyUrl={artist.social?.spotify}
-            artistName={artist.name}
-            compact
-          />
         </section>
       )}
 


### PR DESCRIPTION
Closes PSY-1065.

## Summary

On artist pages, the **Top tracks** embed (Spotify/Bandcamp `MusicEmbed`) moves from 8th in the right sidebar — below Statistics, Similar artists, Tags, Aliases, Labels and Links — to the **top of the column**, above the photo and Statistics. Listening is the fastest way to decide whether you like an unfamiliar band, so it leads (dogfood feedback, 2026-06-10).

Pure reorder: same `hasMusicLink` gating, same compact `MusicEmbed` props. New test pins the contract (embed precedes the Statistics header in DOM order).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/artists` — 22 files / 277 tests pass (incl. the new order-pinning test)
- [x] `bun run lint` — clean on changed files
- [ ] Manual visual check — deferred: pure section reorder; DOM order pinned by test, no styling or behavior change

## Coverage gaps

- No screenshot (the diff moves an existing, unchanged section; the order test asserts the user-visible change).
