### PR TITLE
PSY-1058: profile stats sidebar to Figma board fidelity

### DIFF
--- a/frontend/app/users/me/page.tsx
+++ b/frontend/app/users/me/page.tsx
@@ -130,14 +130,14 @@ export default function SelfProfilePage() {
           <GetStartedChecklist />
         </div>
 
-        <aside className="w-full shrink-0 lg:w-80">
+        <aside className="order-first w-full shrink-0 lg:order-none lg:w-80">
           {/* No username yet, so the expanded panel's per-username endpoints
               can't resolve — render the card non-expandable (board B shows the
               zero state with the onboarding hint instead of the expander). */}
           <ProfileStatsSidebar
             username=""
             stats={profile?.stats}
-            collectionsTotal={myCollections?.total ?? 0}
+            collectionsTotal={myCollections?.total}
             isOwner
             expandable={false}
           />

--- a/frontend/app/users/me/page.tsx
+++ b/frontend/app/users/me/page.tsx
@@ -7,9 +7,11 @@ import { Loader2, Flag, Pencil } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { SectionHeader } from '@/components/shared/SectionHeader'
 import { GetStartedChecklist } from '@/components/contributor/GetStartedChecklist'
+import { ProfileStatsSidebar } from '@/components/contributor/ProfileStatsSidebar'
 import { UserTierBadge } from '@/components/contributor/UserTierBadge'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useOwnContributorProfile } from '@/features/auth'
