### PR TITLE
PSY-1061: profile preview + tier cards to Figma board H

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -83,9 +83,6 @@ function ProfileTab() {
       {/* Contributor profile preview */}
       <ContributorProfilePreview />
 
-      {/* Tier + advancement requirements */}
-      <TierAdvancementCard tier={(user?.user_tier ?? 'new_user')} />
-
       {/* Identity edit form */}
       <Card>
         <CardHeader>
@@ -174,6 +171,9 @@ function ProfileTab() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Tier + advancement requirements (board-H order: after the form) */}
+      <TierAdvancementCard tier={(user?.user_tier ?? 'new_user')} />
 
       {/* Account details (read-only) */}
       <Card>

--- a/frontend/components/contributor/ContributorProfilePreview.test.tsx
+++ b/frontend/components/contributor/ContributorProfilePreview.test.tsx
@@ -432,7 +432,7 @@ describe('ContributorProfilePreview', () => {
     )
   })
 
-  it('hides "View Public Profile" when username is missing', () => {
+  it('never renders the removed View Public Profile button (dropped per board H)', () => {
     mockUseOwnContributorProfile.mockReturnValue({
       data: makeProfile({
         profile_visibility: 'public',

--- a/frontend/components/contributor/ContributorProfilePreview.test.tsx
+++ b/frontend/components/contributor/ContributorProfilePreview.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 import { ContributorProfilePreview } from './ContributorProfilePreview'
-import type { PublicProfileResponse, ContributionsResponse } from '@/features/auth'
+import type { PublicProfileResponse } from '@/features/auth'
 
 // Mock next/link
 vi.mock('next/link', () => ({
@@ -74,9 +74,7 @@ describe('ContributorProfilePreview', () => {
     })
 
     const { container } = renderWithProviders(<ContributorProfilePreview />)
-    // Skeleton has a specific class
-    const skeletons = container.querySelectorAll('[class*="animate-pulse"], [data-slot="skeleton"]')
-    // Alternative: the skeleton renders placeholder divs
+    // The skeleton renders placeholder divs
     expect(container.querySelector('.space-y-6')).toBeInTheDocument()
   })
 
@@ -147,7 +145,7 @@ describe('ContributorProfilePreview', () => {
     expect(screen.getByText('?')).toBeInTheDocument()
   })
 
-  it('shows "View Public Profile" button when profile is public', () => {
+  it('shows the ● Public pill when profile is public (board H)', () => {
     mockUseOwnContributorProfile.mockReturnValue({
       data: makeProfile({
         profile_visibility: 'public',
@@ -157,28 +155,28 @@ describe('ContributorProfilePreview', () => {
     })
 
     renderWithProviders(<ContributorProfilePreview />)
-    const link = screen.getByText('View Public Profile').closest('a')
-    expect(link).toHaveAttribute('href', '/users/testuser')
-  })
-
-  it('hides "View Public Profile" button when profile is private', () => {
-    mockUseOwnContributorProfile.mockReturnValue({
-      data: makeProfile({ profile_visibility: 'private' }),
-      isLoading: false,
-    })
-
-    renderWithProviders(<ContributorProfilePreview />)
+    expect(screen.getByLabelText('Profile is public')).toHaveTextContent(
+      'Public'
+    )
+    // The card heading + View-Public-Profile button were dropped per board H
+    // (the page header carries the public-profile link since PSY-1054).
     expect(screen.queryByText('View Public Profile')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Your Contributor Profile')
+    ).not.toBeInTheDocument()
   })
 
-  it('shows "Profile is private" notice when profile is private', () => {
+  it('shows the ● Private pill when profile is private', () => {
     mockUseOwnContributorProfile.mockReturnValue({
       data: makeProfile({ profile_visibility: 'private' }),
       isLoading: false,
     })
 
     renderWithProviders(<ContributorProfilePreview />)
-    expect(screen.getByText('Profile is private')).toBeInTheDocument()
+    expect(screen.getByLabelText('Profile is private')).toHaveTextContent(
+      'Private'
+    )
+    expect(screen.queryByText('View Public Profile')).not.toBeInTheDocument()
   })
 
   it('shows joined date', () => {

--- a/frontend/components/contributor/ContributorProfilePreview.tsx
+++ b/frontend/components/contributor/ContributorProfilePreview.tsx
@@ -1,16 +1,8 @@
 'use client'
 
-import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import {
-  CalendarDays,
-  Clock,
-  ExternalLink,
-  TrendingUp,
-  Award,
-} from 'lucide-react'
+import { Clock, TrendingUp, Award } from 'lucide-react'
 import { UserTierBadge } from './UserTierBadge'
 import { ContributionStatsGrid } from './ContributionStatsGrid'
 import { ContributionTimeline } from './ContributionTimeline'
@@ -73,22 +65,11 @@ export function ContributorProfilePreview() {
 
   return (
     <div className="space-y-6">
-      {/* Profile Card */}
+      {/* Profile card (design board H): identity only — no card heading, no
+          View-Public-Profile button (the page header carries that link since
+          PSY-1054); profile_visibility renders as the corner pill. */}
       <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg">Your Contributor Profile</CardTitle>
-            {isPublic && profile.username && (
-              <Link href={`/users/${profile.username}`}>
-                <Button variant="outline" size="sm" className="gap-1.5">
-                  <ExternalLink className="h-3.5 w-3.5" />
-                  View Public Profile
-                </Button>
-              </Link>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent>
+        <CardContent className="p-5">
           <div className="flex items-start gap-4">
             {/* Avatar */}
             {profile.avatar_url ? (
@@ -103,28 +84,34 @@ export function ContributorProfilePreview() {
               </div>
             )}
 
-            <div className="flex-1">
-              <div className="flex items-center gap-2 flex-wrap">
-                <h2 className="text-lg font-semibold">{displayName}</h2>
-                <UserTierBadge tier={profile.user_tier} />
-              </div>
-              {profile.username && (
-                <p className="text-sm text-muted-foreground">
-                  @{profile.username}
-                </p>
-              )}
-              <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
-                <span className="flex items-center gap-1">
-                  <CalendarDays className="h-3.5 w-3.5" />
-                  Joined {formatDate(profile.joined_at)}
-                </span>
-                {!isPublic && (
-                  <span className="text-pending-foreground">
-                    Profile is private
+            <div className="min-w-0 flex-1">
+              <h2 className="text-lg font-semibold">{displayName}</h2>
+              <div className="mt-0.5 flex items-center gap-2 flex-wrap">
+                {profile.username && (
+                  <span className="text-sm text-muted-foreground">
+                    @{profile.username}
                   </span>
                 )}
+                <UserTierBadge tier={profile.user_tier} />
               </div>
+              <p className="mt-2 font-mono text-xs text-muted-foreground">
+                Joined {formatDate(profile.joined_at)}
+              </p>
             </div>
+
+            <span
+              className={`inline-flex shrink-0 items-center gap-1.5 rounded-sm border border-border px-2 py-0.5 font-mono text-xs ${
+                isPublic ? 'text-foreground' : 'text-pending-foreground'
+              }`}
+              aria-label={
+                isPublic ? 'Profile is public' : 'Profile is private'
+              }
+            >
+              <span aria-hidden className="text-[8px] leading-none">
+                ●
+              </span>
+              {isPublic ? 'Public' : 'Private'}
+            </span>
           </div>
         </CardContent>
       </Card>

--- a/frontend/components/contributor/TierAdvancementCard.test.tsx
+++ b/frontend/components/contributor/TierAdvancementCard.test.tsx
@@ -94,7 +94,7 @@ describe('TierAdvancementCard', () => {
     ({ tier, currentLabel, nextLabel, requirementCount }) => {
       const { container } = render(<TierAdvancementCard tier={tier} />)
 
-      // Current tier label appears once next to "Your tier:"
+      // Current tier badge renders in the header row (board H)
       expect(screen.getByText(currentLabel)).toBeInTheDocument()
       // Next tier label appears in the "Next:" block
       expect(screen.getByText(nextLabel)).toBeInTheDocument()

--- a/frontend/components/contributor/TierAdvancementCard.test.tsx
+++ b/frontend/components/contributor/TierAdvancementCard.test.tsx
@@ -20,11 +20,13 @@ vi.mock('next/link', () => ({
 }))
 
 describe('TierAdvancementCard', () => {
-  it('renders the card title and the Award icon header', () => {
+  it('renders the board-H header: sentence-case title + tier badge', () => {
     render(<TierAdvancementCard tier="new_user" />)
-    expect(screen.getByText('Contributor Tier')).toBeInTheDocument()
-    // "Your tier:" label appears next to the current badge
-    expect(screen.getByText('Your tier:')).toBeInTheDocument()
+    expect(screen.getByText('Contributor tier')).toBeInTheDocument()
+    // The current-tier badge sits in the header row (the old "Your tier:"
+    // label was dropped per board H).
+    expect(screen.getByText('New User')).toBeInTheDocument()
+    expect(screen.queryByText('Your tier:')).not.toBeInTheDocument()
   })
 
   it('renders the current tier badge for new_user with next-tier requirements', () => {

--- a/frontend/components/contributor/TierAdvancementCard.tsx
+++ b/frontend/components/contributor/TierAdvancementCard.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { ArrowRight, Award } from 'lucide-react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { UserTierBadge } from './UserTierBadge'
 import { getNextTierInfo, TIERS_HELP_PATH } from '@/lib/tiers'
 import type { UserTier } from '@/features/auth'
@@ -11,47 +10,55 @@ interface TierAdvancementCardProps {
   tier: UserTier
 }
 
+/**
+ * Contributor-tier card on /profile (design board H, PSY-1061): tier badge in
+ * the header, next-tier requirements behind a hairline. The board's numeric
+ * progress bar ("32 / 50 qualifying edits") is deferred — per-user
+ * advancement progress only exists behind the admin evaluate endpoint today
+ * (see the follow-up ticket on PSY-1061).
+ */
 export function TierAdvancementCard({ tier }: TierAdvancementCardProps) {
   const next = getNextTierInfo(tier)
 
   return (
     <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center gap-2">
-          <Award className="h-5 w-5 text-muted-foreground" />
-          <CardTitle className="text-lg">Contributor Tier</CardTitle>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-sm text-muted-foreground">Your tier:</span>
+      <CardContent className="p-5">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-base font-semibold">Contributor tier</h2>
           <UserTierBadge tier={tier} />
         </div>
 
         {next ? (
-          <div className="rounded-md border border-border/60 bg-muted/30 p-4">
-            <div className="flex items-center gap-2 mb-2">
+          <div className="mt-4 border-t border-border/50 pt-3">
+            <div className="flex items-center gap-2 flex-wrap">
               <span className="text-sm text-muted-foreground">Next:</span>
               <UserTierBadge tier={next.tier} />
-              <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
             </div>
-            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            <p className="mt-3 font-mono text-xs uppercase tracking-wider text-muted-foreground">
               Requirements
             </p>
-            <ul className="list-disc pl-5 space-y-1 text-sm">
+            <ul className="mt-1.5 space-y-1 text-sm">
               {next.advancementRequirements?.map(req => (
-                <li key={req.text}>{req.text}</li>
+                <li key={req.text} className="flex items-baseline gap-2">
+                  <span
+                    aria-hidden
+                    className="text-[8px] leading-none text-muted-foreground"
+                  >
+                    ●
+                  </span>
+                  {req.text}
+                </li>
               ))}
             </ul>
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">
-            You&rsquo;re at the highest contributor tier. Thanks for being
-            a pillar of the community.
+          <p className="mt-4 border-t border-border/50 pt-3 text-sm text-muted-foreground">
+            You&rsquo;re at the highest contributor tier. Thanks for being a
+            pillar of the community.
           </p>
         )}
 
-        <p className="text-xs text-muted-foreground">
+        <p className="mt-4 text-xs text-muted-foreground">
           Advancement is automatic and evaluated daily.{' '}
           <Link
             href={TIERS_HELP_PATH}


### PR DESCRIPTION
Closes PSY-1061.

## Summary

Restyles the two `/profile` cards PR #1076 deliberately left untouched, per Figma board H:

- **`ContributorProfilePreview`**: drops the "Your Contributor Profile" heading and the View-Public-Profile button (the page header has carried that link since PSY-1054), and gains the **`● Public` / `● Private` corner pill** bound live to `profile_visibility` (with `aria-label`; the Private state inherits the old notice's `pending-foreground` token, so the hidden-page signal is preserved). Identity block per the board: name, `@handle` + tier badge row, mono `Joined …` line. The Impact / Recent-Activity / Start-Contributing sub-cards keep their current content per the ticket — their redesign is PSY-1060's.
- **`TierAdvancementCard`**: sentence-case "Contributor tier" header with the current-tier badge right-aligned, hairline-separated "Next:" section, dense dot-marker requirement rows, mono REQUIREMENTS label, icons dropped per the decoration-light direction. Highest-tier and new-user variants keep their content.
- **Card order** on the Profile tab now matches board H: preview → form → tier (was preview → tier → form).

## Deferred (with verification)

- **The board's numeric progress bar ("32 / 50 qualifying edits") is NOT in this PR — filed PSY-1087.** The counter needs an approved-edits numerator that only exists in the admin-gated evaluate endpoint (`UserEvaluationResult.ApprovedEdits`, registered on `rc.Admin`); `ContributionStats` has no matching field and `lib/tiers.ts` is static text. The adversarial panel's Completeness lawyer independently verified there is genuinely no user-facing numeric source — shipping the bar would have meant fabricated numbers. PSY-1087 scopes the self-scoped advancement endpoint + bar.

## Adversarial review

`/adversarial-review` — **CLEAN** (3-lens Opus panel: Saboteur+Maintainer, Security, Completeness); two LOW doc-drift items fixed in commit `a1ed1288` (a test comment referencing the removed "Your tier:" label ×2 corroborated, and a moot test name). Panel verified: `ProfileVisibility` is a closed `public | private` union (no third value can render misleadingly); `pending-foreground` token exists both modes; the e2e `pages/profile.spec.ts` assertions are order-independent and unaffected; no ambiguous `getByText` collisions between tier badges; removed icons leave no orphans; the pill's aria-label is a strict superset of its visible text; Security CLEAN (self-view-only surface, no auth-flow change, React escaping intact).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run app/profile components/contributor` — 297 passing (preview tests updated to the pill contract — `getByLabelText` public/private, heading + button asserted absent; tier tests updated to the board-H header; new-user/highest-tier variant tests unchanged and green)
- [x] `bunx eslint` on changed files — 0 errors (pre-existing `<img>` avatar warning only; three pre-existing unused-var warnings in the touched test file cleaned as drive-bys)
- [x] `/adversarial-review` — CLEAN; two LOW fixes in separate commit `a1ed1288`
- [x] e2e `pages/profile.spec.ts` assertions verified order-independent by the panel (no spec run needed — its targets: page heading, tabs, email, Account Details, Settings sections, all untouched)
- [x] Manual repro on the local dev stack as `testuser2`: pill renders `● Public` live, heading/button gone, board-H card order, tier card matches the board (screenshots below)

## Screenshots

**Preview card (board H)** — identity block + `● Public` pill, no heading/button:
![preview card](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-a6287ff18363cbc8acf9/psy-1061-01-preview-card.png)

**Tier card (board H, sans deferred bar)** — sentence-case header + badge, hairline Next section, dense requirements; board-H order visible (form above, tier below):
![tier card](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-a6287ff18363cbc8acf9/psy-1061-02-tier-card.png)

**Dark mode** — tokens only:
![dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-a6287ff18363cbc8acf9/psy-1061-03-dark.png)

## Coverage gaps

- **`● Private` pill not screenshot-verified live** (test user is public); covered by the unit test (`getByLabelText('Profile is private')`).
- **New-user variants (Start Contributing, requirements checklist) not screenshot-verified** — content untouched by this diff, asserted by existing unit tests.
- **Impact / Recent-Activity cards sit between the preview card and the form** — they're inside the preview component and appear on no board; their placement/fate is PSY-1060's design call (disclosed by the panel as LOW, pre-existing structure).
