### PR TITLE
PSY-1073: station-scoped WFMU discovery + family show dedup cmd

### DIFF
--- a/backend/cmd/dedup-radio-shows/main.go
+++ b/backend/cmd/dedup-radio-shows/main.go
@@ -89,6 +89,7 @@ func printResult(r *catalog.WFMUDedupResult) {
 	fmt.Printf("Show-code groups found:      %d\n", r.GroupsTotal)
 	fmt.Printf("Groups needing changes:      %d\n", r.GroupsWithDuplicates)
 	fmt.Printf("Rows skipped (no ext. id):   %d\n", r.ShowsWithNoExternalID)
+	fmt.Printf("Slugs recanonicalised:       %d\n", r.SlugsRecanonicalised)
 	fmt.Println()
 	fmt.Println("Per station:")
 	for _, slug := range catalog.WFMUFamilySlugs {

--- a/backend/cmd/dedup-radio-shows/main.go
+++ b/backend/cmd/dedup-radio-shows/main.go
@@ -1,0 +1,123 @@
+// Command dedup-radio-shows collapses the duplicated WFMU-family show
+// catalog (PSY-1073). Before station-scoped discovery, every discover cycle
+// assigned the entire WFMU DJ index to whichever family station triggered
+// it, so all four stations (WFMU 91.1, Give the Drummer, Rock'n'Soul,
+// Sheena's Jungle Room) carried a full duplicate copy of every show plus its
+// episode/play history.
+//
+// The command fetches WFMU's schedule pages to compute the canonical owner
+// of each show code (the station whose stream airs it; everything ambiguous
+// or defunct defaults to the flagship), then merges each code's duplicate
+// rows onto the owner: episodes follow their show, duplicate episode copies
+// keep whichever side logged more plays, import jobs re-point to the
+// survivor, and the duplicate rows are deleted. The whole run is one
+// transaction.
+//
+// Usage:
+//
+//	go run ./cmd/dedup-radio-shows               # dry-run (default)
+//	go run ./cmd/dedup-radio-shows --confirm     # apply changes
+//
+// Dry-run executes the full plan inside a transaction and rolls it back, so
+// the printed counts are exactly what --confirm would commit. Idempotent:
+// re-running after a live run reports zero duplicate groups.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/joho/godotenv"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/services/catalog"
+)
+
+var (
+	confirm bool
+	envFile string
+)
+
+func main() {
+	flag.BoolVar(&confirm, "confirm", false, "Apply changes (default: dry-run only)")
+	flag.StringVar(&envFile, "env", "", "Path to .env file (defaults to .env.development / .env)")
+	flag.Parse()
+
+	loadEnv()
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	if err := db.Connect(cfg); err != nil {
+		log.Fatalf("connect db: %v", err)
+	}
+	database := db.GetDB()
+
+	mode := "DRY RUN"
+	if confirm {
+		mode = "LIVE"
+	}
+	fmt.Printf("=== WFMU Radio Show Dedup (%s) — PSY-1073 ===\n\n", mode)
+
+	// Ownership comes from wfmu.org's live schedule pages — the same source
+	// the station-scoped importer uses, so cleanup and future discovery
+	// agree on every show's home. A fetch failure aborts: guessing
+	// ownership would mis-home shows.
+	provider := catalog.NewWFMUProvider()
+	defer provider.Close()
+
+	fmt.Println("Fetching WFMU schedule pages for show ownership...")
+	ownership, err := provider.FetchShowOwnership()
+	if err != nil {
+		log.Fatalf("fetch show ownership from wfmu.org: %v", err)
+	}
+	fmt.Printf("Resolved ownership for %d show codes (codes not listed default to the flagship).\n\n", len(ownership))
+
+	result, err := catalog.DedupWFMUFamilyShows(database, ownership, !confirm)
+	if err != nil {
+		log.Fatalf("dedup failed (transaction rolled back): %v", err)
+	}
+
+	printResult(result)
+}
+
+func printResult(r *catalog.WFMUDedupResult) {
+	fmt.Println("=== Summary ===")
+	fmt.Printf("Show-code groups found:      %d\n", r.GroupsTotal)
+	fmt.Printf("Groups needing changes:      %d\n", r.GroupsWithDuplicates)
+	fmt.Printf("Rows skipped (no ext. id):   %d\n", r.ShowsWithNoExternalID)
+	fmt.Println()
+	fmt.Println("Per station:")
+	for _, slug := range catalog.WFMUFamilySlugs {
+		c := r.PerStation[slug]
+		fmt.Printf("  %-22s shows kept=%d reassigned-in=%d deleted=%d | episodes moved-in=%d dup-deleted=%d | jobs reassigned=%d\n",
+			slug, c.ShowsKept, c.ShowsReassignedIn, c.ShowsDeleted, c.EpisodesMovedIn, c.EpisodesDeleted, c.JobsReassigned)
+	}
+	fmt.Println()
+	if r.DryRun {
+		fmt.Println("DRY RUN — full plan executed in a transaction and rolled back.")
+		fmt.Println("No DB writes. Re-run with --confirm to apply these exact changes.")
+	} else {
+		fmt.Println("LIVE — changes committed.")
+	}
+}
+
+func loadEnv() {
+	if envFile != "" {
+		if err := godotenv.Load(envFile); err != nil {
+			log.Fatalf("load env file %s: %v", envFile, err)
+		}
+		log.Printf("loaded env from %s", envFile)
+		return
+	}
+	for _, ef := range []string{".env.development", ".env"} {
+		if err := godotenv.Load(ef); err == nil {
+			log.Printf("loaded env from %s", ef)
+			return
+		}
+	}
+	log.Println("no .env loaded; using process environment")
+}

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -53,6 +53,27 @@ func (s *RadioService) getProvider(source string) (RadioPlaylistProvider, error)
 	}
 }
 
+// stationScopedShowDiscoverer is implemented by providers whose discovery
+// source mixes multiple stations' shows in one index. WFMU's DJ index spans
+// the 91.1 broadcast plus three stream-only channels; importing it unfiltered
+// for every family station duplicated the entire catalog under each channel
+// (PSY-1073). When a provider implements this, discovery flows call the
+// station-scoped method so each station only receives shows that air on its
+// stream.
+type stationScopedShowDiscoverer interface {
+	DiscoverShowsForStation(stationSlug string) ([]RadioShowImport, error)
+}
+
+// discoverShowsForStation routes discovery through the station-scoped path
+// when the provider supports it, falling back to the provider-wide index for
+// single-station providers (KEXP, NTS).
+func discoverShowsForStation(provider RadioPlaylistProvider, station *catalogm.RadioStation) ([]RadioShowImport, error) {
+	if scoped, ok := provider.(stationScopedShowDiscoverer); ok {
+		return scoped.DiscoverShowsForStation(station.Slug)
+	}
+	return provider.DiscoverShows()
+}
+
 // parseImportDate parses an import-window bound (since/until). The value may
 // arrive date-only ("2026-03-02") from the API, or as a Postgres DATE-column
 // round-trip ("2026-03-02T00:00:00Z") when read back from a persisted import
@@ -86,8 +107,8 @@ func (s *RadioService) ImportStation(stationID uint, backfillDays int) (*contrac
 
 	result := &contracts.RadioImportResult{}
 
-	// 1. Discover shows
-	importedShows, err := provider.DiscoverShows()
+	// 1. Discover shows (station-scoped for multi-stream providers, PSY-1073)
+	importedShows, err := discoverShowsForStation(provider, &station)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("discover shows: %v", err))
 		return result, nil
@@ -290,7 +311,9 @@ func (s *RadioService) DiscoverStationShows(stationID uint) (*contracts.RadioDis
 
 	result := &contracts.RadioDiscoverResult{}
 
-	importedShows, err := provider.DiscoverShows()
+	// Station-scoped for multi-stream providers (PSY-1073): each WFMU-family
+	// station only receives the shows that air on its own stream.
+	importedShows, err := discoverShowsForStation(provider, &station)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("discover shows: %v", err))
 		return result, nil

--- a/backend/internal/services/catalog/radio_provider_wfmu.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu.go
@@ -55,6 +55,13 @@ func (p *WFMUProvider) Close() {
 }
 
 // DiscoverShows returns all WFMU programs by parsing the DJ index page.