+import { useMyCollections } from '@/features/collections'
 
 function CenteredSpinner() {
   return (
@@ -36,6 +38,10 @@ export default function SelfProfilePage() {
   const router = useRouter()
   const { user, isAuthenticated, isLoading } = useAuthContext()
   const { data: profile } = useOwnContributorProfile()
+  // Own-collections total for the stats card. The public count is
+  // username-keyed and can't resolve here; the self view counts the user's
+  // own collections instead (includes private ones — it's their own card).
+  const { data: myCollections } = useMyCollections()
 
   useEffect(() => {
     if (isLoading) return
@@ -87,38 +93,55 @@ export default function SelfProfilePage() {
         </div>
       </header>
 
-      {/* Claim-username banner */}
-      <div className="mb-8 flex items-center gap-4 rounded-md border border-border bg-muted/40 px-4 py-3.5">
-        <div className="min-w-0 flex-1">
-          <p className="flex items-center gap-1.5 text-sm font-semibold">
-            <Flag className="h-3.5 w-3.5 text-primary" aria-hidden />
-            Claim your username
-          </p>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            Your public profile lives at /users/&lt;username&gt; — pick a
-            handle to make it shareable.
-          </p>
-        </div>
-        <Button asChild size="sm" className="shrink-0">
-          <Link href="/profile">Set username</Link>
-        </Button>
-      </div>
-
-      <div className="max-w-2xl space-y-8">
-        <section aria-label="Bio">
-          <SectionHeader title="Bio" as="h2" size="md" />
-          <div className="mt-2 flex items-center justify-between gap-3 rounded-md border border-dashed border-border bg-muted/20 px-4 py-3">
-            <p className="text-sm text-muted-foreground">
-              Add a short bio so people know who you are — the scenes you
-              haunt, what you&apos;re into.
-            </p>
-            <Button asChild variant="outline" size="sm" className="shrink-0">
-              <Link href="/profile">Add bio</Link>
+      {/* Two-column body mirroring the public profile (design board B):
+          onboarding content leads, the zeroed stats card sits in the rail. */}
+      <div className="flex flex-col gap-10 lg:flex-row">
+        <div className="min-w-0 flex-1 space-y-8">
+          {/* Claim-username banner */}
+          <div className="flex items-center gap-4 rounded-md border border-border bg-muted/40 px-4 py-3.5">
+            <div className="min-w-0 flex-1">
+              <p className="flex items-center gap-1.5 text-sm font-semibold">
+                <Flag className="h-3.5 w-3.5 text-primary" aria-hidden />
+                Claim your username
+              </p>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                Your public profile lives at /users/&lt;username&gt; — pick a
+                handle to make it shareable.
+              </p>
+            </div>
+            <Button asChild size="sm" className="shrink-0">
+              <Link href="/profile">Set username</Link>
             </Button>
           </div>
-        </section>
 
-        <GetStartedChecklist />
+          <section aria-label="Bio">
+            <SectionHeader title="Bio" as="h2" size="md" />
+            <div className="mt-2 flex items-center justify-between gap-3 rounded-md border border-dashed border-border bg-muted/20 px-4 py-3">
+              <p className="text-sm text-muted-foreground">
+                Add a short bio so people know who you are — the scenes you
+                haunt, what you&apos;re into.
+              </p>
+              <Button asChild variant="outline" size="sm" className="shrink-0">
+                <Link href="/profile">Add bio</Link>
+              </Button>
+            </div>
+          </section>
+
+          <GetStartedChecklist />
+        </div>
+
+        <aside className="w-full shrink-0 lg:w-80">
+          {/* No username yet, so the expanded panel's per-username endpoints
+              can't resolve — render the card non-expandable (board B shows the
+              zero state with the onboarding hint instead of the expander). */}
+          <ProfileStatsSidebar
+            username=""
+            stats={profile?.stats}
+            collectionsTotal={myCollections?.total ?? 0}
+            isOwner
+            expandable={false}
+          />
+        </aside>
       </div>
     </div>
   )

--- a/frontend/components/contributor/ActivityHeatmap.test.tsx
+++ b/frontend/components/contributor/ActivityHeatmap.test.tsx
@@ -142,13 +142,13 @@ describe('ActivityHeatmap', () => {
 
     render(<ActivityHeatmap username="alice" />)
 
-    // Max cell should have emerald-700 (level 4 dark)
+    // Max cell should have the full primary token (level 4)
     const maxCell = screen.getByTestId('heatmap-cell-2026-03-31')
-    expect(maxCell.className).toContain('emerald-700')
+    expect(maxCell.className).toMatch(/(?:^|\s)bg-primary(?:\s|$)/)
 
-    // Low cell should have emerald-200 (level 1)
+    // Low cell should have primary/25 (level 1)
     const lowCell = screen.getByTestId('heatmap-cell-2026-03-30')
-    expect(lowCell.className).toContain('emerald-200')
+    expect(lowCell.className).toContain('bg-primary/25')
   })
 
   it('renders legend with Less/More labels', () => {
@@ -256,7 +256,7 @@ describe('ActivityHeatmap', () => {
       expect(cell.className).toContain('bg-muted/40')
     })
 
-    it('ratio === 0.25 boundary stays on level 1 (emerald-200)', () => {
+    it('ratio === 0.25 boundary stays on level 1 (primary/25)', () => {
       mockUseActivityHeatmap.mockReturnValue({
         data: {
           days: [
@@ -268,10 +268,10 @@ describe('ActivityHeatmap', () => {
       })
       render(<ActivityHeatmap username="alice" />)
       const cell = screen.getByTestId('heatmap-cell-2026-03-31')
-      expect(cell.className).toContain('emerald-200')
+      expect(cell.className).toContain('bg-primary/25')
     })
 
-    it('ratio === 0.50 boundary stays on level 2 (emerald-300)', () => {
+    it('ratio === 0.50 boundary stays on level 2 (primary/50)', () => {
       mockUseActivityHeatmap.mockReturnValue({
         data: {
           days: [
@@ -283,10 +283,10 @@ describe('ActivityHeatmap', () => {
       })
       render(<ActivityHeatmap username="alice" />)
       const cell = screen.getByTestId('heatmap-cell-2026-03-31')
-      expect(cell.className).toContain('emerald-300')
+      expect(cell.className).toContain('bg-primary/50')
     })
 
-    it('ratio === 0.75 boundary stays on level 3 (emerald-500)', () => {
+    it('ratio === 0.75 boundary stays on level 3 (primary/75)', () => {
       mockUseActivityHeatmap.mockReturnValue({
         data: {
           days: [
@@ -298,11 +298,10 @@ describe('ActivityHeatmap', () => {
       })
       render(<ActivityHeatmap username="alice" />)
       const cell = screen.getByTestId('heatmap-cell-2026-03-31')
-      // emerald-500 — be explicit to disambiguate from level-2 (-300) and level-4 (-700)
-      expect(cell.className).toMatch(/(?:^|\s)bg-emerald-500(?:\s|$)/)
+      expect(cell.className).toContain('bg-primary/75')
     })
 
-    it('ratio > 0.75 maps to level 4 (emerald-700)', () => {
+    it('ratio > 0.75 maps to level 4 (bare primary)', () => {
       mockUseActivityHeatmap.mockReturnValue({
         data: {
           days: [
@@ -313,7 +312,7 @@ describe('ActivityHeatmap', () => {
       })
       render(<ActivityHeatmap username="alice" />)
       const cell = screen.getByTestId('heatmap-cell-2026-03-31')
-      expect(cell.className).toContain('emerald-700')
+      expect(cell.className).toMatch(/(?:^|\s)bg-primary(?:\s|$)/)
     })
   })
 

--- a/frontend/components/contributor/ActivityHeatmap.tsx
+++ b/frontend/components/contributor/ActivityHeatmap.tsx
@@ -57,14 +57,15 @@ function formatTooltipDate(date: Date): string {
 
 /**
  * Map intensity level (0-4) to a Tailwind class for the cell background.
- * Uses emerald shades with dark mode variants.
+ * Opacity ramp on the primary token (design board G) so the scale tracks
+ * both themes without per-mode overrides.
  */
 const INTENSITY_CLASSES = [
-  'bg-muted/40',                                          // 0: no activity
-  'bg-emerald-200 dark:bg-emerald-900/70',                // level 1
-  'bg-emerald-300 dark:bg-emerald-700',                   // level 2
-  'bg-emerald-500 dark:bg-emerald-500',                   // level 3
-  'bg-emerald-700 dark:bg-emerald-300',                   // level 4: max
+  'bg-muted/40',      // 0: no activity
+  'bg-primary/25',    // level 1
+  'bg-primary/50',    // level 2
+  'bg-primary/75',    // level 3
+  'bg-primary',       // level 4: max
 ]
 
 function getIntensityLevel(count: number, maxCount: number): number {

--- a/frontend/components/contributor/PercentileRankings.test.tsx
+++ b/frontend/components/contributor/PercentileRankings.test.tsx
@@ -65,8 +65,10 @@ describe('PercentileRankings', () => {
     })
 
     render(<PercentileRankings username="alice" />)
-    // Should have skeleton elements (card renders)
-    expect(document.querySelectorAll('[class*="animate-pulse"], [data-slot="skeleton"]').length).toBeGreaterThan(0)
+    expect(
+      document.querySelectorAll('[class*="animate-pulse"], [data-slot="skeleton"]')
+        .length
+    ).toBeGreaterThan(0)
   })
 
   it('renders nothing when no data (error)', () => {
@@ -91,7 +93,7 @@ describe('PercentileRankings', () => {
     expect(container.innerHTML).toBe('')
   })
 
-  it('renders overall score badge', () => {
+  it('renders the section header with the overall standing (board G)', () => {
     mockUsePercentileRankings.mockReturnValue({
       data: makeRankings(),
       isLoading: false,
@@ -99,7 +101,8 @@ describe('PercentileRankings', () => {
     })
 
     render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('Top 35% overall')).toBeInTheDocument()
+    expect(screen.getByText('Percentile rankings')).toBeInTheDocument()
+    expect(screen.getByText('overall · top 35%')).toBeInTheDocument()
   })
 
   it('renders all ranking dimension labels', () => {
@@ -117,7 +120,7 @@ describe('PercentileRankings', () => {
     expect(screen.getByText('Requests Fulfilled')).toBeInTheDocument()
   })
 
-  it('renders "Top X%" for each dimension', () => {
+  it('renders "top X%" for each dimension', () => {
     mockUsePercentileRankings.mockReturnValue({
       data: makeRankings(),
       isLoading: false,
@@ -125,11 +128,11 @@ describe('PercentileRankings', () => {
     })
 
     render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('Top 20%')).toBeInTheDocument() // 80 percentile
-    expect(screen.getByText('Top 40%')).toBeInTheDocument() // 60 percentile
-    expect(screen.getByText('Top 60%')).toBeInTheDocument() // 40 percentile
-    expect(screen.getByText('Top 80%')).toBeInTheDocument() // 20 percentile
-    expect(screen.getByText('Top 10%')).toBeInTheDocument() // 90 percentile
+    expect(screen.getByText('top 20%')).toBeInTheDocument() // 80 percentile
+    expect(screen.getByText('top 40%')).toBeInTheDocument() // 60 percentile
+    expect(screen.getByText('top 60%')).toBeInTheDocument() // 40 percentile
+    expect(screen.getByText('top 80%')).toBeInTheDocument() // 20 percentile
+    expect(screen.getByText('top 10%')).toBeInTheDocument() // 90 percentile
   })
 
   it('renders progress bars with correct widths', () => {
@@ -151,51 +154,7 @@ describe('PercentileRankings', () => {
     expect(widths).toContain('90%')
   })
 
-  it('renders green color for high percentile (>= 75)', () => {
-    mockUsePercentileRankings.mockReturnValue({
-      data: makeRankings({
-        rankings: [
-          {
-            dimension: 'shows_submitted',
-            label: 'Shows Submitted',
-            percentile: 85,
-            value: 20,
-          },
-        ],
-        overall_score: 85,
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    render(<PercentileRankings username="alice" />)
-    const progressBar = document.querySelector('[style*="width: 85%"]')
-    expect(progressBar?.className).toContain('bg-green-500')
-  })
-
-  it('renders red color for low percentile (< 25)', () => {
-    mockUsePercentileRankings.mockReturnValue({
-      data: makeRankings({
-        rankings: [
-          {
-            dimension: 'shows_submitted',
-            label: 'Shows Submitted',
-            percentile: 10,
-            value: 1,
-          },
-        ],
-        overall_score: 10,
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    render(<PercentileRankings username="alice" />)
-    const progressBar = document.querySelector('[style*="width: 10%"]')
-    expect(progressBar?.className).toContain('bg-red-500')
-  })
-
-  it('renders heading text "Rankings"', () => {
+  it('renders every bar fill in the primary token (single-hue, board G)', () => {
     mockUsePercentileRankings.mockReturnValue({
       data: makeRankings(),
       isLoading: false,
@@ -203,10 +162,14 @@ describe('PercentileRankings', () => {
     })
 
     render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('Rankings')).toBeInTheDocument()
+    const fills = document.querySelectorAll('div.h-full')
+    expect(fills.length).toBe(5)
+    fills.forEach(fill => {
+      expect(fill.className).toContain('bg-primary')
+    })
   })
 
-  it('only shows overall badge when rankings array is empty (count_only privacy)', () => {
+  it('only shows overall standing when rankings array is empty (count_only privacy)', () => {
     mockUsePercentileRankings.mockReturnValue({
       data: makeRankings({
         rankings: [],
@@ -217,44 +180,9 @@ describe('PercentileRankings', () => {
     })
 
     render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('Top 50% overall')).toBeInTheDocument()
+    expect(screen.getByText('overall · top 50%')).toBeInTheDocument()
     // No individual dimension labels
     expect(screen.queryByText('Shows Submitted')).not.toBeInTheDocument()
-  })
-
-  it('renders value counts for each dimension', () => {
-    mockUsePercentileRankings.mockReturnValue({
-      data: makeRankings(),
-      isLoading: false,
-      error: null,
-    })
-
-    render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('15')).toBeInTheDocument()
-    expect(screen.getByText('5')).toBeInTheDocument()
-    expect(screen.getByText('8')).toBeInTheDocument()
-    expect(screen.getByText('2')).toBeInTheDocument()
-    expect(screen.getByText('12')).toBeInTheDocument()
-  })
-
-  it('formats large values with k suffix', () => {
-    mockUsePercentileRankings.mockReturnValue({
-      data: makeRankings({
-        rankings: [
-          {
-            dimension: 'tags_applied',
-            label: 'Tags Applied',
-            percentile: 99,
-            value: 1500,
-          },
-        ],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('1.5k')).toBeInTheDocument()
   })
 
   it('passes username to the hook', () => {
@@ -266,79 +194,6 @@ describe('PercentileRankings', () => {
 
     render(<PercentileRankings username="testuser" />)
     expect(mockUsePercentileRankings).toHaveBeenCalledWith('testuser')
-  })
-
-  // COLOR BOUNDARY COVERAGE
-  // The helpers split percentile into 4 bands: <25 red, [25,50) orange,
-  // [50,75) yellow, >=75 green. The existing tests cover high/low;
-  // these tests pin the two middle bands so a future refactor can't
-  // silently re-band the colors.
-  describe('color band mapping', () => {
-    it('renders yellow color for [50, 75) band — boundary at 50', () => {
-      mockUsePercentileRankings.mockReturnValue({
-        data: makeRankings({
-          rankings: [
-            {
-              dimension: 'shows_submitted',
-              label: 'Shows Submitted',
-              percentile: 50,
-              value: 5,
-            },
-          ],
-          overall_score: 50,
-        }),
-        isLoading: false,
-        error: null,
-      })
-
-      render(<PercentileRankings username="alice" />)
-      const progressBar = document.querySelector('[style*="width: 50%"]')
-      expect(progressBar?.className).toContain('bg-yellow-500')
-    })
-
-    it('renders orange color for [25, 50) band — boundary at 25', () => {
-      mockUsePercentileRankings.mockReturnValue({
-        data: makeRankings({
-          rankings: [
-            {
-              dimension: 'shows_submitted',
-              label: 'Shows Submitted',
-              percentile: 25,
-              value: 2,
-            },
-          ],
-          overall_score: 25,
-        }),
-        isLoading: false,
-        error: null,
-      })
-
-      render(<PercentileRankings username="alice" />)
-      const progressBar = document.querySelector('[style*="width: 25%"]')
-      expect(progressBar?.className).toContain('bg-orange-500')
-    })
-
-    it('green boundary at exactly 75 still uses green', () => {
-      mockUsePercentileRankings.mockReturnValue({
-        data: makeRankings({
-          rankings: [
-            {
-              dimension: 'shows_submitted',
-              label: 'Shows Submitted',
-              percentile: 75,
-              value: 10,
-            },
-          ],
-          overall_score: 75,
-        }),
-        isLoading: false,
-        error: null,
-      })
-
-      render(<PercentileRankings username="alice" />)
-      const progressBar = document.querySelector('[style*="width: 75%"]')
-      expect(progressBar?.className).toContain('bg-green-500')
-    })
   })
 
   // MIN-WIDTH GUARD
@@ -365,7 +220,7 @@ describe('PercentileRankings', () => {
 
       render(<PercentileRankings username="alice" />)
       // The visible bar should be 2% wide (min), not 0%.
-      const bar = document.querySelector('div.h-full.rounded-full') as HTMLElement | null
+      const bar = document.querySelector('div.h-full.bg-primary') as HTMLElement | null
       expect(bar).not.toBeNull()
       expect(bar?.style.width).toBe('2%')
     })
@@ -388,49 +243,8 @@ describe('PercentileRankings', () => {
       })
 
       render(<PercentileRankings username="alice" />)
-      const bar = document.querySelector('div.h-full.rounded-full') as HTMLElement | null
+      const bar = document.querySelector('div.h-full.bg-primary') as HTMLElement | null
       expect(bar?.style.width).toBe('2%')
     })
-  })
-
-  // VALUE FORMAT EDGE CASES
-  it('formats exactly 1000 as "1.0k"', () => {
-    mockUsePercentileRankings.mockReturnValue({
-      data: makeRankings({
-        rankings: [
-          {
-            dimension: 'tags_applied',
-            label: 'Tags Applied',
-            percentile: 99,
-            value: 1000,
-          },
-        ],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('1.0k')).toBeInTheDocument()
-  })
-
-  it('formats 999 as plain "999" (no k suffix)', () => {
-    mockUsePercentileRankings.mockReturnValue({
-      data: makeRankings({
-        rankings: [
-          {
-            dimension: 'tags_applied',
-            label: 'Tags Applied',
-            percentile: 99,
-            value: 999,
-          },
-        ],
-      }),
-      isLoading: false,
-      error: null,
-    })
-
-    render(<PercentileRankings username="alice" />)
-    expect(screen.getByText('999')).toBeInTheDocument()
   })
 })

--- a/frontend/components/contributor/PercentileRankings.tsx
+++ b/frontend/components/contributor/PercentileRankings.tsx
@@ -1,61 +1,31 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Trophy } from 'lucide-react'
+import { SectionHeader } from '@/components/shared/SectionHeader'
 import { usePercentileRankings } from '@/features/auth'
 import type { PercentileRanking } from '@/features/auth'
 
-function getPercentileColor(percentile: number): string {
-  if (percentile >= 75) return 'bg-green-500'
-  if (percentile >= 50) return 'bg-yellow-500'
-  if (percentile >= 25) return 'bg-orange-500'
-  return 'bg-red-500'
-}
-
-function getPercentileTextColor(percentile: number): string {
-  if (percentile >= 75) return 'text-green-500'
-  if (percentile >= 50) return 'text-yellow-500'
-  if (percentile >= 25) return 'text-orange-500'
-  return 'text-red-500'
-}
-
-function formatDimensionValue(value: number): string {
-  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`
-  return String(value)
-}
-
+/**
+ * Percentile-ranking bars for the profile stats expander (design board G):
+ * editorial single-hue treatment — primary-colored fill on a muted track,
+ * "top N%" in mono — replacing the old traffic-light Card (PSY-1058). Bar
+ * width is the user's percentile standing, so "top 4%" renders nearly full.
+ */
 function RankingBar({ ranking }: { ranking: PercentileRanking }) {
   return (
-    <div className="space-y-1.5">
-      <div className="flex items-center justify-between text-sm">
-        <span className="text-muted-foreground">{ranking.label}</span>
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">
-            {formatDimensionValue(ranking.value)}
-          </span>
-          <span className={`text-xs font-medium ${getPercentileTextColor(ranking.percentile)}`}>
-            Top {100 - ranking.percentile}%
-          </span>
-        </div>
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm">{ranking.label}</span>
+        <span className="shrink-0 font-mono text-xs tabular-nums">
+          top {100 - ranking.percentile}%
+        </span>
       </div>
-      <div className="h-2 w-full rounded-full bg-muted">
+      <div className="h-1.5 w-full bg-muted">
         <div
-          className={`h-full rounded-full transition-all ${getPercentileColor(ranking.percentile)}`}
+          className="h-full bg-primary transition-all"
           style={{ width: `${Math.max(ranking.percentile, 2)}%` }}
         />
       </div>
-    </div>
-  )
-}
-
-function OverallBadge({ score }: { score: number }) {
-  return (
-    <div className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/30 px-3 py-2">
-      <Trophy className={`h-4 w-4 ${getPercentileTextColor(score)}`} />
-      <span className="text-sm font-medium">
-        Top {100 - score}% overall
-      </span>
     </div>
   )
 }
@@ -69,19 +39,15 @@ export function PercentileRankings({ username }: PercentileRankingsProps) {
 
   if (isLoading) {
     return (
-      <Card className="bg-muted/30 border-border/50">
-        <CardHeader className="pb-3">
-          <Skeleton className="h-5 w-40" />
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="space-y-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-2 w-full" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-40" />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="space-y-1.5">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-1.5 w-full" />
+          </div>
+        ))}
+      </div>
     )
   }
 
@@ -93,20 +59,22 @@ export function PercentileRankings({ username }: PercentileRankingsProps) {
   const hasDetailedRankings = rankings.rankings.length > 0
 
   return (
-    <Card className="bg-muted/30 border-border/50">
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-base font-semibold">Rankings</CardTitle>
-          <OverallBadge score={rankings.overall_score} />
-        </div>
-      </CardHeader>
+    <div>
+      <SectionHeader
+        title="Percentile rankings"
+        action={
+          <span className="font-mono text-xs text-primary">
+            overall · top {100 - rankings.overall_score}%
+          </span>
+        }
+      />
       {hasDetailedRankings && (
-        <CardContent className="space-y-3">
-          {rankings.rankings.map((ranking) => (
+        <div className="mt-1 space-y-2.5">
+          {rankings.rankings.map(ranking => (
             <RankingBar key={ranking.dimension} ranking={ranking} />
           ))}
-        </CardContent>
+        </div>
       )}
-    </Card>
+    </div>
   )
 }

--- a/frontend/components/contributor/ProfileStatsSidebar.test.tsx
+++ b/frontend/components/contributor/ProfileStatsSidebar.test.tsx
@@ -169,6 +169,25 @@ describe('ProfileStatsSidebar', () => {
       ).not.toBeInTheDocument()
     })
 
+    it('keeps the expander (and drops the hint) when only breakdown rows are non-zero', () => {
+      // Follows / subscriptions / followers are NOT counted in
+      // total_contributions; the expander is their only surface.
+      render(
+        <ProfileStatsSidebar
+          username="alice"
+          stats={makeStats({ following_count: 5 })}
+          collectionsTotal={0}
+          isOwner
+        />
+      )
+      expect(
+        screen.getByRole('button', { name: /show all statistics/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(/Log a show or follow an artist/)
+      ).not.toBeInTheDocument()
+    })
+
     it('omits the owner-directed hint for visitors', () => {
       render(
         <ProfileStatsSidebar

--- a/frontend/components/contributor/ProfileStatsSidebar.test.tsx
+++ b/frontend/components/contributor/ProfileStatsSidebar.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ProfileStatsSidebar } from './ProfileStatsSidebar'
+import type { ContributionStats } from '@/features/auth'
+
+vi.mock('./ActivityHeatmap', () => ({
+  ActivityHeatmap: ({ username }: { username: string }) => (
+    <div data-testid="activity-heatmap">Heatmap for {username}</div>
+  ),
+}))
+
+vi.mock('./PercentileRankings', () => ({
+  PercentileRankings: () => (
+    <div data-testid="percentile-rankings">Rankings</div>
+  ),
+}))
+
+function makeStats(
+  overrides: Partial<ContributionStats> = {}
+): ContributionStats {
+  return {
+    shows_submitted: 0,
+    venues_submitted: 0,
+    venue_edits_submitted: 0,
+    releases_created: 0,
+    labels_created: 0,
+    festivals_created: 0,
+    artists_edited: 0,
+    revisions_made: 0,
+    pending_edits_submitted: 0,
+    tag_votes_cast: 0,
+    relationship_votes_cast: 0,
+    request_votes_cast: 0,
+    collection_items_added: 0,
+    collection_subscriptions: 0,
+    shows_attended: 0,
+    reports_filed: 0,
+    reports_resolved: 0,
+    followers_count: 0,
+    following_count: 0,
+    moderation_actions: 0,
+    total_contributions: 0,
+    ...overrides,
+  } as ContributionStats
+}
+
+describe('ProfileStatsSidebar', () => {
+  it('renders nothing when stats are hidden and no count is available', () => {
+    const { container } = render(
+      <ProfileStatsSidebar username="alice" stats={undefined} statsCount={undefined} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders headline numerals with board-A lowercase labels', () => {
+    render(
+      <ProfileStatsSidebar
+        username="alice"
+        stats={makeStats({ shows_attended: 127, total_contributions: 340 })}
+        collectionsTotal={8}
+      />
+    )
+    expect(screen.getByText('127')).toBeInTheDocument()
+    expect(screen.getByText('shows attended')).toBeInTheDocument()
+    expect(screen.getByText('8')).toBeInTheDocument()
+    expect(screen.getByText('collections')).toBeInTheDocument()
+    expect(screen.getByText('340')).toBeInTheDocument()
+    expect(screen.getByText('contributions')).toBeInTheDocument()
+  })
+
+  it('formats approval_rate as a percentage from the 0-1 backend fraction', () => {
+    render(
+      <ProfileStatsSidebar
+        username="alice"
+        stats={makeStats({ total_contributions: 340, approval_rate: 0.92 })}
+      />
+    )
+    expect(screen.getByText('92%')).toBeInTheDocument()
+    expect(screen.getByText('approval rate')).toBeInTheDocument()
+  })
+
+  it('omits the approval rate row when approval_rate is absent', () => {
+    render(
+      <ProfileStatsSidebar
+        username="alice"
+        stats={makeStats({ total_contributions: 5 })}
+      />
+    )
+    expect(screen.queryByText('approval rate')).not.toBeInTheDocument()
+  })
+
+  it('shows the expander affordance with the contents explainer when collapsed', () => {
+    render(
+      <ProfileStatsSidebar
+        username="alice"
+        stats={makeStats({ total_contributions: 5 })}
+      />
+    )
+    expect(
+      screen.getByRole('button', { name: /show all statistics/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'full counters · 365-day activity heatmap · percentile rankings'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('expands to the breakdown list, heatmap and rankings, then collapses', () => {
+    render(
+      <ProfileStatsSidebar
+        username="alice"
+        stats={makeStats({
+          shows_submitted: 86,
+          tag_votes_cast: 120,
+          total_contributions: 206,
+        })}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /show all statistics/i }))
+
+    expect(screen.getByText('All contributions')).toBeInTheDocument()
+    expect(screen.getByText('Shows submitted')).toBeInTheDocument()
+    expect(screen.getByText('86')).toBeInTheDocument()
+    expect(screen.getByText('Tag votes')).toBeInTheDocument()
+    // Zero rows are filtered from the dense list.
+    expect(screen.queryByText('Venues submitted')).not.toBeInTheDocument()
+    expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument()
+    expect(screen.getByTestId('percentile-rankings')).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /hide the full statistics/i })
+    )
+    expect(screen.queryByText('All contributions')).not.toBeInTheDocument()
+  })
+
+  it('suppresses the expander when expandable is false', () => {
+    render(
+      <ProfileStatsSidebar
+        username=""
+        stats={makeStats({ total_contributions: 5 })}
+        expandable={false}
+      />
+    )
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /show all statistics/i })
+    ).not.toBeInTheDocument()
+  })
+
+  describe('zero state (board B)', () => {
+    it('shows zeroed numerals, the owner onboarding hint, and no expander', () => {
+      render(
+        <ProfileStatsSidebar
+          username="alice"
+          stats={makeStats()}
+          collectionsTotal={0}
+          isOwner
+        />
+      )
+      expect(screen.getAllByText('0')).toHaveLength(3)
+      expect(
+        screen.getByText(
+          'Log a show or follow an artist and your profile starts filling in.'
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /show all statistics/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('omits the owner-directed hint for visitors', () => {
+      render(
+        <ProfileStatsSidebar
+          username="alice"
+          stats={makeStats()}
+          collectionsTotal={0}
+        />
+      )
+      expect(
+        screen.queryByText(/Log a show or follow an artist/)
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /show all statistics/i })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('count-only fallback', () => {
+    it('renders a single contributions numeral without an expander', () => {
+      render(<ProfileStatsSidebar username="alice" statsCount={42} />)
+      expect(screen.getByText('42')).toBeInTheDocument()
+      expect(screen.getByText('contributions')).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /show all statistics/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders nothing when the count is zero', () => {
+      const { container } = render(
+        <ProfileStatsSidebar username="alice" statsCount={0} />
+      )
+      expect(container.innerHTML).toBe('')
+    })
+  })
+})

--- a/frontend/components/contributor/ProfileStatsSidebar.tsx
+++ b/frontend/components/contributor/ProfileStatsSidebar.tsx
@@ -2,10 +2,8 @@
 
 import { useState } from 'react'
 import { SectionHeader } from '@/components/shared/SectionHeader'
-import { StatsList } from '@/components/shared/StatsList'
-import { BracketLink } from '@/components/shared/BracketLink'
+import { statNumberFormatter } from '@/components/shared/StatsList'
 import { ActivityHeatmap } from './ActivityHeatmap'
-import { ContributionStatsGrid } from './ContributionStatsGrid'
 import { PercentileRankings } from './PercentileRankings'
 import type { ContributionStats } from '@/features/auth'
 
@@ -16,20 +14,100 @@ interface ProfileStatsSidebarProps {
   statsCount?: number
   /** Total public collections (from the collections query), shown as a headline stat. */
   collectionsTotal?: number
+  /**
+   * Viewer owns this profile. Gates the zero-state onboarding hint, whose copy
+   * addresses the profile owner ("Log a show…"), not a visitor.
+   */
+  isOwner?: boolean
+  /**
+   * Whether the "Show all stats" expander is available. The claim state
+   * (/users/me) has no username yet, so the heatmap / rankings endpoints the
+   * expanded panel fetches from can't resolve — it passes false.
+   */
+  expandable?: boolean
+}
+
+interface HeadlineStat {
+  label: string
+  value: string
 }
 
 /**
- * The right-rail statistics card (PSY-1045). The What.cd-style dashboard is
- * deliberately DEMOTED here: a few headline numbers always visible, with the
- * full counters + activity heatmap + percentile rankings behind a collapsed
- * "Show all stats" expander. This inverts the old layout where the ~20-counter
- * grid led the page.
+ * The breakdown rows for the expanded "All contributions" panel (design board
+ * G). Shows attended and approval rate are headline stats, so they're not
+ * repeated here. NOTE: deliberately NOT the icon-card <ContributionStatsGrid>
+ * — that component still serves the /profile preview card (PSY-1061 owns its
+ * fate); this dense list is the sidebar's own rendering.
+ */
+const ALL_CONTRIBUTION_ROWS: {
+  label: string
+  key: Exclude<keyof ContributionStats, 'approval_rate'>
+}[] = [
+  { label: 'Shows submitted', key: 'shows_submitted' },
+  { label: 'Venues submitted', key: 'venues_submitted' },
+  { label: 'Venue edits', key: 'venue_edits_submitted' },
+  { label: 'Releases created', key: 'releases_created' },
+  { label: 'Labels created', key: 'labels_created' },
+  { label: 'Festivals created', key: 'festivals_created' },
+  { label: 'Artists edited', key: 'artists_edited' },
+  { label: 'Revisions', key: 'revisions_made' },
+  { label: 'Pending edits', key: 'pending_edits_submitted' },
+  { label: 'Tag votes', key: 'tag_votes_cast' },
+  { label: 'Relationship votes', key: 'relationship_votes_cast' },
+  { label: 'Request votes', key: 'request_votes_cast' },
+  { label: 'Collection items', key: 'collection_items_added' },
+  { label: 'Subscriptions', key: 'collection_subscriptions' },
+  { label: 'Reports filed', key: 'reports_filed' },
+  { label: 'Reports resolved', key: 'reports_resolved' },
+  { label: 'Followers', key: 'followers_count' },
+  { label: 'Following', key: 'following_count' },
+  { label: 'Moderation actions', key: 'moderation_actions' },
+]
+
+function AllContributionsList({ stats }: { stats: ContributionStats }) {
+  const rows = ALL_CONTRIBUTION_ROWS.map(({ label, key }) => ({
+    label,
+    value: stats[key],
+  })).filter(row => row.value !== 0)
+
+  return (
+    <div>
+      <SectionHeader title="All contributions" />
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No contributions yet.</p>
+      ) : (
+        <dl>
+          {rows.map(row => (
+            <div
+              key={row.label}
+              className="flex items-baseline justify-between gap-2 border-b border-border/40 py-1.5"
+            >
+              <dt className="text-sm">{row.label}</dt>
+              <dd className="font-mono text-sm tabular-nums">
+                {statNumberFormatter.format(row.value)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The right-rail statistics card (PSY-1045, restyled to design boards A/B/G in
+ * PSY-1058). The What.cd-style dashboard is deliberately DEMOTED here: a few
+ * headline numbers always visible, with the full counters + activity heatmap +
+ * percentile rankings behind a collapsed "Show all stats" expander. This
+ * inverts the old layout where the ~20-counter grid led the page.
  */
 export function ProfileStatsSidebar({
   username,
   stats,
   statsCount,
   collectionsTotal,
+  isOwner = false,
+  expandable = true,
 }: ProfileStatsSidebarProps) {
   const [expanded, setExpanded] = useState(false)
 
@@ -39,48 +117,111 @@ export function ProfileStatsSidebar({
   // Nothing visible at all (stats hidden, no count) — no card.
   if (!hasFullStats && !hasCountOnly) return null
 
-  const headline = hasFullStats
+  const headline: HeadlineStat[] = hasFullStats
     ? [
-        { label: 'Shows attended', value: stats.shows_attended },
+        {
+          label: 'shows attended',
+          value: statNumberFormatter.format(stats.shows_attended),
+        },
         ...(collectionsTotal !== undefined
-          ? [{ label: 'Collections', value: collectionsTotal }]
+          ? [
+              {
+                label: 'collections',
+                value: statNumberFormatter.format(collectionsTotal),
+              },
+            ]
           : []),
-        { label: 'Contributions', value: stats.total_contributions },
+        {
+          label: 'contributions',
+          value: statNumberFormatter.format(stats.total_contributions),
+        },
         ...(stats.approval_rate !== undefined && stats.approval_rate !== null
           ? [
               {
-                label: 'Approval rate',
-                value: `${Math.round(stats.approval_rate)}%`,
+                label: 'approval rate',
+                // approval_rate is a 0–1 fraction (backend contract).
+                value: `${Math.round(stats.approval_rate * 100)}%`,
               },
             ]
           : []),
       ]
-    : [{ label: 'Contributions', value: statsCount! }]
+    : [
+        {
+          label: 'contributions',
+          value: statNumberFormatter.format(statsCount!),
+        },
+      ]
+
+  // Brand-new profile (design board B): zeroed numerals, no expander — the
+  // expanded panel would be all empty states. Owners get the onboarding hint.
+  const isAllZero =
+    hasFullStats &&
+    stats.shows_attended === 0 &&
+    (collectionsTotal ?? 0) === 0 &&
+    stats.total_contributions === 0
+  const canExpand = expandable && hasFullStats && !isAllZero
 
   return (
-    <section aria-label="Statistics">
+    <section
+      aria-label="Statistics"
+      className="rounded-md border border-border bg-card p-5"
+    >
       <SectionHeader
         title="Statistics"
         action={
-          hasFullStats ? (
-            <BracketLink
-              label={expanded ? 'Hide stats' : 'All stats'}
-              onClick={() => setExpanded(e => !e)}
-              active={expanded}
-              ariaLabel={
-                expanded
-                  ? 'Hide the full statistics dashboard'
-                  : 'Show all statistics, activity heatmap and rankings'
-              }
-            />
+          canExpand && expanded ? (
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              aria-expanded={true}
+              aria-label="Hide the full statistics dashboard"
+              className="font-mono text-xs text-primary hover:underline"
+            >
+              ▴ Hide
+            </button>
           ) : undefined
         }
       />
-      <StatsList items={headline} />
 
-      {hasFullStats && expanded && (
+      <div className="mt-3 space-y-2.5">
+        {headline.map(item => (
+          <div key={item.label} className="flex items-baseline gap-3">
+            <span className="w-14 shrink-0 text-right font-mono text-2xl font-bold leading-none tabular-nums">
+              {item.value}
+            </span>
+            <span className="min-w-0 text-sm text-muted-foreground">
+              {item.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {canExpand && !expanded && (
+        <div className="mt-4 border-t border-border/50 pt-3">
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            aria-expanded={false}
+            aria-label="Show all statistics, activity heatmap and rankings"
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            ▸ Show all stats
+          </button>
+          <p className="mt-1 font-mono text-xs leading-relaxed text-muted-foreground">
+            full counters · 365-day activity heatmap · percentile rankings
+          </p>
+        </div>
+      )}
+
+      {isAllZero && isOwner && (
+        <p className="mt-4 border-t border-border/50 pt-3 text-sm leading-relaxed text-muted-foreground">
+          Log a show or follow an artist and your profile starts filling in.
+        </p>
+      )}
+
+      {canExpand && expanded && (
         <div className="mt-4 space-y-6">
-          <ContributionStatsGrid stats={stats} />
+          <AllContributionsList stats={stats} />
           <div>
             <SectionHeader title="Activity" />
             <ActivityHeatmap username={username} />

--- a/frontend/components/contributor/ProfileStatsSidebar.tsx
+++ b/frontend/components/contributor/ProfileStatsSidebar.tsx
@@ -28,7 +28,10 @@ interface ProfileStatsSidebarProps {
 }
 
 interface HeadlineStat {
+  /** Full label (desktop rail, board A). */
   label: string
+  /** Compact label (mobile strip, board D). */
+  compact: string
   value: string
 }
 
@@ -38,31 +41,41 @@ interface HeadlineStat {
  * repeated here. NOTE: deliberately NOT the icon-card <ContributionStatsGrid>
  * — that component still serves the /profile preview card (PSY-1061 owns its
  * fate); this dense list is the sidebar's own rendering.
+ *
+ * `satisfies Record<BreakdownKey, string>` makes this exhaustive: adding a
+ * numeric field to ContributionStats is a compile error here until it gets a
+ * label (or is excluded as a headline stat). Insertion order is display order.
  */
-const ALL_CONTRIBUTION_ROWS: {
-  label: string
-  key: Exclude<keyof ContributionStats, 'approval_rate'>
-}[] = [
-  { label: 'Shows submitted', key: 'shows_submitted' },
-  { label: 'Venues submitted', key: 'venues_submitted' },
-  { label: 'Venue edits', key: 'venue_edits_submitted' },
-  { label: 'Releases created', key: 'releases_created' },
-  { label: 'Labels created', key: 'labels_created' },
-  { label: 'Festivals created', key: 'festivals_created' },
-  { label: 'Artists edited', key: 'artists_edited' },
-  { label: 'Revisions', key: 'revisions_made' },
-  { label: 'Pending edits', key: 'pending_edits_submitted' },
-  { label: 'Tag votes', key: 'tag_votes_cast' },
-  { label: 'Relationship votes', key: 'relationship_votes_cast' },
-  { label: 'Request votes', key: 'request_votes_cast' },
-  { label: 'Collection items', key: 'collection_items_added' },
-  { label: 'Subscriptions', key: 'collection_subscriptions' },
-  { label: 'Reports filed', key: 'reports_filed' },
-  { label: 'Reports resolved', key: 'reports_resolved' },
-  { label: 'Followers', key: 'followers_count' },
-  { label: 'Following', key: 'following_count' },
-  { label: 'Moderation actions', key: 'moderation_actions' },
-]
+type BreakdownKey = Exclude<
+  keyof ContributionStats,
+  'approval_rate' | 'shows_attended' | 'total_contributions'
+>
+
+const BREAKDOWN_LABELS = {
+  shows_submitted: 'Shows submitted',
+  venues_submitted: 'Venues submitted',
+  venue_edits_submitted: 'Venue edits',
+  releases_created: 'Releases created',
+  labels_created: 'Labels created',
+  festivals_created: 'Festivals created',
+  artists_edited: 'Artists edited',
+  revisions_made: 'Revisions',
+  pending_edits_submitted: 'Pending edits',
+  tag_votes_cast: 'Tag votes',
+  relationship_votes_cast: 'Relationship votes',
+  request_votes_cast: 'Request votes',
+  collection_items_added: 'Collection items',
+  collection_subscriptions: 'Subscriptions',
+  reports_filed: 'Reports filed',
+  reports_resolved: 'Reports resolved',
+  followers_count: 'Followers',
+  following_count: 'Following',
+  moderation_actions: 'Moderation actions',
+} satisfies Record<BreakdownKey, string>
+
+const ALL_CONTRIBUTION_ROWS = (
+  Object.keys(BREAKDOWN_LABELS) as BreakdownKey[]
+).map(key => ({ key, label: BREAKDOWN_LABELS[key] }))
 
 function AllContributionsList({ stats }: { stats: ContributionStats }) {
   const rows = ALL_CONTRIBUTION_ROWS.map(({ label, key }) => ({
@@ -121,24 +134,28 @@ export function ProfileStatsSidebar({
     ? [
         {
           label: 'shows attended',
+          compact: 'shows',
           value: statNumberFormatter.format(stats.shows_attended),
         },
         ...(collectionsTotal !== undefined
           ? [
               {
                 label: 'collections',
+                compact: 'lists',
                 value: statNumberFormatter.format(collectionsTotal),
               },
             ]
           : []),
         {
           label: 'contributions',
+          compact: 'contrib',
           value: statNumberFormatter.format(stats.total_contributions),
         },
         ...(stats.approval_rate !== undefined && stats.approval_rate !== null
           ? [
               {
                 label: 'approval rate',
+                compact: 'approval',
                 // approval_rate is a 0–1 fraction (backend contract).
                 value: `${Math.round(stats.approval_rate * 100)}%`,
               },
@@ -148,17 +165,23 @@ export function ProfileStatsSidebar({
     : [
         {
           label: 'contributions',
+          compact: 'contrib',
           value: statNumberFormatter.format(statsCount!),
         },
       ]
 
   // Brand-new profile (design board B): zeroed numerals, no expander — the
   // expanded panel would be all empty states. Owners get the onboarding hint.
+  // The breakdown check matters: follows / subscriptions / followers are NOT
+  // counted in total_contributions, and the expander is their only surface.
+  const hasBreakdownRows =
+    hasFullStats && ALL_CONTRIBUTION_ROWS.some(({ key }) => stats[key] !== 0)
   const isAllZero =
     hasFullStats &&
     stats.shows_attended === 0 &&
     (collectionsTotal ?? 0) === 0 &&
-    stats.total_contributions === 0
+    stats.total_contributions === 0 &&
+    !hasBreakdownRows
   const canExpand = expandable && hasFullStats && !isAllZero
 
   return (
@@ -183,14 +206,18 @@ export function ProfileStatsSidebar({
         }
       />
 
-      <div className="mt-3 space-y-2.5">
+      <div className="mt-3 flex flex-wrap justify-between gap-x-4 gap-y-3 lg:flex-col lg:justify-start lg:gap-y-2.5">
         {headline.map(item => (
-          <div key={item.label} className="flex items-baseline gap-3">
-            <span className="w-14 shrink-0 text-right font-mono text-2xl font-bold leading-none tabular-nums">
+          <div
+            key={item.label}
+            className="flex flex-col gap-1 lg:flex-row lg:items-baseline lg:gap-3"
+          >
+            <span className="font-mono text-2xl font-bold leading-none tabular-nums lg:min-w-14 lg:shrink-0 lg:text-right">
               {item.value}
             </span>
-            <span className="min-w-0 text-sm text-muted-foreground">
-              {item.label}
+            <span className="min-w-0 text-xs text-muted-foreground lg:text-sm">
+              <span className="lg:hidden">{item.compact}</span>
+              <span className="hidden lg:inline">{item.label}</span>
             </span>
           </div>
         ))}
@@ -208,7 +235,12 @@ export function ProfileStatsSidebar({
             ▸ Show all stats
           </button>
           <p className="mt-1 font-mono text-xs leading-relaxed text-muted-foreground">
-            full counters · 365-day activity heatmap · percentile rankings
+            <span className="lg:hidden">
+              counters · heatmap · percentile rankings
+            </span>
+            <span className="hidden lg:inline">
+              full counters · 365-day activity heatmap · percentile rankings
+            </span>
           </p>
         </div>
       )}

--- a/frontend/components/contributor/PublicProfile.test.tsx
+++ b/frontend/components/contributor/PublicProfile.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 import { PublicProfile } from './PublicProfile'
 import type { PublicProfileResponse } from '@/features/auth'
@@ -65,12 +65,6 @@ vi.mock('@/lib/context/AuthContext', () => ({
 vi.mock('./UserTierBadge', () => ({
   UserTierBadge: ({ tier }: { tier: string }) => (
     <span data-testid="tier-badge">{tier}</span>
-  ),
-}))
-
-vi.mock('./ContributionStatsGrid', () => ({
-  ContributionStatsGrid: () => (
-    <div data-testid="stats-grid">Stats Grid</div>
   ),
 }))
 
@@ -406,9 +400,11 @@ describe('PublicProfile', () => {
     // (PSY-1045) — no expander, no grid.
     expect(screen.getByText('Statistics')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
-    expect(screen.getByText('Contributions')).toBeInTheDocument()
-    expect(screen.queryByText('[All stats]')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('stats-grid')).not.toBeInTheDocument()
+    expect(screen.getByText('contributions')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /show all statistics/i })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('All contributions')).not.toBeInTheDocument()
   })
 
   it('does not show stats count when it is 0', () => {
@@ -461,20 +457,24 @@ describe('PublicProfile', () => {
     // headline numbers visible, grid/heatmap/rankings only after expanding.
     expect(screen.getByText('Statistics')).toBeInTheDocument()
     expect(screen.getByText('18')).toBeInTheDocument() // total contributions headline
-    expect(screen.queryByTestId('stats-grid')).not.toBeInTheDocument()
+    expect(screen.queryByText('All contributions')).not.toBeInTheDocument()
     expect(screen.queryByTestId('activity-heatmap')).not.toBeInTheDocument()
     expect(screen.queryByTestId('percentile-rankings')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /show all statistics/i }))
 
-    expect(screen.getByTestId('stats-grid')).toBeInTheDocument()
+    // The dense breakdown list (board G) renders non-zero rows only.
+    expect(screen.getByText('All contributions')).toBeInTheDocument()
+    expect(screen.getByText('Shows submitted')).toBeInTheDocument()
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.queryByText('Releases created')).not.toBeInTheDocument()
     expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument()
     expect(screen.getByTestId('percentile-rankings')).toBeInTheDocument()
 
     fireEvent.click(
       screen.getByRole('button', { name: /hide the full statistics/i })
     )
-    expect(screen.queryByTestId('stats-grid')).not.toBeInTheDocument()
+    expect(screen.queryByText('All contributions')).not.toBeInTheDocument()
   })
 
   it('shows recent activity when contributions exist', () => {
@@ -633,12 +633,13 @@ describe('PublicProfile', () => {
 
     renderWithProviders(<PublicProfile username="alice" />)
     // Full stats win over the count-only fallback: the expander affordance
-    // renders (count-only mode has no expander) and opening it shows the grid.
+    // renders (count-only mode has no expander) and opening it shows the
+    // breakdown panel.
     expect(
       screen.getByRole('button', { name: /show all statistics/i })
     ).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /show all statistics/i }))
-    expect(screen.getByTestId('stats-grid')).toBeInTheDocument()
+    expect(screen.getByText('All contributions')).toBeInTheDocument()
   })
 
   // --- Owner-only Edit affordance (PSY-1025) ---

--- a/frontend/components/contributor/PublicProfile.tsx
+++ b/frontend/components/contributor/PublicProfile.tsx
@@ -331,7 +331,9 @@ export function PublicProfile({ username }: PublicProfileProps) {
             )}
         </div>
 
-        <aside className="w-full lg:w-80 shrink-0">
+        {/* order-first: on mobile the stats render as a compact strip ABOVE
+            the main content (design board D); on lg the rail sits right. */}
+        <aside className="order-first w-full shrink-0 lg:order-none lg:w-80">
           <ProfileStatsSidebar
             username={username}
             stats={profile.stats}

--- a/frontend/components/contributor/PublicProfile.tsx
+++ b/frontend/components/contributor/PublicProfile.tsx
@@ -337,6 +337,7 @@ export function PublicProfile({ username }: PublicProfileProps) {
             stats={profile.stats}
             statsCount={profile.stats_count}
             collectionsTotal={collectionsTotal}
+            isOwner={isOwner}
           />
         </aside>
       </div>

--- a/frontend/components/shared/StatsList.tsx
+++ b/frontend/components/shared/StatsList.tsx
@@ -32,11 +32,12 @@ export interface StatsListProps {
   className?: string
 }
 
-const numberFormatter = new Intl.NumberFormat('en-US')
+/** Shared en-US thousands-separator formatter for stat surfaces. */
+export const statNumberFormatter = new Intl.NumberFormat('en-US')
 
 function formatValue(value: StatsListItem['value']): ReactNode {
   if (typeof value === 'number') {
-    return numberFormatter.format(value)
+    return statNumberFormatter.format(value)
   }
   return value
 }


### PR DESCRIPTION
Closes PSY-1058.

## Summary

Restyles the public-profile stats sidebar to the Figma source-of-truth boards (Product Designs file, `Profile` page):

- **Board A (populated)**: bordered `bg-card` STATISTICS card with large Space Mono headline numerals (right-aligned column, lowercase labels), an **approval-rate row**, and the "▸ Show all stats" expander with its mono contents explainer.
- **Board G (expanded)**: dense **All contributions** label/value list with hairlines (zero rows filtered; derived from an exhaustive `BREAKDOWN_LABELS satisfies Record<…>` map so a future `ContributionStats` field is a compile error until labeled), **Activity** heatmap recolored from emerald to a primary-token opacity ramp, and **Percentile rankings** restyled from the traffic-light Card (green/yellow/orange/red + Trophy + value counts) to single-hue primary bars with `top N%` mono values and an `overall · top N%` header.
- **Board B (zero state)**: zeroed numerals, no expander, owner-gated onboarding hint ("Log a show or follow an artist…" — suppressed for visitors, whose copy it doesn't address).
- **Board D (mobile)**: headline renders as a horizontal numeral-over-compact-label strip (`shows / lists / contrib / approval`) ordered **above** the main column below `lg`, with the abbreviated explainer.
- **`/users/me` claim state**: previously rendered **no stats card at all**; now a two-column layout with the board-B zeroed card (non-expandable — no username for the per-username heatmap/rankings endpoints; collections total from `useMyCollections`, which counts the owner's own lists including private ones).

**Behavior fix (not just a restyle):** the approval-rate headline previously did `Math.round(stats.approval_rate)` on the backend's **0–1 fraction** (`contributor_profile.go:399-401`), so a 92% contributor rendered as "1%". Now `* 100`, matching `ContributionStatsGrid.formatPercentage`, with a regression test (0.92 → "92%").

Also: `StatsList`'s number formatter is now exported (`statNumberFormatter`) and shared instead of duplicated; `ContributionStatsGrid` is deliberately untouched (still serves the /profile preview card — PSY-1061 owns its fate).

## Deferred (board-G adaptations, disclosed)

- **All-contributions is single-column**, not board G's two columns — board G is drawn at 560px exposition width; the production rail is `lg:w-80` (320px) where two columns don't fit. Flagged for the PSY-1060 design pass if the boards should encode the rail-width adaptation.
- **Heatmap window/copy**: board G captions the heatmap "LAST ~6 MONTHS"; the component genuinely renders 52 weeks (26 below 640px viewport) and says so. Kept the truthful copy; flagged for PSY-1060.

## Adversarial review

`/adversarial-review` — 5 findings addressed in commit `07e86fc9`.
- [HIGH, corroborated ×2] `isAllZero` ignored breakdown-only data (follows / subscriptions / followers are excluded from `total_contributions`), suppressing the expander — their only surface — and showing the wrong onboarding hint → fixed: zero state now also requires every breakdown row to be zero; regression test added.
- [HIGH] Board-D mobile compact strip had no implementing code → fixed: responsive strip + `order-first` at both call sites, verified live at 390px.
- [MEDIUM] `ALL_CONTRIBUTION_ROWS` had no exhaustiveness guard vs `ContributionStats` → fixed via `satisfies Record<BreakdownKey, string>`.
- [MEDIUM] approval-rate `* 100` was a silent behavior change → disclosed prominently above as a bug fix.
- [LOW] `/users/me` passed `collectionsTotal ?? 0` (eager stale "0", inconsistent with the public profile's omit-while-loading) → fixed; [LOW] fixed `w-14` numeral column overflowed 4-digit values → `min-w`.
Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff. Security: CLEAN (verified privacy gating is server-enforced; `isOwner` gates copy only; the private-inclusive collections count renders only on the owner-only claim page).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/contributor components/shared` — 37 files / 654 tests passing (new `ProfileStatsSidebar.test.tsx` with 12 tests incl. approval-rate fraction formatting, zero-state owner/visitor gating, breakdown-only expander regression, count-only fallback; `PercentileRankings.test.tsx` rewritten for the board-G contract; heatmap boundary tests migrated to the primary ramp)
- [x] `bunx eslint` on changed files — 0 errors (the `<img>` avatar warning in `PublicProfile.tsx` is pre-existing; drive-by fix for a pre-existing unused `render` import in its test)
- [x] `/code-review` — 7 finder angles; actionable findings fixed in the implementation commit (shared formatter export, narrower key typing, real collections total on /users/me)
- [x] `/adversarial-review` — CONCERNS addressed; fixes in separate commit `07e86fc9`
- [x] No e2e spec selects on the restyled DOM (verified: nothing under `frontend/e2e/` references `/users/` routes or the stats card; `pages/profile.spec.ts` targets the untouched `/profile` settings page)
- [x] Manual repro against the local dev stack (main dev DB, migrations brought current; approval-rate inputs seeded for `testuser2`): all five board states verified live (screenshots below)

## Screenshots

**Board A — populated, collapsed (visitor view of `testuser2`)** — bordered card, mono numerals, approval rate, expander + explainer; the main column also shows the count-only Following and hidden-attendance privacy states:
![populated collapsed](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-501a62bbe6f0cf02ad3f/psy-1058-01-populated-collapsed.png)

**Board G — expanded** — All contributions dense rows (zero-filtered), Activity heatmap (primary ramp), Percentile rankings with `overall · top 27%`:
![expanded](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-501a62bbe6f0cf02ad3f/psy-1058-02-expanded-full.png)

**Board D — mobile strip (390px)** — compact numeral-over-label strip above Bio, abbreviated explainer:
![mobile strip](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-501a62bbe6f0cf02ad3f/psy-1058-03-mobile-strip.png)

**Board E — dark mode, expanded** — semantic tokens track; primary numerals/bars on the vinyl-shop palette:
![dark expanded](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-501a62bbe6f0cf02ad3f/psy-1058-04-dark-expanded.png)

**Board B — `/users/me` claim state (fresh signup)** — the previously-missing zeroed stats card with the onboarding hint:
![claim zero state](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-501a62bbe6f0cf02ad3f/psy-1058-05-users-me-claim-zero.png)

## Coverage gaps

- **Sidebar count-only state (stats hidden, `stats_count` only) not visually verified live** — `testuser2`'s stats are fully visible; the state is covered by unit tests (count-only numeral, no expander).
- **4-digit numeral wrap (`min-w-14` growth) not visually verified** — seeded data tops out at 2 digits.
- **Mobile expanded panel not screenshot-verified** (collapsed strip verified at 390px; the expander works identically to desktop and is unit-tested).
- **Light-mode-only verification for boards A/B/D** — dark mode verified on the expanded view (board E); all colors are semantic tokens with no new per-mode overrides.
- **Owner-viewing-own-zeroed `/users/[username]` profile not exercised end-to-end** — the onboarding hint's `isOwner` gating is unit-tested on the component directly, and the live owner-hint capture is the `/users/me` call site; the `PublicProfile`-threaded `isOwner` + zeroed-stats combination wasn't separately screenshot-verified.
- **`/users/me` desktop two-column reflow and a non-zero `useMyCollections` total not verified live** — the claim-state screenshot is a fresh (zeroed) account; the collections numeral resolving non-zero on that page is covered by the shared component's unit tests only.
