### PR TITLE
PSY-1081: station-scoped graph endpoint (radio co-occurrence)

### DIFF
--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -438,8 +438,9 @@ func (h *RadioHandler) GetRadioStationTopLabelsHandler(ctx context.Context, req 
 // GetRadioStationGraphRequest asks for a station's co-occurrence subgraph.
 //
 // `Window` accepts "12m" (rolling last 12 months, the default) or "all".
-// Unknown values are coerced to the 12m default by the service so a client
-// mistake degrades gracefully rather than 500ing.
+// Huma's enum validation rejects other values with a 422; the service
+// additionally coerces unknown values to the 12m default so non-HTTP callers
+// degrade gracefully rather than 500ing.
 type GetRadioStationGraphRequest struct {
 	Slug   string `path:"slug" doc:"Radio station slug or numeric ID" example:"kexp"`
 	Window string `query:"window" required:"false" default:"12m" enum:"all,12m" doc:"Time window: '12m' (rolling last 12 months, default) or 'all'" example:"12m"`

--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -59,6 +59,7 @@ type RadioAggregationReader interface {
 	GetAsHeardOnForArtist(artistID uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetAsHeardOnForRelease(releaseID uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetNewReleaseRadar(stationID uint, limit int) ([]*contracts.RadioNewReleaseRadarEntry, error)
+	GetStationGraph(stationID uint, window string, limit int) (*contracts.RadioStationGraphResponse, error)
 	GetRadioStats() (*contracts.RadioStatsResponse, error)
 }
 
@@ -428,6 +429,47 @@ func (h *RadioHandler) GetRadioStationTopLabelsHandler(ctx context.Context, req 
 	resp.Body.Labels = labels
 	resp.Body.Count = len(labels)
 	return resp, nil
+}
+
+// ============================================================================
+// Public: Station Graph (PSY-1081)
+// ============================================================================
+
+// GetRadioStationGraphRequest asks for a station's co-occurrence subgraph.
+//
+// `Window` accepts "12m" (rolling last 12 months, the default) or "all".
+// Unknown values are coerced to the 12m default by the service so a client
+// mistake degrades gracefully rather than 500ing.
+type GetRadioStationGraphRequest struct {
+	Slug   string `path:"slug" doc:"Radio station slug or numeric ID" example:"kexp"`
+	Window string `query:"window" required:"false" default:"12m" enum:"all,12m" doc:"Time window: '12m' (rolling last 12 months, default) or 'all'" example:"12m"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"150" default:"75" doc:"Max artists (graph nodes), ranked by station play count (default 75)" example:"75"`
+}
+
+// GetRadioStationGraphResponse wraps the contracts payload for huma.
+type GetRadioStationGraphResponse struct {
+	Body *contracts.RadioStationGraphResponse
+}
+
+// GetRadioStationGraphHandler handles GET /radio-stations/{slug}/graph.
+//
+// PSY-1081 — station-scoped radio co-occurrence subgraph. Mirrors
+// GET /scenes/{slug}/graph and GET /venues/{id}/bill-network in shape (the
+// shared frontend ForceGraphView renders all three), with nodes = the
+// station's top-N artists by play count and edges = within-station episode
+// co-occurrence.
+func (h *RadioHandler) GetRadioStationGraphHandler(ctx context.Context, req *GetRadioStationGraphRequest) (*GetRadioStationGraphResponse, error) {
+	stationID, err := h.resolveStationID(req.Slug)
+	if err != nil {
+		return nil, err
+	}
+
+	graph, err := h.aggregationReader.GetStationGraph(stationID, req.Window, req.Limit)
+	if err != nil {
+		return nil, mapRadioStationErrorMsg(err, "Failed to fetch station graph")
+	}
+
+	return &GetRadioStationGraphResponse{Body: graph}, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -2422,6 +2422,7 @@ type MockRadioService struct {
 	GetAsHeardOnForArtistFn       func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetAsHeardOnForReleaseFn      func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
 	GetNewReleaseRadarFn          func(uint, int) ([]*contracts.RadioNewReleaseRadarEntry, error)
+	GetStationGraphFn             func(uint, string, int) (*contracts.RadioStationGraphResponse, error)
 	GetRadioStatsFn               func() (*contracts.RadioStatsResponse, error)
 	ImportStationFn               func(uint, int) (*contracts.RadioImportResult, error)
 	FetchNewEpisodesFn            func(uint) (*contracts.RadioImportResult, error)
@@ -2595,6 +2596,12 @@ func (m *MockRadioService) GetAsHeardOnForRelease(releaseID uint) ([]*contracts.
 func (m *MockRadioService) GetNewReleaseRadar(stationID uint, limit int) ([]*contracts.RadioNewReleaseRadarEntry, error) {
 	if m.GetNewReleaseRadarFn != nil {
 		return m.GetNewReleaseRadarFn(stationID, limit)
+	}
+	return nil, nil
+}
+func (m *MockRadioService) GetStationGraph(stationID uint, window string, limit int) (*contracts.RadioStationGraphResponse, error) {
+	if m.GetStationGraphFn != nil {
+		return m.GetStationGraphFn(stationID, window, limit)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/routes/radio.go
+++ b/backend/internal/api/routes/radio.go
@@ -17,6 +17,7 @@ func setupRadioRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/radio-stations/{slug}/now-playing", radioHandler.GetRadioStationNowPlayingHandler)
 	huma.Get(rc.API, "/radio-stations/{slug}/top-artists", radioHandler.GetRadioStationTopArtistsHandler)
 	huma.Get(rc.API, "/radio-stations/{slug}/top-labels", radioHandler.GetRadioStationTopLabelsHandler)
+	huma.Get(rc.API, "/radio-stations/{slug}/graph", radioHandler.GetRadioStationGraphHandler)
 
 	// Public radio show endpoints
 	huma.Get(rc.API, "/radio-shows", radioHandler.ListRadioShowsHandler)

--- a/backend/internal/services/catalog/artist_graph_helpers.go
+++ b/backend/internal/services/catalog/artist_graph_helpers.go
@@ -1,0 +1,40 @@
+package catalog
+
+// Shared helpers for the artist graph endpoints (scene graph PSY-367, venue
+// bill network PSY-365, station graph PSY-1081). Extracted in PSY-1081 when a
+// third copy of the upcoming-show-count batch query was about to land.
+
+import (
+	"gorm.io/gorm"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+)
+
+// batchArtistUpcomingShowCounts returns a map of artist_id → upcoming
+// approved show count (globally, not scoped to the graph's anchor entity), so
+// the graph node green-dot indicator stays consistent with the rest of the
+// app. Returns an empty map (never nil) so callers can index without a nil
+// check. Errors degrade to zero counts — the indicator is decorative, not
+// load-bearing (same posture as the original scene/venue helpers).
+func batchArtistUpcomingShowCounts(db *gorm.DB, artistIDs []uint) map[uint]int {
+	out := make(map[uint]int, len(artistIDs))
+	if len(artistIDs) == 0 {
+		return out
+	}
+	type row struct {
+		ArtistID  uint
+		ShowCount int64
+	}
+	var rows []row
+	db.Table("show_artists").
+		Select("show_artists.artist_id, COUNT(DISTINCT shows.id) AS show_count").
+		Joins("JOIN shows ON shows.id = show_artists.show_id").
+		Where("show_artists.artist_id IN ? AND shows.status = ? AND shows.event_date > NOW()",
+			artistIDs, catalogm.ShowStatusApproved).
+		Group("show_artists.artist_id").
+		Scan(&rows)
+	for _, r := range rows {
+		out[r.ArtistID] = int(r.ShowCount)
+	}
+	return out
+}

--- a/backend/internal/services/catalog/radio_station_graph.go
+++ b/backend/internal/services/catalog/radio_station_graph.go
@@ -1,0 +1,416 @@
+package catalog
+
+// PSY-1081 — Station-scoped radio co-occurrence subgraph.
+//
+// The radio analog of the scene graph (PSY-367) and the venue bill network
+// (PSY-365): nodes are the station's top-N artists by play count, edges are
+// within-station co-occurrence (two artists matched in the same episode on
+// THIS station), and clusters group artists by the radio show they are most
+// played on.
+//
+// Derivation decision: edges are computed AT QUERY TIME from radio_plays.
+// The aggregate pipeline (ComputeAffinity → radio_artist_affinity →
+// SyncAffinityToRelationships) collapses station attribution to a
+// station_count integer — neither table records WHICH stations contributed a
+// pair — so the aggregate radio_cooccurrence edges cannot be filtered to one
+// station. Parameterizing the aggregate computation by station would require
+// a schema change (station dimension on the affinity PK). Restricting the
+// query-time self-join to the top-N matched artists bounds the pair space at
+// N(N-1)/2, which keeps the derivation cheap enough to run per request.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+const (
+	stationGraphWindow12M = "12m"
+	stationGraphWindowAll = "all"
+
+	// stationGraphDefaultNodeLimit is the default top-N artist cap. The
+	// handler exposes `limit` (1..stationGraphMaxNodeLimit); the service
+	// clamps defensively for non-HTTP callers.
+	stationGraphDefaultNodeLimit = 75
+	stationGraphMaxNodeLimit     = 150
+
+	// stationGraphMinCoOccurrence is the minimum number of shared episodes
+	// for an edge to surface. Mirrors ComputeAffinity's HAVING >= 2 and the
+	// venue bill network's min-shared-shows threshold.
+	stationGraphMinCoOccurrence = 2
+)
+
+// stationGraphArtistRow is one top-N artist with display fields, station play
+// count, and the show (on this station) the artist is most played on — the
+// cluster signal. Primary-show fields are nullable defensively (LEFT JOIN).
+type stationGraphArtistRow struct {
+	ArtistID        uint    `gorm:"column:artist_id"`
+	Name            string  `gorm:"column:name"`
+	Slug            *string `gorm:"column:slug"`
+	City            *string `gorm:"column:city"`
+	State           *string `gorm:"column:state"`
+	PlayCount       int     `gorm:"column:play_count"`
+	PrimaryShowID   *uint   `gorm:"column:primary_show_id"`
+	PrimaryShowName *string `gorm:"column:primary_show_name"`
+}
+
+// stationGraphEdgeRow is one co-occurring artist pair within the station.
+// artist_a_id < artist_b_id (canonical ordering from the self-join).
+type stationGraphEdgeRow struct {
+	ArtistAID         uint   `gorm:"column:artist_a_id"`
+	ArtistBID         uint   `gorm:"column:artist_b_id"`
+	CoOccurrenceCount int    `gorm:"column:co_occurrence_count"`
+	LastCoOccurrence  string `gorm:"column:last_co_occurrence"`
+}
+
+// GetStationGraph returns the station-scoped co-occurrence graph for
+// GET /radio-stations/{slug}/graph. See the file-level comment for the
+// derivation decision.
+func (s *RadioService) GetStationGraph(stationID uint, window string, limit int) (*contracts.RadioStationGraphResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Load the station (slug + name feed the info block; missing → 404,
+	// consistent with the other station-scoped reads).
+	var station catalogm.RadioStation
+	if err := s.db.Select("id, slug, name").First(&station, stationID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrRadioStationNotFound(stationID)
+		}
+		return nil, fmt.Errorf("failed to get radio station: %w", err)
+	}
+
+	resolvedWindow := normalizeStationGraphWindow(window)
+	cutoff := stationGraphWindowCutoff(resolvedWindow)
+
+	if limit <= 0 {
+		limit = stationGraphDefaultNodeLimit
+	}
+	if limit > stationGraphMaxNodeLimit {
+		limit = stationGraphMaxNodeLimit
+	}
+
+	resp := &contracts.RadioStationGraphResponse{
+		Station: contracts.RadioStationGraphInfo{
+			ID:   station.ID,
+			Slug: station.Slug,
+			Name: station.Name,
+		},
+		Clusters: []contracts.RadioStationGraphCluster{},
+		Nodes:    []contracts.RadioStationGraphNode{},
+		Links:    []contracts.RadioStationGraphLink{},
+	}
+	switch resolvedWindow {
+	case stationGraphWindowAll:
+		resp.Station.Window = "all_time"
+	default:
+		resp.Station.Window = "last_12m"
+	}
+
+	// 1. Top-N matched artists by play count + each artist's primary show.
+	rows, err := s.queryStationGraphArtists(stationID, cutoff, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query station graph artists: %w", err)
+	}
+	resp.Station.ArtistCount = len(rows)
+	if len(rows) == 0 {
+		return resp, nil
+	}
+
+	artistIDs := make([]uint, 0, len(rows))
+	for _, r := range rows {
+		artistIDs = append(artistIDs, r.ArtistID)
+	}
+
+	// 2. Cluster pass — group by primary show, mirroring the scene graph's
+	//    primary-venue clustering (same size floor, first-class cap, and
+	//    "other" rollup).
+	clusters, clusterIDByShow := buildStationGraphClusters(rows)
+	resp.Clusters = clusters
+	clusterByArtist := make(map[uint]string, len(rows))
+	for _, r := range rows {
+		clusterID := sceneClusterOtherID
+		if r.PrimaryShowID != nil {
+			if cid, ok := clusterIDByShow[*r.PrimaryShowID]; ok {
+				clusterID = cid
+			}
+		}
+		clusterByArtist[r.ArtistID] = clusterID
+	}
+
+	// 3. Within-station co-occurrence edges between the top-N artists.
+	edges, err := s.queryStationGraphEdges(stationID, artistIDs, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query station graph edges: %w", err)
+	}
+
+	connected := make(map[uint]bool, len(rows))
+	for _, e := range edges {
+		// Score normalization mirrors SyncAffinityToRelationships
+		// (min(1, count/50)) so the radio_cooccurrence edge grammar stays
+		// consistent; the cross-station multiplier doesn't apply because the
+		// scope is a single station by construction.
+		score := float64(e.CoOccurrenceCount) / 50.0
+		if score > 1.0 {
+			score = 1.0
+		}
+		detail := map[string]any{
+			"co_occurrence_count": e.CoOccurrenceCount,
+		}
+		if e.LastCoOccurrence != "" {
+			detail["last_co_occurrence"] = e.LastCoOccurrence
+		}
+		resp.Links = append(resp.Links, contracts.RadioStationGraphLink{
+			SourceID:       e.ArtistAID,
+			TargetID:       e.ArtistBID,
+			Type:           catalogm.RelationshipTypeRadioCooccurrence,
+			Score:          score,
+			Detail:         detail,
+			IsCrossCluster: clusterByArtist[e.ArtistAID] != clusterByArtist[e.ArtistBID],
+		})
+		connected[e.ArtistAID] = true
+		connected[e.ArtistBID] = true
+	}
+	resp.Station.EdgeCount = len(resp.Links)
+
+	// 4. Node list. Upcoming-show counts use the shared scene/venue helper so
+	//    the green-dot indicator stays consistent across all three graphs.
+	upcomingByArtist := batchArtistUpcomingShowCounts(s.db, artistIDs)
+	for _, r := range rows {
+		resp.Nodes = append(resp.Nodes, contracts.RadioStationGraphNode{
+			ID:                r.ArtistID,
+			Name:              r.Name,
+			Slug:              derefString(r.Slug),
+			City:              derefString(r.City),
+			State:             derefString(r.State),
+			UpcomingShowCount: upcomingByArtist[r.ArtistID],
+			ClusterID:         clusterByArtist[r.ArtistID],
+			IsIsolate:         !connected[r.ArtistID],
+			PlayCount:         r.PlayCount,
+		})
+	}
+
+	return resp, nil
+}
+
+// normalizeStationGraphWindow coerces the caller's `window` string to a known
+// value. Empty/unknown input falls back to "12m" — the endpoint's default
+// (unlike the venue bill network, which defaults to all-time) — so a
+// malformed query param degrades gracefully rather than 500ing.
+func normalizeStationGraphWindow(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case stationGraphWindowAll:
+		return stationGraphWindowAll
+	default:
+		return stationGraphWindow12M
+	}
+}
+
+// stationGraphWindowCutoff returns the inclusive air-date lower bound as a
+// YYYY-MM-DD string (radio_episodes.air_date is a DATE column), or "" for the
+// all-time case so the query helpers can skip the predicate.
+func stationGraphWindowCutoff(window string) string {
+	if window == stationGraphWindowAll {
+		return ""
+	}
+	return time.Now().UTC().AddDate(-1, 0, 0).Format("2006-01-02")
+}
+
+// queryStationGraphArtists runs the top-N + primary-show CTE. station_plays
+// narrows once to this station's matched plays (and the window); top_artists
+// ranks by play count; artist_show_counts resolves each top artist's
+// most-played show on the station with ROW_NUMBER (tie-break: more recent
+// air date, then show id — same shape as the scene graph's primary-venue
+// CTE). Final ORDER BY name for determinism.
+func (s *RadioService) queryStationGraphArtists(stationID uint, cutoff string, limit int) ([]stationGraphArtistRow, error) {
+	windowFilter := ""
+	args := []any{stationID}
+	if cutoff != "" {
+		windowFilter = "AND re.air_date >= ?"
+		args = append(args, cutoff)
+	}
+	args = append(args, limit)
+
+	q := fmt.Sprintf(`
+		WITH station_plays AS (
+			SELECT rp.artist_id, re.show_id, re.air_date
+			FROM radio_plays rp
+			JOIN radio_episodes re ON re.id = rp.episode_id
+			JOIN radio_shows rsh ON rsh.id = re.show_id
+			WHERE rsh.station_id = ? AND rp.artist_id IS NOT NULL %s
+		),
+		top_artists AS (
+			SELECT artist_id, COUNT(*) AS play_count
+			FROM station_plays
+			GROUP BY artist_id
+			ORDER BY play_count DESC, artist_id ASC
+			LIMIT ?
+		),
+		artist_show_counts AS (
+			SELECT
+				sp.artist_id,
+				sp.show_id,
+				ROW_NUMBER() OVER (
+					PARTITION BY sp.artist_id
+					ORDER BY COUNT(*) DESC, MAX(sp.air_date) DESC, sp.show_id ASC
+				) AS rn
+			FROM station_plays sp
+			JOIN top_artists ta ON ta.artist_id = sp.artist_id
+			GROUP BY sp.artist_id, sp.show_id
+		)
+		SELECT
+			a.id    AS artist_id,
+			a.name  AS name,
+			a.slug  AS slug,
+			a.city  AS city,
+			a.state AS state,
+			ta.play_count  AS play_count,
+			ascnt.show_id  AS primary_show_id,
+			rsh.name       AS primary_show_name
+		FROM top_artists ta
+		JOIN artists a ON a.id = ta.artist_id
+		LEFT JOIN artist_show_counts ascnt ON ascnt.artist_id = ta.artist_id AND ascnt.rn = 1
+		LEFT JOIN radio_shows rsh ON rsh.id = ascnt.show_id
+		ORDER BY a.name ASC
+	`, windowFilter)
+
+	var rows []stationGraphArtistRow
+	if err := s.db.Raw(q, args...).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// queryStationGraphEdges self-joins radio_plays within each of this station's
+// episodes, restricted to the top-N artist set. The weight is
+// COUNT(DISTINCT episode) — the number of episodes on this station where both
+// artists appeared — per the PSY-1081 spec ("two artists in the same episode
+// on THIS station"). Note this intentionally differs from ComputeAffinity's
+// COUNT(*) of play-pairs, which double-counts an episode when an artist is
+// played twice in it. last_co_occurrence is cast to text in SQL so the scan
+// target is a plain string.
+func (s *RadioService) queryStationGraphEdges(stationID uint, artistIDs []uint, cutoff string) ([]stationGraphEdgeRow, error) {
+	if len(artistIDs) < 2 {
+		return nil, nil
+	}
+	windowFilter := ""
+	args := []any{stationID, artistIDs, artistIDs}
+	if cutoff != "" {
+		windowFilter = "AND re.air_date >= ?"
+		args = append(args, cutoff)
+	}
+	args = append(args, stationGraphMinCoOccurrence)
+
+	q := fmt.Sprintf(`
+		SELECT
+			rp1.artist_id AS artist_a_id,
+			rp2.artist_id AS artist_b_id,
+			COUNT(DISTINCT rp1.episode_id) AS co_occurrence_count,
+			TO_CHAR(MAX(re.air_date), 'YYYY-MM-DD') AS last_co_occurrence
+		FROM radio_plays rp1
+		JOIN radio_plays rp2 ON rp2.episode_id = rp1.episode_id
+			AND rp1.artist_id < rp2.artist_id
+		JOIN radio_episodes re ON re.id = rp1.episode_id
+		JOIN radio_shows rsh ON rsh.id = re.show_id
+		WHERE rsh.station_id = ?
+			AND rp1.artist_id IN ?
+			AND rp2.artist_id IN ?
+			%s
+		GROUP BY rp1.artist_id, rp2.artist_id
+		HAVING COUNT(DISTINCT rp1.episode_id) >= ?
+	`, windowFilter)
+
+	var rows []stationGraphEdgeRow
+	if err := s.db.Raw(q, args...).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// buildStationGraphClusters converts the per-artist primary-show rows into a
+// sorted cluster list, mirroring buildSceneClusters: shows with at least
+// sceneClusterMinSize artists are first-class (capped at the Okabe-Ito
+// palette size); the remainder roll up to "other". Returns the cluster list
+// and a show_id → cluster_id lookup.
+func buildStationGraphClusters(rows []stationGraphArtistRow) ([]contracts.RadioStationGraphCluster, map[uint]string) {
+	type showCount struct {
+		showID uint
+		name   string
+		count  int
+	}
+	byShow := make(map[uint]*showCount)
+	for _, r := range rows {
+		if r.PrimaryShowID == nil {
+			continue
+		}
+		entry, ok := byShow[*r.PrimaryShowID]
+		if !ok {
+			entry = &showCount{showID: *r.PrimaryShowID, name: derefString(r.PrimaryShowName)}
+			byShow[*r.PrimaryShowID] = entry
+		}
+		entry.count++
+	}
+
+	shows := make([]*showCount, 0, len(byShow))
+	for _, v := range byShow {
+		shows = append(shows, v)
+	}
+	// Sort by count desc, then name asc for deterministic ordering on ties —
+	// same insertion-sort shape as buildSceneClusters.
+	for i := 1; i < len(shows); i++ {
+		for j := i; j > 0; j-- {
+			a, b := shows[j], shows[j-1]
+			better := a.count > b.count || (a.count == b.count && a.name < b.name)
+			if !better {
+				break
+			}
+			shows[j], shows[j-1] = b, a
+		}
+	}
+
+	clusterIDByShow := make(map[uint]string, len(shows))
+	clusters := make([]contracts.RadioStationGraphCluster, 0, len(shows)+1)
+	otherSize := 0
+
+	for i, v := range shows {
+		if v.count >= sceneClusterMinSize && len(clusters) < sceneClusterMaxFirstClass {
+			cid := fmt.Sprintf("rs_%d", v.showID)
+			clusterIDByShow[v.showID] = cid
+			clusters = append(clusters, contracts.RadioStationGraphCluster{
+				ID:         cid,
+				Label:      v.name,
+				Size:       v.count,
+				ColorIndex: i,
+			})
+			continue
+		}
+		clusterIDByShow[v.showID] = sceneClusterOtherID
+		otherSize += v.count
+	}
+
+	// Artists with no primary show (defensive — LEFT JOIN miss) land in "other".
+	for _, r := range rows {
+		if r.PrimaryShowID == nil {
+			otherSize++
+		}
+	}
+
+	if otherSize > 0 {
+		clusters = append(clusters, contracts.RadioStationGraphCluster{
+			ID:         sceneClusterOtherID,
+			Label:      sceneClusterOtherLabel,
+			Size:       otherSize,
+			ColorIndex: -1,
+		})
+	}
+
+	return clusters, clusterIDByShow
+}

--- a/backend/internal/services/catalog/radio_station_graph_test.go
+++ b/backend/internal/services/catalog/radio_station_graph_test.go
@@ -1,0 +1,522 @@
+package catalog
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/testutil"
+	"psychic-homily-backend/internal/utils"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNormalizeStationGraphWindow(t *testing.T) {
+	tests := []struct {
+		in, expected string
+	}{
+		{"12m", stationGraphWindow12M},
+		{"all", stationGraphWindowAll},
+		{"ALL", stationGraphWindowAll},
+		{" all ", stationGraphWindowAll},
+		{"", stationGraphWindow12M},
+		{"bogus", stationGraphWindow12M},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.in), func(t *testing.T) {
+			assert.Equal(t, tc.expected, normalizeStationGraphWindow(tc.in))
+		})
+	}
+}
+
+func TestGetStationGraph_NilDB(t *testing.T) {
+	svc := &RadioService{}
+	_, err := svc.GetStationGraph(1, "12m", 75)
+	assert.EqualError(t, err, "database not initialized")
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type RadioStationGraphTestSuite struct {
+	suite.Suite
+	testDB       *testutil.TestDatabase
+	db           *gorm.DB
+	radioService *RadioService
+}
+
+func (suite *RadioStationGraphTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.radioService = &RadioService{db: suite.testDB.DB}
+}
+
+func (suite *RadioStationGraphTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+// SetupTest wipes data so every test starts from a known empty state
+// (migrations seed WFMU network + stations on the test container).
+func (suite *RadioStationGraphTestSuite) SetupTest() {
+	suite.cleanupTables()
+}
+
+func (suite *RadioStationGraphTestSuite) TearDownTest() {
+	suite.cleanupTables()
+}
+
+func (suite *RadioStationGraphTestSuite) cleanupTables() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order.
+	_, _ = sqlDB.Exec("DELETE FROM radio_plays")
+	_, _ = sqlDB.Exec("DELETE FROM radio_episodes")
+	_, _ = sqlDB.Exec("DELETE FROM radio_shows")
+	_, _ = sqlDB.Exec("DELETE FROM radio_stations")
+	_, _ = sqlDB.Exec("DELETE FROM radio_networks")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+}
+
+func TestRadioStationGraphTestSuite(t *testing.T) {
+	suite.Run(t, new(RadioStationGraphTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *RadioStationGraphTestSuite) createStation(name, slug string) *catalogm.RadioStation {
+	station := &catalogm.RadioStation{Name: name, Slug: slug, BroadcastType: catalogm.BroadcastTypeBoth}
+	suite.Require().NoError(suite.db.Create(station).Error)
+	return station
+}
+
+func (suite *RadioStationGraphTestSuite) createShow(stationID uint, name, slug string) *catalogm.RadioShow {
+	show := &catalogm.RadioShow{StationID: stationID, Name: name, Slug: slug}
+	suite.Require().NoError(suite.db.Create(show).Error)
+	return show
+}
+
+func (suite *RadioStationGraphTestSuite) createEpisode(showID uint, airDate string) *catalogm.RadioEpisode {
+	ep := &catalogm.RadioEpisode{ShowID: showID, AirDate: airDate}
+	suite.Require().NoError(suite.db.Create(ep).Error)
+	return ep
+}
+
+func (suite *RadioStationGraphTestSuite) createArtist(name string) *catalogm.Artist {
+	slug := utils.GenerateArtistSlug(name)
+	artist := &catalogm.Artist{Name: name, Slug: &slug}
+	suite.Require().NoError(suite.db.Create(artist).Error)
+	return artist
+}
+
+// createMatchedPlay inserts a play linked to a knowledge-graph artist.
+func (suite *RadioStationGraphTestSuite) createMatchedPlay(episodeID uint, position int, artist *catalogm.Artist) {
+	play := &catalogm.RadioPlay{
+		EpisodeID:  episodeID,
+		Position:   position,
+		ArtistName: artist.Name,
+		ArtistID:   &artist.ID,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+}
+
+// createUnmatchedPlay inserts a play with no artist link (artist_id NULL).
+func (suite *RadioStationGraphTestSuite) createUnmatchedPlay(episodeID uint, position int, artistName string) {
+	play := &catalogm.RadioPlay{EpisodeID: episodeID, Position: position, ArtistName: artistName}
+	suite.Require().NoError(suite.db.Create(play).Error)
+}
+
+func recentDate(monthsAgo int) string {
+	return time.Now().UTC().AddDate(0, -monthsAgo, 0).Format("2006-01-02")
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_NotFound() {
+	_, err := suite.radioService.GetStationGraph(99999, "12m", 75)
+	suite.Require().Error(err)
+	var radioErr *apperrors.RadioError
+	suite.Require().True(errors.As(err, &radioErr))
+	suite.Equal(apperrors.CodeRadioStationNotFound, radioErr.Code)
+}
+
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_EmptyStation() {
+	station := suite.createStation("KEXP", "kexp")
+
+	graph, err := suite.radioService.GetStationGraph(station.ID, "12m", 75)
+	suite.Require().NoError(err)
+
+	suite.Equal(station.ID, graph.Station.ID)
+	suite.Equal("kexp", graph.Station.Slug)
+	suite.Equal("KEXP", graph.Station.Name)
+	suite.Equal("last_12m", graph.Station.Window)
+	suite.Equal(0, graph.Station.ArtistCount)
+	suite.Equal(0, graph.Station.EdgeCount)
+	suite.Empty(graph.Clusters)
+	suite.Empty(graph.Nodes)
+	suite.Empty(graph.Links)
+}
+
+// TestGetStationGraph_BasicGraph covers the core shape: top artists as nodes,
+// episode co-occurrence as edges above the >=2 threshold, isolates flagged,
+// unmatched plays excluded.
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_BasicGraph() {
+	station := suite.createStation("KEXP", "kexp")
+	show := suite.createShow(station.ID, "Morning Show", "kexp-morning")
+
+	artistA := suite.createArtist("Alpha")
+	artistB := suite.createArtist("Beta")
+	artistC := suite.createArtist("Gamma")
+
+	// Episode 1 and 2: A + B co-occur (weight 2). Episode 2 also has C
+	// (A–C and B–C co-occur once each — below the threshold of 2).
+	ep1 := suite.createEpisode(show.ID, recentDate(2))
+	suite.createMatchedPlay(ep1.ID, 1, artistA)
+	suite.createMatchedPlay(ep1.ID, 2, artistB)
+	// Duplicate play of A in ep1 — must NOT inflate the A–B weight
+	// (weight is episodes, not play-pairs).
+	suite.createMatchedPlay(ep1.ID, 3, artistA)
+	// Unmatched play — must be ignored entirely.
+	suite.createUnmatchedPlay(ep1.ID, 4, "Unmatched Mystery Band")
+
+	ep2 := suite.createEpisode(show.ID, recentDate(1))
+	suite.createMatchedPlay(ep2.ID, 1, artistA)
+	suite.createMatchedPlay(ep2.ID, 2, artistB)
+	suite.createMatchedPlay(ep2.ID, 3, artistC)
+
+	graph, err := suite.radioService.GetStationGraph(station.ID, "12m", 75)
+	suite.Require().NoError(err)
+
+	// Nodes: 3 matched artists, ordered by name; play counts include the
+	// duplicate play of A.
+	suite.Equal(3, graph.Station.ArtistCount)
+	suite.Require().Len(graph.Nodes, 3)
+	suite.Equal("Alpha", graph.Nodes[0].Name)
+	suite.Equal(3, graph.Nodes[0].PlayCount)
+	suite.Equal("Beta", graph.Nodes[1].Name)
+	suite.Equal(2, graph.Nodes[1].PlayCount)
+	suite.Equal("Gamma", graph.Nodes[2].Name)
+	suite.Equal(1, graph.Nodes[2].PlayCount)
+
+	// Edges: only A–B clears the >=2 episode threshold.
+	suite.Equal(1, graph.Station.EdgeCount)
+	suite.Require().Len(graph.Links, 1)
+	link := graph.Links[0]
+	suite.Equal(minUint(artistA.ID, artistB.ID), link.SourceID)
+	suite.Equal(maxUint(artistA.ID, artistB.ID), link.TargetID)
+	suite.Equal(catalogm.RelationshipTypeRadioCooccurrence, link.Type)
+	suite.InDelta(2.0/50.0, link.Score, 1e-9)
+	detail, ok := link.Detail.(map[string]any)
+	suite.Require().True(ok)
+	suite.Equal(2, detail["co_occurrence_count"])
+	suite.Equal(recentDate(1), detail["last_co_occurrence"])
+
+	// Isolates: C has no surviving edges.
+	suite.False(graph.Nodes[0].IsIsolate)
+	suite.False(graph.Nodes[1].IsIsolate)
+	suite.True(graph.Nodes[2].IsIsolate)
+
+	// Small show rolls into the "other" cluster (below the size floor).
+	suite.Require().Len(graph.Clusters, 1)
+	suite.Equal(sceneClusterOtherID, graph.Clusters[0].ID)
+	suite.Equal(3, graph.Clusters[0].Size)
+	for _, n := range graph.Nodes {
+		suite.Equal(sceneClusterOtherID, n.ClusterID)
+	}
+}
+
+// TestGetStationGraph_StationScoped asserts that co-occurrence on another
+// station never leaks into this station's graph — the whole point of the
+// query-time derivation (the aggregate affinity table can't do this).
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_StationScoped() {
+	stationA := suite.createStation("KEXP", "kexp")
+	showA := suite.createShow(stationA.ID, "Morning Show", "kexp-morning")
+	stationB := suite.createStation("WFMU", "wfmu")
+	showB := suite.createShow(stationB.ID, "Evening Show", "wfmu-evening")
+
+	artist1 := suite.createArtist("Alpha")
+	artist2 := suite.createArtist("Beta")
+
+	// One shared episode on station A (below threshold alone)…
+	epA := suite.createEpisode(showA.ID, recentDate(1))
+	suite.createMatchedPlay(epA.ID, 1, artist1)
+	suite.createMatchedPlay(epA.ID, 2, artist2)
+
+	// …and three shared episodes on station B.
+	for i := 0; i < 3; i++ {
+		epB := suite.createEpisode(showB.ID, recentDate(i+1))
+		suite.createMatchedPlay(epB.ID, 1, artist1)
+		suite.createMatchedPlay(epB.ID, 2, artist2)
+	}
+
+	// Station A: the single shared episode is below the threshold → no edge.
+	graphA, err := suite.radioService.GetStationGraph(stationA.ID, "12m", 75)
+	suite.Require().NoError(err)
+	suite.Equal(2, graphA.Station.ArtistCount)
+	suite.Empty(graphA.Links)
+
+	// Station B: weight 3 — station A's episode is not counted.
+	graphB, err := suite.radioService.GetStationGraph(stationB.ID, "12m", 75)
+	suite.Require().NoError(err)
+	suite.Require().Len(graphB.Links, 1)
+	detail := graphB.Links[0].Detail.(map[string]any)
+	suite.Equal(3, detail["co_occurrence_count"])
+}
+
+// TestGetStationGraph_WindowFilter asserts the 12m default excludes old
+// episodes and window=all includes them.
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_WindowFilter() {
+	station := suite.createStation("KEXP", "kexp")
+	show := suite.createShow(station.ID, "Morning Show", "kexp-morning")
+
+	artistA := suite.createArtist("Alpha")
+	artistB := suite.createArtist("Beta")
+
+	// Two co-occurring episodes, both ~2 years old.
+	old1 := time.Now().UTC().AddDate(-2, 0, 0).Format("2006-01-02")
+	old2 := time.Now().UTC().AddDate(-2, 1, 0).Format("2006-01-02")
+	for _, d := range []string{old1, old2} {
+		ep := suite.createEpisode(show.ID, d)
+		suite.createMatchedPlay(ep.ID, 1, artistA)
+		suite.createMatchedPlay(ep.ID, 2, artistB)
+	}
+
+	// Default (12m): everything is out of window.
+	graph12m, err := suite.radioService.GetStationGraph(station.ID, "", 75)
+	suite.Require().NoError(err)
+	suite.Equal("last_12m", graph12m.Station.Window)
+	suite.Equal(0, graph12m.Station.ArtistCount)
+	suite.Empty(graph12m.Nodes)
+	suite.Empty(graph12m.Links)
+
+	// window=all: both nodes and the edge appear.
+	graphAll, err := suite.radioService.GetStationGraph(station.ID, "all", 75)
+	suite.Require().NoError(err)
+	suite.Equal("all_time", graphAll.Station.Window)
+	suite.Equal(2, graphAll.Station.ArtistCount)
+	suite.Require().Len(graphAll.Links, 1)
+	detail := graphAll.Links[0].Detail.(map[string]any)
+	suite.Equal(2, detail["co_occurrence_count"])
+	suite.Equal(old2, detail["last_co_occurrence"])
+}
+
+// TestGetStationGraph_LimitCapsNodes asserts the top-N cap keeps the
+// most-played artists and drops edges to excluded artists.
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_LimitCapsNodes() {
+	station := suite.createStation("KEXP", "kexp")
+	show := suite.createShow(station.ID, "Morning Show", "kexp-morning")
+
+	artistA := suite.createArtist("Alpha") // 3 episodes
+	artistB := suite.createArtist("Beta")  // 3 episodes
+	artistC := suite.createArtist("Gamma") // 2 episodes
+
+	// A + B in 3 episodes; C tags along in the first 2 (so A–C and B–C would
+	// clear the threshold if C were included).
+	for i := 0; i < 3; i++ {
+		ep := suite.createEpisode(show.ID, recentDate(i+1))
+		suite.createMatchedPlay(ep.ID, 1, artistA)
+		suite.createMatchedPlay(ep.ID, 2, artistB)
+		if i < 2 {
+			suite.createMatchedPlay(ep.ID, 3, artistC)
+		}
+	}
+
+	graph, err := suite.radioService.GetStationGraph(station.ID, "12m", 2)
+	suite.Require().NoError(err)
+
+	suite.Equal(2, graph.Station.ArtistCount)
+	suite.Require().Len(graph.Nodes, 2)
+	suite.Equal("Alpha", graph.Nodes[0].Name)
+	suite.Equal("Beta", graph.Nodes[1].Name)
+
+	// Only the A–B edge survives; edges touching the excluded C are gone.
+	suite.Require().Len(graph.Links, 1)
+	suite.Equal(minUint(artistA.ID, artistB.ID), graph.Links[0].SourceID)
+	suite.Equal(maxUint(artistA.ID, artistB.ID), graph.Links[0].TargetID)
+}
+
+// TestGetStationGraph_ClustersByShow asserts the primary-show clustering:
+// a show with >= sceneClusterMinSize primary artists becomes a first-class
+// cluster, the tail rolls into "other", and an edge across the boundary is
+// flagged cross-cluster.
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_ClustersByShow() {
+	station := suite.createStation("KEXP", "kexp")
+	show1 := suite.createShow(station.ID, "Drone Zone", "kexp-drone-zone")
+	show2 := suite.createShow(station.ID, "Pop Hour", "kexp-pop-hour")
+
+	// 6 artists whose primary show is show1 (>= sceneClusterMinSize).
+	show1Artists := make([]*catalogm.Artist, 0, sceneClusterMinSize)
+	for i := 0; i < sceneClusterMinSize; i++ {
+		show1Artists = append(show1Artists, suite.createArtist(fmt.Sprintf("Drone Artist %02d", i)))
+	}
+	// One artist whose primary show is show2 (rolls into "other").
+	popArtist := suite.createArtist("Pop Artist")
+
+	// Two show1 episodes with all six artists — pairwise co-occurrence + the
+	// primary-show signal. popArtist guests on both (A–pop weight 2) but has
+	// MORE plays on show2, keeping show2 primary.
+	for i := 0; i < 2; i++ {
+		ep := suite.createEpisode(show1.ID, recentDate(i+1))
+		for pos, a := range show1Artists {
+			suite.createMatchedPlay(ep.ID, pos+1, a)
+		}
+		suite.createMatchedPlay(ep.ID, len(show1Artists)+1, popArtist)
+	}
+	for i := 0; i < 3; i++ {
+		ep := suite.createEpisode(show2.ID, recentDate(i+1))
+		suite.createMatchedPlay(ep.ID, 1, popArtist)
+	}
+
+	graph, err := suite.radioService.GetStationGraph(station.ID, "12m", 75)
+	suite.Require().NoError(err)
+
+	// Clusters: show1 first-class, show2's lone artist in "other".
+	suite.Require().Len(graph.Clusters, 2)
+	show1ClusterID := fmt.Sprintf("rs_%d", show1.ID)
+	suite.Equal(show1ClusterID, graph.Clusters[0].ID)
+	suite.Equal("Drone Zone", graph.Clusters[0].Label)
+	suite.Equal(sceneClusterMinSize, graph.Clusters[0].Size)
+	suite.Equal(0, graph.Clusters[0].ColorIndex)
+	suite.Equal(sceneClusterOtherID, graph.Clusters[1].ID)
+	suite.Equal(1, graph.Clusters[1].Size)
+	suite.Equal(-1, graph.Clusters[1].ColorIndex)
+
+	// Node cluster assignment.
+	clusterByName := make(map[string]string)
+	for _, n := range graph.Nodes {
+		clusterByName[n.Name] = n.ClusterID
+	}
+	for _, a := range show1Artists {
+		suite.Equal(show1ClusterID, clusterByName[a.Name])
+	}
+	suite.Equal(sceneClusterOtherID, clusterByName["Pop Artist"])
+
+	// Cross-cluster flags: edges among show1 artists are intra-cluster;
+	// edges from popArtist into show1 artists cross the boundary.
+	for _, l := range graph.Links {
+		touchesPop := l.SourceID == popArtist.ID || l.TargetID == popArtist.ID
+		suite.Equal(touchesPop, l.IsCrossCluster,
+			"edge %d-%d cross-cluster flag", l.SourceID, l.TargetID)
+	}
+	// Sanity: all pairwise show1 edges (15) + pop edges (6) survived.
+	suite.Len(graph.Links, 21)
+}
+
+// TestGetStationGraph_UpcomingShowCount asserts the green-dot signal is wired:
+// an artist with an upcoming approved live show carries the count.
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_UpcomingShowCount() {
+	station := suite.createStation("KEXP", "kexp")
+	show := suite.createShow(station.ID, "Morning Show", "kexp-morning")
+	artistA := suite.createArtist("Alpha")
+	artistB := suite.createArtist("Beta")
+
+	ep := suite.createEpisode(show.ID, recentDate(1))
+	suite.createMatchedPlay(ep.ID, 1, artistA)
+	suite.createMatchedPlay(ep.ID, 2, artistB)
+
+	liveShow := &catalogm.Show{
+		EventDate: time.Now().UTC().AddDate(0, 1, 0),
+		Status:    catalogm.ShowStatusApproved,
+	}
+	suite.Require().NoError(suite.db.Create(liveShow).Error)
+	suite.Require().NoError(suite.db.Exec(
+		"INSERT INTO show_artists (show_id, artist_id, position) VALUES (?, ?, 0)",
+		liveShow.ID, artistA.ID).Error)
+
+	graph, err := suite.radioService.GetStationGraph(station.ID, "12m", 75)
+	suite.Require().NoError(err)
+	suite.Require().Len(graph.Nodes, 2)
+	suite.Equal(1, graph.Nodes[0].UpcomingShowCount) // Alpha
+	suite.Equal(0, graph.Nodes[1].UpcomingShowCount) // Beta
+}
+
+// TestGetStationGraph_QueryCost seeds a deliberately dense synthetic dataset
+// (5 shows, 120 artists, 240 episodes, 2,400 matched plays) and reports the
+// end-to-end service timing. Logged, not asserted — CI machines vary; the
+// number is recorded in the PSY-1081 PR body against the <250ms target.
+func (suite *RadioStationGraphTestSuite) TestGetStationGraph_QueryCost() {
+	station := suite.createStation("KEXP", "kexp")
+
+	const (
+		showCount       = 5
+		artistCount     = 120
+		episodesPerShow = 48
+		playsPerEpisode = 10
+	)
+
+	shows := make([]*catalogm.RadioShow, 0, showCount)
+	for i := 0; i < showCount; i++ {
+		shows = append(shows, suite.createShow(station.ID,
+			fmt.Sprintf("Show %02d", i), fmt.Sprintf("kexp-show-%02d", i)))
+	}
+
+	artists := make([]*catalogm.Artist, 0, artistCount)
+	for i := 0; i < artistCount; i++ {
+		artists = append(artists, suite.createArtist(fmt.Sprintf("Perf Artist %03d", i)))
+	}
+
+	// Round-robin artists across episodes so co-occurrence pairs repeat
+	// across episodes (dense edges, like a real rotation-heavy station).
+	plays := make([]catalogm.RadioPlay, 0, showCount*episodesPerShow*playsPerEpisode)
+	for si, show := range shows {
+		for e := 0; e < episodesPerShow; e++ {
+			// Distinct air date per (show, episode) — radio_episodes has a
+			// uniqueness constraint on the pair. ~7 days apart keeps all 48
+			// episodes inside the 12m window.
+			airDate := time.Now().UTC().AddDate(0, 0, -(e*7 + 1)).Format("2006-01-02")
+			ep := suite.createEpisode(show.ID, airDate)
+			for p := 0; p < playsPerEpisode; p++ {
+				a := artists[(si*7+e*3+p)%artistCount]
+				plays = append(plays, catalogm.RadioPlay{
+					EpisodeID:  ep.ID,
+					Position:   p + 1,
+					ArtistName: a.Name,
+					ArtistID:   &a.ID,
+				})
+			}
+		}
+	}
+	suite.Require().NoError(suite.db.CreateInBatches(plays, 500).Error)
+
+	start := time.Now()
+	graph, err := suite.radioService.GetStationGraph(station.ID, "12m", 75)
+	elapsed := time.Since(start)
+	suite.Require().NoError(err)
+
+	suite.Equal(75, graph.Station.ArtistCount)
+	suite.NotEmpty(graph.Links)
+	suite.T().Logf("GetStationGraph on %d plays / %d artists / %d episodes: %v (nodes=%d edges=%d clusters=%d)",
+		len(plays), artistCount, showCount*episodesPerShow, elapsed,
+		len(graph.Nodes), len(graph.Links), len(graph.Clusters))
+}
+
+func minUint(a, b uint) uint {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxUint(a, b uint) uint {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -859,28 +859,10 @@ func (s *SceneService) querySceneRelationships(artistIDs []uint, types []string)
 
 // batchUpcomingShowCount returns a map of artist_id → upcoming approved show
 // count, mirroring the batch pattern in GetArtistGraph step 4. Returns an empty
-// map (never nil) so callers can index without a nil check.
+// map (never nil) so callers can index without a nil check. Delegates to the
+// shared graph helper (PSY-1081).
 func (s *SceneService) batchUpcomingShowCount(artistIDs []uint) map[uint]int {
-	out := make(map[uint]int, len(artistIDs))
-	if len(artistIDs) == 0 {
-		return out
-	}
-	type row struct {
-		ArtistID  uint
-		ShowCount int64
-	}
-	var rows []row
-	s.db.Table("show_artists").
-		Select("show_artists.artist_id, COUNT(DISTINCT shows.id) AS show_count").
-		Joins("JOIN shows ON shows.id = show_artists.show_id").
-		Where("show_artists.artist_id IN ? AND shows.status = ? AND shows.event_date > NOW()",
-			artistIDs, catalogm.ShowStatusApproved).
-		Group("show_artists.artist_id").
-		Scan(&rows)
-	for _, r := range rows {
-		out[r.ArtistID] = int(r.ShowCount)
-	}
-	return out
+	return batchArtistUpcomingShowCounts(s.db, artistIDs)
 }
 
 // buildSceneClusters converts the per-artist primary-venue rows into a sorted

--- a/backend/internal/services/catalog/venue_bill_network.go
+++ b/backend/internal/services/catalog/venue_bill_network.go
@@ -377,27 +377,9 @@ func (s *VenueService) batchArtistDetails(artistIDs []uint) (map[uint]venueBillA
 // batchVenueBillUpcomingShowCount mirrors the scene-graph helper: per-artist
 // upcoming approved show count globally (not just at this venue), so the
 // graph node green-dot indicator stays consistent with the rest of the app.
+// Delegates to the shared graph helper (PSY-1081).
 func (s *VenueService) batchVenueBillUpcomingShowCount(artistIDs []uint) map[uint]int {
-	out := make(map[uint]int, len(artistIDs))
-	if len(artistIDs) == 0 {
-		return out
-	}
-	type row struct {
-		ArtistID  uint
-		ShowCount int64
-	}
-	var rows []row
-	s.db.Table("show_artists").
-		Select("show_artists.artist_id, COUNT(DISTINCT shows.id) AS show_count").
-		Joins("JOIN shows ON shows.id = show_artists.show_id").
-		Where("show_artists.artist_id IN ? AND shows.status = ? AND shows.event_date > NOW()",
-			artistIDs, catalogm.ShowStatusApproved).
-		Group("show_artists.artist_id").
-		Scan(&rows)
-	for _, r := range rows {
-		out[r.ArtistID] = int(r.ShowCount)
-	}
-	return out
+	return batchArtistUpcomingShowCounts(s.db, artistIDs)
 }
 
 // derefString returns the pointed-to string or "" when nil. Inline to avoid

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -423,6 +423,82 @@ type RadioNewReleaseRadarEntry struct {
 	StationCount int     `json:"station_count"`
 }
 
+// ──────────────────────────────────────────────
+// Station graph (PSY-1081) — station-scoped radio co-occurrence subgraph
+// ──────────────────────────────────────────────
+//
+// The radio analog of SceneGraphResponse (PSY-367) / VenueBillNetworkResponse
+// (PSY-365): same four-block shape (`station` info, `clusters`, `nodes`,
+// `links`) so the shared frontend ForceGraphView renders any of the three.
+//
+// Edges are derived AT QUERY TIME from radio_plays scoped to this station's
+// episodes. The aggregate radio_artist_affinity table (PSY-169) collapses
+// station attribution to a station_count integer — it does not record WHICH
+// stations contributed a pair — so the aggregate radio_cooccurrence edges in
+// artist_relationships cannot be filtered to a single station.
+
+// RadioStationGraphResponse is the payload for GET /radio-stations/{slug}/graph.
+type RadioStationGraphResponse struct {
+	Station  RadioStationGraphInfo      `json:"station"`
+	Clusters []RadioStationGraphCluster `json:"clusters"`
+	Nodes    []RadioStationGraphNode    `json:"nodes"`
+	Links    []RadioStationGraphLink    `json:"links"`
+}
+
+// RadioStationGraphInfo holds station metadata and aggregate counts for the
+// graph. Mirrors SceneGraphInfo / VenueBillNetworkInfo.
+type RadioStationGraphInfo struct {
+	ID          uint   `json:"id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	ArtistCount int    `json:"artist_count"` // nodes in the response (top-N cap applied)
+	EdgeCount   int    `json:"edge_count"`   // co-occurrence pairs above the min threshold
+	// Window labels the active time window so the frontend can caption the
+	// graph without reverse-engineering the filter. One of: "last_12m"
+	// (default), "all_time".
+	Window string `json:"window"`
+}
+
+// RadioStationGraphCluster groups artists by the radio show (on this station)
+// they are most played on — the station analog of the scene graph's
+// primary-venue cluster signal. Shows below the size threshold roll into a
+// single "other" cluster, matching the scene-graph rules.
+type RadioStationGraphCluster struct {
+	ID         string `json:"id"`          // "rs_<show_id>" or "other"
+	Label      string `json:"label"`       // radio show name or "Other"
+	Size       int    `json:"size"`        // number of artists in this cluster
+	ColorIndex int    `json:"color_index"` // 0-7 = Okabe-Ito index; -1 = "other" (grey)
+}
+
+// RadioStationGraphNode represents an artist in the station graph.
+type RadioStationGraphNode struct {
+	ID                uint   `json:"id"`
+	Name              string `json:"name"`
+	Slug              string `json:"slug"`
+	City              string `json:"city,omitempty"`
+	State             string `json:"state,omitempty"`
+	UpcomingShowCount int    `json:"upcoming_show_count"`
+	ClusterID         string `json:"cluster_id"` // matches RadioStationGraphCluster.ID
+	IsIsolate         bool   `json:"is_isolate"` // true when the artist has no in-graph edges
+	// PlayCount is the artist's play count on this station within the active
+	// window — the station analog of VenueBillNetworkNode.AtVenueShowCount.
+	PlayCount int `json:"play_count"`
+}
+
+// RadioStationGraphLink represents a within-station co-occurrence edge.
+// Type is always "radio_cooccurrence" so the frontend edge grammar matches
+// the aggregate relationship edges. Detail carries `co_occurrence_count`
+// (episodes on THIS station where both artists appeared, within the window)
+// and `last_co_occurrence` (YYYY-MM-DD).
+type RadioStationGraphLink struct {
+	SourceID       uint    `json:"source_id"`
+	TargetID       uint    `json:"target_id"`
+	Type           string  `json:"type"`
+	Score          float64 `json:"score"`
+	Detail         any     `json:"detail,omitempty"`
+	IsCrossCluster bool    `json:"is_cross_cluster"` // derived: source.cluster_id != target.cluster_id
+}
+
 // RadioStatsResponse represents overall radio stats
 type RadioStatsResponse struct {
 	TotalStations int   `json:"total_stations"`
@@ -598,6 +674,7 @@ type RadioServiceInterface interface {
 	GetAsHeardOnForArtist(artistID uint) ([]*RadioAsHeardOnResponse, error)
 	GetAsHeardOnForRelease(releaseID uint) ([]*RadioAsHeardOnResponse, error)
 	GetNewReleaseRadar(stationID uint, limit int) ([]*RadioNewReleaseRadarEntry, error)
+	GetStationGraph(stationID uint, window string, limit int) (*RadioStationGraphResponse, error)
 
 	// Stats
 	GetRadioStats() (*RadioStatsResponse, error)


### PR DESCRIPTION
## Summary

Adds `GET /radio-stations/{slug}/graph` — the station-scoped radio co-occurrence subgraph for the /explore Observatory's Station scope ("the KEXP corner of the graph").

- **Nodes**: the station's top-N artists by play count (default 75, max 150), matched plays only.
- **Links**: within-station co-occurrence — two artists matched in the same episode on THIS station. Weight = number of shared episodes (`co_occurrence_count` in the detail blob, plus `last_co_occurrence`), `type: "radio_cooccurrence"`, score = `min(1, count/50)` mirroring `SyncAffinityToRelationships` so the edge grammar matches the aggregate edges. Edges below 2 shared episodes are dropped (same threshold as `ComputeAffinity` / the venue bill network).
- **Clusters**: keyed by radio show — each artist clusters under the show (on this station) it is most played on, the station analog of the scene graph's primary-venue signal. Same rules as the scene graph: ≥6 artists for a first-class cluster, capped at 8 (Okabe-Ito palette), tail rolls into "other". `is_isolate` / `is_cross_cluster` precomputed server-side.
- **Window**: `window=12m` (rolling, default) or `window=all`, labeled `last_12m` / `all_time` in the station info block — mirrors the venue bill-network param (the `year` variant is intentionally not carried over).
- Response mirrors `SceneGraphResponse` / `VenueBillNetworkResponse` four-block shape (`station` info: id, slug, name, artist_count, edge_count, window) so the shared ForceGraphView can render it.

Also extracts the upcoming-show-count batch query (previously duplicated in `SceneService` and `VenueService`) into a shared package-level helper `batchArtistUpcomingShowCounts`, which the station graph is the third consumer of.

## Investigation

The ticket required deciding between (a) parameterizing the existing co-occurrence computation by station vs (b) deriving station-scoped co-occurrence at query time. **Chose (b), query-time derivation from `radio_plays`/`radio_episodes`. No schema changes.**

Why:
- The Phase 2d aggregate pipeline (`ComputeAffinity` → `radio_artist_affinity` → `SyncAffinityToRelationships` → `artist_relationships` rows of type `radio_cooccurrence`) collapses station attribution to a `station_count` **integer**. Neither table records WHICH stations contributed a pair, so the aggregate edges cannot be filtered to one station (`backend/internal/services/catalog/radio_unmatched.go:248`, `models/catalog/radio.go` `RadioArtistAffinity`).
- Option (a) would require a station dimension on the affinity table (composite-PK change + migration + recompute churn in the scheduled fetch pipeline) — a schema change for data the source tables already hold.
- Option (b) is the `ComputeAffinity` self-join scoped to one station (`radio_plays` → `radio_episodes` → `radio_shows.station_id`) and restricted to the top-N matched artists, bounding the pair space at N(N−1)/2 (N ≤ 150). Measured at single-digit milliseconds on a dense synthetic dataset (below).

One deliberate divergence from `ComputeAffinity`: the edge weight is `COUNT(DISTINCT episode_id)` (episodes where both artists appeared — the ticket's definition) rather than `COUNT(*)` of play-pairs, which double-counts an episode when an artist is played twice in it. Documented at the query site.

## Test plan

- [x] `cd backend && go build ./...`
- [x] `cd backend && go generate ./...` (regenerated `MockRadioService` for the new interface method)
- [x] `cd backend && go test ./internal/services/catalog/ -run "TestNormalizeStationGraphWindow|TestGetStationGraph_NilDB|TestRadioStationGraphTestSuite" -v`
- [x] `cd backend && go test ./...` (full suite)

## Manual repro

Backend-only, no migration → integration tests against a real Postgres testcontainer are the repro (PSY-592 pattern). All in `backend/internal/services/catalog/radio_station_graph_test.go`:

- `TestGetStationGraph_BasicGraph` — nodes with play counts, A–B edge weight 2 (score 2/50, detail `co_occurrence_count`/`last_co_occurrence`), sub-threshold pairs dropped, duplicate plays within an episode do NOT inflate the weight, unmatched (NULL `artist_id`) plays excluded, isolate flagged, small show rolls into "other" cluster.
- `TestGetStationGraph_StationScoped` — the same artist pair co-occurring 3× on station B and 1× on station A yields weight 3 on B's graph and NO edge on A's (no cross-station leakage — the whole point of the derivation choice).
- `TestGetStationGraph_WindowFilter` — 2-year-old episodes excluded under the `12m` default (empty graph), included under `window=all` (`all_time` label, weight 2).
- `TestGetStationGraph_ClustersByShow` — 6 primary artists make "Drone Zone" a first-class `rs_<id>` cluster (ColorIndex 0); a guest artist whose primary show is elsewhere lands in "other" and its 6 edges into the cluster are `is_cross_cluster: true`; the 15 intra-cluster edges are not; 21 edges total.
- `TestGetStationGraph_LimitCapsNodes` — `limit=2` keeps the top-2 by play count and drops edges touching excluded artists.
- `TestGetStationGraph_UpcomingShowCount`, `TestGetStationGraph_EmptyStation`, `TestGetStationGraph_NotFound` (404 via `RadioError`), `TestGetStationGraph_NilDB`, `TestNormalizeStationGraphWindow`.

**Query cost** (`TestGetStationGraph_QueryCost`, dense synthetic dataset — 5 shows, 120 artists, 240 episodes, 2,400 matched plays, round-robin so co-occurrence pairs repeat):

```
GetStationGraph on 2400 plays / 120 artists / 240 episodes: 6.7ms (nodes=75 edges=580 clusters=5)
```

Well under the 250ms target; the timing is logged (not asserted) so CI machine variance can't flake it.

OpenAPI: the new operation is generated by Huma from `GetRadioStationGraphRequest`/`GetRadioStationGraphResponse` (path `GET /radio-stations/{slug}/graph`, query `window` enum `all,12m` default `12m`, `limit` 1–150 default 75). No pointer query/path params (Huma panic rule respected).

## Code review

`/code-review` run inline (dispatched worktree agent — no Agent tool; expected fallback) across the correctness (line-by-line / removed-behavior / cross-file) and cleanup (reuse / simplification / efficiency / altitude) lenses. One finding survived verification and was fixed in the `code-review pass` commit: the handler doc-comment claimed the service coerces unknown `window` values for HTTP clients, but Huma's `enum` validation 422s them first — comment now states both layers accurately. Reuse lens drove the extraction of the previously-duplicated upcoming-show-count batch query into `batchArtistUpcomingShowCounts` (scene + venue now delegate; station graph is the third consumer). The two-query structure, cluster constants reuse, and tie-break determinism were verified against the scene/venue precedents.

## Adversarial review

`/adversarial-review` — **CONCERNS**, no HIGH/CRITICAL; 1 MEDIUM disclosed below, no fix commit required. Panel: Saboteur · Future-Maintainer · Security · Completeness — run inline against the branch diff (dispatched worktree agent, no Agent tool; expected fallback per project pattern).

- Saboteur (CLEAN): probed SQL injection (fully parameterized; `Sprintf` inserts constant fragments only), read-skew between the two queries, `limit=1` short-circuit, duplicate-play weight inflation (COUNT DISTINCT + regression test), window-boundary consistency, and production-scale indexes — verified `idx_radio_plays_episode`, partial `idx_radio_plays_artist_id`, `idx_radio_episodes_show`, `idx_radio_shows_station` all exist (migration 000055).
- Future-Maintainer (CONCERNS): **[MEDIUM, deferred]** `buildStationGraphClusters` mirrors `buildSceneClusters` (~70 lines) — a future cluster-rule change must be made in two places. Deferred deliberately: the size floor / palette cap / "other" id constants (where drift would actually hurt) are already shared, both functions cross-reference each other, and generalizing would require an adapter over deliberately-distinct wire-contract types plus touching the shipped scene graph in this PR. [LOW] `last_12m`/`all_time` label literals duplicated with the venue service.
- Security (CLEAN): public read endpoint consistent with the peer graph endpoints; CPU bounded by the limit cap + indexes; no PII.
- Completeness (CLEAN): acceptance criteria verified against the ticket (scene-graph-shaped payload, show-keyed clusters, server-side `is_isolate`/`is_cross_cluster`, measured query cost). Note: nodes exclude unmatched plays by construction — an unmatched play has no artist entity to graph.

Closes PSY-1081