+//
+// NOTE (PSY-1073): the DJ index is one flat list spanning the 91.1 broadcast
+// AND the three stream-only channels (Give the Drummer, Rock'n'Soul,
+// Sheena's Jungle Room). Importing this unfiltered for every WFMU-family
+// station duplicated the full 574-show catalog under each channel. Import
+// flows must use DiscoverShowsForStation (the stationScopedShowDiscoverer
+// path in radio_import.go) so each station only receives its own shows.
 func (p *WFMUProvider) DiscoverShows() ([]RadioShowImport, error) {
 	<-p.rateLimiter.C
 
@@ -69,6 +76,189 @@ func (p *WFMUProvider) DiscoverShows() ([]RadioShowImport, error) {
 	}
 
 	return shows, nil
+}
+
+// =============================================================================
+// Station-scoped discovery (PSY-1073)
+// =============================================================================
+
+// wfmuStationChannels maps our seeded radio_stations.slug values (migration
+// 20260502023012) to WFMU channel keys. A WFMU-family station whose slug is
+// not in this map cannot be scope-discovered — DiscoverShowsForStation returns
+// an error rather than silently importing the whole catalog again.
+var wfmuStationChannels = map[string]string{
+	"wfmu":                wfmuLiveChannelMain,
+	"wfmu-drummer":        wfmuLiveChannelDrummer,
+	"wfmu-rocknsoulradio": wfmuLiveChannelRockSoul,
+	"wfmu-sheena":         wfmuLiveChannelSheena,
+}
+
+// wfmuChannelSchedulePaths are the wfmu.org pages that enumerate which
+// programs air on each stream. /table is the 91.1 weekly schedule; the three
+// channel landing pages each carry the channel's program roster (anchors with
+// relative /playlists/{CODE} hrefs — description cross-references use
+// absolute URLs and are excluded by extractShowCode's anchored regex).
+// Verified live 2026-06-11: rosters are mutually disjoint and all roster
+// codes exist in the DJ index.
+var wfmuChannelSchedulePaths = map[string]string{
+	wfmuLiveChannelMain:     "/table",
+	wfmuLiveChannelDrummer:  "/drummer",
+	wfmuLiveChannelRockSoul: "/rocknsoulradio",
+	wfmuLiveChannelSheena:   "/sheena",
+}
+
+// wfmuChannelArtifactShows pins the channel-stream-as-show rows to their
+// channels. These DJ-index entries are named after the stream itself and
+// their "episodes" are the channel's whole-stream playlists aired between
+// live-DJ slots. They are not all present on their channel's roster page
+// (only RQ is, as of 2026-06-11), so without this override they would
+// default to the flagship — which is exactly the "Rock'n'Soul Radio is the
+// most-active show on every station" artifact PSY-1073 fixes. Their episode
+// and play data stays intact, scoped to the channel station only.
+var wfmuChannelArtifactShows = map[string]string{
+	"GW": wfmuLiveChannelDrummer,  // "Give The Drummer Radio"
+	"RQ": wfmuLiveChannelRockSoul, // "Rock'n'Soul Radio"
+	"JZ": wfmuLiveChannelSheena,   // "Sheena's Jungle Room Stream"
+}
+
+// DiscoverShowsForStation returns only the WFMU programs that air on the
+// given station's stream (PSY-1073). stationSlug must be one of the seeded
+// WFMU-family slugs in wfmuStationChannels.
+//
+// Ownership rule (channels keep only shows provably theirs; everything
+// ambiguous or unknown defaults to the flagship):
+//  1. Channel-stream artifact codes (wfmuChannelArtifactShows) → their channel.
+//  2. Codes on the 91.1 /table schedule → flagship, even when a channel also
+//     rebroadcasts them (e.g. five 91.1 shows rerun on Rock'n'Soul).
+//  3. Codes on exactly one channel roster page → that channel.
+//  4. Everything else (defunct shows, codes on no roster) → flagship.
+func (p *WFMUProvider) DiscoverShowsForStation(stationSlug string) ([]RadioShowImport, error) {
+	channel, ok := wfmuStationChannels[stationSlug]
+	if !ok {
+		return nil, fmt.Errorf("unknown WFMU station slug %q: add it to wfmuStationChannels before discovery", stationSlug)
+	}
+
+	allShows, err := p.DiscoverShows()
+	if err != nil {
+		return nil, err
+	}
+
+	channelByCode, err := p.fetchShowChannels()
+	if err != nil {
+		return nil, err
+	}
+
+	var scoped []RadioShowImport
+	for _, show := range allShows {
+		owner, found := channelByCode[show.ExternalID]
+		if !found {
+			owner = wfmuLiveChannelMain // unknown/defunct → flagship
+		}
+		if owner == channel {
+			scoped = append(scoped, show)
+		}
+	}
+	return scoped, nil
+}
+
+// FetchShowOwnership returns external show code → owning station slug for
+// every code visible on WFMU's schedule pages, plus the channel-stream
+// artifact codes. Codes absent from the map belong to the flagship by
+// default. Used by cmd/dedup-radio-shows to compute the canonical owner for
+// existing duplicated rows with the same rule set as discovery.
+func (p *WFMUProvider) FetchShowOwnership() (map[string]string, error) {
+	channelByCode, err := p.fetchShowChannels()
+	if err != nil {
+		return nil, err
+	}
+
+	slugByChannel := make(map[string]string, len(wfmuStationChannels))
+	for slug, ch := range wfmuStationChannels {
+		slugByChannel[ch] = slug
+	}
+
+	ownership := make(map[string]string, len(channelByCode))
+	for code, ch := range channelByCode {
+		ownership[code] = slugByChannel[ch]
+	}
+	return ownership, nil
+}
+
+// fetchShowChannels fetches the four schedule pages and resolves each show
+// code to its owning channel per the DiscoverShowsForStation rule set.
+func (p *WFMUProvider) fetchShowChannels() (map[string]string, error) {
+	codesByChannel := make(map[string]map[string]bool, len(wfmuChannelSchedulePaths))
+	// Deterministic fetch order (map iteration order is random).
+	for _, channel := range []string{wfmuLiveChannelMain, wfmuLiveChannelDrummer, wfmuLiveChannelRockSoul, wfmuLiveChannelSheena} {
+		path := wfmuChannelSchedulePaths[channel]
+		<-p.rateLimiter.C
+		body, err := p.doGet(p.baseURL + path)
+		if err != nil {
+			return nil, fmt.Errorf("fetching %s schedule page %s: %w", channel, path, err)
+		}
+		codes, err := parseWFMUScheduleCodes(body)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s schedule page %s: %w", channel, path, err)
+		}
+		if len(codes) == 0 {
+			// An empty roster means the page layout changed (or an error page
+			// slipped through with HTTP 200). Treating it as "this channel
+			// owns nothing" would silently dump the channel's shows on the
+			// flagship — fail loudly instead.
+			return nil, fmt.Errorf("no show codes found on %s schedule page %s: page layout may have changed", channel, path)
+		}
+		codesByChannel[channel] = codes
+	}
+
+	mainCodes := codesByChannel[wfmuLiveChannelMain]
+	channelByCode := make(map[string]string)
+	for code := range mainCodes {
+		channelByCode[code] = wfmuLiveChannelMain
+	}
+	for _, channel := range []string{wfmuLiveChannelDrummer, wfmuLiveChannelRockSoul, wfmuLiveChannelSheena} {
+		for code := range codesByChannel[channel] {
+			if mainCodes[code] {
+				continue // 91.1 broadcast wins over a channel rebroadcast
+			}
+			if existing, dup := channelByCode[code]; dup && existing != channel {
+				// On two channel rosters at once — ambiguous, default flagship.
+				channelByCode[code] = wfmuLiveChannelMain
+				continue
+			}
+			channelByCode[code] = channel
+		}
+	}
+	for code, channel := range wfmuChannelArtifactShows {
+		channelByCode[code] = channel
+	}
+	return channelByCode, nil
+}
+
+// parseWFMUScheduleCodes extracts the set of show codes linked from a WFMU
+// schedule page (/table or a channel landing page). Only anchors whose href
+// is exactly /playlists/{CODE} count — extractShowCode's anchored regex
+// excludes episode links, the index link, and absolute-URL cross-references
+// inside program descriptions.
+func parseWFMUScheduleCodes(body []byte) (map[string]bool, error) {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	codes := make(map[string]bool)
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			if code := extractShowCode(getAttr(n, "href")); code != "" {
+				codes[code] = true
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return codes, nil
 }
 
 // FetchNewEpisodes returns episodes for a WFMU show within [since, until].

--- a/backend/internal/services/catalog/radio_provider_wfmu_scoped_test.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu_scoped_test.go
@@ -188,6 +188,19 @@ func TestWFMU_FetchShowOwnership(t *testing.T) {
 	}, ownership)
 }
 
