### PR TITLE
PSY-1080: festival-scoped graph endpoint (co-bill subgraph)

### DIFF
--- a/backend/internal/api/handlers/catalog/festival_graph.go
+++ b/backend/internal/api/handlers/catalog/festival_graph.go
@@ -1,0 +1,49 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Get Festival Graph (PSY-1080)
+// ============================================================================
+
+// GetFestivalGraphRequest represents the request for the festival-scoped
+// co-bill graph. `Types` mirrors the scene graph's filter: a comma-separated
+// list; empty means all allowed festival edge types. Huma forbids pointer
+// query params, so the empty string is the explicit "no filter" sentinel.
+type GetFestivalGraphRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID or slug" example:"m3f-2026"`
+	Types      string `query:"types" required:"false" doc:"Comma-separated relationship types (festival_cobill,shared_bills,shared_label,similar,radio_cooccurrence). Empty = all allowed types." example:"festival_cobill,shared_bills"`
+}
+
+// GetFestivalGraphResponse represents the response for the festival graph.
+type GetFestivalGraphResponse struct {
+	Body *contracts.FestivalGraphResponse
+}
+
+// GetFestivalGraphHandler handles GET /festivals/{festival_id}/graph — returns
+// the co-bill subgraph of the festival's lineup with billing-tier clusters
+// (PSY-1080). Shape mirrors GET /scenes/{slug}/graph so ForceGraphView
+// consumes it unchanged.
+func (h *FestivalHandler) GetFestivalGraphHandler(ctx context.Context, req *GetFestivalGraphRequest) (*GetFestivalGraphResponse, error) {
+	festivalID, err := h.resolveFestivalID(req.FestivalID)
+	if err != nil {
+		return nil, err
+	}
+
+	graph, err := h.festivalService.GetFestivalGraph(festivalID, parseTypesQueryParam(req.Types))
+	if err != nil {
+		if mapped := shared.MapFestivalError(err); mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to get festival graph", err)
+	}
+
+	return &GetFestivalGraphResponse{Body: graph}, nil
+}

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1801,6 +1801,7 @@ type MockFestivalService struct {
 	AddFestivalVenueFn      func(uint, *contracts.AddFestivalVenueRequest) (*contracts.FestivalVenueResponse, error)
 	RemoveFestivalVenueFn   func(uint, uint) error
 	GetFestivalsForArtistFn func(uint) ([]*contracts.ArtistFestivalListResponse, error)
+	GetFestivalGraphFn      func(uint, []string) (*contracts.FestivalGraphResponse, error)
 }
 
 func (m *MockFestivalService) CreateFestival(req *contracts.CreateFestivalRequest) (*contracts.FestivalDetailResponse, error) {
@@ -1890,6 +1891,12 @@ func (m *MockFestivalService) RemoveFestivalVenue(festivalID uint, venueID uint)
 func (m *MockFestivalService) GetFestivalsForArtist(artistID uint) ([]*contracts.ArtistFestivalListResponse, error) {
 	if m.GetFestivalsForArtistFn != nil {
 		return m.GetFestivalsForArtistFn(artistID)
+	}
+	return nil, nil
+}
+func (m *MockFestivalService) GetFestivalGraph(festivalID uint, types []string) (*contracts.FestivalGraphResponse, error) {
+	if m.GetFestivalGraphFn != nil {
+		return m.GetFestivalGraphFn(festivalID, types)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/routes/festivals.go
+++ b/backend/internal/api/routes/festivals.go
@@ -16,6 +16,8 @@ func setupFestivalRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/festivals/{festival_id}", festivalHandler.GetFestivalHandler)
 	huma.Get(rc.API, "/festivals/{festival_id}/artists", festivalHandler.GetFestivalArtistsHandler)
 	huma.Get(rc.API, "/festivals/{festival_id}/venues", festivalHandler.GetFestivalVenuesHandler)
+	// PSY-1080: co-bill subgraph of the festival's lineup (Observatory festival scope).
+	huma.Get(rc.API, "/festivals/{festival_id}/graph", festivalHandler.GetFestivalGraphHandler)
 	huma.Get(rc.API, "/artists/{artist_id}/festivals", festivalHandler.GetArtistFestivalsHandler)
 
 	// Festival intelligence endpoints (public, computed from existing data)

--- a/backend/internal/services/catalog/festival_graph.go
+++ b/backend/internal/services/catalog/festival_graph.go
@@ -1,0 +1,501 @@
+package catalog
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// PSY-1080 — festival-scoped co-bill subgraph for GET /festivals/{id}/graph.
+//
+// Mirrors the scene graph (PSY-367, scene.go) end-to-end: same response
+// shape, same is_isolate / is_cross_cluster server-side derivation, same
+// type-filter semantics. The cluster signal at festival scope is the
+// artist's billing tier on this festival's bill (festival_artists.billing_tier).
+
+// festivalGraphMaxNodes is the hard ceiling on lineup nodes. Festivals render
+// lineup-complete (no 30-node cap like the artist graph) per the PSY-1080
+// decision, but a runaway lineup must not produce an unbounded payload.
+// When the cap bites, the lineup ordering (tier rank, then position, then
+// name) decides who stays — headliners are never the ones dropped.
+const festivalGraphMaxNodes = 150
+
+// festivalGraphClusterOtherID / Label are the fallback bucket for any lineup
+// row whose billing_tier doesn't match a known tier (defensive — the column
+// is NOT NULL with a default, but unknown values must not crash the graph).
+const (
+	festivalGraphClusterOtherID    = "other"
+	festivalGraphClusterOtherLabel = "Other"
+)
+
+// allowedFestivalEdgeTypes whitelists relationship types the festival graph
+// surfaces (per PSY-1080): the stored cross-signals between lineup members
+// (shared_bills, shared_label, similar, radio_cooccurrence) plus the
+// query-time festival_cobill signal. member_of / side_project are omitted —
+// lineage edges don't carry lineup-structure signal the way co-activity does.
+var allowedFestivalEdgeTypes = map[string]bool{
+	catalogm.RelationshipTypeSharedBills:       true,
+	catalogm.RelationshipTypeSharedLabel:       true,
+	catalogm.RelationshipTypeSimilar:           true,
+	catalogm.RelationshipTypeRadioCooccurrence: true,
+	festivalCobillType:                         true,
+}
+
+// festivalGraphTierOrder fixes the cluster ordering (and Okabe-Ito
+// color_index assignment) from top of the bill down. Mirrors the CASE
+// ordering used by GetFestivalArtists.
+var festivalGraphTierOrder = []catalogm.BillingTier{
+	catalogm.BillingTierHeadliner,
+	catalogm.BillingTierSubHeadliner,
+	catalogm.BillingTierMidCard,
+	catalogm.BillingTierUndercard,
+	catalogm.BillingTierLocal,
+	catalogm.BillingTierDJ,
+	catalogm.BillingTierHost,
+}
+
+// festivalGraphTierLabels maps tiers to legend labels.
+var festivalGraphTierLabels = map[catalogm.BillingTier]string{
+	catalogm.BillingTierHeadliner:    "Headliner",
+	catalogm.BillingTierSubHeadliner: "Sub-headliner",
+	catalogm.BillingTierMidCard:      "Mid-card",
+	catalogm.BillingTierUndercard:    "Undercard",
+	catalogm.BillingTierLocal:        "Local",
+	catalogm.BillingTierDJ:           "DJ",
+	catalogm.BillingTierHost:         "Host",
+}
+
+// festivalLineupRow is one artist on the festival's bill, joined with the
+// artist columns the graph node needs.
+type festivalLineupRow struct {
+	ArtistID    uint    `gorm:"column:artist_id"`
+	Name        string  `gorm:"column:name"`
+	Slug        *string `gorm:"column:slug"`
+	City        *string `gorm:"column:city"`
+	State       *string `gorm:"column:state"`
+	BillingTier string  `gorm:"column:billing_tier"`
+}
+
+// GetFestivalGraph returns the co-bill subgraph of a festival's lineup:
+// nodes are the artists on the bill (lineup-complete up to
+// festivalGraphMaxNodes), clusters are billing tiers, and links are the
+// query-time festival_cobill signal plus stored typed edges between lineup
+// members.
+//
+// festival_cobill semantics at festival scope: every pair on this lineup
+// trivially shares THIS festival, so counting it would yield a complete
+// graph (no structure, O(n²) edges). The derivation therefore counts shared
+// festivals EXCLUDING the festival being viewed — an edge means "these two
+// artists have also shared other festival bills", which is the structural
+// signal the Observatory wants. `detail.count` / `detail.festival_names`
+// likewise cover only those other festivals.
+//
+// types filters to the subset of allowedFestivalEdgeTypes; empty/nil means
+// "all allowed types" (festival_cobill included — unlike the artist graph's
+// opt-in rule (PSY-954), the festival graph exists to show co-bill structure,
+// and the derivation is bounded by the lineup set rather than unbounded).
+func (s *FestivalService) GetFestivalGraph(festivalID uint, types []string) (*contracts.FestivalGraphResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var festival catalogm.Festival
+	if err := s.db.First(&festival, festivalID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	// Whitelist + dedupe types. Mirrors resolveSceneEdgeTypes semantics: empty
+	// input means "all allowed types"; a non-empty input that resolves to
+	// nothing must short-circuit to zero edges, not fall back to "all types".
+	resolvedTypes := resolveFestivalEdgeTypes(types)
+	noEdgesByFilter := len(types) > 0 && len(resolvedTypes) == 0
+	storedTypes, wantCobill := splitFestivalEdgeTypes(resolvedTypes)
+
+	// 1. Lineup query — bill order (tier rank, position, name) so the
+	//    festivalGraphMaxNodes cap drops from the bottom of the bill.
+	rows, err := s.queryFestivalLineup(festivalID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query festival lineup: %w", err)
+	}
+
+	resp := &contracts.FestivalGraphResponse{
+		Festival: contracts.FestivalGraphInfo{
+			ID:          festival.ID,
+			Slug:        festival.Slug,
+			Name:        festival.Name,
+			Year:        festival.EditionYear,
+			ArtistCount: len(rows),
+		},
+		Clusters: []contracts.FestivalGraphCluster{},
+		Nodes:    []contracts.FestivalGraphNode{},
+		Links:    []contracts.FestivalGraphLink{},
+	}
+
+	if len(rows) == 0 {
+		return resp, nil
+	}
+
+	// 2. Cluster pass — one cluster per billing tier present on the bill,
+	//    ordered headliner-first. At most 7 tiers exist, so every tier fits
+	//    inside the 8-color Okabe-Ito palette without a size threshold.
+	clusters, clusterByArtist := buildFestivalTierClusters(rows)
+	resp.Clusters = clusters
+
+	artistIDs := make([]uint, 0, len(rows))
+	for _, r := range rows {
+		artistIDs = append(artistIDs, r.ArtistID)
+	}
+
+	// 3. Batch upcoming-show counts (shared with the scene graph).
+	upcomingByArtist := batchArtistUpcomingShowCounts(s.db, artistIDs)
+
+	// 4. Stored typed edges — both endpoints on the lineup.
+	var storedLinks []sceneRelationshipRow
+	if !noEdgesByFilter && len(storedTypes) > 0 {
+		fetched, err := queryRelationshipsAmongArtists(s.db, artistIDs, storedTypes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query lineup relationships: %w", err)
+		}
+		storedLinks = fetched
+	}
+
+	// 5. Query-time festival_cobill edges among lineup pairs (excluding this
+	//    festival — see method doc).
+	var cobillLinks []contracts.FestivalGraphLink
+	if !noEdgesByFilter && wantCobill {
+		cobillLinks, err = s.queryFestivalGraphCobillEdges(festivalID, artistIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive festival co-bill edges: %w", err)
+		}
+	}
+
+	// 6. Build the link payload + flag cross-cluster (cross-tier) ties.
+	connected := make(map[uint]bool, len(rows))
+	for _, l := range storedLinks {
+		var detail any
+		if len(l.Detail) > 0 {
+			_ = json.Unmarshal(l.Detail, &detail)
+		}
+		resp.Links = append(resp.Links, contracts.FestivalGraphLink{
+			SourceID:       l.SourceArtistID,
+			TargetID:       l.TargetArtistID,
+			Type:           l.RelationshipType,
+			Score:          float64(l.Score),
+			Detail:         detail,
+			IsCrossCluster: clusterByArtist[l.SourceArtistID] != clusterByArtist[l.TargetArtistID],
+		})
+		connected[l.SourceArtistID] = true
+		connected[l.TargetArtistID] = true
+	}
+	for _, l := range cobillLinks {
+		l.IsCrossCluster = clusterByArtist[l.SourceID] != clusterByArtist[l.TargetID]
+		resp.Links = append(resp.Links, l)
+		connected[l.SourceID] = true
+		connected[l.TargetID] = true
+	}
+	resp.Festival.EdgeCount = len(resp.Links)
+
+	// 7. Nodes in bill order, is_isolate from the post-filter link set.
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		city := ""
+		if r.City != nil {
+			city = *r.City
+		}
+		state := ""
+		if r.State != nil {
+			state = *r.State
+		}
+		resp.Nodes = append(resp.Nodes, contracts.FestivalGraphNode{
+			ID:                r.ArtistID,
+			Name:              r.Name,
+			Slug:              slug,
+			City:              city,
+			State:             state,
+			UpcomingShowCount: upcomingByArtist[r.ArtistID],
+			ClusterID:         clusterByArtist[r.ArtistID],
+			IsIsolate:         !connected[r.ArtistID],
+		})
+	}
+
+	return resp, nil
+}
+
+// resolveFestivalEdgeTypes filters the caller's requested types against the
+// festival-graph allowlist and returns a deterministic slice. Empty input →
+// all allowed types. Mirrors resolveSceneEdgeTypes.
+func resolveFestivalEdgeTypes(requested []string) []string {
+	if len(requested) == 0 {
+		out := make([]string, 0, len(allowedFestivalEdgeTypes))
+		for t := range allowedFestivalEdgeTypes {
+			out = append(out, t)
+		}
+		sortStringsAsc(out)
+		return out
+	}
+	seen := make(map[string]bool, len(requested))
+	out := make([]string, 0, len(requested))
+	for _, t := range requested {
+		if !allowedFestivalEdgeTypes[t] || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	sortStringsAsc(out)
+	return out
+}
+
+// splitFestivalEdgeTypes separates the resolved type list into stored
+// relationship types (queried from artist_relationships) and the query-time
+// festival_cobill flag.
+func splitFestivalEdgeTypes(resolved []string) (stored []string, wantCobill bool) {
+	stored = make([]string, 0, len(resolved))
+	for _, t := range resolved {
+		if t == festivalCobillType {
+			wantCobill = true
+			continue
+		}
+		stored = append(stored, t)
+	}
+	return stored, wantCobill
+}
+
+// queryFestivalLineup lists the festival's bill in lineup order (tier rank,
+// then position, then name; artist id as the final determinism tiebreak),
+// capped at festivalGraphMaxNodes. (festival_id, artist_id) is UNIQUE per
+// migration 000039, so no dedup pass is needed.
+func (s *FestivalService) queryFestivalLineup(festivalID uint) ([]festivalLineupRow, error) {
+	const q = `
+		SELECT
+			a.id    AS artist_id,
+			a.name  AS name,
+			a.slug  AS slug,
+			a.city  AS city,
+			a.state AS state,
+			fa.billing_tier AS billing_tier
+		FROM festival_artists fa
+		JOIN artists a ON a.id = fa.artist_id
+		WHERE fa.festival_id = ?
+		ORDER BY
+			CASE fa.billing_tier
+				WHEN 'headliner' THEN 1
+				WHEN 'sub_headliner' THEN 2
+				WHEN 'mid_card' THEN 3
+				WHEN 'undercard' THEN 4
+				WHEN 'local' THEN 5
+				WHEN 'dj' THEN 6
+				WHEN 'host' THEN 7
+				ELSE 8
+			END ASC, fa.position ASC, a.name ASC, a.id ASC
+		LIMIT ?
+	`
+	var rows []festivalLineupRow
+	if err := s.db.Raw(q, festivalID, festivalGraphMaxNodes).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// buildFestivalTierClusters converts lineup rows into tier clusters ordered
+// headliner-first, with color_index assigned contiguously among the tiers
+// actually present. Unknown tiers (defensive) roll into "other" (-1 / grey).
+// Returns the cluster list and an artist_id → cluster_id lookup.
+func buildFestivalTierClusters(rows []festivalLineupRow) ([]contracts.FestivalGraphCluster, map[uint]string) {
+	sizeByTier := make(map[catalogm.BillingTier]int, len(festivalGraphTierOrder))
+	clusterByArtist := make(map[uint]string, len(rows))
+	otherSize := 0
+
+	for _, r := range rows {
+		tier := catalogm.BillingTier(r.BillingTier)
+		if _, known := festivalGraphTierLabels[tier]; !known {
+			clusterByArtist[r.ArtistID] = festivalGraphClusterOtherID
+			otherSize++
+			continue
+		}
+		sizeByTier[tier]++
+		clusterByArtist[r.ArtistID] = festivalTierClusterID(tier)
+	}
+
+	clusters := make([]contracts.FestivalGraphCluster, 0, len(sizeByTier)+1)
+	colorIndex := 0
+	for _, tier := range festivalGraphTierOrder {
+		size, present := sizeByTier[tier]
+		if !present {
+			continue
+		}
+		clusters = append(clusters, contracts.FestivalGraphCluster{
+			ID:         festivalTierClusterID(tier),
+			Label:      festivalGraphTierLabels[tier],
+			Size:       size,
+			ColorIndex: colorIndex,
+		})
+		colorIndex++
+	}
+	if otherSize > 0 {
+		clusters = append(clusters, contracts.FestivalGraphCluster{
+			ID:         festivalGraphClusterOtherID,
+			Label:      festivalGraphClusterOtherLabel,
+			Size:       otherSize,
+			ColorIndex: -1,
+		})
+	}
+
+	return clusters, clusterByArtist
+}
+
+// festivalTierClusterID builds the cluster id for a billing tier.
+func festivalTierClusterID(tier catalogm.BillingTier) string {
+	return "tier_" + string(tier)
+}
+
+// queryFestivalGraphCobillEdges derives festival_cobill edges between lineup
+// pairs, counting shared festivals OTHER than `festivalID` (see
+// GetFestivalGraph doc for why this festival is excluded). Pairs use the
+// canonical artistA < artistB ordering, mirroring queryFestivalCobillRows'
+// cross-edge mode. Scoring reuses festivalCobillScore (PSY-363) and the
+// detail JSONB keeps the same shape ({festival_names, count,
+// most_recent_year}) so the frontend edge tooltip renders unchanged.
+//
+// No edge cap: the pair space is bounded by festivalGraphMaxNodes and the
+// requirement of a shared festival outside this one keeps real-world counts
+// sparse.
+func (s *FestivalService) queryFestivalGraphCobillEdges(festivalID uint, lineupIDs []uint) ([]contracts.FestivalGraphLink, error) {
+	if len(lineupIDs) < 2 {
+		return nil, nil
+	}
+
+	var rows []festivalCobillRow
+	err := s.db.Raw(`
+		SELECT
+			fa1.artist_id AS artist_a,
+			fa2.artist_id AS artist_b,
+			COUNT(DISTINCT fa1.festival_id) AS shared_count,
+			MAX(f.start_date) AS most_recent_start,
+			MAX(EXTRACT(YEAR FROM f.start_date))::int AS most_recent_year
+		FROM festival_artists fa1
+		JOIN festival_artists fa2 ON fa1.festival_id = fa2.festival_id
+			AND fa1.artist_id < fa2.artist_id
+		JOIN festivals f ON f.id = fa1.festival_id
+		WHERE fa1.festival_id <> ?
+			AND fa1.artist_id IN ? AND fa2.artist_id IN ?
+		GROUP BY fa1.artist_id, fa2.artist_id
+		ORDER BY shared_count DESC, most_recent_start DESC, fa1.artist_id ASC, fa2.artist_id ASC
+	`, festivalID, lineupIDs, lineupIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to query festival co-lineup (festival graph): %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	// Tooltip names are best-effort (mirrors computeFestivalCobillCenterEdges):
+	// a failure here degrades to count-only tooltips, never fails the graph.
+	nameMap, err := s.queryFestivalGraphCobillNames(festivalID, rows)
+	if err != nil {
+		nameMap = nil
+	}
+
+	now := time.Now()
+	links := make([]contracts.FestivalGraphLink, 0, len(rows))
+	for _, r := range rows {
+		var festivalNames string
+		if nameMap != nil {
+			festivalNames = strings.Join(nameMap[pairKey(r.ArtistA, r.ArtistB)], ", ")
+		}
+		detail := map[string]interface{}{
+			"festival_names": festivalNames,
+			"count":          r.SharedCount,
+		}
+		if r.MostRecentYear != nil {
+			detail["most_recent_year"] = *r.MostRecentYear
+		} else {
+			detail["most_recent_year"] = nil
+		}
+		links = append(links, contracts.FestivalGraphLink{
+			SourceID: r.ArtistA,
+			TargetID: r.ArtistB,
+			Type:     festivalCobillType,
+			Score:    festivalCobillScore(r.SharedCount, r.MostRecentStart, now),
+			Detail:   detail,
+		})
+	}
+	return links, nil
+}
+
+// queryFestivalGraphCobillNames fetches up to festivalCobillTopFestivalNames
+// shared-festival names (most recent first) per pair, excluding `festivalID`
+// so the tooltip lists only the OTHER festivals the pair has shared —
+// consistent with the edge's count. Pairs are canonical (artistA < artistB),
+// matching queryFestivalGraphCobillEdges' projection, so no key mirroring is
+// needed (unlike queryFestivalCobillNames' center mode).
+func (s *FestivalService) queryFestivalGraphCobillNames(festivalID uint, pairs []festivalCobillRow) (map[string][]string, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+
+	idSet := make(map[uint]struct{}, len(pairs)*2)
+	for _, p := range pairs {
+		idSet[p.ArtistA] = struct{}{}
+		idSet[p.ArtistB] = struct{}{}
+	}
+	idList := make([]uint, 0, len(idSet))
+	for id := range idSet {
+		idList = append(idList, id)
+	}
+
+	type nameRow struct {
+		ArtistA      uint
+		ArtistB      uint
+		FestivalName string
+	}
+	var results []nameRow
+	err := s.db.Raw(`
+		SELECT
+			fa1.artist_id AS artist_a,
+			fa2.artist_id AS artist_b,
+			f.name AS festival_name
+		FROM festival_artists fa1
+		JOIN festival_artists fa2 ON fa1.festival_id = fa2.festival_id
+			AND fa1.artist_id < fa2.artist_id
+		JOIN festivals f ON f.id = fa1.festival_id
+		WHERE fa1.festival_id <> ?
+			AND fa1.artist_id IN ? AND fa2.artist_id IN ?
+		ORDER BY f.start_date DESC, f.edition_year DESC
+	`, festivalID, idList, idList).Scan(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to query festival names (festival graph): %w", err)
+	}
+
+	wanted := make(map[string]struct{}, len(pairs))
+	for _, p := range pairs {
+		wanted[pairKey(p.ArtistA, p.ArtistB)] = struct{}{}
+	}
+
+	out := make(map[string][]string, len(pairs))
+	for _, r := range results {
+		key := pairKey(r.ArtistA, r.ArtistB)
+		if _, ok := wanted[key]; !ok {
+			continue
+		}
+		if len(out[key]) >= festivalCobillTopFestivalNames {
+			continue
+		}
+		out[key] = append(out[key], r.FestivalName)
+	}
+	return out, nil
+}

--- a/backend/internal/services/catalog/festival_graph.go
+++ b/backend/internal/services/catalog/festival_graph.go
@@ -371,9 +371,12 @@ func festivalTierClusterID(tier catalogm.BillingTier) string {
 // detail JSONB keeps the same shape ({festival_names, count,
 // most_recent_year}) so the frontend edge tooltip renders unchanged.
 //
-// No edge cap: the pair space is bounded by festivalGraphMaxNodes and the
-// requirement of a shared festival outside this one keeps real-world counts
-// sparse.
+// No edge cap: the pair space is hard-bounded by festivalGraphMaxNodes
+// (C(150,2) = 11,175 pairs worst case). Note the densest realistic case is
+// NOT rare: consecutive editions of the same series share large lineup
+// chunks, so every returning pair gets an edge via the prior edition. If
+// payload size becomes a problem there, add a LIMIT on this query (it is
+// already ordered strongest-edge-first).
 func (s *FestivalService) queryFestivalGraphCobillEdges(festivalID uint, lineupIDs []uint) ([]contracts.FestivalGraphLink, error) {
 	if len(lineupIDs) < 2 {
 		return nil, nil

--- a/backend/internal/services/catalog/festival_graph_test.go
+++ b/backend/internal/services/catalog/festival_graph_test.go
@@ -1,0 +1,422 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// FestivalGraphIntegrationSuite covers the PSY-1080 festival-scoped co-bill
+// graph endpoint.
+//
+// The endpoint stitches together: the festival's lineup (festival_artists),
+// billing-tier clustering, stored artist_relationships rows scoped to the
+// lineup set, and the query-time festival_cobill derivation that EXCLUDES the
+// festival being viewed (every lineup pair trivially shares this festival —
+// counting it would produce a structureless complete graph). These tests pin
+// down the tier clusters, the current-festival exclusion, the type allowlist
+// + filter semantics, is_isolate / is_cross_cluster derivation, and the
+// 150-node cap dropping from the bottom of the bill.
+type FestivalGraphIntegrationSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *FestivalService
+}
+
+func (s *FestivalGraphIntegrationSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.svc = &FestivalService{db: s.testDB.DB}
+}
+
+func (s *FestivalGraphIntegrationSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *FestivalGraphIntegrationSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	// Delete in FK-safe order.
+	_, _ = sqlDB.Exec("DELETE FROM festival_artists")
+	_, _ = sqlDB.Exec("DELETE FROM festival_venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM artist_relationships")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+}
+
+func TestFestivalGraphIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(FestivalGraphIntegrationSuite))
+}
+
+// --- Helpers ---
+
+func (s *FestivalGraphIntegrationSuite) createArtist(name string) *catalogm.Artist {
+	a := &catalogm.Artist{Name: name}
+	s.Require().NoError(s.db.Create(a).Error)
+	slug := fmt.Sprintf("artist-%d", a.ID)
+	s.db.Model(a).Update("slug", slug)
+	return a
+}
+
+func (s *FestivalGraphIntegrationSuite) createFestival(name, seriesSlug string, year int, startDate string) *contracts.FestivalDetailResponse {
+	req := &contracts.CreateFestivalRequest{
+		Name:        name,
+		SeriesSlug:  seriesSlug,
+		EditionYear: year,
+		StartDate:   startDate,
+		EndDate:     startDate,
+		Status:      "confirmed",
+	}
+	resp, err := s.svc.CreateFestival(req)
+	s.Require().NoError(err)
+	return resp
+}
+
+func (s *FestivalGraphIntegrationSuite) addToLineup(festivalID, artistID uint, tier string, position int) {
+	_, err := s.svc.AddFestivalArtist(festivalID, &contracts.AddFestivalArtistRequest{
+		ArtistID:    artistID,
+		BillingTier: tier,
+		Position:    position,
+	})
+	s.Require().NoError(err)
+}
+
+// seedTypedRelationship inserts a stored relationship of the given type.
+func (s *FestivalGraphIntegrationSuite) seedTypedRelationship(a, b uint, relType string, score float32) {
+	src, tgt := catalogm.CanonicalOrder(a, b)
+	rel := catalogm.ArtistRelationship{
+		SourceArtistID:   src,
+		TargetArtistID:   tgt,
+		RelationshipType: relType,
+		Score:            score,
+		AutoDerived:      true,
+	}
+	s.Require().NoError(s.db.Create(&rel).Error)
+}
+
+func linksByType(links []contracts.FestivalGraphLink) map[string][]contracts.FestivalGraphLink {
+	out := make(map[string][]contracts.FestivalGraphLink)
+	for _, l := range links {
+		out[l.Type] = append(out[l.Type], l)
+	}
+	return out
+}
+
+// --- Tests ---
+
+// TestGetFestivalGraph_NotFound: unknown festival id surfaces the typed
+// festival-not-found error (mapped to 404 by the handler).
+func (s *FestivalGraphIntegrationSuite) TestGetFestivalGraph_NotFound() {
+	_, err := s.svc.GetFestivalGraph(999999, nil)
+	s.Require().Error(err)
+	var festErr *apperrors.FestivalError
+	s.Require().ErrorAs(err, &festErr)
+	s.Equal(apperrors.CodeFestivalNotFound, festErr.Code)
+}
+
+// TestGetFestivalGraph_EmptyLineup: a festival with no artists yields an
+// empty graph with the festival info block populated and non-nil empty
+// arrays so the JSON contract is stable.
+func (s *FestivalGraphIntegrationSuite) TestGetFestivalGraph_EmptyLineup() {
+	fest := s.createFestival("Empty Fest 2026", "empty-fest", 2026, "2026-10-01")
+
+	graph, err := s.svc.GetFestivalGraph(fest.ID, nil)
+	s.Require().NoError(err)
+	s.Equal(fest.ID, graph.Festival.ID)
+	s.Equal("Empty Fest 2026", graph.Festival.Name)
+	s.Equal(fest.Slug, graph.Festival.Slug)
+	s.Equal(2026, graph.Festival.Year)
+	s.Equal(0, graph.Festival.ArtistCount)
+	s.Equal(0, graph.Festival.EdgeCount)
+	s.Empty(graph.Nodes)
+	s.Empty(graph.Links)
+	s.Empty(graph.Clusters)
+	s.NotNil(graph.Nodes, "nodes should be empty array, not nil")
+	s.NotNil(graph.Links, "links should be empty array, not nil")
+	s.NotNil(graph.Clusters, "clusters should be empty array, not nil")
+}
+
+// TestGetFestivalGraph_TierClustersAndCrossClusterFlags: lineup spread across
+// three tiers produces one cluster per tier (headliner-first, contiguous
+// color indices). Stored shared_bills edges are flagged is_cross_cluster only
+// when the endpoints sit on different tiers; lineup members without any edge
+// are isolates.
+func (s *FestivalGraphIntegrationSuite) TestGetFestivalGraph_TierClustersAndCrossClusterFlags() {
+	fest := s.createFestival("Tier Fest 2026", "tier-fest", 2026, "2026-10-01")
+
+	head1 := s.createArtist("Head One")
+	head2 := s.createArtist("Head Two")
+	mid1 := s.createArtist("Mid One")
+	mid2 := s.createArtist("Mid Two")
+	local1 := s.createArtist("Local One")
+
+	s.addToLineup(fest.ID, head1.ID, "headliner", 0)
+	s.addToLineup(fest.ID, head2.ID, "headliner", 1)
+	s.addToLineup(fest.ID, mid1.ID, "mid_card", 0)
+	s.addToLineup(fest.ID, mid2.ID, "mid_card", 1)
+	s.addToLineup(fest.ID, local1.ID, "local", 0)
+
+	// Intra-tier edge (headliner ↔ headliner) and cross-tier edge
+	// (headliner ↔ mid_card).
+	s.seedTypedRelationship(head1.ID, head2.ID, catalogm.RelationshipTypeSharedBills, 0.4)
+	s.seedTypedRelationship(head1.ID, mid1.ID, catalogm.RelationshipTypeSharedBills, 0.3)
+
+	graph, err := s.svc.GetFestivalGraph(fest.ID, nil)
+	s.Require().NoError(err)
+	s.Equal(5, graph.Festival.ArtistCount)
+	s.Equal(2, graph.Festival.EdgeCount)
+
+	// Clusters: headliner (2), mid_card (2), local (1) — in that order with
+	// contiguous color indices.
+	s.Require().Len(graph.Clusters, 3)
+	s.Equal("tier_headliner", graph.Clusters[0].ID)
+	s.Equal("Headliner", graph.Clusters[0].Label)
+	s.Equal(2, graph.Clusters[0].Size)
+	s.Equal(0, graph.Clusters[0].ColorIndex)
+	s.Equal("tier_mid_card", graph.Clusters[1].ID)
+	s.Equal(2, graph.Clusters[1].Size)
+	s.Equal(1, graph.Clusters[1].ColorIndex)
+	s.Equal("tier_local", graph.Clusters[2].ID)
+	s.Equal(1, graph.Clusters[2].Size)
+	s.Equal(2, graph.Clusters[2].ColorIndex)
+
+	// Nodes are in bill order (tier rank, then position) and carry tier
+	// cluster ids.
+	s.Require().Len(graph.Nodes, 5)
+	s.Equal(head1.ID, graph.Nodes[0].ID)
+	s.Equal(head2.ID, graph.Nodes[1].ID)
+	clusterByArtist := make(map[uint]string, 5)
+	isolateByArtist := make(map[uint]bool, 5)
+	for _, n := range graph.Nodes {
+		clusterByArtist[n.ID] = n.ClusterID
+		isolateByArtist[n.ID] = n.IsIsolate
+	}
+	s.Equal("tier_headliner", clusterByArtist[head1.ID])
+	s.Equal("tier_mid_card", clusterByArtist[mid1.ID])
+	s.Equal("tier_local", clusterByArtist[local1.ID])
+
+	// Edge cross-cluster flags: intra-tier edge false, cross-tier edge true.
+	var intra, cross int
+	for _, l := range graph.Links {
+		s.Equal(catalogm.RelationshipTypeSharedBills, l.Type)
+		if l.IsCrossCluster {
+			cross++
+		} else {
+			intra++
+		}
+	}
+	s.Equal(1, intra)
+	s.Equal(1, cross)
+
+	// Isolates: mid2 and local1 have no edges.
+	s.False(isolateByArtist[head1.ID])
+	s.False(isolateByArtist[head2.ID])
+	s.False(isolateByArtist[mid1.ID])
+	s.True(isolateByArtist[mid2.ID])
+	s.True(isolateByArtist[local1.ID])
+}
+
+// TestGetFestivalGraph_CobillExcludesCurrentFestival: every pair on the
+// lineup shares THIS festival by definition, so cobill edges must count only
+// OTHER shared festivals. A+B also share "Other Fest" → exactly one
+// festival_cobill edge with count=1 and the other festival's name in detail;
+// A+C and B+C (who share nothing but this festival) get no edge.
+func (s *FestivalGraphIntegrationSuite) TestGetFestivalGraph_CobillExcludesCurrentFestival() {
+	fest := s.createFestival("Main Fest 2026", "main-fest", 2026, "2026-10-01")
+	other := s.createFestival("Other Fest 2026", "other-fest", 2026, "2026-03-01")
+
+	a := s.createArtist("Artist A")
+	b := s.createArtist("Artist B")
+	c := s.createArtist("Artist C")
+
+	s.addToLineup(fest.ID, a.ID, "headliner", 0)
+	s.addToLineup(fest.ID, b.ID, "mid_card", 0)
+	s.addToLineup(fest.ID, c.ID, "mid_card", 1)
+
+	s.addToLineup(other.ID, a.ID, "mid_card", 0)
+	s.addToLineup(other.ID, b.ID, "mid_card", 1)
+
+	graph, err := s.svc.GetFestivalGraph(fest.ID, nil)
+	s.Require().NoError(err)
+	s.Equal(3, graph.Festival.ArtistCount)
+
+	byType := linksByType(graph.Links)
+	cobill := byType["festival_cobill"]
+	s.Require().Len(cobill, 1, "only the A-B pair shares a festival other than the one being viewed")
+	s.Equal(1, graph.Festival.EdgeCount)
+
+	edge := cobill[0]
+	srcA, tgtB := catalogm.CanonicalOrder(a.ID, b.ID)
+	s.Equal(srcA, edge.SourceID)
+	s.Equal(tgtB, edge.TargetID)
+	// 1 shared (other) festival, started 2026-03-01 → within the 2-year
+	// recency window: min(1/3, 1.0) * 1.2 = 0.4.
+	s.InDelta(0.4, edge.Score, 0.0001)
+	// Headliner ↔ mid_card on this bill → cross-cluster.
+	s.True(edge.IsCrossCluster)
+
+	detail, ok := edge.Detail.(map[string]interface{})
+	s.Require().True(ok, "cobill detail should be the PSY-363 map shape")
+	s.Equal(1, detail["count"])
+	s.Equal("Other Fest 2026", detail["festival_names"])
+	s.Equal(2026, detail["most_recent_year"])
+
+	// C shares only the viewed festival with A/B → isolate.
+	for _, n := range graph.Nodes {
+		if n.ID == c.ID {
+			s.True(n.IsIsolate, "artist C must be an isolate")
+		} else {
+			s.False(n.IsIsolate)
+		}
+	}
+}
+
+// TestGetFestivalGraph_StoredTypesAllowlist: stored edges between lineup
+// members come through with their type field intact for every allowlisted
+// type; member_of is filtered out; edges touching a non-lineup artist are
+// excluded.
+func (s *FestivalGraphIntegrationSuite) TestGetFestivalGraph_StoredTypesAllowlist() {
+	fest := s.createFestival("Allow Fest 2026", "allow-fest", 2026, "2026-10-01")
+
+	a := s.createArtist("Allow A")
+	b := s.createArtist("Allow B")
+	c := s.createArtist("Allow C")
+	outsider := s.createArtist("Outsider")
+
+	s.addToLineup(fest.ID, a.ID, "headliner", 0)
+	s.addToLineup(fest.ID, b.ID, "mid_card", 0)
+	s.addToLineup(fest.ID, c.ID, "mid_card", 1)
+
+	s.seedTypedRelationship(a.ID, b.ID, catalogm.RelationshipTypeSharedBills, 0.5)
+	s.seedTypedRelationship(a.ID, c.ID, catalogm.RelationshipTypeSharedLabel, 0.5)
+	s.seedTypedRelationship(b.ID, c.ID, catalogm.RelationshipTypeSimilar, 0.5)
+	s.seedTypedRelationship(a.ID, b.ID, catalogm.RelationshipTypeRadioCooccurrence, 0.5)
+	// Not allowlisted at festival scope.
+	s.seedTypedRelationship(b.ID, c.ID, catalogm.RelationshipTypeMemberOf, 0.5)
+	// Allowlisted type, but one endpoint is off the lineup.
+	s.seedTypedRelationship(a.ID, outsider.ID, catalogm.RelationshipTypeSharedBills, 0.5)
+
+	graph, err := s.svc.GetFestivalGraph(fest.ID, nil)
+	s.Require().NoError(err)
+
+	byType := linksByType(graph.Links)
+	s.Len(byType[catalogm.RelationshipTypeSharedBills], 1)
+	s.Len(byType[catalogm.RelationshipTypeSharedLabel], 1)
+	s.Len(byType[catalogm.RelationshipTypeSimilar], 1)
+	s.Len(byType[catalogm.RelationshipTypeRadioCooccurrence], 1)
+	s.Empty(byType[catalogm.RelationshipTypeMemberOf], "member_of is not allowlisted at festival scope")
+	s.Equal(4, graph.Festival.EdgeCount)
+
+	// The outsider edge is gone and the outsider is not a node.
+	for _, n := range graph.Nodes {
+		s.NotEqual(outsider.ID, n.ID)
+	}
+}
+
+// TestGetFestivalGraph_TypeFilter: a types filter restricts the edge set; a
+// non-empty filter that resolves to nothing yields zero edges (not "all
+// types"), leaving every node an isolate.
+func (s *FestivalGraphIntegrationSuite) TestGetFestivalGraph_TypeFilter() {
+	fest := s.createFestival("Filter Fest 2026", "filter-fest", 2026, "2026-10-01")
+	other := s.createFestival("Filter Other 2026", "filter-other", 2026, "2026-03-01")
+
+	a := s.createArtist("Filter A")
+	b := s.createArtist("Filter B")
+	s.addToLineup(fest.ID, a.ID, "headliner", 0)
+	s.addToLineup(fest.ID, b.ID, "mid_card", 0)
+	s.addToLineup(other.ID, a.ID, "mid_card", 0)
+	s.addToLineup(other.ID, b.ID, "mid_card", 1)
+
+	s.seedTypedRelationship(a.ID, b.ID, catalogm.RelationshipTypeSharedBills, 0.5)
+
+	// shared_bills only: the cobill edge (A+B share "Filter Other") is excluded.
+	graph, err := s.svc.GetFestivalGraph(fest.ID, []string{"shared_bills"})
+	s.Require().NoError(err)
+	s.Require().Len(graph.Links, 1)
+	s.Equal(catalogm.RelationshipTypeSharedBills, graph.Links[0].Type)
+
+	// festival_cobill only: the stored edge is excluded.
+	graph, err = s.svc.GetFestivalGraph(fest.ID, []string{"festival_cobill"})
+	s.Require().NoError(err)
+	s.Require().Len(graph.Links, 1)
+	s.Equal("festival_cobill", graph.Links[0].Type)
+
+	// Unknown-only filter short-circuits to zero edges.
+	graph, err = s.svc.GetFestivalGraph(fest.ID, []string{"bogus_type"})
+	s.Require().NoError(err)
+	s.Empty(graph.Links)
+	s.Equal(0, graph.Festival.EdgeCount)
+	for _, n := range graph.Nodes {
+		s.True(n.IsIsolate)
+	}
+}
+
+// TestGetFestivalGraph_NodeCapKeepsTopOfBill: a lineup over
+// festivalGraphMaxNodes is capped at the ceiling, dropping from the bottom
+// of the bill (tier rank, then position, then name) — headliners always stay.
+func (s *FestivalGraphIntegrationSuite) TestGetFestivalGraph_NodeCapKeepsTopOfBill() {
+	fest := s.createFestival("Cap Fest 2026", "cap-fest", 2026, "2026-10-01")
+
+	headliners := make([]*catalogm.Artist, 0, 3)
+	for i := 0; i < 3; i++ {
+		a := s.createArtist(fmt.Sprintf("Cap Head %d", i))
+		s.addToLineup(fest.ID, a.ID, "headliner", i)
+		headliners = append(headliners, a)
+	}
+
+	// 150 undercard artists → 153 total, 3 over the cap. Insert the lineup
+	// rows in one batch to keep the test fast.
+	undercards := make([]catalogm.Artist, 150)
+	for i := range undercards {
+		undercards[i] = catalogm.Artist{Name: fmt.Sprintf("Cap Under %03d", i)}
+	}
+	s.Require().NoError(s.db.CreateInBatches(&undercards, 100).Error)
+	lineupRows := make([]catalogm.FestivalArtist, 0, len(undercards))
+	for i := range undercards {
+		lineupRows = append(lineupRows, catalogm.FestivalArtist{
+			FestivalID:  fest.ID,
+			ArtistID:    undercards[i].ID,
+			BillingTier: catalogm.BillingTierUndercard,
+		})
+	}
+	s.Require().NoError(s.db.CreateInBatches(&lineupRows, 100).Error)
+
+	graph, err := s.svc.GetFestivalGraph(fest.ID, nil)
+	s.Require().NoError(err)
+	s.Equal(festivalGraphMaxNodes, graph.Festival.ArtistCount)
+	s.Require().Len(graph.Nodes, festivalGraphMaxNodes)
+
+	present := make(map[uint]bool, len(graph.Nodes))
+	for _, n := range graph.Nodes {
+		present[n.ID] = true
+	}
+	for _, h := range headliners {
+		s.Truef(present[h.ID], "headliner %q must survive the node cap", h.Name)
+	}
+	// Undercards sort by name within the tier (position all 0); the cap
+	// leaves room for 147 of 150, so the last three by name are dropped.
+	for i := 0; i < 147; i++ {
+		s.Truef(present[undercards[i].ID], "undercard %03d should be inside the cap", i)
+	}
+	for i := 147; i < 150; i++ {
+		s.Falsef(present[undercards[i].ID], "undercard %03d should be dropped by the cap", i)
+	}
+
+	// Cluster sizes reflect the capped node set.
+	s.Require().Len(graph.Clusters, 2)
+	s.Equal("tier_headliner", graph.Clusters[0].ID)
+	s.Equal(3, graph.Clusters[0].Size)
+	s.Equal("tier_undercard", graph.Clusters[1].ID)
+	s.Equal(147, graph.Clusters[1].Size)
+}

--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -675,12 +675,12 @@ func (s *SceneService) GetSceneGraph(city, state string, types []string) (*contr
 	}
 
 	// 4. Batch query upcoming-show-count for every node (mirror GetArtistGraph §4).
-	upcomingByArtist := s.batchUpcomingShowCount(artistIDs)
+	upcomingByArtist := batchUpcomingShowCount(s.db, artistIDs)
 
 	// 5. Query in-scope relationships — both endpoints in the scene's artist set.
 	var links []sceneRelationshipRow
 	if !noEdgesByFilter {
-		fetched, err := s.querySceneRelationships(artistIDs, resolvedTypes)
+		fetched, err := queryRelationshipsAmongArtists(s.db, artistIDs, resolvedTypes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query scene relationships: %w", err)
 		}
@@ -835,17 +835,19 @@ func (s *SceneService) querySceneArtistsWithPrimaryVenue(city, state string) ([]
 	return rows, nil
 }
 
-// querySceneRelationships fetches all stored relationships where BOTH source
-// and target artist IDs are in the scene's artist set, optionally filtered to
-// the resolved type list. The relationships table already pre-filters
-// shared_bills below the production threshold (see DeriveSharedBills minShows
-// default), so no `min_weight` query parameter is needed at v1.
-func (s *SceneService) querySceneRelationships(artistIDs []uint, types []string) ([]sceneRelationshipRow, error) {
+// queryRelationshipsAmongArtists fetches all stored relationships where BOTH
+// source and target artist IDs are in the given artist set, optionally
+// filtered to the resolved type list. The relationships table already
+// pre-filters shared_bills below the production threshold (see
+// DeriveSharedBills minShows default), so no `min_weight` query parameter is
+// needed at v1. Shared by the scene graph (PSY-367) and the festival graph
+// (PSY-1080).
+func queryRelationshipsAmongArtists(db *gorm.DB, artistIDs []uint, types []string) ([]sceneRelationshipRow, error) {
 	if len(artistIDs) < 2 {
 		return nil, nil
 	}
 	var rows []sceneRelationshipRow
-	q := s.db.Table("artist_relationships").
+	q := db.Table("artist_relationships").
 		Select("source_artist_id, target_artist_id, relationship_type, score, detail").
 		Where("source_artist_id IN ? AND target_artist_id IN ?", artistIDs, artistIDs)
 	if len(types) > 0 {

--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -675,7 +675,7 @@ func (s *SceneService) GetSceneGraph(city, state string, types []string) (*contr
 	}
 
 	// 4. Batch query upcoming-show-count for every node (mirror GetArtistGraph §4).
-	upcomingByArtist := batchUpcomingShowCount(s.db, artistIDs)
+	upcomingByArtist := s.batchUpcomingShowCount(artistIDs)
 
 	// 5. Query in-scope relationships — both endpoints in the scene's artist set.
 	var links []sceneRelationshipRow

--- a/backend/internal/services/contracts/festival.go
+++ b/backend/internal/services/contracts/festival.go
@@ -149,6 +149,65 @@ type AddFestivalVenueRequest struct {
 }
 
 // ──────────────────────────────────────────────
+// Festival graph (PSY-1080) — co-bill subgraph of a single festival's lineup
+// ──────────────────────────────────────────────
+
+// FestivalGraphResponse is the payload for GET /festivals/{festival_id}/graph.
+// Mirrors SceneGraphResponse field-for-field (`scene` → `festival`) so the
+// frontend ForceGraphView renders either payload unchanged.
+type FestivalGraphResponse struct {
+	Festival FestivalGraphInfo      `json:"festival"`
+	Clusters []FestivalGraphCluster `json:"clusters"`
+	Nodes    []FestivalGraphNode    `json:"nodes"`
+	Links    []FestivalGraphLink    `json:"links"`
+}
+
+// FestivalGraphInfo holds festival metadata for the graph response. Fields
+// mirror SceneGraphInfo (slug + counts) plus festival-specific identifiers.
+type FestivalGraphInfo struct {
+	ID          uint   `json:"id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Year        int    `json:"year"`
+	ArtistCount int    `json:"artist_count"` // lineup artists in the response (includes isolates; capped)
+	EdgeCount   int    `json:"edge_count"`   // total edges in the response (post type-filter)
+}
+
+// FestivalGraphCluster groups lineup artists by billing tier (the cluster
+// signal at festival scope — see PSY-1080). Matches the SceneGraphCluster
+// shape so the same ForceGraphView legend renders both.
+type FestivalGraphCluster struct {
+	ID         string `json:"id"`          // "tier_<billing_tier>" or "other"
+	Label      string `json:"label"`       // human-readable tier name or "Other"
+	Size       int    `json:"size"`        // number of lineup artists in this tier
+	ColorIndex int    `json:"color_index"` // 0-7 = Okabe-Ito index; -1 = "other" (grey)
+}
+
+// FestivalGraphNode mirrors SceneGraphNode — an artist on the festival's bill.
+type FestivalGraphNode struct {
+	ID                uint   `json:"id"`
+	Name              string `json:"name"`
+	Slug              string `json:"slug"`
+	City              string `json:"city,omitempty"`
+	State             string `json:"state,omitempty"`
+	UpcomingShowCount int    `json:"upcoming_show_count"`
+	ClusterID         string `json:"cluster_id"` // matches FestivalGraphCluster.ID
+	IsIsolate         bool   `json:"is_isolate"` // true when the artist has no in-lineup edges (post type-filter)
+}
+
+// FestivalGraphLink mirrors SceneGraphLink — a relationship between two
+// lineup artists. `type` is preserved from the source signal (shared_bills,
+// shared_label, similar, radio_cooccurrence, festival_cobill).
+type FestivalGraphLink struct {
+	SourceID       uint    `json:"source_id"`
+	TargetID       uint    `json:"target_id"`
+	Type           string  `json:"type"`
+	Score          float64 `json:"score"`
+	Detail         any     `json:"detail,omitempty"`
+	IsCrossCluster bool    `json:"is_cross_cluster"` // derived: source.cluster_id != target.cluster_id
+}
+
+// ──────────────────────────────────────────────
 // Festival Service Interface
 // ──────────────────────────────────────────────
 
@@ -169,4 +228,5 @@ type FestivalServiceInterface interface {
 	AddFestivalVenue(festivalID uint, req *AddFestivalVenueRequest) (*FestivalVenueResponse, error)
 	RemoveFestivalVenue(festivalID, venueID uint) error
 	GetFestivalsForArtist(artistID uint) ([]*ArtistFestivalListResponse, error)
+	GetFestivalGraph(festivalID uint, types []string) (*FestivalGraphResponse, error)
 }


### PR DESCRIPTION
## Summary

Adds `GET /festivals/{festival_id}/graph` (ID or slug): the co-bill subgraph of a festival's lineup, in the scene-graph shape so `ForceGraphView` consumes it unchanged.

- **Nodes** — `festival_artists` lineup, lineup-complete with a hard 150-node ceiling that drops from the bottom of the bill (tier rank → position → name), so headliners always survive the cap.
- **Clusters** — billing tiers (headliner-first, contiguous Okabe-Ito color indices; unknown tiers roll into `other`/-1).
- **Links** — query-time `festival_cobill` edges among lineup pairs **excluding the viewed festival** (every pair trivially shares it; counting it would produce a structureless complete graph), plus stored typed edges (`shared_bills`, `shared_label`, `similar`, `radio_cooccurrence`) between lineup members, `type` intact. `is_isolate` / `is_cross_cluster` precomputed server-side. `types` query param filters with the scene-graph semantics (empty = all allowed; unknown-only filter = zero edges).
- **Contract** — `FestivalGraphResponse` mirrors `SceneGraphResponse` field-for-field (`scene` → `festival` info block: id, slug, name, year, artist_count, edge_count).
- Promotes `scene.go`'s `querySceneRelationships` / `batchUpcomingShowCount` to package-level functions shared by both graphs. Cobill scoring/detail reuses the PSY-363 helpers (`festivalCobillScore`, identical detail JSONB shape). No new tables or migrations.

**OpenAPI**: additive only — one new GET path + the `FestivalGraph*` schemas, registered like the sibling festival GETs (public, `rc.API`). `mocks_gen.go` verified against `go generate` (zero diff).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/services/catalog/ -run "Festival" -v -timeout 300s` — all pass (incl. the 7 new FestivalGraph tests)
- [x] `go test ./internal/services/... -timeout 600s` — ok
- [x] `go test ./internal/api/... -timeout 600s` — ok (incl. fresh `internal/api/routes` run covering the new route registration)
- [x] `go test ./cmd/... ./db/... ./internal/auth/... ./internal/config/... ./internal/errors/... ./internal/logger/... ./internal/models/... ./internal/respond/... ./internal/scoring/... ./internal/seeddata/... ./internal/testenv/... ./internal/testutil/... ./internal/utils/... -timeout 600s` — ok (full `./...` coverage across chunks)
- [x] `go generate ./internal/api/handlers/shared/testhelpers/` → zero diff (mock edit matches generator)

## Manual repro

Backend-only (dispatch mode `none`); the integration tests are the repro (PSY-592 pattern) — `FestivalGraphIntegrationSuite` in `backend/internal/services/catalog/festival_graph_test.go`:

- `TestGetFestivalGraph_CobillExcludesCurrentFestival` — A+B share one *other* festival → exactly one `festival_cobill` edge, score 0.4 (1 shared, recency-boosted), detail `{count: 1, festival_names: "Other Fest 2026", most_recent_year: 2026}`; C (shares only the viewed festival) is an isolate.
- `TestGetFestivalGraph_TierClustersAndCrossClusterFlags` — 3 tiers → 3 clusters headliner-first with contiguous color indices; intra-tier edge `is_cross_cluster=false`, cross-tier `true`; edge-less lineup members are isolates.
- `TestGetFestivalGraph_StoredTypesAllowlist` — all 4 stored types pass through with `type` intact; `member_of` filtered; edges touching non-lineup artists excluded.
- `TestGetFestivalGraph_TypeFilter` — `shared_bills`-only excludes cobill and vice versa; unknown-only filter short-circuits to zero edges (not "all types").
- `TestGetFestivalGraph_NodeCapKeepsTopOfBill` — 153-artist lineup capped at 150; all 3 headliners survive; the bottom 3 undercards (by name) are dropped; cluster sizes reflect the capped set.
- Plus `_NotFound` (typed 404) and `_EmptyLineup` (non-nil empty arrays, populated festival info).

## Code review

`/code-review` (high effort, lenses run inline — dispatched sub-agent, no Agent tool): **no findings**. Verified: cross-file callers of the promoted scene helpers; single concrete `FestivalServiceInterface` implementation (compile-asserted) + mock both updated; cobill SQL exclusion + canonical ordering + score math pinned by tests; the cross-edge SQL mirror of `queryFestivalCobillRows` judged acceptable duplication (different service, different exclusion semantics, cross-referenced comments, shared scoring/detail helpers).

## Adversarial review

`/adversarial-review` — **CONCERNS**, 1 finding addressed in `64a861a1`.
- [MEDIUM] No edge cap on the cobill derivation; the in-code "sparse" claim overstated — consecutive editions of a series share large lineup chunks, so returnee pairs each get an edge (hard-bounded at C(150,2)=11,175). Comment corrected to the honest bound + escape hatch (query is already ordered strongest-first, so a LIMIT is a one-liner if payload size becomes a problem). **Deferred**: choosing an edge-cap number is a design decision; behavior unchanged.
- [LOW] SQL duplication vs `queryFestivalCobillRows` cross-edge mode (mitigated, see code review) · defensive paths ("other" cluster, best-effort name-query failure) untested — author's discretion.
Panel: Saboteur · Future-Maintainer · Security · Completeness, run inline against the branch diff (dispatched sub-agent — no Agent tool; per-repo convention). Security: parameterized SQL throughout, types whitelisted before the query, public surface consistent with sibling festival GETs. Completeness: all PSY-1080 acceptance criteria verified.

## Takeover note

Prior dispatched agent stalled at the full-suite test run; this session verified the implementation against the ticket contract, committed, rebased onto latest main (radio wave PSY-1075..1078), and completed the review pipeline.

Closes PSY-1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)
