### PR TITLE
PSY-1077: NTS seeds — drop host_name when it duplicates show name

### DIFF
--- a/backend/internal/seeddata/radio.go
+++ b/backend/internal/seeddata/radio.go
@@ -286,10 +286,14 @@ var RadioShows = []RadioShow{
 
 	// NTS
 	{
-		StationSlug:     "nts-radio",
-		Name:            "Floating Points",
-		Slug:            "floating-points-nts",
-		HostName:        "Floating Points",
+		StationSlug: "nts-radio",
+		Name:        "Floating Points",
+		Slug:        "floating-points-nts",
+		// HostName intentionally empty: NTS residencies are host-named, so
+		// repeating the show name as the host renders "Floating Points w/
+		// Floating Points" on now-playing surfaces (PSY-1077). Leave NULL
+		// when host would equal the show name.
+		HostName:        "",
 		Description:     "Eclectic selections spanning jazz, electronic, ambient, and world music from producer Floating Points.",
 		ScheduleDisplay: "Monthly",
 		ArchiveURL:      "https://www.nts.live/shows/floating-points",
@@ -319,10 +323,12 @@ var RadioShows = []RadioShow{
 		ExternalID:      "breakfast",
 	},
 	{
-		StationSlug:     "nts-radio",
-		Name:            "Anu",
-		Slug:            "anu-nts",
-		HostName:        "Anu",
+		StationSlug: "nts-radio",
+		Name:        "Anu",
+		Slug:        "anu-nts",
+		// HostName intentionally empty: host-named residency (see the
+		// Floating Points entry above; PSY-1077).
+		HostName:        "",
 		Description:     "A mix of left-field club, electronic, and experimental sounds.",
 		ScheduleDisplay: "Monthly",
 		ArchiveURL:      "https://www.nts.live/shows/anu",

--- a/backend/internal/seeddata/radio_sql_test.go
+++ b/backend/internal/seeddata/radio_sql_test.go
@@ -34,6 +34,10 @@ func TestRenderRadioSeedSQL_Shape(t *testing.T) {
 		"'internet', NULL, 'nts_api'",
 		// NULL for empty HostName on "The NTS Breakfast Show" (rotating hosts)
 		"'The NTS Breakfast Show', 'breakfast-show-nts', NULL,",
+		// PSY-1077: NULL HostName on host-named NTS residencies (host would
+		// duplicate the show name, rendering "Floating Points w/ Floating Points")
+		"'Floating Points', 'floating-points-nts', NULL,",
+		"'Anu', 'anu-nts', NULL,",
 		// PSY-508: WFMU sub-stream slugs and apostrophe escapes
 		"'wfmu-drummer'",
 		"'Rock''n''Soul Radio'",
@@ -113,6 +117,20 @@ func TestSqlFloatOrNull(t *testing.T) {
 	}
 	if got := sqlFloatOrNull(91.1); got != "91.1" {
 		t.Errorf("sqlFloatOrNull(91.1) = %q, want 91.1", got)
+	}
+}
+
+// TestRadioShows_NoHostNameDuplicatingShowName guards PSY-1077: host-named
+// residencies (common on NTS) must seed HostName empty (-> NULL) rather than
+// repeating the show name, which renders "Floating Points w/ Floating Points"
+// on now-playing surfaces. Both seed consumers (cmd/seed via GORM and
+// RenderRadioSeedSQL via cmd/gen-e2e-seed) read these structs, so the
+// invariant holds for dev, stage, and E2E databases alike.
+func TestRadioShows_NoHostNameDuplicatingShowName(t *testing.T) {
+	for _, s := range RadioShows {
+		if s.HostName != "" && strings.EqualFold(s.HostName, s.Name) {
+			t.Errorf("show %q (slug %q): HostName duplicates the show name; leave it empty so it seeds as NULL (PSY-1077)", s.Name, s.Slug)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Seeded NTS shows "Floating Points" and "Anu" carried `host_name` equal to the show name, rendering "Floating Points w/ Floating Points" on the Dial. NTS shows are host-named residencies — these two now seed `host_name` as NULL (empty string → NULL in both seed consumers).

**Importer finding:** the NTS importer does NOT write this duplicate on real imports — `parseNTSShow` (`radio_provider_nts.go`) never sets `HostName` because the NTS `/v2/shows` endpoint exposes no host field, and existing provider tests already assert nil (`radio_provider_nts_test.go:142,667`). Seeds were the only writer, so this is a seeds-only fix; no importer change needed.

**Frontend (verified by reading, unchanged):** `StationOnAirBox.tsx:84-85` only renders `w/ {hostName}` when host is non-null; `StationShowsDirectory.tsx:118` renders `host_name ?? '—'` in a separate column.

**Scope-adjacent observation (not changed):** the seeded NTS show *name* "The Do!! You!!! Breakfast Show w/ Charlie Bones" embeds the host, so the on-air box would render "… w/ Charlie Bones w/ Charlie Bones" — a name-*contains*-host case outside this ticket's name-*equals*-host scope; flagging for a possible follow-up.

## Test plan

- [x] `cd backend && go build ./...`
- [x] Full `cd backend && go test ./...` — all packages green
- [x] `go run ./cmd/gen-e2e-seed` — `floating-points-nts` and `anu-nts` rows render `NULL` host_name; `charlie-bones-nts` unchanged

Note: `frontend/e2e/setup-db.sh` is NOT a generated artifact — it pipes `go run ./cmd/gen-e2e-seed` at runtime (line 659), so no frontend file regeneration was needed.

## Manual repro

Backend-only (mode=none); the seed unit tests are the repro:
- `TestRadioShows_NoHostNameDuplicatingShowName` (new) — asserts no seed show's `HostName` case-insensitively equals its `Name`
- `TestRenderRadioSeedSQL_Shape` — new `mustContain` assertions that the two fixed rows render `'…', '<slug>', NULL,`

## Code review

`/code-review` (low): no findings — data-literal change + tests.

## Adversarial review

Inline 4-lens pass: CLEAN. Both seed consumers proven to map `"" → NULL` (`cmd/seed/main.go:908`, `radio_sql.go:91` via `sqlStringOrNull`); idempotent `ON CONFLICT DO NOTHING` means already-seeded DBs need a reseed to pick up the NULL (inherent to the seed model). Charlie Bones name-contains-host case flagged above as out-of-scope follow-up.

Closes PSY-1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