+func TestWFMU_FamilySlugs_MatchProviderChannelMap(t *testing.T) {
+	// wfmuStationChannels (provider, discovery scoping) and WFMUFamilySlugs
+	// (dedup command) describe the same station family. They are maintained
+	// by hand in two files; this pins them together so adding a channel to
+	// one without the other fails loudly instead of silently mis-scoping.
+	assert.Len(t, wfmuStationChannels, len(WFMUFamilySlugs))
+	for _, slug := range WFMUFamilySlugs {
+		assert.Contains(t, wfmuStationChannels, slug)
+	}
+	assert.Contains(t, wfmuStationChannels, WFMUFlagshipSlug)
+	assert.Equal(t, wfmuLiveChannelMain, wfmuStationChannels[WFMUFlagshipSlug])
+}
+
 func TestWFMU_ParseScheduleCodes_RealChannelLandingMarkup(t *testing.T) {
 	// Mirrors the real channel-landing markup shape (KenzoDB expander rows)
 	// to pin the relative-href extraction against the live page structure.

--- a/backend/internal/services/catalog/radio_provider_wfmu_scoped_test.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu_scoped_test.go
@@ -1,0 +1,207 @@
+package catalog
+
+// Tests for WFMU station-scoped show discovery (PSY-1073). The DJ index is
+// one flat list spanning all four WFMU streams; these tests verify that
+// DiscoverShowsForStation filters it down to per-stream catalogs using the
+// /table + channel-landing-page rosters and the channel-artifact overrides.
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Synthetic DJ index covering every ownership class:
+//
+//	WA — on the 91.1 /table schedule → flagship
+//	CK — on /table AND the Rock'n'Soul roster (rebroadcast) → flagship
+//	MY — on the Drummer roster only → drummer
+//	SH — on the Sheena roster only → sheena
+//	RQ — "Rock'n'Soul Radio" channel artifact (also on its roster) → rocknsoul
+//	GW — "Give The Drummer Radio" channel artifact, on NO roster → drummer
+//	JZ — "Sheena's Jungle Room Stream" channel artifact, on NO roster → sheena
+//	ZZ — defunct, on no schedule page → flagship (unknown default)
+const wfmuScopedDJIndexHTML = `<!DOCTYPE html>
+<html><body>
+<p><b>Wake</b> with Clay Pigeon <a href="/playlists/WA">playlists and archives</a></p>
+<p><b>Cool Show</b> with CK Host <a href="/playlists/CK">playlists and archives</a></p>
+<p><b>100% Whatever</b> with Mary Wing <a href="/playlists/MY">playlists and archives</a></p>
+<p><b>Sheena Show</b> with Sheena Host <a href="/playlists/SH">playlists and archives</a></p>
+<p><b>Rock'n'Soul Radio</b> <a href="/playlists/RQ">playlists and archives</a></p>
+<p><b>Give The Drummer Radio</b> <a href="/playlists/GW">playlists and archives</a></p>
+<p><b>Sheena's Jungle Room Stream</b> <a href="/playlists/JZ">playlists and archives</a></p>
+<p><b>Defunct Show</b> with Old Host <a href="/playlists/ZZ">playlists and archives</a></p>
+</body></html>`
+
+const wfmuScopedTableHTML = `<!DOCTYPE html>
+<html><body>
+<a href="/playlists/WA" class="show-title-link">Wake</a>
+<a href="/playlists/CK" class="show-title-link">Cool Show</a>
+</body></html>`
+
+// Drummer roster includes an absolute-URL cross-reference to WA inside a
+// description — those must NOT count as roster membership (only exact
+// relative /playlists/{CODE} hrefs do).
+const wfmuScopedDrummerHTML = `<!DOCTYPE html>
+<html><body>
+<a href="/playlists/MY" title="Browse playlists &amp; archives">100% Whatever with Mary Wing</a>
+<i>Also hear her on <a href="https://wfmu.org/playlists/WA">Wake</a> sometimes.</i>
+</body></html>`
+
+const wfmuScopedRockSoulHTML = `<!DOCTYPE html>
+<html><body>
+<a href="/playlists/RQ" title="Browse playlists &amp; archives">Rock'n'Soul Radio</a>
+<a href="/playlists/CK" title="Browse playlists &amp; archives">Cool Show (91.1 rebroadcast)</a>
+</body></html>`
+
+const wfmuScopedSheenaHTML = `<!DOCTYPE html>
+<html><body>
+<a href="/playlists/SH" title="Browse playlists &amp; archives">Sheena Show</a>
+</body></html>`
+
+// newScopedWFMUTestServer serves the synthetic DJ index plus all four
+// schedule pages.
+func newScopedWFMUTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		switch r.URL.Path {
+		case "/playlists/":
+			_, _ = fmt.Fprint(w, wfmuScopedDJIndexHTML)
+		case "/table":
+			_, _ = fmt.Fprint(w, wfmuScopedTableHTML)
+		case "/drummer":
+			_, _ = fmt.Fprint(w, wfmuScopedDrummerHTML)
+		case "/rocknsoulradio":
+			_, _ = fmt.Fprint(w, wfmuScopedRockSoulHTML)
+		case "/sheena":
+			_, _ = fmt.Fprint(w, wfmuScopedSheenaHTML)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func scopedShowCodes(shows []RadioShowImport) []string {
+	codes := make([]string, 0, len(shows))
+	for _, s := range shows {
+		codes = append(codes, s.ExternalID)
+	}
+	return codes
+}
+
+func TestWFMU_DiscoverShowsForStation_ScopesByStream(t *testing.T) {
+	server := newScopedWFMUTestServer(t)
+
+	tests := []struct {
+		stationSlug string
+		wantCodes   []string
+	}{
+		// Flagship: 91.1 schedule (incl. the CK rebroadcast — /table wins)
+		// plus the defunct unknown.
+		{"wfmu", []string{"WA", "CK", "ZZ"}},
+		// Drummer: roster show + the GW artifact pinned by override.
+		{"wfmu-drummer", []string{"MY", "GW"}},
+		// Rock'n'Soul: only its artifact — CK went to the flagship.
+		{"wfmu-rocknsoulradio", []string{"RQ"}},
+		// Sheena: roster show + the JZ artifact pinned by override.
+		{"wfmu-sheena", []string{"SH", "JZ"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.stationSlug, func(t *testing.T) {
+			provider := NewWFMUProviderWithClient(server.Client(), server.URL)
+			defer provider.Close()
+
+			shows, err := provider.DiscoverShowsForStation(tc.stationSlug)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantCodes, scopedShowCodes(shows))
+		})
+	}
+}
+
+func TestWFMU_DiscoverShowsForStation_UnknownSlugErrors(t *testing.T) {
+	server := newScopedWFMUTestServer(t)
+	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	_, err := provider.DiscoverShowsForStation("wfmu-new-channel")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown WFMU station slug")
+}
+
+func TestWFMU_DiscoverShowsForStation_EmptyRosterErrors(t *testing.T) {
+	// A schedule page that parses but contains no show links means the page
+	// layout changed — discovery must fail loudly instead of silently
+	// dumping that channel's shows on the flagship.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		switch r.URL.Path {
+		case "/playlists/":
+			_, _ = fmt.Fprint(w, wfmuScopedDJIndexHTML)
+		case "/table":
+			_, _ = fmt.Fprint(w, wfmuScopedTableHTML)
+		case "/drummer":
+			_, _ = fmt.Fprint(w, `<html><body>maintenance page, no roster</body></html>`)
+		case "/rocknsoulradio":
+			_, _ = fmt.Fprint(w, wfmuScopedRockSoulHTML)
+		case "/sheena":
+			_, _ = fmt.Fprint(w, wfmuScopedSheenaHTML)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	_, err := provider.DiscoverShowsForStation("wfmu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no show codes found")
+}
+
+func TestWFMU_FetchShowOwnership(t *testing.T) {
+	server := newScopedWFMUTestServer(t)
+	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	ownership, err := provider.FetchShowOwnership()
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		"WA": "wfmu",
+		"CK": "wfmu", // /table beats the Rock'n'Soul rebroadcast listing
+		"MY": "wfmu-drummer",
+		"GW": "wfmu-drummer", // artifact override
+		"RQ": "wfmu-rocknsoulradio",
+		"SH": "wfmu-sheena",
+		"JZ": "wfmu-sheena", // artifact override
+		// ZZ intentionally absent: unknown codes default to the flagship
+		// at the consumer (DiscoverShowsForStation / dedup).
+	}, ownership)
+}
+
+func TestWFMU_ParseScheduleCodes_RealChannelLandingMarkup(t *testing.T) {
+	// Mirrors the real channel-landing markup shape (KenzoDB expander rows)
+	// to pin the relative-href extraction against the live page structure.
+	page := `<html><body>
+<span class="expander_section_with_desc">
+<a href="/playlists/MY" title="Browse playlists &amp; archives">100% Whatever with Mary Wing</a>
+<span id="expander_target_28">
+<i>desc with cross-ref <a href="https://wfmu.org/playlists/GB">Someday Matinee</a></i>
+</span></span>
+<a href="/playlists/shows/162230">See the playlist</a>
+<a href="/playlists/">index</a>
+</body></html>`
+
+	codes, err := parseWFMUScheduleCodes([]byte(page))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{"MY": true}, codes)
+}

