### PR TITLE
PSY-1070: replace Festival History bars with dense appearance rows

### DIFF
--- a/frontend/features/festivals/components/ArtistTrajectoryChart.test.tsx
+++ b/frontend/features/festivals/components/ArtistTrajectoryChart.test.tsx
@@ -43,7 +43,7 @@ describe('ArtistTrajectoryChart', () => {
       isLoading: false,
     })
     renderWithProviders(<ArtistTrajectoryChart artistIdOrSlug={1} />)
-    expect(screen.getByText('Festival History')).toBeInTheDocument()
+    expect(screen.getByText('Festival appearances')).toBeInTheDocument()
     expect(screen.getByText('SXSW 2024')).toBeInTheDocument()
     expect(screen.getByText('Pitchfork 2023')).toBeInTheDocument()
   })
@@ -56,7 +56,7 @@ describe('ArtistTrajectoryChart', () => {
     renderWithProviders(
       <ArtistTrajectoryChart artistIdOrSlug={1} defaultCollapsed />
     )
-    expect(screen.getByText('Festival History')).toBeInTheDocument()
+    expect(screen.getByText('Festival appearances')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument()
     expect(screen.queryByText('SXSW 2024')).not.toBeInTheDocument()
   })

--- a/frontend/features/festivals/components/ArtistTrajectoryChart.tsx
+++ b/frontend/features/festivals/components/ArtistTrajectoryChart.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { Loader2 } from 'lucide-react'
 import { BracketLink } from '@/components/shared/BracketLink'
 import { useArtistFestivalTrajectory } from '../hooks/useFestivals'
-import { getBillingTierLabel, getTierBarWidth } from '../types'
+import { getBillingTierLabel } from '../types'
 import type { ArtistTrajectory } from '../types'
 
 interface ArtistTrajectoryChartProps {
@@ -21,39 +21,43 @@ interface ArtistTrajectoryChartProps {
   defaultCollapsed?: boolean
 }
 
-function ChartBody({ data }: { data: ArtistTrajectory }) {
+function AppearanceRows({ data }: { data: ArtistTrajectory }) {
   return (
     <>
-      <div className="space-y-2">
+      {/* Dense rows per the Figma Artists board (PSY-1070): year · full
+          linked festival name · billed-as. The previous tier-width bars
+          encoded billing tier as decoration while truncating the festival
+          name — the actual content — to 140px. */}
+      <div className="flex items-baseline gap-4 pb-1.5 border-b border-border/60 text-[11px] uppercase tracking-wider text-muted-foreground">
+        <span className="w-12 shrink-0">Year</span>
+        <span className="min-w-0 flex-1">Festival</span>
+        <span className="w-28 shrink-0">Billed as</span>
+      </div>
+      <div className="divide-y divide-border/60">
         {data.appearances.map(entry => (
           <div
             key={`${entry.festival_slug}-${entry.year}`}
-            className="flex items-center gap-3"
+            className="flex items-baseline gap-4 py-2 text-sm"
           >
-            <span className="text-xs text-muted-foreground w-10 text-right tabular-nums">
+            <span className="w-12 shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
               {entry.year}
             </span>
-            <div className="flex-1">
-              <div
-                className="h-5 rounded bg-primary/20 flex items-center px-2"
-                style={{ width: `${getTierBarWidth(entry.tier)}%` }}
+            <span className="min-w-0 flex-1 font-medium">
+              <Link
+                href={`/festivals/${entry.festival_slug}`}
+                className="hover:text-primary hover:underline"
               >
-                <span className="text-[10px] text-foreground/80 truncate">
-                  {getBillingTierLabel(entry.tier)}
-                </span>
-              </div>
-            </div>
-            <Link
-              href={`/festivals/${entry.festival_slug}`}
-              className="text-xs text-muted-foreground hover:text-primary transition-colors truncate max-w-[140px]"
-            >
-              {entry.festival_name}
-            </Link>
+                {entry.festival_name}
+              </Link>
+            </span>
+            <span className="w-28 shrink-0 text-muted-foreground">
+              {getBillingTierLabel(entry.tier)}
+            </span>
           </div>
         ))}
       </div>
       {data.total_appearances > 1 && (
-        <div className="mt-3 text-xs text-muted-foreground">
+        <div className="mt-2 font-mono text-[11px] text-muted-foreground">
           {/* Factual count only — Rising/Steady trend judgments were removed
               (PSY-1056): our lineup history is incomplete, so any trend read
               off it is a guess. */}
@@ -92,14 +96,14 @@ export function ArtistTrajectoryChart({
       <div>
         <div className="flex items-baseline justify-between gap-2 mb-2">
           <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-            Festival History
+            Festival appearances
           </h2>
           <BracketLink
             label={open ? 'Hide' : 'Show'}
             onClick={() => setOpen(!open)}
           />
         </div>
-        {open && <ChartBody data={data} />}
+        {open && <AppearanceRows data={data} />}
       </div>
     )
   }
@@ -107,9 +111,9 @@ export function ArtistTrajectoryChart({
   return (
     <div>
       <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-        Festival History
+        Festival appearances
       </h2>
-      <ChartBody data={data} />
+      <AppearanceRows data={data} />
     </div>
   )
 }

--- a/frontend/features/festivals/index.test.ts
+++ b/frontend/features/festivals/index.test.ts
@@ -16,7 +16,6 @@ describe('festivals public API barrel', () => {
     expect(typeof festivals.formatFestivalLocation).toBe('function')
     expect(typeof festivals.formatFestivalDateRange).toBe('function')
     expect(typeof festivals.formatFestivalDates).toBe('function')
-    expect(typeof festivals.getTierBarWidth).toBe('function')
     expect(Array.isArray(festivals.FESTIVAL_STATUSES)).toBe(true)
     expect(Array.isArray(festivals.BILLING_TIERS)).toBe(true)
     expect(festivals.BILLING_TIER_ORDER).toBe(festivals.BILLING_TIERS)

--- a/frontend/features/festivals/index.ts
+++ b/frontend/features/festivals/index.ts
@@ -44,7 +44,6 @@ export {
   formatFestivalLocation,
   formatFestivalDateRange,
   formatFestivalDates,
-  getTierBarWidth,
 } from './types'
 
 // Hooks

--- a/frontend/features/festivals/types.test.ts
+++ b/frontend/features/festivals/types.test.ts
@@ -11,7 +11,6 @@ import {
   formatFestivalLocation,
   formatFestivalDateRange,
   formatFestivalDates,
-  getTierBarWidth,
 } from './types'
 
 describe('status constants', () => {
@@ -128,18 +127,3 @@ describe('formatFestivalDateRange', () => {
   })
 })
 
-describe('getTierBarWidth', () => {
-  it('returns a descending width per known tier', () => {
-    expect(getTierBarWidth('headliner')).toBe(100)
-    expect(getTierBarWidth('sub_headliner')).toBe(80)
-    expect(getTierBarWidth('mid_card')).toBe(60)
-    expect(getTierBarWidth('undercard')).toBe(40)
-    expect(getTierBarWidth('local')).toBe(25)
-    expect(getTierBarWidth('dj')).toBe(25)
-    expect(getTierBarWidth('host')).toBe(15)
-  })
-
-  it('falls back to 30 for unknown tiers', () => {
-    expect(getTierBarWidth('mystery')).toBe(30)
-  })
-})

--- a/frontend/features/festivals/types.ts
+++ b/frontend/features/festivals/types.ts
@@ -324,16 +324,3 @@ export interface SeriesComparison {
   lineup_growth: number
 }
 
-/** Width percentage for trajectory bar chart based on billing tier */
-export function getTierBarWidth(tier: string): number {
-  switch (tier) {
-    case 'headliner': return 100
-    case 'sub_headliner': return 80
-    case 'mid_card': return 60
-    case 'undercard': return 40
-    case 'local': return 25
-    case 'dj': return 25
-    case 'host': return 15
-    default: return 30
-  }
-}


### PR DESCRIPTION
Closes PSY-1070.

## Summary

The artist page's **Festival History** section drops its tier-width bar chart for **dense appearance rows**, per the approved Figma design (Product Designs file → **Artists** page — the artist page's first Figma artifact, built this session):

- **YEAR** (mono, muted) · **FESTIVAL** (full linked name in the primary slot — previously truncated to 140px at the far right) · **BILLED AS** (tier label as plain text)
- Header renamed "Festival History" → **"Festival appearances"**
- Collapsed-by-default + `[Show]`/`[Hide]` toggle (PSY-644) and the factual "N festival appearances" footer (PSY-1056) unchanged
- `getTierBarWidth` removed end to end — the bars were its only consumer (verified): function, tests, barrel export

Why: bar width encoded billing tier — pure decoration (two mid-card appearances rendered as two identical salmon blocks) while exiling the actual content. The new rows match the DenseTable idiom the discography uses directly above.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `features/festivals` + `features/artists` suites — 38 files / 404 tests pass (chart heading assertions updated)
- [x] `bun run lint` — clean on changed files
- [x] Zero `getTierBarWidth` references repo-wide
- [x] Manual repro on an isolated dispatch stack: seeded Snooper with two mid-card festival appearances, verified collapsed default + [Show]/[Hide] toggle + row rendering live (screenshots below)

## Screenshots

**Expanded** — YEAR · full linked FESTIVAL · BILLED AS, mono count footer (matches the Figma Artists board):
![expanded](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-0bccb4404a0848757201/psy1070-expanded.png)

**Collapsed (default)** — header + [Show] bracket only:
![collapsed](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-0bccb4404a0848757201/psy1070-collapsed.png)

## Coverage gaps

- Dark mode not visually verified (semantic tokens only; no hardcoded colors added).
