### PR TITLE
PSY-1076: /radio/playlists + full New Release Radar hub destinations

### DIFF
--- a/frontend/app/radio/_components/DialSidebarBoxes.test.tsx
+++ b/frontend/app/radio/_components/DialSidebarBoxes.test.tsx
@@ -65,6 +65,15 @@ describe('NewReleaseRadarBox', () => {
       screen.queryByRole('link', { name: 'Florry — Sounds Like...' })
     ).not.toBeInTheDocument()
   })
+
+  it('links the full radar view in the box footer (PSY-1076)', () => {
+    render(<NewReleaseRadarBox releases={[makeEntry()]} isLoading={false} />)
+
+    expect(screen.getByRole('link', { name: 'full radar →' })).toHaveAttribute(
+      'href',
+      '/radio/new-releases'
+    )
+  })
 })
 
 describe('DialStatsBox', () => {

--- a/frontend/app/radio/_components/DialSidebarBoxes.tsx
+++ b/frontend/app/radio/_components/DialSidebarBoxes.tsx
@@ -2,7 +2,9 @@
 
 import Link from 'next/link'
 import { Loader2 } from 'lucide-react'
+import { BracketLink } from '@/components/shared/BracketLink'
 import { StatsList } from '@/components/shared/StatsList'
+import { getNewReleaseHref } from '@/features/radio'
 import type { RadioNewReleaseRadarEntry, RadioStats } from '@/features/radio'
 
 /**
@@ -59,12 +61,9 @@ export function NewReleaseRadarBox({
             ? `${entry.artist_name} — ${entry.album_title}`
             : entry.artist_name
           // Link the whole "Artist — Album" line to the release when matched,
-          // else to the artist, else plain text (no dead links).
-          const href = entry.release_slug
-            ? `/releases/${entry.release_slug}`
-            : entry.artist_slug
-              ? `/artists/${entry.artist_slug}`
-              : null
+          // else to the artist, else plain text (no dead links). Shared with
+          // the /radio/new-releases full view (PSY-1076).
+          const href = getNewReleaseHref(entry)
           const subline = [
             entry.label_name,
             `${entry.play_count} ${entry.play_count === 1 ? 'play' : 'plays'}`,
@@ -97,6 +96,14 @@ export function NewReleaseRadarBox({
           )
         })}
       </ul>
+      {/* PSY-1076: the box is a capped teaser — link to the full radar view. */}
+      <div className="mt-3 border-t border-border pt-2.5">
+        <BracketLink
+          label="full radar →"
+          href="/radio/new-releases"
+          className="font-mono text-xs"
+        />
+      </div>
     </SidebarBox>
   )
 }

--- a/frontend/app/radio/_components/RadioHub.test.tsx
+++ b/frontend/app/radio/_components/RadioHub.test.tsx
@@ -118,6 +118,44 @@ describe('RadioHub', () => {
     ).toBeInTheDocument()
   })
 