--- a/backend/internal/services/catalog/radio_wfmu_dedup.go
+++ b/backend/internal/services/catalog/radio_wfmu_dedup.go
@@ -43,7 +43,6 @@ var WFMUFamilySlugs = []string{
 
 // WFMUDedupStationCounts aggregates per-station outcomes of a dedup run.
 type WFMUDedupStationCounts struct {
-	StationID         uint
 	ShowsKept         int // canonical rows that ended up on this station
 	ShowsReassignedIn int // rows moved onto this station from a sibling
 	ShowsDeleted      int // duplicate rows deleted from this station
@@ -123,7 +122,7 @@ func runWFMUDedup(tx *gorm.DB, ownership map[string]string, result *WFMUDedupRes
 		stationIDs = append(stationIDs, st.ID)
 	}
 	for _, slug := range WFMUFamilySlugs {
-		result.PerStation[slug] = &WFMUDedupStationCounts{StationID: stationIDBySlug[slug]}
+		result.PerStation[slug] = &WFMUDedupStationCounts{}
 	}
 
 	// Group every family show row by external code.
@@ -181,6 +180,15 @@ func runWFMUDedup(tx *gorm.DB, ownership map[string]string, result *WFMUDedupRes
 				Update("station_id", ownerID).Error; err != nil {
 				return fmt.Errorf("reassigning show id=%d to station %s: %w", winner.ID, ownerSlug, err)
 			}
+			// Keep the denormalized station_id on the winner's own import
+			// jobs consistent with its new home (loser-pointing jobs were
+			// already re-pointed during the merges above).
+			res := tx.Model(&catalogm.RadioImportJob{}).Where("show_id = ?", winner.ID).
+				Update("station_id", ownerID)
+			if res.Error != nil {
+				return fmt.Errorf("updating import jobs for reassigned show id=%d: %w", winner.ID, res.Error)
+			}
+			result.PerStation[ownerSlug].JobsReassigned += int(res.RowsAffected)
 			result.PerStation[ownerSlug].ShowsReassignedIn++
 		}
 		result.PerStation[ownerSlug].ShowsKept++
@@ -236,7 +244,9 @@ func mergeWFMUDuplicateShow(
 	loserStationCounts := result.PerStation[slugByStationID[loser.StationID]]
 	ownerCounts := result.PerStation[ownerSlug]
 
-	// 1a. Winner copies beaten by a richer loser copy.
+	// 1a. Winner copies beaten by a richer loser copy. Richness compares
+	// actual radio_plays rows, not the denormalized play_count column — a
+	// stale counter must never decide which copy's play history survives.
 	res := tx.Exec(`
 		DELETE FROM radio_episodes w
 		WHERE w.show_id = ?
@@ -245,7 +255,8 @@ func mergeWFMUDuplicateShow(
 			WHERE l.show_id = ?
 			  AND l.air_date = w.air_date
 			  AND COALESCE(l.external_id, '') = COALESCE(w.external_id, '')
-			  AND l.play_count > w.play_count
+			  AND (SELECT COUNT(*) FROM radio_plays WHERE episode_id = l.id) >
+			      (SELECT COUNT(*) FROM radio_plays WHERE episode_id = w.id)
 		  )`, winner.ID, loser.ID)
 	if res.Error != nil {
 		return fmt.Errorf("deleting outplayed winner episodes: %w", res.Error)

--- a/backend/internal/services/catalog/radio_wfmu_dedup.go
+++ b/backend/internal/services/catalog/radio_wfmu_dedup.go
@@ -1,0 +1,325 @@
+package catalog
+
+// WFMU family show dedup (PSY-1073).
+//
+// Before the station-scoped discovery fix, every discover cycle assigned the
+// ENTIRE WFMU DJ index (574 shows) to whichever family station triggered it,
+// so each of the four stations carried a full duplicate catalog — the same
+// program existed as four distinct radio_shows rows (one per station), each
+// with its own copy of the episode/play history.
+//
+// DedupWFMUFamilyShows collapses each external-show-code group down to one
+// canonical row on the station that actually airs the show (the ownership
+// map comes from WFMUProvider.FetchShowOwnership; codes absent from the map
+// default to the flagship). Episode history merges into the winner —
+// duplicate (air_date, external_id) copies keep whichever side logged more
+// plays — and import jobs re-point to the winner before loser rows are
+// deleted. The whole run executes in one transaction; dry-run executes the
+// identical plan and rolls it back, so reported counts always match what a
+// live run would do.
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"gorm.io/gorm"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+)
+
+// WFMUFlagshipSlug is the seeded slug of the WFMU 91.1 flagship station.
+const WFMUFlagshipSlug = "wfmu"
+
+// WFMUFamilySlugs are the seeded slugs of the four WFMU-family stations
+// (migration 20260502023012). Keep in sync with wfmuStationChannels in
+// radio_provider_wfmu.go.
+var WFMUFamilySlugs = []string{
+	WFMUFlagshipSlug,
+	"wfmu-drummer",
+	"wfmu-rocknsoulradio",
+	"wfmu-sheena",
+}
+
+// WFMUDedupStationCounts aggregates per-station outcomes of a dedup run.
+type WFMUDedupStationCounts struct {
+	StationID         uint
+	ShowsKept         int // canonical rows that ended up on this station
+	ShowsReassignedIn int // rows moved onto this station from a sibling
+	ShowsDeleted      int // duplicate rows deleted from this station
+	EpisodesMovedIn   int // episodes re-pointed to a winner on this station
+	EpisodesDeleted   int // duplicate-episode copies deleted from this station's losers/winners
+	JobsReassigned    int // radio_import_jobs re-pointed to a winner on this station
+}
+
+// WFMUDedupResult is the full outcome of a DedupWFMUFamilyShows run.
+type WFMUDedupResult struct {
+	DryRun                bool
+	GroupsTotal           int // distinct external show codes across the family
+	GroupsWithDuplicates  int // codes that had >1 row or a misplaced single row
+	ShowsWithNoExternalID int // rows skipped (cannot be grouped)
+	PerStation            map[string]*WFMUDedupStationCounts // keyed by station slug
+}
+
+// errDryRunRollback aborts the dedup transaction after the full plan has
+// executed, turning a live run into a dry run with identical counts.
+var errDryRunRollback = errors.New("wfmu dedup dry-run rollback")
+
+// DedupWFMUFamilyShows merges duplicated WFMU-family show rows onto their
+// canonical stations. ownership maps external show code → owning station
+// slug (see WFMUProvider.FetchShowOwnership); codes missing from the map
+// default to the flagship. With dryRun=true the full plan executes inside a
+// transaction and is rolled back, so the returned counts are exact.
+//
+// Idempotent: a second run finds every group already singular and on its
+// owner, and reports all-zero mutation counts.
+func DedupWFMUFamilyShows(db *gorm.DB, ownership map[string]string, dryRun bool) (*WFMUDedupResult, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	result := &WFMUDedupResult{
+		DryRun:     dryRun,
+		PerStation: make(map[string]*WFMUDedupStationCounts, len(WFMUFamilySlugs)),
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := runWFMUDedup(tx, ownership, result); err != nil {
+			return err
+		}
+		if dryRun {
+			return errDryRunRollback
+		}
+		return nil
+	})
+	if errors.Is(err, errDryRunRollback) {
+		err = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func runWFMUDedup(tx *gorm.DB, ownership map[string]string, result *WFMUDedupResult) error {
+	// Load the family stations. All four must exist — a partial family means
+	// the seed migration hasn't run and "default to flagship" could target
+	// the wrong database.
+	var stations []catalogm.RadioStation
+	if err := tx.Where("slug IN ?", WFMUFamilySlugs).Find(&stations).Error; err != nil {
+		return fmt.Errorf("loading WFMU family stations: %w", err)
+	}
+	if len(stations) != len(WFMUFamilySlugs) {
+		return fmt.Errorf("expected %d WFMU family stations, found %d (slugs %v): run the WFMU seed migration first",
+			len(WFMUFamilySlugs), len(stations), WFMUFamilySlugs)
+	}
+
+	stationIDBySlug := make(map[string]uint, len(stations))
+	slugByStationID := make(map[uint]string, len(stations))
+	var stationIDs []uint
+	for _, st := range stations {
+		stationIDBySlug[st.Slug] = st.ID
+		slugByStationID[st.ID] = st.Slug
+		stationIDs = append(stationIDs, st.ID)
+	}
+	for _, slug := range WFMUFamilySlugs {
+		result.PerStation[slug] = &WFMUDedupStationCounts{StationID: stationIDBySlug[slug]}
+	}
+
+	// Group every family show row by external code.
+	var shows []catalogm.RadioShow
+	if err := tx.Where("station_id IN ?", stationIDs).Order("id").Find(&shows).Error; err != nil {
+		return fmt.Errorf("loading WFMU family shows: %w", err)
+	}
+
+	groups := make(map[string][]catalogm.RadioShow)
+	for _, show := range shows {
+		if show.ExternalID == nil || *show.ExternalID == "" {
+			result.ShowsWithNoExternalID++
+			continue
+		}
+		groups[*show.ExternalID] = append(groups[*show.ExternalID], show)
+	}
+	result.GroupsTotal = len(groups)
+
+	// Deterministic processing order for stable output and reproducible runs.
+	codes := make([]string, 0, len(groups))
+	for code := range groups {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+
+	flagshipID := stationIDBySlug[WFMUFlagshipSlug]
+	for _, code := range codes {
+		group := groups[code]
+
+		ownerSlug := ownership[code]
+		ownerID, ok := stationIDBySlug[ownerSlug]
+		if !ok {
+			ownerSlug = WFMUFlagshipSlug
+			ownerID = flagshipID
+		}
+
+		winner, losers := pickWFMUDedupWinner(group, ownerID, flagshipID)
+		if len(losers) == 0 && winner.StationID == ownerID {
+			result.PerStation[ownerSlug].ShowsKept++
+			continue // already singular and correctly placed
+		}
+		result.GroupsWithDuplicates++
+
+		for _, loser := range losers {
+			if err := mergeWFMUDuplicateShow(tx, &winner, loser, ownerID, ownerSlug, slugByStationID, result); err != nil {
+				return fmt.Errorf("merging show %q (code %s) loser id=%d into winner id=%d: %w",
+					loser.Name, code, loser.ID, winner.ID, err)
+			}
+		}
+
+		if winner.StationID != ownerID {
+			// Safe wrt UNIQUE(station_id, external_id): if the owner station
+			// had a row for this code it would have been chosen as winner.
+			if err := tx.Model(&catalogm.RadioShow{}).Where("id = ?", winner.ID).
+				Update("station_id", ownerID).Error; err != nil {
+				return fmt.Errorf("reassigning show id=%d to station %s: %w", winner.ID, ownerSlug, err)
+			}
+			result.PerStation[ownerSlug].ShowsReassignedIn++
+		}
+		result.PerStation[ownerSlug].ShowsKept++
+	}
+
+	return nil
+}
+
+// pickWFMUDedupWinner chooses the canonical row for a code group: the row
+// already on the owner station, else the flagship row, else the oldest row
+// (lowest ID — the group is pre-sorted by ID). Everything else is a loser.
+func pickWFMUDedupWinner(group []catalogm.RadioShow, ownerID, flagshipID uint) (catalogm.RadioShow, []catalogm.RadioShow) {
+	winnerIdx := 0
+	for i, show := range group {
+		if show.StationID == ownerID {
+			winnerIdx = i
+			break
+		}
+		if show.StationID == flagshipID && group[winnerIdx].StationID != flagshipID {
+			winnerIdx = i
+		}
+	}
+
+	winner := group[winnerIdx]
+	losers := make([]catalogm.RadioShow, 0, len(group)-1)
+	for i, show := range group {
+		if i != winnerIdx {
+			losers = append(losers, show)
+		}
+	}
+	return winner, losers
+}
+
+// mergeWFMUDuplicateShow folds one duplicate row into the winner:
+//
+//  1. For (air_date, external_id) episodes present on BOTH sides, keep the
+//     copy with more logged plays (ties keep the winner's) — plays cascade
+//     with their episode, so the richer history always survives.
+//  2. Re-point the loser's remaining episodes to the winner.
+//  3. Re-point radio_import_jobs (plain FK, no cascade) to the winner.
+//  4. Copy metadata the winner is missing (host, description, artwork, …)
+//     from the loser — it may be the seeded, admin-curated row.
+//  5. Delete the loser row.
+func mergeWFMUDuplicateShow(
+	tx *gorm.DB,
+	winner *catalogm.RadioShow, // pointer: adopted metadata must persist across multi-loser merges
+	loser catalogm.RadioShow,
+	ownerID uint,
+	ownerSlug string,
+	slugByStationID map[uint]string,
+	result *WFMUDedupResult,
+) error {
+	loserStationCounts := result.PerStation[slugByStationID[loser.StationID]]
+	ownerCounts := result.PerStation[ownerSlug]
+
+	// 1a. Winner copies beaten by a richer loser copy.
+	res := tx.Exec(`
+		DELETE FROM radio_episodes w
+		WHERE w.show_id = ?
+		  AND EXISTS (
+			SELECT 1 FROM radio_episodes l
+			WHERE l.show_id = ?
+			  AND l.air_date = w.air_date
+			  AND COALESCE(l.external_id, '') = COALESCE(w.external_id, '')
+			  AND l.play_count > w.play_count
+		  )`, winner.ID, loser.ID)
+	if res.Error != nil {
+		return fmt.Errorf("deleting outplayed winner episodes: %w", res.Error)
+	}
+	ownerCounts.EpisodesDeleted += int(res.RowsAffected)
+
+	// 1b. Loser copies that still collide with a surviving winner copy.
+	res = tx.Exec(`
+		DELETE FROM radio_episodes l
+		WHERE l.show_id = ?
+		  AND EXISTS (
+			SELECT 1 FROM radio_episodes w
+			WHERE w.show_id = ?
+			  AND w.air_date = l.air_date
+			  AND COALESCE(w.external_id, '') = COALESCE(l.external_id, '')
+		  )`, loser.ID, winner.ID)
+	if res.Error != nil {
+		return fmt.Errorf("deleting duplicate loser episodes: %w", res.Error)
+	}
+	loserStationCounts.EpisodesDeleted += int(res.RowsAffected)
+
+	// 2. Move what's left.
+	res = tx.Model(&catalogm.RadioEpisode{}).Where("show_id = ?", loser.ID).
+		Update("show_id", winner.ID)
+	if res.Error != nil {
+		return fmt.Errorf("moving loser episodes: %w", res.Error)
+	}
+	ownerCounts.EpisodesMovedIn += int(res.RowsAffected)
+
+	// 3. radio_import_jobs.show_id has no ON DELETE clause — re-point jobs
+	// (and their station denormalization) before deleting the loser.
+	res = tx.Model(&catalogm.RadioImportJob{}).Where("show_id = ?", loser.ID).
+		Updates(map[string]interface{}{"show_id": winner.ID, "station_id": ownerID})
+	if res.Error != nil {
+		return fmt.Errorf("reassigning import jobs: %w", res.Error)
+	}
+	ownerCounts.JobsReassigned += int(res.RowsAffected)
+
+	// 4. Null-safe metadata adoption (the loser may be the curated seed row).
+	// winner's in-memory fields are updated too, so a later loser in the same
+	// group can't overwrite metadata adopted from an earlier one.
+	updates := map[string]interface{}{}
+	if winner.HostName == nil && loser.HostName != nil {
+		updates["host_name"] = *loser.HostName
+		winner.HostName = loser.HostName
+	}
+	if winner.Description == nil && loser.Description != nil {
+		updates["description"] = *loser.Description
+		winner.Description = loser.Description
+	}
+	if winner.ScheduleDisplay == nil && loser.ScheduleDisplay != nil {
+		updates["schedule_display"] = *loser.ScheduleDisplay
+		winner.ScheduleDisplay = loser.ScheduleDisplay
+	}
+	if winner.ArchiveURL == nil && loser.ArchiveURL != nil {
+		updates["archive_url"] = *loser.ArchiveURL
+		winner.ArchiveURL = loser.ArchiveURL
+	}
+	if winner.ImageURL == nil && loser.ImageURL != nil {
+		updates["image_url"] = *loser.ImageURL
+		winner.ImageURL = loser.ImageURL
+	}
+	if len(updates) > 0 {
+		if err := tx.Model(&catalogm.RadioShow{}).Where("id = ?", winner.ID).
+			Updates(updates).Error; err != nil {
+			return fmt.Errorf("adopting loser metadata: %w", err)
+		}
+	}
+
+	// 5. Drop the duplicate row.
+	if err := tx.Delete(&catalogm.RadioShow{}, loser.ID).Error; err != nil {
+		return fmt.Errorf("deleting loser show: %w", err)
+	}
+	loserStationCounts.ShowsDeleted++
+
+	return nil
+}

--- a/backend/internal/services/catalog/radio_wfmu_dedup.go
+++ b/backend/internal/services/catalog/radio_wfmu_dedup.go
@@ -26,6 +26,7 @@ import (
 	"gorm.io/gorm"
 
 	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/utils"
 )
 
 // WFMUFlagshipSlug is the seeded slug of the WFMU 91.1 flagship station.
@@ -57,6 +58,7 @@ type WFMUDedupResult struct {
 	GroupsTotal           int // distinct external show codes across the family
 	GroupsWithDuplicates  int // codes that had >1 row or a misplaced single row
 	ShowsWithNoExternalID int // rows skipped (cannot be grouped)
+	SlugsRecanonicalised  int // winners whose -N suffixed slug reverted to the freed base slug
 	PerStation            map[string]*WFMUDedupStationCounts // keyed by station slug
 }
 
@@ -149,6 +151,7 @@ func runWFMUDedup(tx *gorm.DB, ownership map[string]string, result *WFMUDedupRes
 	sort.Strings(codes)
 
 	flagshipID := stationIDBySlug[WFMUFlagshipSlug]
+	var winnersToRecanonicalise []uint
 	for _, code := range codes {
 		group := groups[code]
 
@@ -192,8 +195,40 @@ func runWFMUDedup(tx *gorm.DB, ownership map[string]string, result *WFMUDedupRes
 			result.PerStation[ownerSlug].ShowsReassignedIn++
 		}
 		result.PerStation[ownerSlug].ShowsKept++
+		winnersToRecanonicalise = append(winnersToRecanonicalise, winner.ID)
 	}
 
+	return recanonicaliseWFMUShowSlugs(tx, winnersToRecanonicalise, result)
+}
+
+// recanonicaliseWFMUShowSlugs reverts -N suffixed slugs on surviving rows to
+// their base slug where the merge freed it. The broken discovery created the
+// duplicates in arbitrary order, so the canonical-URL slug ("wake") often
+// died with a loser while the winner kept a disambiguated one ("wake-4").
+// Mirrors the slug pass of cmd/dedup-shows (PSY-559). Skipped when any other
+// row — radio show on any station — still holds the base slug.
+func recanonicaliseWFMUShowSlugs(tx *gorm.DB, winnerIDs []uint, result *WFMUDedupResult) error {
+	for _, id := range winnerIDs {
+		var show catalogm.RadioShow
+		if err := tx.First(&show, id).Error; err != nil {
+			return fmt.Errorf("reloading show id=%d for slug pass: %w", id, err)
+		}
+		base := utils.GenerateArtistSlug(show.Name)
+		if base == "" || show.Slug == base {
+			continue
+		}
+		var taken int64
+		if err := tx.Model(&catalogm.RadioShow{}).Where("slug = ?", base).Count(&taken).Error; err != nil {
+			return fmt.Errorf("checking base slug %q: %w", base, err)
+		}
+		if taken > 0 {
+			continue
+		}
+		if err := tx.Model(&catalogm.RadioShow{}).Where("id = ?", id).Update("slug", base).Error; err != nil {
+			return fmt.Errorf("recanonicalising slug for show id=%d: %w", id, err)
+		}
+		result.SlugsRecanonicalised++
+	}
 	return nil
 }
 

--- a/backend/internal/services/catalog/radio_wfmu_dedup_test.go
+++ b/backend/internal/services/catalog/radio_wfmu_dedup_test.go
@@ -1,0 +1,355 @@
+package catalog
+
+// Integration tests for the WFMU family show dedup (PSY-1073). Seeds the
+// duplicated-catalog state the broken discovery produced (the same show as a
+// distinct row under every family station, each with its own episode/play
+// copies), runs the cleanup, and asserts per-station scoping, play-data
+// preservation, FK integrity (import jobs), dry-run no-op, and idempotency.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/testutil"
+)
+
+type WFMUDedupIntegrationTestSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+
+	// Family stations as seeded by migration 20260502023012, looked up once.
+	stationsBySlug map[string]catalogm.RadioStation
+}
+
+func (s *WFMUDedupIntegrationTestSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+
+	// The WFMU seed migration creates the four family stations — use them
+	// directly so the test validates the real slugs the command relies on.
+	var stations []catalogm.RadioStation
+	s.Require().NoError(s.db.Where("slug IN ?", WFMUFamilySlugs).Find(&stations).Error)
+	s.Require().Len(stations, len(WFMUFamilySlugs), "WFMU seed migration should create all 4 family stations")
+	s.stationsBySlug = make(map[string]catalogm.RadioStation, len(stations))
+	for _, st := range stations {
+		s.stationsBySlug[st.Slug] = st
+	}
+}
+
+func (s *WFMUDedupIntegrationTestSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+// SetupTest wipes show-level data (keeping the migration-seeded stations) so
+// every test starts from a known state. Migrations also seed a handful of
+// flagship shows — those are wiped too.
+func (s *WFMUDedupIntegrationTestSuite) SetupTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	// FK-safe order: jobs reference shows without cascade.
+	_, _ = sqlDB.Exec("DELETE FROM radio_import_jobs")
+	_, _ = sqlDB.Exec("DELETE FROM radio_plays")
+	_, _ = sqlDB.Exec("DELETE FROM radio_episodes")
+	_, _ = sqlDB.Exec("DELETE FROM radio_shows")
+}
+
+func TestWFMUDedupIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(WFMUDedupIntegrationTestSuite))
+}
+
+// =============================================================================
+// Seed helpers
+// =============================================================================
+
+func (s *WFMUDedupIntegrationTestSuite) stationID(slug string) uint {
+	return s.stationsBySlug[slug].ID
+}
+
+func (s *WFMUDedupIntegrationTestSuite) createShow(stationSlug, name, slug, externalID string, hostName *string) catalogm.RadioShow {
+	show := catalogm.RadioShow{
+		StationID:  s.stationID(stationSlug),
+		Name:       name,
+		Slug:       slug,
+		ExternalID: &externalID,
+		HostName:   hostName,
+		IsActive:   true,
+	}
+	s.Require().NoError(s.db.Create(&show).Error)
+	return show
+}
+
+func (s *WFMUDedupIntegrationTestSuite) createEpisodeWithPlays(showID uint, airDate, externalID string, playCount int) catalogm.RadioEpisode {
+	ep := catalogm.RadioEpisode{
+		ShowID:     showID,
+		AirDate:    airDate,
+		ExternalID: &externalID,
+		PlayCount:  playCount,
+	}
+	s.Require().NoError(s.db.Create(&ep).Error)
+	for i := 0; i < playCount; i++ {
+		play := catalogm.RadioPlay{
+			EpisodeID:  ep.ID,
+			Position:   i,
+			ArtistName: "Test Artist",
+		}
+		s.Require().NoError(s.db.Create(&play).Error)
+	}
+	return ep
+}
+
+// seedDuplicatedFamily recreates the PSY-1073 blast radius in miniature:
+//
+//	MG "Midnight in the Guest Room" — airs on Drummer; duplicated on all 4
+//	  stations with overlapping + disjoint episode copies of varying richness.
+//	RQ "Rock'n'Soul Radio" — the channel-stream artifact, duplicated on all 4.
+//	WA "Wake" — flagship show (no ownership entry → flagship default),
+//	  duplicated on all 4.
+//
+// Returns the per-station MG rows for FK assertions.
+func (s *WFMUDedupIntegrationTestSuite) seedDuplicatedFamily() map[string]catalogm.RadioShow {
+	host := "Curated Host"
+	mg := map[string]catalogm.RadioShow{
+		// Flagship copy is the oldest (created first) and carries curated
+		// metadata the winner lacks.
+		"wfmu":                s.createShow("wfmu", "Midnight in the Guest Room", "mg-wfmu", "MG", &host),
+		"wfmu-drummer":        s.createShow("wfmu-drummer", "Midnight in the Guest Room", "mg-drummer", "MG", nil),
+		"wfmu-rocknsoulradio": s.createShow("wfmu-rocknsoulradio", "Midnight in the Guest Room", "mg-rns", "MG", nil),
+		"wfmu-sheena":         s.createShow("wfmu-sheena", "Midnight in the Guest Room", "mg-sheena", "MG", nil),
+	}
+
+	// Episode "100" exists on three stations with different richness:
+	// flagship 3 plays, drummer (the future winner) 5, rocknsoul 7 (richest —
+	// must survive even though its show row is a loser).
+	s.createEpisodeWithPlays(mg["wfmu"].ID, "2026-01-05", "100", 3)
+	s.createEpisodeWithPlays(mg["wfmu"].ID, "2026-01-12", "101", 2) // flagship-only → moves
+	s.createEpisodeWithPlays(mg["wfmu-drummer"].ID, "2026-01-05", "100", 5)
+	s.createEpisodeWithPlays(mg["wfmu-drummer"].ID, "2026-01-19", "102", 1)
+	s.createEpisodeWithPlays(mg["wfmu-rocknsoulradio"].ID, "2026-01-05", "100", 7)
+	// sheena copy has no episodes.
+
+	// Import job pinned to a loser row (flagship copy) — must be re-pointed,
+	// not orphaned (radio_import_jobs.show_id has no ON DELETE clause).
+	job := catalogm.RadioImportJob{
+		ShowID:    mg["wfmu"].ID,
+		StationID: s.stationID("wfmu"),
+		Since:     "2026-01-01",
+		Until:     "2026-02-01",
+		Status:    catalogm.RadioImportJobStatusCompleted,
+	}
+	s.Require().NoError(s.db.Create(&job).Error)
+
+	// The channel-stream artifact, duplicated everywhere, each with its own
+	// whole-stream episode (disjoint dates → all histories merge intact).
+	for i, slug := range WFMUFamilySlugs {
+		show := s.createShow(slug, "Rock'n'Soul Radio", "rq-"+slug, "RQ", nil)
+		s.createEpisodeWithPlays(show.ID, "2026-02-0"+string(rune('1'+i)), "rq-ep-"+slug, 2)
+	}
+
+	// Flagship-default show (no ownership entry).
+	for _, slug := range WFMUFamilySlugs {
+		s.createShow(slug, "Wake", "wa-"+slug, "WA", nil)
+	}
+
+	return mg
+}
+
+// testOwnership mirrors what WFMUProvider.FetchShowOwnership would return
+// for the seeded fixture: MG airs on Drummer, RQ is the Rock'n'Soul
+// artifact, WA is absent (defaults to flagship).
+func testOwnership() map[string]string {
+	return map[string]string{
+		"MG": "wfmu-drummer",
+		"RQ": "wfmu-rocknsoulradio",
+	}
+}
+
+func (s *WFMUDedupIntegrationTestSuite) showCodesByStation(slug string) []string {
+	var shows []catalogm.RadioShow
+	s.Require().NoError(s.db.Where("station_id = ?", s.stationID(slug)).Find(&shows).Error)
+	codes := make([]string, 0, len(shows))
+	for _, show := range shows {
+		s.Require().NotNil(show.ExternalID)
+		codes = append(codes, *show.ExternalID)
+	}
+	return codes
+}
+
+func (s *WFMUDedupIntegrationTestSuite) countRows(table string) int64 {
+	var n int64
+	s.Require().NoError(s.db.Table(table).Count(&n).Error)
+	return n
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+func (s *WFMUDedupIntegrationTestSuite) TestDryRun_ReportsPlanWithoutMutating() {
+	s.seedDuplicatedFamily()
+
+	showsBefore := s.countRows("radio_shows")
+	episodesBefore := s.countRows("radio_episodes")
+	playsBefore := s.countRows("radio_plays")
+
+	result, err := DedupWFMUFamilyShows(s.db, testOwnership(), true)
+	s.Require().NoError(err)
+
+	s.True(result.DryRun)
+	s.Equal(3, result.GroupsTotal)          // MG, RQ, WA
+	s.Equal(3, result.GroupsWithDuplicates) // every group has 4 copies
+	// The plan ran: counts reflect the full merge (3 groups x 3 losers)...
+	totalDeleted := 0
+	for _, c := range result.PerStation {
+		totalDeleted += c.ShowsDeleted
+	}
+	s.Equal(9, totalDeleted)
+	s.Positive(result.PerStation["wfmu-drummer"].EpisodesMovedIn)
+	// ...but nothing was committed.
+	s.Equal(showsBefore, s.countRows("radio_shows"))
+	s.Equal(episodesBefore, s.countRows("radio_episodes"))
+	s.Equal(playsBefore, s.countRows("radio_plays"))
+}
+
+func (s *WFMUDedupIntegrationTestSuite) TestConfirm_ScopesShowsToOwnerStations() {
+	mg := s.seedDuplicatedFamily()
+
+	result, err := DedupWFMUFamilyShows(s.db, testOwnership(), false)
+	s.Require().NoError(err)
+	s.False(result.DryRun)
+	s.Equal(3, result.GroupsTotal)
+	s.Equal(3, result.GroupsWithDuplicates)
+
+	// Per-station scoping: each show exists exactly once, on its owner.
+	s.ElementsMatch([]string{"WA"}, s.showCodesByStation("wfmu"))
+	s.ElementsMatch([]string{"MG"}, s.showCodesByStation("wfmu-drummer"))
+	s.ElementsMatch([]string{"RQ"}, s.showCodesByStation("wfmu-rocknsoulradio"))
+	s.ElementsMatch([]string{}, s.showCodesByStation("wfmu-sheena"))
+
+	// MG winner is the pre-existing drummer row (owner station).
+	var winner catalogm.RadioShow
+	s.Require().NoError(s.db.First(&winner, mg["wfmu-drummer"].ID).Error)
+	s.Equal(s.stationID("wfmu-drummer"), winner.StationID)
+
+	// Curated metadata adopted from the flagship loser.
+	s.Require().NotNil(winner.HostName)
+	s.Equal("Curated Host", *winner.HostName)
+
+	// Episode history merged: ep 100 survives as the RICHEST copy (7 plays,
+	// from the rocknsoul loser), 101 moved from flagship, 102 was already
+	// the winner's.
+	var episodes []catalogm.RadioEpisode
+	s.Require().NoError(s.db.Where("show_id = ?", winner.ID).Order("air_date").Find(&episodes).Error)
+	s.Require().Len(episodes, 3)
+	epByExt := map[string]catalogm.RadioEpisode{}
+	for _, ep := range episodes {
+		s.Require().NotNil(ep.ExternalID)
+		epByExt[*ep.ExternalID] = ep
+	}
+	s.Equal(7, epByExt["100"].PlayCount, "richest duplicate copy must win")
+	s.Equal(2, epByExt["101"].PlayCount)
+	s.Equal(1, epByExt["102"].PlayCount)
+
+	// Play rows follow their episodes: 7 + 2 + 1 for MG, plus 4 artifact
+	// episodes x 2 plays for RQ = 18 total. The poorer ep-100 copies
+	// (3 and 5 plays) cascaded away with their duplicate episodes.
+	s.Equal(int64(18), s.countRows("radio_plays"))
+	var ep100Plays int64
+	s.Require().NoError(s.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", epByExt["100"].ID).Count(&ep100Plays).Error)
+	s.Equal(int64(7), ep100Plays)
+
+	// RQ artifact kept all four whole-stream episode histories.
+	var rq catalogm.RadioShow
+	s.Require().NoError(s.db.Where("station_id = ? AND external_id = ?", s.stationID("wfmu-rocknsoulradio"), "RQ").First(&rq).Error)
+	var rqEpisodes int64
+	s.Require().NoError(s.db.Model(&catalogm.RadioEpisode{}).Where("show_id = ?", rq.ID).Count(&rqEpisodes).Error)
+	s.Equal(int64(4), rqEpisodes)
+
+	// Import job re-pointed from the deleted flagship row to the winner.
+	var job catalogm.RadioImportJob
+	s.Require().NoError(s.db.First(&job).Error)
+	s.Equal(winner.ID, job.ShowID)
+	s.Equal(s.stationID("wfmu-drummer"), job.StationID)
+	s.Equal(1, result.PerStation["wfmu-drummer"].JobsReassigned)
+}
+
+func (s *WFMUDedupIntegrationTestSuite) TestConfirm_IsIdempotent() {
+	s.seedDuplicatedFamily()
+
+	_, err := DedupWFMUFamilyShows(s.db, testOwnership(), false)
+	s.Require().NoError(err)
+
+	showsAfterFirst := s.countRows("radio_shows")
+	episodesAfterFirst := s.countRows("radio_episodes")
+	playsAfterFirst := s.countRows("radio_plays")
+
+	second, err := DedupWFMUFamilyShows(s.db, testOwnership(), false)
+	s.Require().NoError(err)
+
+	s.Equal(0, second.GroupsWithDuplicates, "second run must find nothing to do")
+	for slug, c := range second.PerStation {
+		s.Zero(c.ShowsDeleted, "station %s", slug)
+		s.Zero(c.ShowsReassignedIn, "station %s", slug)
+		s.Zero(c.EpisodesMovedIn, "station %s", slug)
+		s.Zero(c.EpisodesDeleted, "station %s", slug)
+		s.Zero(c.JobsReassigned, "station %s", slug)
+	}
+	s.Equal(showsAfterFirst, s.countRows("radio_shows"))
+	s.Equal(episodesAfterFirst, s.countRows("radio_episodes"))
+	s.Equal(playsAfterFirst, s.countRows("radio_plays"))
+}
+
+func (s *WFMUDedupIntegrationTestSuite) TestSingleMisplacedShow_IsReassignedNotDeleted() {
+	// A show that exists ONLY on the flagship but is owned by a channel
+	// (e.g. Bodega Pop airing on Give the Drummer Radio) moves station —
+	// keeping its row, episodes, and slug intact.
+	show := s.createShow("wfmu", "Solo Channel Show", "solo-show", "SOLO", nil)
+	ep := s.createEpisodeWithPlays(show.ID, "2026-03-01", "solo-ep", 4)
+
+	result, err := DedupWFMUFamilyShows(s.db, map[string]string{"SOLO": "wfmu-sheena"}, false)
+	s.Require().NoError(err)
+
+	s.Equal(1, result.GroupsWithDuplicates)
+	s.Equal(1, result.PerStation["wfmu-sheena"].ShowsReassignedIn)
+
+	var reloaded catalogm.RadioShow
+	s.Require().NoError(s.db.First(&reloaded, show.ID).Error)
+	s.Equal(s.stationID("wfmu-sheena"), reloaded.StationID)
+
+	var playCount int64
+	s.Require().NoError(s.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", ep.ID).Count(&playCount).Error)
+	s.Equal(int64(4), playCount)
+}
+
+func (s *WFMUDedupIntegrationTestSuite) TestShowsWithoutExternalID_AreSkipped() {
+	show := catalogm.RadioShow{
+		StationID: s.stationID("wfmu"),
+		Name:      "Hand-curated show",
+		Slug:      "hand-curated",
+		IsActive:  true,
+	}
+	s.Require().NoError(s.db.Create(&show).Error)
+
+	result, err := DedupWFMUFamilyShows(s.db, testOwnership(), false)
+	s.Require().NoError(err)
+
+	s.Equal(1, result.ShowsWithNoExternalID)
+	s.Equal(0, result.GroupsTotal)
+	var still catalogm.RadioShow
+	s.NoError(s.db.First(&still, show.ID).Error)
+}
+
+func (s *WFMUDedupIntegrationTestSuite) TestUnknownOwnershipSlug_DefaultsToFlagship() {
+	// An ownership entry pointing outside the family (corrupt map, future
+	// channel not yet seeded) must not error — it defaults to the flagship.
+	s.createShow("wfmu-sheena", "Mystery Show", "mystery-show", "MYST", nil)
+
+	result, err := DedupWFMUFamilyShows(s.db, map[string]string{"MYST": "wfmu-not-a-station"}, false)
+	s.Require().NoError(err)
+
+	s.Equal(1, result.PerStation["wfmu"].ShowsReassignedIn)
+	s.ElementsMatch([]string{"MYST"}, s.showCodesByStation("wfmu"))
+}

--- a/backend/internal/services/catalog/radio_wfmu_dedup_test.go
+++ b/backend/internal/services/catalog/radio_wfmu_dedup_test.go
@@ -234,6 +234,11 @@ func (s *WFMUDedupIntegrationTestSuite) TestConfirm_ScopesShowsToOwnerStations()
 	s.Require().NoError(s.db.First(&winner, mg["wfmu-drummer"].ID).Error)
 	s.Equal(s.stationID("wfmu-drummer"), winner.StationID)
 
+	// Slug recanonicalised: the disambiguated "mg-drummer" reverts to the
+	// base slug for the show name once the merge frees it.
+	s.Equal("midnight-in-the-guest-room", winner.Slug)
+	s.Positive(result.SlugsRecanonicalised)
+
 	// Curated metadata adopted from the flagship loser.
 	s.Require().NotNil(winner.HostName)
 	s.Equal("Curated Host", *winner.HostName)

--- a/backend/internal/services/catalog/radio_wfmu_dedup_test.go
+++ b/backend/internal/services/catalog/radio_wfmu_dedup_test.go
@@ -302,12 +302,47 @@ func (s *WFMUDedupIntegrationTestSuite) TestConfirm_IsIdempotent() {
 	s.Equal(playsAfterFirst, s.countRows("radio_plays"))
 }
 
+func (s *WFMUDedupIntegrationTestSuite) TestRicherEpisodeCopy_DecidedByActualPlays_NotStaleCounter() {
+	// The merge keeps whichever duplicate episode copy has more REAL
+	// radio_plays rows. A stale/inflated play_count column must not decide
+	// which play history survives.
+	winnerShow := s.createShow("wfmu-drummer", "Counter Test", "ct-drummer", "CT", nil)
+	loserShow := s.createShow("wfmu", "Counter Test", "ct-wfmu", "CT", nil)
+
+	// Winner's copy: 2 real plays, but a lying play_count of 9.
+	winnerEp := s.createEpisodeWithPlays(winnerShow.ID, "2026-04-01", "300", 2)
+	s.Require().NoError(s.db.Model(&catalogm.RadioEpisode{}).Where("id = ?", winnerEp.ID).Update("play_count", 9).Error)
+	// Loser's copy: 5 real plays, but a stale play_count of 0.
+	loserEp := s.createEpisodeWithPlays(loserShow.ID, "2026-04-01", "300", 5)
+	s.Require().NoError(s.db.Model(&catalogm.RadioEpisode{}).Where("id = ?", loserEp.ID).Update("play_count", 0).Error)
+
+	_, err := DedupWFMUFamilyShows(s.db, map[string]string{"CT": "wfmu-drummer"}, false)
+	s.Require().NoError(err)
+
+	// The loser's 5-play copy survived; the winner's 2-play copy is gone.
+	var surviving []catalogm.RadioEpisode
+	s.Require().NoError(s.db.Where("show_id = ?", winnerShow.ID).Find(&surviving).Error)
+	s.Require().Len(surviving, 1)
+	s.Equal(loserEp.ID, surviving[0].ID)
+	var plays int64
+	s.Require().NoError(s.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", surviving[0].ID).Count(&plays).Error)
+	s.Equal(int64(5), plays)
+}
+
 func (s *WFMUDedupIntegrationTestSuite) TestSingleMisplacedShow_IsReassignedNotDeleted() {
 	// A show that exists ONLY on the flagship but is owned by a channel
 	// (e.g. Bodega Pop airing on Give the Drummer Radio) moves station —
 	// keeping its row, episodes, and slug intact.
 	show := s.createShow("wfmu", "Solo Channel Show", "solo-show", "SOLO", nil)
 	ep := s.createEpisodeWithPlays(show.ID, "2026-03-01", "solo-ep", 4)
+	job := catalogm.RadioImportJob{
+		ShowID:    show.ID,
+		StationID: s.stationID("wfmu"),
+		Since:     "2026-03-01",
+		Until:     "2026-03-31",
+		Status:    catalogm.RadioImportJobStatusCompleted,
+	}
+	s.Require().NoError(s.db.Create(&job).Error)
 
 	result, err := DedupWFMUFamilyShows(s.db, map[string]string{"SOLO": "wfmu-sheena"}, false)
 	s.Require().NoError(err)
@@ -318,6 +353,12 @@ func (s *WFMUDedupIntegrationTestSuite) TestSingleMisplacedShow_IsReassignedNotD
 	var reloaded catalogm.RadioShow
 	s.Require().NoError(s.db.First(&reloaded, show.ID).Error)
 	s.Equal(s.stationID("wfmu-sheena"), reloaded.StationID)
+
+	// The reassigned show's own import jobs follow it to the new station.
+	var reloadedJob catalogm.RadioImportJob
+	s.Require().NoError(s.db.First(&reloadedJob, job.ID).Error)
+	s.Equal(s.stationID("wfmu-sheena"), reloadedJob.StationID)
+	s.Equal(show.ID, reloadedJob.ShowID)
 
 	var playCount int64
 	s.Require().NoError(s.db.Model(&catalogm.RadioPlay{}).Where("episode_id = ?", ep.ID).Count(&playCount).Error)


### PR DESCRIPTION
## Summary

**Mechanism found (hypothesis confirmed):** `DiscoverStationShows(stationID)` → `WFMUProvider.DiscoverShows()` parses the entire wfmu.org `/playlists/` DJ index — one flat list spanning the 91.1 broadcast AND the three stream-only channels — then `upsertRadioShow(stationID, …)` assigns every show to whichever station triggered discovery. The scheduled `runDiscoverCycle` calls this for **every** active station, so all four WFMU-family stations each accumulated the full 574-show catalog as distinct rows (`UNIQUE(station_id, external_id)` permits the same code under four station_ids). Seed data was NOT a factor (seeds only place shows under the flagship).

**Fix (importer):** new `WFMUProvider.DiscoverShowsForStation(stationSlug)` scopes discovery per stream using wfmu.org's own schedule pages: `/table` (91.1 weekly schedule) + the three channel landing-page rosters (`/drummer`, `/rocknsoulradio`, `/sheena`). `radio_import.go` routes `ImportStation`/`DiscoverStationShows` through an optional `stationScopedShowDiscoverer` interface — KEXP/NTS are untouched. All four pages verified live (2026-06-11) to serve under the provider UA; rosters are mutually disjoint and every roster code exists in the DJ index.

**Ownership rule** (channels keep only shows provably theirs; ambiguous/unknown → flagship):
1. Channel-stream artifact codes → their channel (see below).
2. On the 91.1 `/table` schedule → flagship (wins over channel rebroadcast listings — 5 real codes overlap `/table` ∩ Rock'n'Soul today).
3. On exactly one channel roster → that channel (rosters are disjoint today; a 2-roster code would default flagship).
4. Everything else (defunct shows, no roster) → flagship.

**Artifact disposition:** the channel-stream-as-show rows — `GW` "Give The Drummer Radio", `RQ` "Rock'n'Soul Radio", `JZ` "Sheena's Jungle Room Stream" — are DJ-index entries whose "episodes" are the channel's whole-stream playlists between live-DJ slots. They are pinned to their own channel station via an explicit override map (only RQ appears on a roster page), and their episode/play history is preserved there, singular. No play data is destroyed: duplicate episode copies merge keeping whichever copy has more actual `radio_plays` rows.

**Cleanup:** `cmd/dedup-radio-shows` (PSY-559 `dedup-shows` pattern). Dry-run by default — it executes the FULL merge plan in a transaction and rolls back, so printed counts are exactly what `--confirm` commits. Per code group: winner = row on the owner station (else flagship row, else oldest); richer duplicate episode copies win; remaining episodes move to the winner (plays cascade with them); `radio_import_jobs` (plain FK, no cascade) re-point before loser deletion; null-safe metadata adoption from curated seed rows; winner slugs recanonicalise to the freed base slug. Idempotent: re-run reports zero changes.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go vet ./internal/services/catalog/ ./cmd/dedup-radio-shows/` — clean
- [x] `cd backend && go test ./...` — full suite, exit 0
- [x] `cd backend && go test ./internal/services/catalog/ -count=1` — full package incl. all radio suites, pass (48s)

## Manual repro (PSY-592 pattern — integration tests ARE the repro)

`radio_wfmu_dedup_test.go` (real Postgres testcontainer, uses the migration-seeded family stations so the slugs the command relies on are validated against real migrations):
- `TestDryRun_ReportsPlanWithoutMutating` — seeds the duplicated family (3 shows × 4 stations, overlapping episode copies), dry-run reports 9 shows-to-delete and non-zero episode moves while `radio_shows`/`radio_episodes`/`radio_plays` row counts are byte-identical before/after.
- `TestConfirm_ScopesShowsToOwnerStations` — after `--confirm` semantics: flagship=[WA], drummer=[MG], rocknsoul=[RQ], sheena=[]; the richest ep-100 copy (7 plays, from a loser row) survives; flagship-only episode moved; curated `host_name` adopted; import job re-pointed to the winner + drummer station; RQ artifact keeps all 4 whole-stream episodes; winner slug recanonicalised to `midnight-in-the-guest-room`.
- `TestConfirm_IsIdempotent` — second run: `GroupsWithDuplicates == 0`, every per-station mutation count zero, row counts unchanged.
- `TestRicherEpisodeCopy_DecidedByActualPlays_NotStaleCounter` — a lying `play_count` (9 vs 2 real) loses to 5 real plays.
- `TestSingleMisplacedShow_IsReassignedNotDeleted`, `TestShowsWithoutExternalID_AreSkipped`, `TestUnknownOwnershipSlug_DefaultsToFlagship`.

`radio_provider_wfmu_scoped_test.go` (httptest, fixture pages mirroring real wfmu.org markup):
- `TestWFMU_DiscoverShowsForStation_ScopesByStream` — per-station code sets incl. `/table`-beats-rebroadcast, artifact overrides, defunct→flagship.
- `TestWFMU_DiscoverShowsForStation_UnknownSlugErrors`, `TestWFMU_DiscoverShowsForStation_EmptyRosterErrors` (layout change fails loudly instead of dumping a channel's shows on the flagship), `TestWFMU_FetchShowOwnership`, `TestWFMU_FamilySlugs_MatchProviderChannelMap`, `TestWFMU_ParseScheduleCodes_RealChannelLandingMarkup`.

## Code review

`/code-review` run inline (sub-agent worktree, no Agent tool — per project convention). 3 findings, fixed in `bec43e41`:
- Richer-copy decision used the denormalized `play_count` column → now compares actual `radio_plays` rows (+ regression test).
- Winner reassignment left the winner's own import jobs with a stale denormalized `station_id` → updated alongside.
- Dead `WFMUDedupStationCounts.StationID` field removed.

## Adversarial review

`/adversarial-review` — CONCERNS, 3 MEDIUM findings; 2 fixed in `514ff65b`, 1 disclosed:
- [MEDIUM] Completeness: surviving shows could keep `-N` suffixed slugs while the merge freed the base → slug recanonicalisation pass added (PSY-559 precedent), asserted in tests.
- [MEDIUM] Future-Maintainer: `wfmuStationChannels` / `WFMUFamilySlugs` hand-synced across two files → consistency unit test pins them.
- [MEDIUM] Saboteur (disclosed, not code-fixed): running the cleanup while the radio discover/fetch ticker is mid-cycle can abort the transaction (unique-violation → full rollback, fail-closed) or briefly block imports. Safe either way — nothing half-merged — just re-run. Prefer a quiet window.

Panel: Saboteur · Future-Maintainer · Security (clean: parameterized SQL, fixed-host fetches, no new surface) · Completeness. Lenses run inline against the branch diff (dispatched sub-agent — no Agent tool), per `pattern_subagent_inline_code_review`.

## Post-merge operator action required

The cleanup command must be **run against stage/prod by a human after deploy** (the deployed importer fix prevents re-duplication; the command repairs existing rows):

```bash
cd backend
go run ./cmd/dedup-radio-shows                 # dry-run: prints exact plan, writes nothing
go run ./cmd/dedup-radio-shows --confirm       # apply
go run ./cmd/dedup-radio-shows                 # verify idempotency: all counts zero
```

Expected dry-run output shape (stage numbers will be ~574 groups, ~570 with duplicates):

```
=== WFMU Radio Show Dedup (DRY RUN) — PSY-1073 ===
Fetching WFMU schedule pages for show ownership...
Resolved ownership for ~160 show codes (codes not listed default to the flagship).
=== Summary ===
Show-code groups found:      574
Groups needing changes:      ~570
Rows skipped (no ext. id):   0
Slugs recanonicalised:       N
Per station:
  wfmu                   shows kept=~480 reassigned-in=… deleted=… | episodes moved-in=… dup-deleted=… | jobs reassigned=…
  wfmu-drummer           shows kept=~30 …
  wfmu-rocknsoulradio    shows kept=~35 …
  wfmu-sheena            shows kept=~33 …
DRY RUN — full plan executed in a transaction and rolled back.
```

Run during a quiet window relative to the radio discover/fetch tickers (see adversarial disclosure above). It needs outbound access to wfmu.org for the ownership fetch; a fetch failure aborts before touching the DB.

Closes PSY-1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)
