### PR TITLE
PSY-1074: station tabs are strictly per-station (playlists feed + top artists/labels)

### DIFF
--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -259,7 +259,7 @@ func (h *RadioHandler) GetRadioStationNowPlayingHandler(ctx context.Context, req
 // ============================================================================
 
 // GetRadioStationEpisodesRequest lists a station's latest playlists across
-// all of its shows (and network channels, for a flagship).
+// all of its shows — strictly the requested station (PSY-1074).
 type GetRadioStationEpisodesRequest struct {
 	Slug   string `path:"slug" doc:"Radio station slug or numeric ID" example:"wfmu"`
 	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" default:"20" doc:"Max results (default 20)" example:"20"`
@@ -269,7 +269,7 @@ type GetRadioStationEpisodesRequest struct {
 // GetRadioStationEpisodesResponse is the station latest-playlists feed.
 type GetRadioStationEpisodesResponse struct {
 	Body struct {
-		Episodes []*contracts.RadioStationEpisodeRow `json:"episodes" doc:"Latest episodes across the station's shows, newest first, with channel attribution"`
+		Episodes []*contracts.RadioStationEpisodeRow `json:"episodes" doc:"Latest episodes across the station's shows, newest first"`
 		Total    int64                               `json:"total" doc:"Total number of episodes"`
 	}
 }

--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -686,7 +686,7 @@ func (s *RadioService) GetEpisodeDetail(episodeID uint) (*contracts.RadioEpisode
 // =============================================================================
 
 // playsScope narrows a top-artists/labels aggregation query (radio_plays rp
-// joined to radio_episodes re) to a show or a station family, applied with
+// joined to radio_episodes re) to a show or a station, applied with
 // .Scopes(). The episode feeds use the separate episodeFeedScope type — see
 // its comment for why the two are not interchangeable.
 type playsScope func(*gorm.DB) *gorm.DB
@@ -697,10 +697,10 @@ func showScope(showID uint) playsScope {
 	}
 }
 
-func stationFamilyScope(stationIDs []uint) playsScope {
+func stationScope(stationID uint) playsScope {
 	return func(q *gorm.DB) *gorm.DB {
 		return q.Joins("JOIN radio_shows rsh ON rsh.id = re.show_id").
-			Where("rsh.station_id IN ?", stationIDs)
+			Where("rsh.station_id = ?", stationID)
 	}
 }
 
@@ -709,14 +709,14 @@ func (s *RadioService) GetTopArtistsForShow(showID uint, periodDays, limit int) 
 	return s.topArtists(showScope(showID), periodDays, limit)
 }
 
-// GetTopArtistsForStation returns the most-played artists across a station's
-// shows — for a network flagship, across the whole network (PSY-1048).
+// GetTopArtistsForStation returns the most-played artists across the
+// requested station's shows — strictly that station, never its network
+// siblings (PSY-1074).
 func (s *RadioService) GetTopArtistsForStation(stationID uint, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error) {
-	ids, err := s.stationFamilyIDs(stationID)
-	if err != nil {
+	if err := s.verifyStationExists(stationID); err != nil {
 		return nil, err
 	}
-	return s.topArtists(stationFamilyScope(ids), periodDays, limit)
+	return s.topArtists(stationScope(stationID), periodDays, limit)
 }
 
 func (s *RadioService) topArtists(scope playsScope, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error) {
@@ -776,14 +776,14 @@ func (s *RadioService) GetTopLabelsForShow(showID uint, periodDays, limit int) (
 	return s.topLabels(showScope(showID), periodDays, limit)
 }
 
-// GetTopLabelsForStation returns the most-featured labels across a station's
-// shows — for a network flagship, across the whole network (PSY-1048).
+// GetTopLabelsForStation returns the most-featured labels across the
+// requested station's shows — strictly that station, never its network
+// siblings (PSY-1074).
 func (s *RadioService) GetTopLabelsForStation(stationID uint, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error) {
-	ids, err := s.stationFamilyIDs(stationID)
-	if err != nil {
+	if err := s.verifyStationExists(stationID); err != nil {
 		return nil, err
 	}
-	return s.topLabels(stationFamilyScope(ids), periodDays, limit)
+	return s.topLabels(stationScope(stationID), periodDays, limit)
 }
 
 func (s *RadioService) topLabels(scope playsScope, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error) {
@@ -870,41 +870,21 @@ func (s *RadioService) ResolveStationIDBySlug(slug string) (uint, error) {
 	return station.ID, nil
 }
 
-// stationFamilyIDs returns the station IDs a station page aggregates over:
-// the station itself, plus — when the station is a network flagship — every
-// station in its network. Non-flagship channels and standalone stations
-// aggregate only themselves.
-//
-// Two deliberate policy notes (PSY-1048):
-//   - The family includes INACTIVE sibling channels: a flagship page is the
-//     network's archive, so retired channels' playlists stay reachable. The
-//     dial-wide feed (GetRecentEpisodes) separately filters to active
-//     stations — hub policy, not archive policy.
-//   - GetNewReleaseRadar keeps its pre-existing single-station semantics
-//     (rs.id = ?) and does NOT expand to the family; reconciling that is a
-//     product call deferred to PSY-1050.
-func (s *RadioService) stationFamilyIDs(stationID uint) ([]uint, error) {
+// verifyStationExists returns ErrRadioStationNotFound for an unknown station
+// ID — the station-scoped reads (episodes feed, top artists/labels) call it
+// so an unknown numeric ID surfaces as a 404 rather than an empty 200.
+func (s *RadioService) verifyStationExists(stationID uint) error {
 	if s.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return fmt.Errorf("database not initialized")
 	}
 	var station catalogm.RadioStation
-	if err := s.db.Select("id", "is_flagship", "network_id").
-		First(&station, stationID).Error; err != nil {
+	if err := s.db.Select("id").First(&station, stationID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, apperrors.ErrRadioStationNotFound(stationID)
+			return apperrors.ErrRadioStationNotFound(stationID)
 		}
-		return nil, fmt.Errorf("failed to get radio station: %w", err)
+		return fmt.Errorf("failed to get radio station: %w", err)
 	}
-	if !station.IsFlagship || station.NetworkID == nil {
-		return []uint{station.ID}, nil
-	}
-	var ids []uint
-	if err := s.db.Model(&catalogm.RadioStation{}).
-		Where("network_id = ?", *station.NetworkID).
-		Pluck("id", &ids).Error; err != nil {
-		return nil, fmt.Errorf("failed to list network stations: %w", err)
-	}
-	return ids, nil
+	return nil
 }
 
 // episodeArtistPreviews returns up to episodePreviewArtistCount distinct
@@ -959,15 +939,14 @@ func (s *RadioService) episodeArtistPreviews(episodeIDs []uint) (map[uint][]cont
 }
 
 // GetStationEpisodes returns the station's latest playlists across all of
-// its shows — for a network flagship, across all network channels — newest
-// first, with channel attribution per row.
+// its shows, newest first — strictly the requested station, never its
+// network siblings (PSY-1074); channel shows live under their own tabs.
 func (s *RadioService) GetStationEpisodes(stationID uint, limit, offset int) ([]*contracts.RadioStationEpisodeRow, int64, error) {
-	ids, err := s.stationFamilyIDs(stationID)
-	if err != nil {
+	if err := s.verifyStationExists(stationID); err != nil {
 		return nil, 0, err
 	}
 	return s.episodeRows(func(q *gorm.DB) *gorm.DB {
-		return q.Where("rsh.station_id IN ?", ids)
+		return q.Where("rsh.station_id = ?", stationID)
 	}, limit, offset)
 }
 
@@ -982,8 +961,8 @@ func (s *RadioService) GetRecentEpisodes(limit, offset int) ([]*contracts.RadioS
 
 // episodeFeedScope narrows the episode-feed base query (radio_episodes re
 // joined to radio_shows rsh and radio_stations rst). Distinct from
-// playsScope: stationFamilyScope embeds its own rsh join and would produce
-// a duplicate alias here.
+// playsScope: stationScope embeds its own rsh join and would produce a
+// duplicate alias here.
 type episodeFeedScope func(*gorm.DB) *gorm.DB
 
 // episodeRows is the shared core of the station-scoped and dial-wide feeds.

--- a/backend/internal/services/catalog/radio_test.go
+++ b/backend/internal/services/catalog/radio_test.go
@@ -1255,7 +1255,7 @@ func (suite *RadioServiceIntegrationTestSuite) TestGetEpisodes_ArtistPreview() {
 	suite.Equal("Third Artist", preview[2].ArtistName)
 }
 
-func (suite *RadioServiceIntegrationTestSuite) TestGetStationEpisodes_FlagshipIncludesNetwork() {
+func (suite *RadioServiceIntegrationTestSuite) TestGetStationEpisodes_StrictPerStation() {
 	flagship, sibling, standalone := suite.createNetworkFamily()
 
 	flagShow := suite.createShow(flagship.ID, "Flag Show")
@@ -1265,26 +1265,26 @@ func (suite *RadioServiceIntegrationTestSuite) TestGetStationEpisodes_FlagshipIn
 	suite.createEpisode(sibShow.ID, "2026-06-09")
 	suite.createEpisode(aloneShow.ID, "2026-06-07")
 
-	// Flagship aggregates the whole network, newest first, with channel attribution.
+	// A flagship's feed contains ONLY its own episodes — never its network
+	// siblings' (PSY-1074 reversed the PSY-1048 flagship-aggregates rule).
 	rows, total, err := suite.radioService.GetStationEpisodes(flagship.ID, 10, 0)
 	suite.Require().NoError(err)
-	suite.Equal(int64(2), total)
-	suite.Require().Len(rows, 2)
-	suite.Equal("Sib Show", rows[0].ShowName)
-	suite.Equal("Channel Two", rows[0].StationName)
-	suite.Equal("channel-two", rows[0].StationSlug)
-	suite.Equal("2026-06-09", rows[0].AirDate)
-	suite.Equal("Flag Show", rows[1].ShowName)
-	suite.Equal("Flagship", rows[1].StationName)
-	suite.Require().NotNil(rows[1].ArtistPreview, "episodes without plays must serialize artist_preview as [], not null")
-	suite.Empty(rows[1].ArtistPreview)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(rows, 1)
+	suite.Equal("Flag Show", rows[0].ShowName)
+	suite.Equal("Flagship", rows[0].StationName)
+	suite.Equal("flagship", rows[0].StationSlug)
+	suite.Equal("2026-06-08", rows[0].AirDate)
+	suite.Require().NotNil(rows[0].ArtistPreview, "episodes without plays must serialize artist_preview as [], not null")
+	suite.Empty(rows[0].ArtistPreview)
 
-	// A non-flagship channel aggregates only itself.
+	// A channel's feed contains only its own episodes.
 	sibRows, sibTotal, err := suite.radioService.GetStationEpisodes(sibling.ID, 10, 0)
 	suite.Require().NoError(err)
 	suite.Equal(int64(1), sibTotal)
 	suite.Require().Len(sibRows, 1)
 	suite.Equal("Sib Show", sibRows[0].ShowName)
+	suite.Equal("channel-two", sibRows[0].StationSlug)
 
 	// Unknown station -> not found error.
 	_, _, err = suite.radioService.GetStationEpisodes(99999, 10, 0)
@@ -1320,7 +1320,7 @@ func (suite *RadioServiceIntegrationTestSuite) TestGetRecentEpisodes_ActiveStati
 	suite.Equal("2026-06-08", page2[0].AirDate)
 }
 
-func (suite *RadioServiceIntegrationTestSuite) TestGetTopArtistsForStation_AggregatesNetwork() {
+func (suite *RadioServiceIntegrationTestSuite) TestGetTopArtistsForStation_StrictPerStation() {
 	flagship, sibling, standalone := suite.createNetworkFamily()
 	flagShow := suite.createShow(flagship.ID, "Flag Show")
 	sibShow := suite.createShow(sibling.ID, "Sib Show")
@@ -1334,16 +1334,29 @@ func (suite *RadioServiceIntegrationTestSuite) TestGetTopArtistsForStation_Aggre
 	suite.createPlay(sibEp.ID, 2, "Channel Artist")
 	suite.createPlay(aloneEp.ID, 1, "Outsider Artist")
 
+	// A flagship's top artists count ONLY its own plays — sibling channels'
+	// plays are excluded (PSY-1074 reversed the PSY-1048 network aggregation).
 	artists, err := suite.radioService.GetTopArtistsForStation(flagship.ID, 90, 10)
 	suite.Require().NoError(err)
-	suite.Require().Len(artists, 2)
+	suite.Require().Len(artists, 1)
 	suite.Equal("Shared Artist", artists[0].ArtistName)
-	suite.Equal(2, artists[0].PlayCount)
-	suite.Equal(2, artists[0].EpisodeCount)
-	suite.Equal("Channel Artist", artists[1].ArtistName)
+	suite.Equal(1, artists[0].PlayCount)
+	suite.Equal(1, artists[0].EpisodeCount)
+
+	// A channel's top artists count only its own plays. Both have 1 play, so
+	// assert membership rather than tie-break order.
+	sibArtists, err := suite.radioService.GetTopArtistsForStation(sibling.ID, 90, 10)
+	suite.Require().NoError(err)
+	suite.Require().Len(sibArtists, 2)
+	sibNames := []string{sibArtists[0].ArtistName, sibArtists[1].ArtistName}
+	suite.ElementsMatch([]string{"Shared Artist", "Channel Artist"}, sibNames)
+
+	// Unknown station -> not found error.
+	_, err = suite.radioService.GetTopArtistsForStation(99999, 90, 10)
+	suite.Require().Error(err)
 }
 
-func (suite *RadioServiceIntegrationTestSuite) TestGetTopLabelsForStation_AggregatesNetwork() {
+func (suite *RadioServiceIntegrationTestSuite) TestGetTopLabelsForStation_StrictPerStation() {
 	flagship, sibling, _ := suite.createNetworkFamily()
 	flagShow := suite.createShow(flagship.ID, "Flag Show")
 	sibShow := suite.createShow(sibling.ID, "Sib Show")
@@ -1361,11 +1374,21 @@ func (suite *RadioServiceIntegrationTestSuite) TestGetTopLabelsForStation_Aggreg
 		suite.Require().NoError(suite.db.Create(&plays[i]).Error)
 	}
 
+	// A flagship's top labels count ONLY its own plays (PSY-1074).
 	labels, err := suite.radioService.GetTopLabelsForStation(flagship.ID, 90, 10)
 	suite.Require().NoError(err)
-	suite.Require().Len(labels, 2)
+	suite.Require().Len(labels, 1)
 	suite.Equal("Family Label", labels[0].LabelName)
-	suite.Equal(2, labels[0].PlayCount)
+	suite.Equal(1, labels[0].PlayCount)
+
+	// A channel's top labels count only its own plays.
+	sibLabels, err := suite.radioService.GetTopLabelsForStation(sibling.ID, 90, 10)
+	suite.Require().NoError(err)
+	suite.Require().Len(sibLabels, 2)
+
+	// Unknown station -> not found error.
+	_, err = suite.radioService.GetTopLabelsForStation(99999, 90, 10)
+	suite.Require().Error(err)
 }
 
 func TestRadioService_NilDB_ResolveStationID(t *testing.T) {

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -230,8 +230,9 @@ type RadioEpisodeResponse struct {
 }
 
 // RadioStationEpisodeRow is an episode row in the station-scoped and
-// dial-wide latest-playlists feeds: episode fields plus show and channel
-// (station) attribution (PSY-1048).
+// dial-wide latest-playlists feeds: episode fields plus show and station
+// attribution (PSY-1048). Station-scoped feeds are strictly per-station
+// (PSY-1074); the station_* fields exist for the dial-wide hub feed.
 type RadioStationEpisodeRow struct {
 	ID            uint                        `json:"id"`
 	Title         *string                     `json:"title"`

--- a/frontend/features/radio/components/StationPlaylistsFeed.test.tsx
+++ b/frontend/features/radio/components/StationPlaylistsFeed.test.tsx
@@ -124,32 +124,29 @@ describe('StationPlaylistsFeed', () => {
     expect(screen.getByText('—')).toBeInTheDocument()
   })
 
-  it('shows channel attribution for network stations', () => {
-    const channelRow = makeRow({
-      id: 2,
-      show_name: 'Give the Drummer Some',
-      show_slug: 'drummer-some',
-      station_id: 9,
-      station_name: 'Give the Drummer Radio',
-      station_slug: 'wfmu-drummer',
-    })
-    setEpisodes([makeRow(), channelRow])
+  it('uses the per-station heading with no channel column on a network flagship (PSY-1074)', () => {
+    // The station-scoped endpoint now returns only the requested station's
+    // rows, so flagship tabs render the same single-station table as
+    // everyone else — no "all channels" heading, no CHANNEL column.
+    setEpisodes([makeRow()])
     render(<StationPlaylistsFeed station={makeStation()} />)
 
+    expect(screen.getByText('Latest playlists')).toBeInTheDocument()
     expect(
-      screen.getByText('Latest playlists — all WFMU channels')
-    ).toBeInTheDocument()
-    expect(screen.getByText('Channel')).toBeInTheDocument()
-    expect(screen.getByText('Give the Drummer Radio')).toBeInTheDocument()
-
-    // Channel rows attribute their links to the originating station.
-    const channelShowLink = screen.getByRole('link', { name: 'Give the Drummer Some' })
-    expect(channelShowLink).toHaveAttribute('href', '/radio/wfmu-drummer/drummer-some')
+      screen.queryByText('Latest playlists — all WFMU channels')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('Channel')).not.toBeInTheDocument()
   })
 
-  it('omits the channel column on sub-channel pages (single-station feed)', () => {
+  it('builds row links from the row station on sub-channel pages', () => {
     setEpisodes([
-      makeRow({ station_name: 'Give the Drummer Radio', station_slug: 'wfmu-drummer' }),
+      makeRow({
+        show_name: 'Give the Drummer Some',
+        show_slug: 'drummer-some',
+        station_id: 9,
+        station_name: 'Give the Drummer Radio',
+        station_slug: 'wfmu-drummer',
+      }),
     ])
     render(
       <StationPlaylistsFeed
@@ -163,6 +160,8 @@ describe('StationPlaylistsFeed', () => {
 
     expect(screen.getByText('Latest playlists')).toBeInTheDocument()
     expect(screen.queryByText('Channel')).not.toBeInTheDocument()
+    const showLink = screen.getByRole('link', { name: 'Give the Drummer Some' })
+    expect(showLink).toHaveAttribute('href', '/radio/wfmu-drummer/drummer-some')
   })
 
   it('omits the channel column for standalone stations', () => {

--- a/frontend/features/radio/components/StationPlaylistsFeed.tsx
+++ b/frontend/features/radio/components/StationPlaylistsFeed.tsx
@@ -20,9 +20,9 @@ interface StationPlaylistsFeedProps {
 
 /**
  * "Latest playlists" dense table (PSY-1050): newest episodes across all of a
- * station's shows, from GET /radio-stations/{slug}/episodes (PSY-1048). For a
- * network flagship the server already merges channel stations into the feed,
- * so the CHANNEL column attributes each row to its originating station.
+ * station's shows, from GET /radio-stations/{slug}/episodes (PSY-1048). The
+ * feed is strictly per-station (PSY-1074) — a network flagship's tab shows
+ * only its own playlists; channel shows live under their own tabs.
  *
  * Pagination is in-place: start at 10 rows, "More playlists" grows the query
  * limit by 20 (keepPreviousData keeps the table stable while the larger page
@@ -37,20 +37,12 @@ export function StationPlaylistsFeed({ station }: StationPlaylistsFeedProps) {
 
   const episodes = data?.episodes ?? []
   const total = data?.total ?? 0
-  // CHANNEL column only makes sense when rows can come from more than one
-  // station: the server merges channel stations into the feed for network
-  // FLAGSHIPS only. Sub-channel and standalone feeds are single-station.
-  const showChannel = station.network?.is_flagship === true
-
-  const title = showChannel
-    ? `Latest playlists — all ${station.network!.name} channels`
-    : 'Latest playlists'
 
   const canLoadMore = episodes.length < total && limit < MAX_LIMIT
 
   return (
     <section aria-label="Latest playlists">
-      <SectionHeader title={title} as="h2" size="md" />
+      <SectionHeader title="Latest playlists" as="h2" size="md" />
 
       {isLoading && (
         <div className="flex justify-center py-6">
@@ -70,13 +62,12 @@ export function StationPlaylistsFeed({ station }: StationPlaylistsFeedProps) {
                 <th className="w-16">Date</th>
                 <th>Show</th>
                 <th>Played</th>
-                {showChannel && <th>Channel</th>}
                 <th className="text-right w-16">Tracks</th>
               </tr>
             </thead>
             <tbody>
               {episodes.map(row => (
-                <PlaylistRow key={row.id} row={row} showChannel={showChannel} />
+                <PlaylistRow key={row.id} row={row} />
               ))}
             </tbody>
           </DenseTable>
@@ -99,13 +90,7 @@ export function StationPlaylistsFeed({ station }: StationPlaylistsFeedProps) {
   )
 }
 
-function PlaylistRow({
-  row,
-  showChannel,
-}: {
-  row: RadioStationEpisodeRow
-  showChannel: boolean
-}) {
+function PlaylistRow({ row }: { row: RadioStationEpisodeRow }) {
   const playlistUrl = `/radio/${row.station_slug}/${row.show_slug}/${row.air_date}`
   const showUrl = `/radio/${row.station_slug}/${row.show_slug}`
 
@@ -131,11 +116,6 @@ function PlaylistRow({
       <td className="text-muted-foreground">
         <ArtistPreview artists={row.artist_preview} />
       </td>
-      {showChannel && (
-        <td className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-          {row.station_name}
-        </td>
-      )}
       <td className="text-right text-muted-foreground">{row.play_count}</td>
     </tr>
   )

--- a/frontend/features/radio/components/StationSidebar.tsx
+++ b/frontend/features/radio/components/StationSidebar.tsx
@@ -221,8 +221,8 @@ function TopLabelsBox({ stationSlug }: { stationSlug: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// New Release Radar (station-filtered; existing endpoint, single-station
-// semantics — network-family expansion is a deferred product call)
+// New Release Radar (station-filtered; single-station semantics, consistent
+// with every other station-scoped read since PSY-1074)
 // ---------------------------------------------------------------------------
 
 function NewReleaseRadarBox({ station }: { station: RadioStationDetail }) {

--- a/frontend/features/radio/hooks/useStationEpisodes.ts
+++ b/frontend/features/radio/hooks/useStationEpisodes.ts
@@ -14,9 +14,9 @@ interface UseStationEpisodesOptions {
 }
 
 /**
- * Latest playlists across all of a station's shows (PSY-1048), newest first,
- * with show + channel attribution on each row. A network flagship's feed
- * already includes its channel stations server-side.
+ * Latest playlists across all of a station's shows (PSY-1048), newest first.
+ * Strictly per-station (PSY-1074): a network flagship's feed contains only
+ * its own playlists — channel shows live under their own tabs.
  *
  * `keepPreviousData` so a "more playlists" limit bump re-renders the table in
  * place instead of flashing back to a loading state.

--- a/frontend/features/radio/types.ts
+++ b/frontend/features/radio/types.ts
@@ -373,8 +373,9 @@ export interface RadioEpisodePreviewArtist {
 
 /**
  * An episode row in the station-scoped and dial-wide latest-playlists feeds:
- * episode fields plus show and channel (station) attribution. A network
- * flagship's feed already includes its channels server-side.
+ * episode fields plus show and station attribution. Station-scoped feeds are
+ * strictly per-station (PSY-1074); the station_* fields exist for the
+ * dial-wide hub feed's STATION column.
  */
 export interface RadioStationEpisodeRow {
   id: number


### PR DESCRIPTION
## Summary

Station tabs are now **strictly per-station**: the playlists feed and the sidebar TOP ARTISTS / TOP LABELS on a station page scope to the requested station only. This **reverses the PSY-1048 "flagship aggregates network" rule** per user decision (2026-06-11) — the WFMU 91.1 tab no longer mixes Sheena's/Rock'n'Soul/Drummer shows into its feed; users find channel shows under their respective tabs. The dial-wide hub feed (`GET /radio/episodes/recent`) is unchanged (cross-station by design).

- Backend: `GetStationEpisodes` / `GetTopArtistsForStation` / `GetTopLabelsForStation` drop the `stationFamilyIDs` expansion (helper deleted along with its PSY-1048 policy notes, including the PSY-1050 new-release-radar divergence note — the divergence disappears now that everything is per-station). A new `verifyStationExists` helper preserves the unknown-station 404. `stationFamilyScope([]uint)` → `stationScope(uint)`.
- Handler/OpenAPI doc strings and the `RadioStationEpisodeRow` contract comments updated; `station_*` fields stay (the hub feed renders its STATION column from them).
- Frontend: `StationPlaylistsFeed` heading is always "Latest playlists" (flagship special-case heading removed) and the CHANNEL column + multi-station row logic are gone. Stale family-scope doc text updated in `useStationEpisodes`, `types.ts`, `StationSidebar`. The hub's `LatestPlaylistsTable` is untouched.
- Integration tests renamed honestly: `TestGetStationEpisodes_StrictPerStation`, `TestGetTopArtistsForStation_StrictPerStation`, `TestGetTopLabelsForStation_StrictPerStation` — flagship feeds/aggregates now assert ONLY-own-station data. NilDB tests unchanged.

## Test plan

- [x] `cd backend && go build ./...`
- [x] `cd backend && go test ./...` — full suite green (one intermediate failure was my own new test asserting tie-break order between two 1-play artists; fixed with `ElementsMatch`)
- [x] `cd frontend && bun run typecheck`
- [x] `cd frontend && bun run lint` — 0 errors (148 pre-existing warnings)
- [x] `cd frontend && bun run test:run features/radio app/radio` — 35 files, 268 tests passed

## Manual repro (isolated dispatch stack)

Stack seed had WFMU shows but no episodes, so repro rows were inserted into the isolated stack DB: a same-named "Give The Drummer Some" show under both WFMU 91.1 and the Drummer channel (mirroring the PSY-1073 seed duplication), episodes under each, plus one play per station. Assertions are on `station_slug` uniformity, not show names.

`GET /radio-stations/wfmu/episodes?limit=5` — all rows `station_slug=wfmu`; the Drummer's newer (06-10) episode is correctly absent:

```
total: 2
2026-06-09 | wfmu | WFMU | Bodega Pop
2026-06-08 | wfmu | WFMU | Give The Drummer Some
```

`GET /radio-stations/wfmu-drummer/episodes?limit=5` — only Drummer rows:

```
total: 1
2026-06-10 | wfmu-drummer | Give the Drummer Radio | Give The Drummer Some
```

`GET /radio-stations/wfmu/top-artists` → only "Flagship Only Artist"; `GET /radio-stations/wfmu-drummer/top-artists` → only "Drummer Only Artist".

## Screenshots

WFMU 91.1 tab — per-station "LATEST PLAYLISTS" heading, no CHANNEL column, only 91.1 rows; TOP ARTISTS shows only the flagship's play:

![wfmu flagship tab](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1074-screenshots/wfmu-flagship-tab.png)

Give the Drummer Radio channel tab — only its own playlist + top artist:

![wfmu drummer channel tab](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1074-screenshots/wfmu-drummer-channel-tab.png)

Hub `/radio` — dial-wide table UNCHANGED, still cross-station with STATION column:

![radio hub dial-wide](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1074-screenshots/radio-hub-dial-wide.png)

## Code review

Lenses run inline (dispatched sub-agent, no Agent tool). No correctness findings: unknown-station 404 preserved via `verifyStationExists`, nil-DB paths preserved, handler interfaces/mocks unchanged, hub feed untouched. Considered narrowing `StationPlaylistsFeed`'s prop to just the slug; skipped — peer station-page panels all take the full `station`, keeping the component family consistent.

## Adversarial review

Inline (Saboteur / Future-Maintainer / Security / Completeness). Verdict: **CLEAN**.

- Future-Maintainer: repo-wide grep for stale "network family"/"flagship aggregates"/"all channels" doc text — only survivor is the intentional negative assertion in `StationPlaylistsFeed.test.tsx`.
- Saboteur: inactive-station archives still served per-station (no `is_active` filter added — hub-vs-archive policy preserved); unverified numeric-ID path still 404s in the service; verify-then-query race yields a harmless empty 200 (pre-existing pattern).
- Security: parameterized queries only; no new inputs; doc-only OpenAPI changes.
- Completeness: all five ACs verified (curl excerpts, screenshots, renamed tests, doc-text grep).

Closes PSY-1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)