+  it('links the full playlists feed under the latest-playlists table (PSY-1076)', () => {
+    mockUseRecentRadioEpisodes.mockReturnValue({
+      data: {
+        episodes: [
+          {
+            id: 1,
+            title: null,
+            air_date: '2026-06-09',
+            play_count: 24,
+            archive_url: null,
+            show_id: 3,
+            show_name: 'The Night Owl Show',
+            show_slug: 'night-owl',
+            station_id: 2,
+            station_name: 'WFMU',
+            station_slug: 'wfmu',
+            artist_preview: [],
+          },
+        ],
+        total: 574,
+      },
+      isLoading: false,
+      error: null,
+    })
+    render(<RadioHub />)
+
+    expect(
+      screen.getByRole('link', { name: 'all playlists →' })
+    ).toHaveAttribute('href', '/radio/playlists')
+  })
+
+  it('omits the all-playlists link when the feed is empty', () => {
+    render(<RadioHub />)
+    expect(
+      screen.queryByRole('link', { name: 'all playlists →' })
+    ).not.toBeInTheDocument()
+  })
+
   it('renders an error state when stations fail to load', () => {
     mockUseRadioStations.mockReturnValue({
       data: undefined,

--- a/frontend/app/radio/_components/RadioHub.tsx
+++ b/frontend/app/radio/_components/RadioHub.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Loader2, Radio } from 'lucide-react'
+import { BracketLink } from '@/components/shared/BracketLink'
 import {
   useRadioStats,
   useRadioStations,
@@ -95,6 +96,17 @@ export default function RadioHub() {
               isLoading={recentLoading}
               error={recentError}
             />
+            {/* PSY-1076: the hub table is a capped teaser — link the full,
+                paginated dial-wide feed. */}
+            {!recentError && (recentData?.episodes?.length ?? 0) > 0 && (
+              <div className="mt-2">
+                <BracketLink
+                  label="all playlists →"
+                  href="/radio/playlists"
+                  className="font-mono text-xs"
+                />
+              </div>
+            )}
           </section>
 
           <aside className="flex flex-col gap-5">

--- a/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.test.tsx
+++ b/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.test.tsx
@@ -128,6 +128,7 @@ describe('NewReleaseRadarPage', () => {
       isLoading: false,
       // The bumped-limit query is in flight; the old page is the placeholder.
       isFetching: (opts?.limit ?? 20) > 20,
+      isPlaceholderData: (opts?.limit ?? 20) > 20,
       error: null,
     }))
     render(<NewReleaseRadarPage />)

--- a/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.test.tsx
+++ b/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.test.tsx
@@ -114,6 +114,28 @@ describe('NewReleaseRadarPage', () => {
     )
   })
 
+  it('keeps a disabled "Loading…" control mounted while a limit bump is in flight', () => {
+    // keepPreviousData serves the OLD full page (20 rows) against the NEW
+    // limit (40) while fetching — the control must not flicker out.
+    const fullPage = {
+      releases: Array.from({ length: 20 }, (_, i) =>
+        makeEntry({ artist_name: `Artist ${i}` })
+      ),
+      count: 20,
+    }
+    mockUseNewReleaseRadar.mockImplementation((opts: { limit?: number }) => ({
+      data: fullPage,
+      isLoading: false,
+      // The bumped-limit query is in flight; the old page is the placeholder.
+      isFetching: (opts?.limit ?? 20) > 20,
+      error: null,
+    }))
+    render(<NewReleaseRadarPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'More releases' }))
+    expect(screen.getByRole('button', { name: 'Loading…' })).toBeDisabled()
+  })
+
   it('hides the load-more control when the radar comes back short', () => {
     setReleases([makeEntry()])
     render(<NewReleaseRadarPage />)

--- a/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.test.tsx
+++ b/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { RadioNewReleaseRadarEntry } from '@/features/radio'
+
+const mockUseNewReleaseRadar = vi.fn()
+
+vi.mock('@/features/radio', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/features/radio')>()
+  return {
+    ...actual,
+    useNewReleaseRadar: (...args: unknown[]) => mockUseNewReleaseRadar(...args),
+  }
+})
+
+import NewReleaseRadarPage from './NewReleaseRadarPage'
+
+function makeEntry(
+  overrides: Partial<RadioNewReleaseRadarEntry> = {}
+): RadioNewReleaseRadarEntry {
+  return {
+    artist_name: 'Wet Leg',
+    artist_id: 4,
+    artist_slug: 'wet-leg',
+    album_title: 'Moisturizer',
+    label_name: 'Domino',
+    release_id: 8,
+    release_slug: 'wet-leg-moisturizer',
+    label_id: 2,
+    label_slug: 'domino',
+    play_count: 24,
+    station_count: 2,
+    ...overrides,
+  }
+}
+
+function setReleases(releases: RadioNewReleaseRadarEntry[]) {
+  mockUseNewReleaseRadar.mockReturnValue({
+    data: { releases, count: releases.length },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  })
+}
+
+describe('NewReleaseRadarPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders breadcrumb, heading, and a row with release + label links', () => {
+    setReleases([makeEntry()])
+    render(<NewReleaseRadarPage />)
+
+    expect(screen.getByRole('link', { name: 'Radio' })).toHaveAttribute(
+      'href',
+      '/radio'
+    )
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'New release radar' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: 'Wet Leg — Moisturizer' })
+    ).toHaveAttribute('href', '/releases/wet-leg-moisturizer')
+    expect(screen.getByRole('link', { name: 'Domino' })).toHaveAttribute(
+      'href',
+      '/labels/domino'
+    )
+    expect(screen.getByText('24')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('falls back to the artist page, then plain text (no dead links)', () => {
+    setReleases([
+      makeEntry({ release_slug: null }),
+      makeEntry({
+        artist_name: 'Florry',
+        album_title: 'Sounds Like...',
+        artist_slug: null,
+        release_slug: null,
+        label_name: null,
+        label_slug: null,
+      }),
+    ])
+    render(<NewReleaseRadarPage />)
+
+    expect(
+      screen.getByRole('link', { name: 'Wet Leg — Moisturizer' })
+    ).toHaveAttribute('href', '/artists/wet-leg')
+
+    expect(screen.getByText('Florry — Sounds Like...')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Florry — Sounds Like...' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('grows the in-place limit on "More releases" while pages come back full', () => {
+    // A full first page (20 of 20) means more may exist.
+    setReleases(
+      Array.from({ length: 20 }, (_, i) =>
+        makeEntry({ artist_name: `Artist ${i}` })
+      )
+    )
+    render(<NewReleaseRadarPage />)
+
+    expect(screen.getByText('showing 20 releases')).toBeInTheDocument()
+    expect(mockUseNewReleaseRadar).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 20 })
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'More releases' }))
+    expect(mockUseNewReleaseRadar).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 40 })
+    )
+  })
+
+  it('hides the load-more control when the radar comes back short', () => {
+    setReleases([makeEntry()])
+    render(<NewReleaseRadarPage />)
+
+    expect(screen.getByText('showing 1 release')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'More releases' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the load-more control at the API limit cap of 100', () => {
+    setReleases(
+      Array.from({ length: 100 }, (_, i) =>
+        makeEntry({ artist_name: `Artist ${i}` })
+      )
+    )
+    render(<NewReleaseRadarPage />)
+
+    // 20 → 40 → 60 → 80 → 100: four clicks reach the cap.
+    for (let i = 0; i < 4; i++) {
+      fireEvent.click(screen.getByRole('button', { name: 'More releases' }))
+    }
+    expect(mockUseNewReleaseRadar).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 100 })
+    )
+
+    expect(screen.getByText('showing 100 releases')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'More releases' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders an empty state when nothing is on the radar', () => {
+    setReleases([])
+    render(<NewReleaseRadarPage />)
+    expect(screen.getByText('Nothing on the radar yet.')).toBeInTheDocument()
+  })
+
+  it('renders an error state when the radar fails to load', () => {
+    mockUseNewReleaseRadar.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new Error('boom'),
+    })
+    render(<NewReleaseRadarPage />)
+    expect(
+      screen.getByText("Couldn't load the new release radar.")
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.tsx
+++ b/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.tsx
@@ -33,7 +33,11 @@ export default function NewReleaseRadarPage() {
   const releases = data?.releases ?? []
 
   // A short page means the radar is exhausted; a full page may have more.
-  const canLoadMore = releases.length >= limit && limit < MAX_LIMIT
+  // While a limit bump is in flight, keepPreviousData serves the OLD (short)
+  // page against the NEW limit — keep the control mounted so it shows its
+  // disabled "Loading…" state instead of flickering out and back.
+  const canLoadMore =
+    (releases.length >= limit || isFetching) && limit < MAX_LIMIT
 
   return (
     <div className="flex min-h-screen items-start justify-center">
@@ -64,7 +68,7 @@ export default function NewReleaseRadarPage() {
           </div>
         )}
 
-        {!isLoading && error != null && (
+        {!isLoading && !!error && (
           <p className="py-6 text-sm text-muted-foreground">
             Couldn&apos;t load the new release radar.
           </p>

--- a/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.tsx
+++ b/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import { BracketLink } from '@/components/shared/BracketLink'
+import { DenseTable } from '@/components/shared/DenseTable'
+import { getNewReleaseHref, useNewReleaseRadar } from '@/features/radio'
+import type { RadioNewReleaseRadarEntry } from '@/features/radio'
+
+const INITIAL_LIMIT = 20
+const LOAD_MORE_STEP = 20
+// GET /radio/new-releases caps limit at 100 and exposes no offset, so the
+// full radar view tops out at the 100 hottest entries (documented cap,
+// PSY-1076). The response carries count (page size) but no grand total.
+const MAX_LIMIT = 100
+
+/**
+ * /radio/new-releases (PSY-1076): the full New Release Radar — the hub
+ * sidebar box's capped teaser (PSY-1049) as a dedicated dense-table view
+ * with label/plays/stations columns. Link resolution shares
+ * getNewReleaseHref with the hub box (release → artist → plain text, no
+ * dead links).
+ *
+ * Pagination is in-place (PSY-1050's choice): "More releases" grows the
+ * query limit by 20 up to the API cap. With no total in the response, the
+ * control shows whenever the last page came back full.
+ */
+export default function NewReleaseRadarPage() {
+  const [limit, setLimit] = useState(INITIAL_LIMIT)
+  const { data, isLoading, isFetching, error } = useNewReleaseRadar({ limit })
+
+  const releases = data?.releases ?? []
+
+  // A short page means the radar is exhausted; a full page may have more.
+  const canLoadMore = releases.length >= limit && limit < MAX_LIMIT
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-4xl px-4 py-8 md:px-8">
+        {/* Breadcrumb */}
+        <div className="mb-6">
+          <Link
+            href="/radio"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Radio
+          </Link>
+        </div>
+
+        <header className="mb-6">
+          <h1 className="text-3xl font-bold">New release radar</h1>
+          <p className="mt-1.5 text-muted-foreground">
+            New releases surfaced by radio play across the dial — most played
+            first.
+          </p>
+        </header>
+
+        {isLoading && (
+          <div className="flex justify-center py-10">
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+            <span className="sr-only">Loading new release radar</span>
+          </div>
+        )}
+
+        {!isLoading && error != null && (
+          <p className="py-6 text-sm text-muted-foreground">
+            Couldn&apos;t load the new release radar.
+          </p>
+        )}
+
+        {!isLoading && !error && releases.length === 0 && (
+          <p className="py-6 text-sm text-muted-foreground">
+            Nothing on the radar yet.
+          </p>
+        )}
+
+        {!isLoading && !error && releases.length > 0 && (
+          <>
+            <DenseTable variant="standard">
+              <thead>
+                <tr>
+                  <th>Release</th>
+                  <th>Label</th>
+                  <th className="text-right">Plays</th>
+                  <th className="text-right">Stations</th>
+                </tr>
+              </thead>
+              <tbody>
+                {releases.map((entry, idx) => (
+                  <RadarRow
+                    key={`${entry.artist_name}-${entry.album_title}-${idx}`}
+                    entry={entry}
+                  />
+                ))}
+              </tbody>
+            </DenseTable>
+
+            <div className="flex items-baseline gap-2 mt-2">
+              {canLoadMore && (
+                <BracketLink
+                  label={isFetching ? 'Loading…' : 'More releases'}
+                  onClick={() =>
+                    setLimit(l => Math.min(l + LOAD_MORE_STEP, MAX_LIMIT))
+                  }
+                  disabled={isFetching}
+                />
+              )}
+              <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                showing {releases.length}{' '}
+                {releases.length === 1 ? 'release' : 'releases'}
+              </span>
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function RadarRow({ entry }: { entry: RadioNewReleaseRadarEntry }) {
+  const title = entry.album_title
+    ? `${entry.artist_name} — ${entry.album_title}`
+    : entry.artist_name
+  const href = getNewReleaseHref(entry)
+
+  return (
+    <tr>
+      <td>
+        {href ? (
+          <Link
+            href={href}
+            className="font-medium text-primary transition-colors hover:underline"
+          >
+            {title}
+          </Link>
+        ) : (
+          <span className="font-medium text-foreground">{title}</span>
+        )}
+      </td>
+      <td className="text-muted-foreground">
+        {entry.label_name ? (
+          entry.label_slug ? (
+            <Link
+              href={`/labels/${entry.label_slug}`}
+              className="hover:text-foreground transition-colors"
+            >
+              {entry.label_name}
+            </Link>
+          ) : (
+            entry.label_name
+          )
+        ) : (
+          <span aria-hidden>—</span>
+        )}
+      </td>
+      <td className="text-right text-muted-foreground">{entry.play_count}</td>
+      <td className="text-right text-muted-foreground">
+        {entry.station_count}
+      </td>
+    </tr>
+  )
+}

--- a/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.tsx
+++ b/frontend/app/radio/new-releases/_components/NewReleaseRadarPage.tsx
@@ -28,16 +28,19 @@ const MAX_LIMIT = 100
  */
 export default function NewReleaseRadarPage() {
   const [limit, setLimit] = useState(INITIAL_LIMIT)
-  const { data, isLoading, isFetching, error } = useNewReleaseRadar({ limit })
+  const { data, isLoading, isFetching, isPlaceholderData, error } =
+    useNewReleaseRadar({ limit })
 
   const releases = data?.releases ?? []
 
   // A short page means the radar is exhausted; a full page may have more.
   // While a limit bump is in flight, keepPreviousData serves the OLD (short)
-  // page against the NEW limit — keep the control mounted so it shows its
-  // disabled "Loading…" state instead of flickering out and back.
+  // page against the NEW limit — isPlaceholderData keeps the control mounted
+  // in its disabled "Loading…" state instead of flickering out and back
+  // (and, unlike isFetching, doesn't resurrect it on background refetches of
+  // an exhausted radar).
   const canLoadMore =
-    (releases.length >= limit || isFetching) && limit < MAX_LIMIT
+    (releases.length >= limit || isPlaceholderData) && limit < MAX_LIMIT
 
   return (
     <div className="flex min-h-screen items-start justify-center">

--- a/frontend/app/radio/new-releases/page.tsx
+++ b/frontend/app/radio/new-releases/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from 'next'
+import NewReleaseRadarPage from './_components/NewReleaseRadarPage'
+
+export const metadata: Metadata = {
+  title: 'New release radar — Radio',
+  description:
+    'New releases surfaced by radio play across the dial — independent radio wired into the knowledge graph',
+  openGraph: {
+    title: 'New release radar — Radio',
+    description:
+      'New releases surfaced by radio play across the dial — independent radio wired into the knowledge graph',
+    type: 'website',
+    url: '/radio/new-releases',
+  },
+}
+
+export default function RadioNewReleasesPage() {
+  return <NewReleaseRadarPage />
+}

--- a/frontend/app/radio/playlists/_components/PlaylistsFeedPage.test.tsx
+++ b/frontend/app/radio/playlists/_components/PlaylistsFeedPage.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { RadioStationEpisodeRow } from '@/features/radio'
+
+const mockUseRecentRadioEpisodes = vi.fn()
+
+vi.mock('@/features/radio', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/features/radio')>()
+  return {
+    ...actual,
+    useRecentRadioEpisodes: (...args: unknown[]) =>
+      mockUseRecentRadioEpisodes(...args),
+  }
+})
+
+import PlaylistsFeedPage from './PlaylistsFeedPage'
+
+function makeRow(
+  overrides: Partial<RadioStationEpisodeRow> = {}
+): RadioStationEpisodeRow {
+  return {
+    id: 1,
+    title: null,
+    air_date: '2026-06-09',
+    play_count: 24,
+    archive_url: null,
+    show_id: 3,
+    show_name: 'The Night Owl Show',
+    show_slug: 'night-owl',
+    station_id: 2,
+    station_name: 'WFMU',
+    station_slug: 'wfmu',
+    artist_preview: [
+      { artist_name: 'CAN', artist_id: 9, artist_slug: 'can' },
+      { artist_name: "it's all meat", artist_id: null, artist_slug: null },
+    ],
+    ...overrides,
+  }
+}
+
+function setEpisodes(
+  episodes: RadioStationEpisodeRow[],
+  total = episodes.length
+) {
+  mockUseRecentRadioEpisodes.mockReturnValue({
+    data: { episodes, total },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  })
+}
+
+describe('PlaylistsFeedPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the breadcrumb, heading, and feed rows via the hub table', () => {
+    setEpisodes([makeRow()], 574)
+    render(<PlaylistsFeedPage />)
+
+    expect(screen.getByRole('link', { name: 'Radio' })).toHaveAttribute(
+      'href',
+      '/radio'
+    )
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'All playlists' })
+    ).toBeInTheDocument()
+
+    // Row anatomy comes from the shared LatestPlaylistsTable.
+    expect(
+      screen.getByRole('link', { name: 'The Night Owl Show' })
+    ).toHaveAttribute('href', '/radio/wfmu/night-owl')
+    expect(screen.getByText('Jun 9')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'CAN' })).toHaveAttribute(
+      'href',
+      '/artists/can'
+    )
+  })
+
+  it('grows the in-place limit on "More playlists" and reports the total', () => {
+    setEpisodes([makeRow()], 574)
+    render(<PlaylistsFeedPage />)
+
+    expect(screen.getByText('showing 1 of 574 playlists')).toBeInTheDocument()
+    expect(mockUseRecentRadioEpisodes).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 20 })
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'More playlists' }))
+    expect(mockUseRecentRadioEpisodes).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 40 })
+    )
+  })
+
+  it('hides the load-more control once every playlist is shown', () => {
+    setEpisodes([makeRow()], 1)
+    render(<PlaylistsFeedPage />)
+
+    expect(screen.getByText('showing 1 of 1 playlists')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'More playlists' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the load-more control at the API limit cap of 100', () => {
+    // 100 rows shown out of 574: more exist, but the endpoint caps limit.
+    setEpisodes(
+      Array.from({ length: 100 }, (_, i) => makeRow({ id: i + 1 })),
+      574
+    )
+    render(<PlaylistsFeedPage />)
+
+    // 20 → 40 → 60 → 80 → 100: four clicks reach the cap.
+    for (let i = 0; i < 4; i++) {
+      fireEvent.click(screen.getByRole('button', { name: 'More playlists' }))
+    }
+    expect(mockUseRecentRadioEpisodes).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 100 })
+    )
+
+    expect(screen.getByText('showing 100 of 574 playlists')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'More playlists' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the shared error state when the feed fails', () => {
+    mockUseRecentRadioEpisodes.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new Error('boom'),
+    })
+    render(<PlaylistsFeedPage />)
+
+    expect(
+      screen.getByText("Couldn't load the latest playlists.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/showing/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/app/radio/playlists/_components/PlaylistsFeedPage.tsx
+++ b/frontend/app/radio/playlists/_components/PlaylistsFeedPage.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { BracketLink } from '@/components/shared/BracketLink'
+import { useRecentRadioEpisodes } from '@/features/radio'
+import { LatestPlaylistsTable } from '../../_components/LatestPlaylistsTable'
+
+const INITIAL_LIMIT = 20
+const LOAD_MORE_STEP = 20
+// The recent-episodes endpoint caps limit at 100; past that the feed points
+// readers at the per-station and per-show pages instead of paginating
+// further in place (same call as StationPlaylistsFeed, PSY-1050).
+const MAX_LIMIT = 100
+
+/**
+ * /radio/playlists (PSY-1076): the full dial-wide latest-playlists feed —
+ * the hub's "Latest playlists — across the dial" teaser (PSY-1049) as a
+ * dedicated destination. Reuses the hub's LatestPlaylistsTable so the row
+ * anatomy has one source of truth.
+ *
+ * Pagination is in-place (PSY-1050's choice): "More playlists" grows the
+ * query limit by 20 (keepPreviousData keeps the table stable while the
+ * larger page loads) up to the API's limit cap of 100.
+ */
+export default function PlaylistsFeedPage() {
+  const [limit, setLimit] = useState(INITIAL_LIMIT)
+  const { data, isLoading, isFetching, error } = useRecentRadioEpisodes({
+    limit,
+  })
+
+  const episodes = data?.episodes ?? []
+  const total = data?.total ?? 0
+
+  const canLoadMore = episodes.length < total && limit < MAX_LIMIT
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        {/* Breadcrumb */}
+        <div className="mb-6">
+          <Link
+            href="/radio"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Radio
+          </Link>
+        </div>
+
+        <header className="mb-6">
+          <h1 className="text-3xl font-bold">All playlists</h1>
+          <p className="mt-1.5 text-muted-foreground">
+            Every playlist tracked across the dial, newest first.
+          </p>
+        </header>
+
+        <LatestPlaylistsTable
+          rows={data?.episodes}
+          isLoading={isLoading}
+          error={error}
+        />
+
+        {!isLoading && !error && episodes.length > 0 && (
+          <div className="flex items-baseline gap-2 mt-2">
+            {canLoadMore && (
+              <BracketLink
+                label={isFetching ? 'Loading…' : 'More playlists'}
+                onClick={() =>
+                  setLimit(l => Math.min(l + LOAD_MORE_STEP, MAX_LIMIT))
+                }
+                disabled={isFetching}
+              />
+            )}
+            <span className="font-mono text-xs text-muted-foreground tabular-nums">
+              showing {episodes.length} of {total} playlists
+            </span>
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/frontend/app/radio/playlists/page.tsx
+++ b/frontend/app/radio/playlists/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from 'next'
+import PlaylistsFeedPage from './_components/PlaylistsFeedPage'
+
+export const metadata: Metadata = {
+  title: 'All playlists — Radio',
+  description:
+    'Every playlist tracked across the dial, newest first — independent radio wired into the knowledge graph',
+  openGraph: {
+    title: 'All playlists — Radio',
+    description:
+      'Every playlist tracked across the dial, newest first — independent radio wired into the knowledge graph',
+    type: 'website',
+    url: '/radio/playlists',
+  },
+}
+
+export default function RadioPlaylistsPage() {
+  return <PlaylistsFeedPage />
+}

--- a/frontend/features/radio/hooks/useNewReleaseRadar.ts
+++ b/frontend/features/radio/hooks/useNewReleaseRadar.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { apiRequest } from '@/lib/api'
 import { radioEndpoints, radioQueryKeys } from '../api'
 import type { RadioNewReleasesResponse } from '../types'
@@ -12,7 +12,11 @@ interface UseNewReleaseRadarOptions {
 }
 
 /**
- * Hook to fetch new releases discovered via radio
+ * Hook to fetch new releases discovered via radio.
+ *
+ * `keepPreviousData` so the /radio/new-releases "more releases" limit bump
+ * (PSY-1076) re-renders the table in place instead of flashing back to a
+ * loading state; harmless for the fixed-limit hub sidebar box.
  */
 export function useNewReleaseRadar({
   stationId,
@@ -35,6 +39,7 @@ export function useNewReleaseRadar({
         method: 'GET',
       }),
     enabled,
+    placeholderData: keepPreviousData,
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/frontend/features/radio/hooks/useRecentRadioEpisodes.ts
+++ b/frontend/features/radio/hooks/useRecentRadioEpisodes.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { apiRequest } from '@/lib/api'
 import { radioEndpoints, radioQueryKeys } from '../api'
 import type { RadioRecentEpisodesResponse } from '../types'
@@ -15,7 +15,12 @@ interface UseRecentRadioEpisodesOptions {
  * Fetch the dial-wide latest-playlists feed (PSY-1048): the newest episodes
  * across every active station, with show/station attribution and a short
  * artist preview per row. Drives the "Latest playlists — across the dial"
- * table on the /radio hub (PSY-1049).
+ * table on the /radio hub (PSY-1049) and the /radio/playlists full feed
+ * (PSY-1076).
+ *
+ * `keepPreviousData` so a "more playlists" limit bump re-renders the table in
+ * place instead of flashing back to a loading state (matches
+ * useStationEpisodes' PSY-1050 behavior; harmless for the fixed-limit hub).
  */
 export function useRecentRadioEpisodes({
   limit = 20,
@@ -38,6 +43,7 @@ export function useRecentRadioEpisodes({
         method: 'GET',
       }),
     enabled,
+    placeholderData: keepPreviousData,
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/frontend/features/radio/index.ts
+++ b/frontend/features/radio/index.ts
@@ -110,3 +110,6 @@ export {
   walkEpisodeNeighbors,
 } from './lib/episodeArchive'
 export type { ArtistMatchStats, EpisodeNeighbors } from './lib/episodeArchive'
+
+// PSY-1076: New Release Radar link resolution (hub box + /radio/new-releases)
+export { getNewReleaseHref } from './types'

--- a/frontend/features/radio/types.ts
+++ b/frontend/features/radio/types.ts
@@ -261,6 +261,18 @@ export interface RadioAsHeardOn {
   last_played: string
 }
 
+// New Release Radar link resolution (PSY-1076, extracted from the hub's
+// sidebar box): link the "Artist — Album" line to the release when matched,
+// else to the artist, else nowhere (no dead links). Shared by the hub box
+// and the /radio/new-releases full view — keep them in lockstep.
+export function getNewReleaseHref(
+  entry: Pick<RadioNewReleaseRadarEntry, 'release_slug' | 'artist_slug'>
+): string | null {
+  if (entry.release_slug) return `/releases/${entry.release_slug}`
+  if (entry.artist_slug) return `/artists/${entry.artist_slug}`
+  return null
+}
+
 export interface RadioNewReleaseRadarEntry {
   artist_name: string
   artist_id: number | null


### PR DESCRIPTION
## Summary

The Dial hub's latest-playlists table and New Release Radar box were capped teasers with no "view all" destinations. This adds the two pages and the two mono bracket links the Option A mock called for.

**Orchestrator decisions (documented, not relitigated):**
- **Two dedicated pages**: `/radio/playlists` (dial-wide paginated feed over existing `GET /radio/episodes/recent`) and `/radio/new-releases` (full New Release Radar over existing `GET /radio/new-releases`). The radar endpoint caps `limit` at 100 with no offset, so the full view tops out at the 100 hottest entries — documented in the component. The recent-episodes endpoint also caps `limit` at 100; past that the playlists page stops offering load-more (the "showing N of M" line stays honest).
- **Pagination**: in-place "+20 load more" `BracketLink` capped at the API limit — PSY-1050's pattern (`StationPlaylistsFeed`'s grow-the-limit + `keepPreviousData`, added to both hooks).

**Proxy finding:** `frontend/proxy.ts` has **no radio entries** — its `ENTITY_CHECKS`/`config.matcher` intercept only `shows/venues/artists/releases/labels/festivals/tags/scenes` prefixes, so the new static segments under `/radio` need no `RESERVED_SEGMENTS` handling. Nothing to do. (Theoretical note: a future station slugged `playlists`/`new-releases` would be shadowed by these static segments — Next prefers static over `[station-slug]`.)

**Reuse:** the playlists page reuses the hub's `LatestPlaylistsTable` wholesale (one source of truth for row anatomy). New Release Radar link resolution (release → artist → plain text, no dead links) is extracted to `getNewReleaseHref` and shared by the hub box and the new page. Barrel addition sits at the end of `features/radio/index.ts` with a `// PSY-1076` comment per the parallel-agent contract (PSY-1075 owns `useStationOverview.ts`/`lib/stationOverview.ts`; neither touched).

Known duplication accepted: `MAX_LIMIT = 100` is a local const in three feed components (precedent: `StationPlaylistsFeed`); consolidate if the backend cap ever changes.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (148 pre-existing warnings, count unchanged)
- [x] `bun run test:run features/radio app/radio` — 37 files / 284 tests passed
- [x] New tests: both pages (rows render, load-more grows limit, total respected, cap at 100, empty + error states, in-flight placeholder state) and both hub links (present with data, absent when feed empty)

## Manual repro

Isolated dispatch stack (`stack-up.sh` self-escalated from shared; :57057 → :57056). Seeded the isolated DB with 24 extra episodes + cross-station `is_new` plays so both feeds exercise pagination. Via agent-browser:

- `/radio` hub renders both links → `[ all playlists → ]` navigates to `/radio/playlists`, table renders 20 rows, "More playlists" grows to "showing 25 of 25 playlists" and the control hides
- `[ full radar → ]` navigates to `/radio/new-releases`, dense table renders 3 cross-station entries with label/plays/stations columns, short page correctly hides load-more

| | |
|---|---|
| Hub | ![hub](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1076-screenshots/01-radio-hub.png) |
| Hub links (both visible) | ![hub links](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1076-screenshots/02-hub-links.png) |
| /radio/playlists | ![playlists](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1076-screenshots/03-playlists-page.png) |
| Load-more before | ![before](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1076-screenshots/04-playlists-loadmore-before.png) |
| Load-more after (25 of 25, control hidden) | ![after](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1076-screenshots/05-playlists-loadmore-after.png) |
| /radio/new-releases | ![radar](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1076-screenshots/06-new-releases-page.png) |

## Code review

Inline three-lens review (sub-agent fallback). Finding fixed in `26ae9aaf`: the radar load-more unmounted mid-fetch under `keepPreviousData` (old short page vs bumped limit) instead of showing its disabled "Loading…" state. Also unified error-check style across the two pages. Noted, not changed: breadcrumb shell duplication matches every existing radio page.

## Adversarial review

Inline four-lens pass (Saboteur / Future-Maintainer / Security / Completeness) — verdict CLEAN, marker written. Fix in `947138bd`: gate the radar control on `isPlaceholderData` rather than `isFetching`, so background refetches of an exhausted radar can't resurrect a phantom button. Security: all hrefs from server-provided slugs, bounded numeric params, no raw HTML.

Closes PSY-1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)
