### PR TITLE
PSY-1075: slim useStationOverview after the live now-playing swap

### DIFF
--- a/frontend/app/radio/_components/DialStationStrip.test.tsx
+++ b/frontend/app/radio/_components/DialStationStrip.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react'
 import type {
   RadioStationListItem,
   RadioStationDetail,
-  RadioShowDetail,
   RadioEpisodeDetail,
   RadioNowPlaying,
 } from '@/features/radio'
@@ -60,13 +59,6 @@ const stationDetail = {
   name: 'WFMU',
   website: 'https://wfmu.org',
 } as RadioStationDetail
-
-const showDetail = {
-  id: 3,
-  slug: 'night-owl',
-  name: 'The Night Owl Show',
-  host_name: 'Pedro Santos',
-} as RadioShowDetail
 
 const latestEpisode = { air_date: '2026-06-09' } as RadioEpisodeDetail
 
@@ -125,16 +117,13 @@ function channelNowPlaying(
   })
 }
 
+// Mirrors the slimmed StationOverview shape (PSY-1075): station detail for
+// [▶ Listen], plus the signature show + latest episode for [ live playlist ].
 function overviewLoaded() {
   return {
     station: stationDetail,
     nowPlayingShow: { id: 3, slug: 'night-owl' },
-    nowPlayingShowDetail: showDetail,
-    nowPlaying: { current: null, recentArtists: [] },
     latestEpisode,
-    isLoading: false,
-    isEmpty: false,
-    error: null,
   }
 }
 
