### PR TITLE
PSY-1072: restore radio.spec after the PSY-1050/1051 radio rebuilds

### DIFF
--- a/frontend/e2e/pages/radio.spec.ts
+++ b/frontend/e2e/pages/radio.spec.ts
@@ -111,8 +111,15 @@ test.describe('Radio browse flow', () => {
     await expect(main.getByRole('heading', { name: 'Shows' })).toBeVisible()
 
     // At least one seeded show card link is present (KEXP seeds 6 shows).
+    // PSY-1072: scope to the shows directory's landmark — the PSY-1050
+    // station-page rebuild also links the show name from the on-air box and
+    // the playlists feed (client-fetched, so the un-scoped match count varies
+    // 2–3 and trips strict mode). StationShowsDirectory renders
+    // `<section aria-label="Shows">` → role=region.
     await expect(
-      main.getByRole('link', { name: KEXP_SHOW_NAME })
+      main
+        .getByRole('region', { name: 'Shows' })
+        .getByRole('link', { name: KEXP_SHOW_NAME })
     ).toBeVisible({ timeout: 10_000 })
   })
 
@@ -120,11 +127,14 @@ test.describe('Radio browse flow', () => {
     page,
   }) => {
     // Start at the station so the click target is the real rendered show
-    // card link (not a hand-built URL).
+    // card link (not a hand-built URL). PSY-1072: scoped to the shows
+    // directory region — the on-air box + playlists feed (PSY-1050) also
+    // link the show name, tripping strict mode un-scoped.
     await page.goto(`/radio/${KEXP_SLUG}`)
 
     const showLink = page
       .getByRole('main')
+      .getByRole('region', { name: 'Shows' })
       .getByRole('link', { name: KEXP_SHOW_NAME })
     await expect(showLink).toBeVisible({ timeout: 10_000 })
     await showLink.click()
@@ -141,32 +151,38 @@ test.describe('Radio browse flow', () => {
       main.getByRole('heading', { name: KEXP_SHOW_NAME, level: 1 })
     ).toBeVisible({ timeout: 10_000 })
 
-    // Breadcrumb links back up the chain (Radio + the station name). The
-    // station name appears in both the breadcrumb and the "on {station}"
-    // line, so allow more than one match via `.first()`.
-    await expect(main.getByRole('link', { name: 'Radio' })).toBeVisible()
+    // PSY-1072: the PSY-1051 show-page rebuild replaced the Radio + station
+    // breadcrumb chain with a single "← {station}" back-link (the hub stays
+    // reachable via the top-bar Radio link, which lives outside <main>).
+    // `name` matching is substring, so KEXP_STATION_NAME matches "← KEXP";
+    // `.first()` guards against the station name also appearing in body copy.
     await expect(
       main.getByRole('link', { name: KEXP_STATION_NAME }).first()
     ).toBeVisible()
 
-    // "Recent Episodes" section renders. PSY-899 seeds one KEXP episode for
-    // this show (air date 2025-01-15), so this asserts the populated path:
-    // the section heading shows + the episode-archive row link into the dated
-    // episode route resolves. The episode list is CLIENT-fetched
-    // (RadioShowDetail.tsx useRadioEpisodes), so the row appears
-    // asynchronously — allow up to 10s. Target the row by its href to the
-    // dated episode route (`/radio/kexp/the-morning-show/2025-01-15`): that
-    // URL is the exact deep-chain link the seed makes reachable and is immune
-    // to date-format / play-count text variation. (The row's accessible name
-    // includes the title "The Morning Show — …", so a name query would be a
-    // weaker assertion that also reads as colliding with the show H1.)
+    // Episode archive renders. PSY-899 seeds one KEXP episode for this show
+    // (air date 2025-01-15), so this asserts the populated path: the section
+    // heading shows + the archive-table row links into the dated episode
+    // route. PSY-1072: the PSY-1051 rebuild renamed the section from
+    // "Recent Episodes" to "Playlists — N episode(s)" and renders it as the
+    // archive table. The row link is CLIENT-fetched, so allow up to 10s.
+    // Target the row by its href to the dated episode route
+    // (`/radio/kexp/the-morning-show/2025-01-15`): that URL is the exact
+    // deep-chain link the seed makes reachable and is immune to date-format /
+    // play-count text variation.
     await expect(
-      main.getByRole('heading', { name: /recent episodes/i })
+      main.getByRole('heading', { name: /playlists/i })
     ).toBeVisible({ timeout: 10_000 })
+    // `.first()`: the archive table links the dated route from several cells
+    // (date, episode title, "Open latest playlist", playlist row) — the
+    // assertion's intent is "the dated episode route is linked", not "exactly
+    // once".
     await expect(
-      main.locator(
-        `a[href="/radio/${KEXP_SLUG}/${KEXP_SHOW_SLUG}/${KEXP_EPISODE_AIR_DATE}"]`
-      )
+      main
+        .locator(
+          `a[href="/radio/${KEXP_SLUG}/${KEXP_SHOW_SLUG}/${KEXP_EPISODE_AIR_DATE}"]`
+        )
+        .first()
     ).toBeVisible({ timeout: 10_000 })
   })
 


### PR DESCRIPTION
Closes PSY-1072.

## Summary
Full-E2E-on-main has been **red since 2026-06-10** on E2E shard 4/4 — `radio.spec.ts` asserts DOM that the PSY-1050 (station page) and PSY-1051 (show page) rebuilds changed. Test-only restoration; no app code touched. Three layers, peeled by running the spec locally (CI always died at the first failure, masking the rest):

1. **Station page (PSY-1050):** the show name is linked from the on-air box and the client-fetched playlists feed as well as the shows directory — the un-scoped `getByRole('link', { name })` matched 2–3 elements (count varies with fetch timing) → strict-mode violation at `:117`/`:130`. Fix: scope both assertions to `StationShowsDirectory`'s `<section aria-label="Shows">` landmark (`role=region`) — deterministic no matter how many other surfaces link the same show.
2. **Show page (PSY-1051):** the Radio + station breadcrumb chain is now a single **`← KEXP`** back-link (the hub stays reachable via the top-bar Radio link, outside `<main>` — PSY-1057), and "Recent Episodes" became the **"Playlists — N episode(s)"** archive table. Fix: drop the dead Radio-link assertion; match the heading on `/playlists/i`.
3. The archive table links the dated episode route from **4 cells** (date, title, "Open latest playlist", playlist row) → `.first()`, since the assertion's intent is "the dated route is linked", not "exactly once".

## Test plan
- [x] `bun run test:e2e -- pages/radio.spec.ts` — **2 consecutive full-spec passes, 4/4 each** (~16s), against the E2E stack (ephemeral Postgres :5433 + backend :8080 + seeded data).
- [x] The layered failures above were each reproduced locally before fixing (run logs show the exact strict-mode element lists / not-found errors).
- No app code changed — spec-only diff (1 file, +37/−21).

## Heads up
- This is the **third** full-E2E-on-main gap from a page rewrite (PSY-389 → `home.spec`, PSY-1016 → `radio.spec`, now PSY-1050/1051 → `radio.spec`). The per-agent "run the spec covering any surface you change" rule shipped in #1067 — the rebuilds that broke this predate or missed it.
- `/adversarial-review` bypassed per the test-only carveout — the verification for a spec restoration is the spec run itself (2 consecutive green passes), documented above.
