### PR TITLE
PSY-1078: filter 'Music behind DJ' pseudo-artists from aggregations

### DIFF
--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -685,6 +686,27 @@ func (s *RadioService) GetEpisodeDetail(episodeID uint) (*contracts.RadioEpisode
 // Aggregation queries
 // =============================================================================
 
+// WFMU playlists log background/segment music as plays whose artist_name
+// carries the "Music behind DJ:" prefix (casing varies; the colon is always
+// present in observed data). These are not artists — left in, they dominate
+// top-artists boxes and artist previews. Aggregated surfaces exclude them;
+// raw playlist surfaces (episode detail, now-playing current track) keep the
+// rows so the playlist stays an honest record. Import-time flagging plus a
+// backfill is the durable follow-up; this is the query-time filter (PSY-1078).
+const pseudoArtistNamePrefix = "Music behind DJ:"
+
+// pseudoArtistExclusionSQL is the shared predicate for aggregation queries
+// over radio_plays aliased as rp. Compile-time constant (no interpolated
+// input); the prefix contains no LIKE wildcards.
+const pseudoArtistExclusionSQL = "rp.artist_name NOT ILIKE '" + pseudoArtistNamePrefix + "%'"
+
+// isPseudoArtistName is the Go-side mirror of pseudoArtistExclusionSQL, for
+// derivations that aggregate play rows in memory (now-playing recent artists).
+func isPseudoArtistName(name string) bool {
+	return len(name) >= len(pseudoArtistNamePrefix) &&
+		strings.EqualFold(name[:len(pseudoArtistNamePrefix)], pseudoArtistNamePrefix)
+}
+
 // playsScope narrows a top-artists/labels aggregation query (radio_plays rp
 // joined to radio_episodes re) to a show or a station, applied with
 // .Scopes(). The episode feeds use the separate episodeFeedScope type — see
@@ -735,6 +757,7 @@ func (s *RadioService) topArtists(scope playsScope, periodDays, limit int) ([]*c
 		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
 		Joins("LEFT JOIN artists a ON a.id = rp.artist_id").
 		Scopes(scope).
+		Where(pseudoArtistExclusionSQL).
 		Group("rp.artist_name, rp.artist_id, a.slug").
 		Order("play_count DESC").
 		Limit(limit)
@@ -916,7 +939,7 @@ func (s *RadioService) episodeArtistPreviews(episodeIDs []uint) (map[uint][]cont
 			       MIN(rp.position) AS first_pos,
 			       ROW_NUMBER() OVER (PARTITION BY rp.episode_id ORDER BY MIN(rp.position)) AS rn
 			FROM radio_plays rp
-			WHERE rp.episode_id IN ? AND rp.artist_name != ''
+			WHERE rp.episode_id IN ? AND rp.artist_name != '' AND `+pseudoArtistExclusionSQL+`
 			GROUP BY rp.episode_id, rp.artist_name
 		) g
 		LEFT JOIN artists a ON a.id = g.artist_id

--- a/backend/internal/services/catalog/radio_now_playing.go
+++ b/backend/internal/services/catalog/radio_now_playing.go
@@ -551,7 +551,8 @@ func (s *RadioService) episodePlayRows(episodeID uint) ([]nowPlayingPlayRow, err
 // walk plays most-recent-first, de-duplicate by name (case-insensitive),
 // cap at the hop limit. skipLast drops the final row (the archive payload's
 // "current" track); skipArtistName seeds the dedup set (the live payload's
-// current artist).
+// current artist). WFMU "Music behind DJ:" segment rows are skipped — the
+// hops exist to surface artists, not background-music log entries (PSY-1078).
 func recentArtistsFromPlayRows(rows []nowPlayingPlayRow, skipLast bool, skipArtistName string) []contracts.RadioEpisodePreviewArtist {
 	out := []contracts.RadioEpisodePreviewArtist{}
 	seen := make(map[string]bool)
@@ -563,6 +564,9 @@ func recentArtistsFromPlayRows(rows []nowPlayingPlayRow, skipLast bool, skipArti
 			continue
 		}
 		row := rows[i]
+		if isPseudoArtistName(row.ArtistName) {
+			continue
+		}
 		key := recentArtistKey(row.ArtistName)
 		if key == "" || seen[key] {
 			continue

--- a/backend/internal/services/catalog/radio_pseudo_artist_test.go
+++ b/backend/internal/services/catalog/radio_pseudo_artist_test.go
@@ -1,0 +1,131 @@
+package catalog
+
+// PSY-1078: WFMU logs background/segment music as plays named
+// "Music behind DJ: <name>". Aggregated surfaces (top artists, episode
+// artist previews, now-playing recent artists) must exclude them; raw
+// playlist surfaces must keep them. Methods here run as part of
+// RadioServiceIntegrationTestSuite (radio_test.go).
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestIsPseudoArtistName(t *testing.T) {
+	pseudo := []string{
+		"Music behind DJ: The Shadows",
+		"Music Behind DJ: Living Guitars", // casing varies in real WFMU data
+		"MUSIC BEHIND DJ: LOUD",
+		"Music behind DJ:", // bare prefix (424 rows observed)
+	}
+	for _, name := range pseudo {
+		assert.True(t, isPseudoArtistName(name), "expected pseudo-artist: %q", name)
+	}
+
+	realArtists := []string{
+		"The Shadows",
+		"Music",
+		"Music behind DJ", // no colon — never observed; don't over-match
+		"DJ Shadow",
+		"Behind the DJ",
+		"",
+	}
+	for _, name := range realArtists {
+		assert.False(t, isPseudoArtistName(name), "expected real artist: %q", name)
+	}
+}
+
+func TestRecentArtistsFromPlayRows_SkipsPseudoArtists(t *testing.T) {
+	row := func(name string, pos int) nowPlayingPlayRow {
+		return nowPlayingPlayRow{RadioPlay: catalogm.RadioPlay{ArtistName: name, Position: pos}}
+	}
+	rows := []nowPlayingPlayRow{
+		row("A", 1),
+		row("Music behind DJ: Mr. Weather", 2),
+		row("B", 3),
+		row("Music Behind DJ: Living Guitars", 4),
+		row("C", 5),
+	}
+
+	got := recentArtistsFromPlayRows(rows, true, "")
+	names := make([]string, len(got))
+	for i, p := range got {
+		names[i] = p.ArtistName
+	}
+	assert.Equal(t, []string{"B", "A"}, names)
+}
+
+// =============================================================================
+// INTEGRATION TESTS (run via RadioServiceIntegrationTestSuite)
+// =============================================================================
+
+// seedPseudoArtistEpisode seeds one show with an episode mixing real artists
+// and pseudo-artist segment rows, with the pseudo rows outnumbering the real
+// plays (the failure mode on the live WFMU station page).
+func (suite *RadioServiceIntegrationTestSuite) seedPseudoArtistEpisode() (stationID, showID uint, episode *catalogm.RadioEpisode) {
+	station := suite.createStation("WFMU")
+	show := suite.createShow(station.ID, "Garbage Time")
+	ep := suite.createEpisode(show.ID, "2026-06-09")
+
+	suite.createPlay(ep.ID, 1, "Music behind DJ: The Shadows")
+	suite.createPlay(ep.ID, 2, "The Shadows")
+	suite.createPlay(ep.ID, 3, "Music behind DJ: The Shadows")
+	suite.createPlay(ep.ID, 4, "Music Behind DJ: Living Guitars") // casing variant
+	suite.createPlay(ep.ID, 5, "Music behind DJ:")                // bare prefix
+	suite.createPlay(ep.ID, 6, "Deerhunter")
+
+	return station.ID, show.ID, ep
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestTopArtists_ExcludePseudoArtists() {
+	stationID, showID, _ := suite.seedPseudoArtistEpisode()
+
+	// Show-scoped and station-scoped paths share topArtists; assert both.
+	forShow, err := suite.radioService.GetTopArtistsForShow(showID, 0, 10)
+	suite.Require().NoError(err)
+	forStation, err := suite.radioService.GetTopArtistsForStation(stationID, 0, 10)
+	suite.Require().NoError(err)
+
+	// Both real artists have 1 play each, so ordering within the tie is not
+	// asserted — only membership and the absence of pseudo-artists.
+	suite.Require().Len(forShow, 2)
+	suite.Require().Len(forStation, 2)
+
+	gotNames := []string{forShow[0].ArtistName, forShow[1].ArtistName}
+	suite.ElementsMatch([]string{"The Shadows", "Deerhunter"}, gotNames)
+	gotNames = []string{forStation[0].ArtistName, forStation[1].ArtistName}
+	suite.ElementsMatch([]string{"The Shadows", "Deerhunter"}, gotNames)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestEpisodeArtistPreview_ExcludesPseudoArtists() {
+	_, showID, _ := suite.seedPseudoArtistEpisode()
+
+	episodes, total, err := suite.radioService.GetEpisodes(showID, 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(episodes, 1)
+
+	preview := episodes[0].ArtistPreview
+	suite.Require().Len(preview, 2)
+	suite.Equal("The Shadows", preview[0].ArtistName)
+	suite.Equal("Deerhunter", preview[1].ArtistName)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestEpisodeDetailPlaylist_KeepsPseudoArtistRows() {
+	_, _, ep := suite.seedPseudoArtistEpisode()
+
+	detail, err := suite.radioService.GetEpisodeDetail(ep.ID)
+	suite.Require().NoError(err)
+
+	// The playlist is the honest raw record: all 6 rows, segments included.
+	suite.Require().Len(detail.Plays, 6)
+	suite.Equal("Music behind DJ: The Shadows", detail.Plays[0].ArtistName)
+	suite.Equal("Music Behind DJ: Living Guitars", detail.Plays[3].ArtistName)
+}


### PR DESCRIPTION
## Summary

WFMU playlists log background/segment music as plays whose `artist_name` carries the `Music behind DJ:` prefix. These pseudo-artists were dominating the WFMU station page's TOP ARTISTS box (8 of 9 entries on the live page) and leaking into artist-hop previews. This PR adds the decided **query-time filter** (ticket option 2): aggregated surfaces exclude them; raw playlist surfaces keep them.

**Filtered surfaces:**
- Top artists, show- and station-scoped (`topArtists` — shared by both paths)
- Episode artist previews (`episodeArtistPreviews` — feeds `GetEpisodes` and the station/dial-wide episode feeds)
- Now-playing archive fallback's recent-artists hops (`recentArtistsFromPlayRows` — DB-derived only; the live provider path is passed through untouched)

**Deliberately unfiltered (honest raw record):** episode-detail playlists (`GetEpisodeDetail` / `GetEpisodeByShowAndDate`) and the now-playing current track.

The predicate lives in ONE place: `pseudoArtistNamePrefix` + `pseudoArtistExclusionSQL` (SQL, compile-time constant) + `isPseudoArtistName` (Go mirror for the in-memory derivation), in `backend/internal/services/catalog/radio.go`.

### Spike findings (local DB with real WFMU data)

`SELECT DISTINCT artist_name FROM radio_plays WHERE artist_name ILIKE '%behind DJ%' OR artist_name ILIKE 'music behind%'`:

- 48 distinct names, **5,299 rows**, ALL matching `ILIKE 'Music behind DJ:%'` — the colon is present in every observed row, including a bare `Music behind DJ:` (424 rows). Casing varies (`Music behind DJ:` / `Music Behind DJ:`), so the match is case-insensitive.
- Zero rows match `music behind dj%` without the colon — the filter is locked to the colon-suffixed prefix (tighter than the ticket's `LIKE 'Music behind DJ%'` sketch).
- **Candidates observed but NOT filtered** (per ticket guidance — needs a follow-up decision, not speculative patterns): `-mic break-` (24 plays), `DJ Terre T speaks` (15), `Ivy Interview Part 1–4` (8). Real artists like "Talking Heads", "Cindytalk", "DJ Shadow"-style names sit adjacent to any broader pattern, which is why the filter stays tight.

### Durable follow-up (out of scope here)

Import-time flagging in the WFMU provider + backfill for existing rows is the durable fix (ticket option 1). Until then, residual pseudo-row influence remains by design on surfaces outside this ticket's ACs: top **labels** (a segment row's `label_name` still counts), New Release Radar (only 5 pseudo rows have `is_new`), stats, and the matching/affinity pipeline.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] Full `go test ./...` — green
- [x] New `radio_pseudo_artist_test.go`:
  - `TestIsPseudoArtistName` — prefix variants (casing, bare prefix) vs real artists ("Music behind DJ" without colon, "DJ Shadow", "Behind the DJ") 
  - `TestRecentArtistsFromPlayRows_SkipsPseudoArtists` — now-playing hops skip segment rows
  - `TestTopArtists_ExcludePseudoArtists` — show- AND station-scoped paths exclude pseudo rows (seeded 4 pseudo + 2 real plays)
  - `TestEpisodeArtistPreview_ExcludesPseudoArtists` — previews show only real artists
  - `TestEpisodeDetailPlaylist_KeepsPseudoArtistRows` — playlist still renders all 6 raw rows, segments included

## Manual repro

Backend-only change (dispatch mode `none`); the integration tests above are the repro. BEFORE evidence from stage (read-only): `GET https://stage.api.psychichomily.com/radio-stations/wfmu/top-artists?limit=9` returns `"Music behind DJ:"` at position 3 with 12 plays / 3 episodes (2026-06-11).

## Code review

`/code-review` (inline lenses, dispatched sub-agent): no findings. Verified `artist_name` is `NOT NULL` (no `NOT ILIKE` three-valued-logic dropout), ASCII-prefix parity between Postgres `ILIKE` and `strings.EqualFold`, and all callers of the three touched functions.

## Adversarial review

`/adversarial-review` — CLEAN, no fix commit needed.
- [LOW] `rp.` alias coupling in the shared SQL predicate — documented in the constant's comment; misuse fails loudly.
- [LOW] Residual pseudo-row influence on top-labels/radar/stats/affinity — out of decided scope, disclosed above under the import-time follow-up.
Panel: Saboteur · Future-Maintainer · Security · Completeness. Run inline against the branch diff (no Agent tool in dispatched worktrees, per repo convention).

Closes PSY-1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