@@ -313,9 +302,7 @@ describe('DialStationStrip', () => {
     mockUseStationOverview.mockReturnValue({
       ...overviewLoaded(),
       nowPlayingShow: null,
-      nowPlayingShowDetail: undefined,
       latestEpisode: undefined,
-      isEmpty: true,
     })
     render(<DialStationStrip station={makeStation({ sibling_stations: [] })} />)
 
@@ -334,10 +321,8 @@ describe('DialStationStrip', () => {
     mockUseStationOverview.mockReturnValue({
       ...overviewLoaded(),
       station: undefined,
-      nowPlayingShowDetail: undefined,
+      nowPlayingShow: null,
       latestEpisode: undefined,
-      isLoading: true,
-      isEmpty: false,
     })
     render(<DialStationStrip station={makeStation({ sibling_stations: [] })} />)
     expect(screen.getByText('Loading on-air info')).toBeInTheDocument()

--- a/frontend/app/radio/_components/DialStationStrip.tsx
+++ b/frontend/app/radio/_components/DialStationStrip.tsx
@@ -45,7 +45,7 @@ interface DialStationStripProps {
 export function DialStationStrip({ station }: DialStationStripProps) {
   const {
     station: detail,
-    nowPlayingShowDetail,
+    nowPlayingShow,
     latestEpisode,
   } = useStationOverview(station.slug)
 
@@ -64,8 +64,8 @@ export function DialStationStrip({ station }: DialStationStripProps) {
     .join(' · ')
 
   const livePlaylistUrl =
-    nowPlayingShowDetail && latestEpisode
-      ? `/radio/${station.slug}/${nowPlayingShowDetail.slug}/${latestEpisode.air_date}`
+    nowPlayingShow && latestEpisode
+      ? `/radio/${station.slug}/${nowPlayingShow.slug}/${latestEpisode.air_date}`
       : null
 
   return (

--- a/frontend/features/radio/hooks/index.ts
+++ b/frontend/features/radio/hooks/index.ts
@@ -10,7 +10,8 @@ export { useArtistRadioPlays } from './useArtistRadioPlays'
 export { useReleaseRadioPlays } from './useReleaseRadioPlays'
 export { useNewReleaseRadar } from './useNewReleaseRadar'
 export { useRadioStats } from './useRadioStats'
-// PSY-1016 heuristic, consumed by the Dial surfaces (PSY-1049/1050).
+// PSY-1016 heuristic, consumed by the Dial strips (PSY-1049); slimmed to the
+// actions-column data after PSY-1022's live now-playing swap (PSY-1075).
 // (useShowLatestEpisode stays un-exported here — its consumers import the
 // file directly; PSY-1057 narrowed the public surface.)
 export { useStationOverview } from './useStationOverview'

--- a/frontend/features/radio/hooks/useShowLatestEpisode.ts
+++ b/frontend/features/radio/hooks/useShowLatestEpisode.ts
@@ -9,11 +9,10 @@ import type { RadioEpisodeDetail } from '../types'
  *
  * Two-step chain because the public API has no "latest episode with plays"
  * endpoint: the episodes list (air_date DESC) gives the newest air-date, then
- * the by-date endpoint returns that episode's plays + entity links. This is
- * the v1 fallback the Dial's on-air surfaces read from (StationOnAirBox,
- * useStationOverview); a future live now-playing endpoint (PSY-1022) replaces
- * this hook without changing its consumers, since both produce a
- * RadioEpisodeDetail-shaped playlist.
+ * the by-date endpoint returns that episode's plays + entity links. The live
+ * on-air lines moved to PSY-1022's now-playing endpoint; this hook survives
+ * to anchor the archive playlist deep-links (StationOnAirBox,
+ * useStationOverview's [ live playlist ]).
  */
 export function useShowLatestEpisode(showSlug: string | undefined) {
   const slug = showSlug ?? ''

--- a/frontend/features/radio/hooks/useStationOverview.ts
+++ b/frontend/features/radio/hooks/useStationOverview.ts
@@ -3,51 +3,35 @@
 import { useMemo } from 'react'
 import { useRadioStation } from './useRadioStation'
 import { useRadioShows } from './useRadioShows'
-import { useRadioShow } from './useRadioShow'
 import { useShowLatestEpisode } from './useShowLatestEpisode'
-import {
-  pickNowPlayingShow,
-  deriveNowPlaying,
-  type NowPlaying,
-} from '../lib/stationOverview'
+import { pickNowPlayingShow } from '../lib/stationOverview'
 import type {
   RadioStationDetail,
   RadioShowListItem,
-  RadioShowDetail,
   RadioEpisodeDetail,
 } from '../types'
 
 export interface StationOverview {
   station: RadioStationDetail | undefined
-  /** The show driving the Now Playing card (v1: most-active show). */
+  /** The station's signature show (v1 heuristic: most logged episodes). */
   nowPlayingShow: RadioShowListItem | null
-  /** Detail for nowPlayingShow (host + description for the card). */
-  nowPlayingShowDetail: RadioShowDetail | undefined
-  /** Derived now-playing surface (current track + recent artists). */
-  nowPlaying: NowPlaying
   /**
-   * nowPlayingShow's most-recent episode (the playlist behind `nowPlaying`).
-   * Exposed so surfaces can deep-link to the live playlist page
-   * (/radio/{station}/{show}/{air_date}) — PSY-1049's [ live playlist ].
+   * nowPlayingShow's most-recent archived episode. Exposed so surfaces can
+   * deep-link to the live playlist page (/radio/{station}/{show}/{air_date})
+   * — PSY-1049's [ live playlist ].
    */
   latestEpisode: RadioEpisodeDetail | undefined
-  isLoading: boolean
-  /** True once the station resolved but it has no shows at all. */
-  isEmpty: boolean
-  error: unknown
 }
 
 /**
- * Assemble everything a station-overview surface renders for one station
- * (PSY-1016, now consumed by the Dial strips — PSY-1049). Orchestrates the
- * station detail, its shows, and the now-playing show's most-recent episode
- * into one render shape.
+ * Resolve a station's detail plus the archive deep-link target behind the
+ * Dial strip's actions column (PSY-1016, slimmed in PSY-1075): the station
+ * detail ([▶ Listen] external URL) and the signature show's latest episode
+ * (the [ live playlist ] link).
  *
- * "Now Playing" is the v1 fallback (the most-recent playlist of the station's
- * most-active show) — not live on-air data. See lib/stationOverview and
- * PSY-1022 for the live-data successor; this hook is the single seam that
- * would change when that lands.
- *
+ * The on-air lines themselves moved to the live now-playing endpoint
+ * (PSY-1022, useStationNowPlaying); this hook no longer derives a
+ * now-playing surface.
  */
 export function useStationOverview(stationSlug: string): StationOverview {
   const stationQuery = useRadioStation(stationSlug)
@@ -58,29 +42,11 @@ export function useStationOverview(stationSlug: string): StationOverview {
 
   const nowPlayingShow = useMemo(() => pickNowPlayingShow(shows), [shows])
 
-  // Full detail for the now-playing show: the list item lacks host_name +
-  // description, which the Now Playing card needs (show title + "with {host}"
-  // + the vibe line).
-  const nowPlayingShowDetailQuery = useRadioShow(nowPlayingShow?.slug ?? '')
-
   const latest = useShowLatestEpisode(nowPlayingShow?.slug)
-  const nowPlaying = useMemo(() => deriveNowPlaying(latest.episode), [latest.episode])
-
-  const isLoading =
-    stationQuery.isLoading ||
-    (!!station && showsQuery.isLoading) ||
-    (!!nowPlayingShow && (nowPlayingShowDetailQuery.isLoading || latest.isLoading))
-
-  const isEmpty = !!station && !showsQuery.isLoading && !nowPlayingShow
 
   return {
     station,
     nowPlayingShow,
-    nowPlayingShowDetail: nowPlayingShowDetailQuery.data,
-    nowPlaying,
     latestEpisode: latest.episode,
-    isLoading,
-    isEmpty,
-    error: stationQuery.error ?? showsQuery.error ?? latest.error,
   }
 }

--- a/frontend/features/radio/index.ts
+++ b/frontend/features/radio/index.ts
@@ -88,12 +88,13 @@ export {
 } from './components'
 
 // PSY-1016: station-overview derivation helpers
+// (pickNowPlayingShow stays un-exported here — only useStationOverview
+// consumes it; PSY-1075 narrowed the public surface.)
 export {
-  pickNowPlayingShow,
   formatShortAirDate,
   formatStationLocation,
 } from './lib/stationOverview'
-export type { ArtistHop, NowPlaying } from './lib/stationOverview'
+export type { ArtistHop } from './lib/stationOverview'
 
 // PSY-1051: episode-archive derivation helpers + neighbors hook
 // (RadioEpisodePreviewArtist is re-exported in the types block above)

--- a/frontend/features/radio/lib/episodeArchive.ts
+++ b/frontend/features/radio/lib/episodeArchive.ts
@@ -54,9 +54,8 @@ export interface ArtistMatchStats {
 
 /**
  * "N of M artists matched to the graph" for a playlist's meta line. Distinct
- * by artist name (case-insensitive, trimmed — same dedup rule as
- * recentArtistsFromEpisode); a name counts as matched when any of its plays
- * carries an artist_id.
+ * by artist name (case-insensitive, trimmed); a name counts as matched when
+ * any of its plays carries an artist_id.
  */
 export function computeArtistMatchStats(
   plays: RadioPlay[] | null | undefined

--- a/frontend/features/radio/lib/stationOverview.test.ts
+++ b/frontend/features/radio/lib/stationOverview.test.ts
@@ -1,12 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
   pickNowPlayingShow,
-  recentArtistsFromEpisode,
-  deriveNowPlaying,
   formatShortAirDate,
   formatStationLocation,
 } from './stationOverview'
-import type { RadioShowListItem, RadioPlay, RadioEpisodeDetail } from '../types'
+import type { RadioShowListItem } from '../types'
 
 function makeShow(overrides: Partial<RadioShowListItem> = {}): RadioShowListItem {
   return {
@@ -24,58 +22,6 @@ function makeShow(overrides: Partial<RadioShowListItem> = {}): RadioShowListItem
     schedule_display: null,
     latest_air_date: null,
     ...overrides,
-  }
-}
-
-function makePlay(overrides: Partial<RadioPlay> = {}): RadioPlay {
-  return {
-    id: 1,
-    episode_id: 100,
-    position: 1,
-    artist_name: 'Sleater-Kinney',
-    track_title: 'Dig Me Out',
-    album_title: 'Dig Me Out',
-    label_name: 'Kill Rock Stars',
-    release_year: 1997,
-    is_new: false,
-    rotation_status: null,
-    dj_comment: null,
-    is_live_performance: false,
-    is_request: false,
-    artist_id: 1,
-    artist_slug: 'sleater-kinney',
-    release_id: null,
-    release_slug: null,
-    label_id: null,
-    label_slug: null,
-    musicbrainz_artist_id: null,
-    musicbrainz_recording_id: null,
-    musicbrainz_release_id: null,
-    air_timestamp: null,
-    ...overrides,
-  }
-}
-
-function makeEpisode(plays: RadioPlay[], airDate = '2026-06-04'): RadioEpisodeDetail {
-  return {
-    id: 100,
-    show_id: 1,
-    show_name: 'Variety Mix',
-    show_slug: 'variety-mix',
-    station_name: 'KEXP',
-    station_slug: 'kexp',
-    title: null,
-    air_date: airDate,
-    air_time: null,
-    duration_minutes: null,
-    description: null,
-    archive_url: null,
-    mixcloud_url: null,
-    genre_tags: null,
-    mood_tags: null,
-    play_count: plays.length,
-    plays,
-    created_at: '2026-06-04T00:00:00Z',
   }
 }
 
@@ -100,81 +46,6 @@ describe('pickNowPlayingShow', () => {
       makeShow({ id: 2, episode_count: 9 }),
     ]
     expect(pickNowPlayingShow(shows)?.id).toBe(2)
-  })
-})
-
-describe('recentArtistsFromEpisode', () => {
-  it('returns artists most-recent first (plays stored position-ASC)', () => {
-    const plays = [
-      makePlay({ id: 1, position: 1, artist_name: 'Wipers' }),
-      makePlay({ id: 2, position: 2, artist_name: 'Unwound' }),
-      makePlay({ id: 3, position: 3, artist_name: 'Bikini Kill' }),
-    ]
-    const hops = recentArtistsFromEpisode(plays)
-    expect(hops.map(h => h.name)).toEqual(['Bikini Kill', 'Unwound', 'Wipers'])
-  })
-
-  it('de-duplicates artists case-insensitively, keeping the most-recent casing', () => {
-    // Walking newest-first, the most-recent occurrence's casing wins; the
-    // earlier duplicate is dropped.
-    const plays = [
-      makePlay({ id: 1, position: 1, artist_name: 'Wipers' }),
-      makePlay({ id: 2, position: 2, artist_name: 'WIPERS' }),
-      makePlay({ id: 3, position: 3, artist_name: 'Unwound' }),
-    ]
-    const hops = recentArtistsFromEpisode(plays)
-    expect(hops.map(h => h.name)).toEqual(['Unwound', 'WIPERS'])
-  })
-
-  it('skips the currently-playing track so it is not echoed', () => {
-    const plays = [
-      makePlay({ id: 1, position: 1, artist_name: 'Wipers' }),
-      makePlay({ id: 2, position: 2, artist_name: 'Unwound' }),
-    ]
-    const hops = recentArtistsFromEpisode(plays, { skipPlayId: 2 })
-    expect(hops.map(h => h.name)).toEqual(['Wipers'])
-  })
-
-  it('honors the limit', () => {
-    const plays = Array.from({ length: 10 }, (_, i) =>
-      makePlay({ id: i + 1, position: i + 1, artist_name: `Artist ${i}` })
-    )
-    expect(recentArtistsFromEpisode(plays, { limit: 3 })).toHaveLength(3)
-  })
-
-  it('preserves the artist graph slug (or null)', () => {
-    const plays = [
-      makePlay({ id: 1, artist_name: 'Linked', artist_slug: 'linked' }),
-      makePlay({ id: 2, position: 2, artist_name: 'Unlinked', artist_slug: null }),
-    ]
-    const hops = recentArtistsFromEpisode(plays)
-    expect(hops).toEqual([
-      { name: 'Unlinked', slug: null },
-      { name: 'Linked', slug: 'linked' },
-    ])
-  })
-
-  it('returns an empty array for no plays', () => {
-    expect(recentArtistsFromEpisode(undefined)).toEqual([])
-    expect(recentArtistsFromEpisode([])).toEqual([])
-  })
-})
-
-describe('deriveNowPlaying', () => {
-  it('treats the last (highest-position) play as the current track', () => {
-    const episode = makeEpisode([
-      makePlay({ id: 1, position: 1, artist_name: 'Wipers' }),
-      makePlay({ id: 2, position: 2, artist_name: 'Sleater-Kinney' }),
-    ])
-    const np = deriveNowPlaying(episode)
-    expect(np.current?.artist_name).toBe('Sleater-Kinney')
-    // the current track is not echoed in the recent-artists row
-    expect(np.recentArtists.map(h => h.name)).toEqual(['Wipers'])
-  })
-
-  it('handles an episode with no plays gracefully', () => {
-    expect(deriveNowPlaying(makeEpisode([]))).toEqual({ current: null, recentArtists: [] })
-    expect(deriveNowPlaying(undefined)).toEqual({ current: null, recentArtists: [] })
   })
 })
 

--- a/frontend/features/radio/lib/stationOverview.ts
+++ b/frontend/features/radio/lib/stationOverview.ts
@@ -3,17 +3,12 @@
  * surfaces since PSY-1049/1050).
  *
  * Pure, hook-free transforms that turn the radio API responses into the
- * shapes the on-air surfaces render. Keeping the derivation here (rather
- * than inline in components) makes the "Now Playing" v1-fallback contract
- * testable and gives a future real now-playing endpoint a single seam to
- * slot into without changing the consumers' render shape (PSY-1022).
+ * shapes the station surfaces render. The "Now Playing" derivation that
+ * originally lived here was superseded by the live now-playing endpoint
+ * (PSY-1022) and removed (PSY-1075).
  */
 
-import type {
-  RadioPlay,
-  RadioShowListItem,
-  RadioEpisodeDetail,
-} from '../types'
+import type { RadioShowListItem } from '../types'
 
 /**
  * A single artist hop (name + optional graph link). `slug` is null when the
@@ -26,27 +21,15 @@ export interface ArtistHop {
 }
 
 /**
- * The "Now Playing" surface, derived from the most-recent episode of a
- * station's now-playing show (v1 fallback — see pickNowPlayingShow). A real
- * now-playing endpoint (PSY-1022) would populate this same shape from live
- * on-air data without touching the panel components.
- */
-export interface NowPlaying {
-  /** The track playing "right now" (v1: the latest logged play in the episode). */
-  current: RadioPlay | null
-  /** Recently-played artists (distinct, most-recent first), excluding `current`. */
-  recentArtists: ArtistHop[]
-}
-
-/**
- * Pick the show to treat as the station's "current" show for the Now Playing
- * surface. Shows have no recency field on the list endpoint (they sort
- * name-ASC), so v1 uses episode_count as the proxy for "the station's active /
- * signature show" — the show with the most logged episodes. Ties break on the
- * lower id (stable, deterministic). Returns null for a station with no shows.
+ * Pick the station's signature show. Shows have no recency field on the list
+ * endpoint (they sort name-ASC), so this uses episode_count as the proxy for
+ * "the station's active / signature show" — the show with the most logged
+ * episodes. Ties break on the lower id (stable, deterministic). Returns null
+ * for a station with no shows.
  *
- * This is the documented v1 heuristic; PSY-1022's live now-playing endpoint
- * supersedes it.
+ * The live on-air lines use PSY-1022's now-playing endpoint instead; this
+ * heuristic survives only to anchor the Dial strip's [ live playlist ]
+ * archive deep-link (useStationOverview).
  */
 export function pickNowPlayingShow(
   shows: RadioShowListItem[] | undefined
@@ -57,56 +40,6 @@ export function pickNowPlayingShow(
     if (show.episode_count === best.episode_count && show.id < best.id) return show
     return best
   })
-}
-
-/**
- * Distinct artist hops from an episode's plays, most-recent first.
- *
- * Plays are stored position-ASC (position 1 = first track of the set, highest
- * position = most-recently spun), so we walk the list in reverse to surface
- * the freshest artists. De-duplicates by artist name (case-insensitive) so a
- * back-to-back double-spin doesn't waste a hop slot. `skipPlayId` drops the
- * "currently playing" track so it isn't echoed in the recently-played row.
- */
-export function recentArtistsFromEpisode(
-  plays: RadioPlay[] | undefined,
-  options: { limit?: number; skipPlayId?: number } = {}
-): ArtistHop[] {
-  const { limit = 4, skipPlayId } = options
-  if (!plays || plays.length === 0) return []
-
-  const seen = new Set<string>()
-  const hops: ArtistHop[] = []
-  for (let i = plays.length - 1; i >= 0; i--) {
-    const play = plays[i]
-    if (play.id === skipPlayId) continue
-    if (!play.artist_name) continue
-    const key = play.artist_name.trim().toLowerCase()
-    if (seen.has(key)) continue
-    seen.add(key)
-    hops.push({ name: play.artist_name, slug: play.artist_slug })
-    if (hops.length >= limit) break
-  }
-  return hops
-}
-
-/**
- * Build the Now Playing surface from the now-playing show's most-recent
- * episode (v1 fallback). `current` is the latest logged play (highest
- * position); `recentArtists` are the distinct artists spun just before it.
- */
-export function deriveNowPlaying(
-  episode: RadioEpisodeDetail | undefined
-): NowPlaying {
-  const plays = episode?.plays ?? []
-  const current = plays.length > 0 ? plays[plays.length - 1] : null
-  return {
-    current,
-    recentArtists: recentArtistsFromEpisode(plays, {
-      limit: 4,
-      skipPlayId: current?.id,
-    }),
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

PSY-1022 moved the Dial's ON AIR surfaces to the live now-playing endpoint, leaving `useStationOverview` computing a `nowPlaying` derivation nothing consumed. This slims the hook to exactly what its sole consumer (`DialStationStrip`) reads and deletes the now-dead lib helpers.

**Deleted (consumer evidence: repo-wide grep before each deletion):**
- `nowPlaying` return field + `deriveNowPlaying` + `recentArtistsFromEpisode` + `NowPlaying` type — the hook was their only consumer chain.
- The `useRadioShow` detail query inside the hook — `DialStationStrip` read only `nowPlayingShowDetail.slug`, which is by construction identical to `nowPlayingShow.slug` (the detail query's own input). The strip now uses `nowPlayingShow.slug`; the rendered `[ live playlist ]` URL is byte-identical, and each strip saves one network request whose host/description payload served the pre-PSY-1022 Now Playing card.
- Unread `isLoading` / `isEmpty` / `error` return fields (the strip's loading/error states come from `useStationNowPlaying`).
- Dead barrel exports: `pickNowPlayingShow` (value) and `NowPlaying` (type) — zero importers via the barrel.

**Kept (verified consumers):**
- `pickNowPlayingShow` function — still anchors the hook's archive deep-link (verified `DialChannelRow`/`StationOnAirBox` use `useStationNowPlaying`, not it).
- `latestEpisode` + the `useShowLatestEpisode` fetch — feeds the `[ live playlist ]` link.
- `ArtistHop`, `formatShortAirDate`, `formatStationLocation` — live consumers across the radio surfaces (incl. `LatestPlaylistsTable`).

Doc comments refreshed at every touched seam (hook, lib header, `useShowLatestEpisode`, `episodeArchive`, barrels) so nothing still frames PSY-1022 as future work.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors
- [x] `bun run test:run features/radio app/radio` — 35 files, 260 tests passed

## Manual repro

Per-worktree dispatch stack (`stack-up.sh`, auto-escalated to isolated mode) + agent-browser on `$STACK_FRONTEND_URL/radio`: the Dial renders identically — station strips, ● ON AIR lines with current track + earlier hops, channel sub-rows, and the `[▶ Listen]` + `[ live playlist ]` actions.

## Screenshots

![The Dial after the slim](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1075-screenshots/radio-dial.png)

## Code review

Inline 7-angle review (no Agent tool in worktrees): no findings. Only behavioral delta beyond deletion is the dropped detail query, traced above; deleted tests covered only deleted code.

## Adversarial review

Inline 4-lens pass (Saboteur / Future-Maintainer / Security / Completeness): CLEAN. Saboteur probe on the detail-query drop confirmed the list-endpoint slug is the same value every other Dial link already uses unfetched. Pass marker written.

Closes PSY-1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)
