### PR TITLE
PSY-1071: Cmd+K Clear-recent as a CommandItem (AT-reachable)

### DIFF
--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -365,14 +365,54 @@ describe('CommandPalette', () => {
     })
     expect(screen.getByText('Recent')).toBeInTheDocument()
 
-    // Click the inline "Clear" button on the Recent header. cmdk renders
-    // the heading itself with role="button" whose accessible name includes
-    // child text ("Recent Clear"); the actual <button> is a child element,
-    // so target it by text instead of role.
-    await user.click(screen.getByText('Clear'))
+    // PSY-1071: Clear is a CommandItem row (role="option") at the end of
+    // the Recent group — no longer a button inside the aria-hidden heading.
+    await user.click(screen.getByRole('option', { name: /clear recent searches/i }))
 
-    // Recent group disappears immediately
+    // Recent group disappears immediately, palette stays open
     expect(screen.queryByText('Recent')).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  // PSY-1071: the old Clear button lived inside the cmdk group heading,
+  // which cmdk renders with aria-hidden="true" — invisible to AT (WCAG
+  // 4.1.2). As a CommandItem it must be exposed as an option with an
+  // accessible name and operable via the existing arrow-key model.
+  it('clear-recent is an AT-visible option and keyboard-operable (PSY-1071)', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CommandPalette />)
+
+    // Seed a recent entry, then reopen
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+    await user.click(screen.getByText('Shows'))
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+    expect(screen.getByText('Recent')).toBeInTheDocument()
+
+    // getByRole excludes aria-hidden subtrees by default, so this both
+    // finds the control by accessible name AND proves AT can reach it.
+    const clearItem = screen.getByRole('option', { name: /clear recent searches/i })
+    expect(clearItem.closest('[aria-hidden="true"]')).toBeNull()
+
+    // Keyboard path: first option (the recent entry) is auto-selected on
+    // open; one ArrowDown lands on the clear row, Enter activates it.
+    await user.keyboard('{ArrowDown}{Enter}')
+
+    expect(screen.queryByText('Recent')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('option', { name: /clear recent searches/i })
+    ).not.toBeInTheDocument()
+    // Clearing keeps the palette open and triggers no navigation beyond
+    // the seeding click on Shows.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(mockPush).toHaveBeenCalledTimes(1)
   })
 
   it('navigates to an entity result when an entity row is clicked', async () => {

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -13,7 +13,8 @@ import {
 // PSY-1019: rows are icon-less in the editorial re-skin (Figma 539:5) — the
 // uppercase mono group headings carry the wayfinding, so names sit flush-left.
 // The Recent clock is the one deliberate exception: in the no-query state it
-// distinguishes "something you searched before" from a live result.
+// distinguishes "something you searched before" from a live result. The X on
+// the clear-recent action row (PSY-1071) marks it as an action, not a result.
 import { Search, Clock, X, Loader2 } from 'lucide-react'
 import { adminNavGroups, adminTabHref } from '@/components/layout/adminNav'
 import type { AdminTab } from '@/components/layout/adminNav'
@@ -436,23 +437,7 @@ export function CommandPalette() {
         )}
 
         {showRecent && (
-          <CommandGroup
-            className={groupClassName}
-            heading={
-              <div className="flex items-center justify-between">
-                <span>Recent</span>
-                <button
-                  onClick={handleClearRecent}
-                  // font-sans + normal-case break the inheritance from the
-                  // mono/uppercase group-heading styles — this is an action,
-                  // not a heading.
-                  className="font-sans text-[10px] font-normal normal-case tracking-normal text-muted-foreground hover:text-foreground"
-                >
-                  Clear
-                </button>
-              </div>
-            }
-          >
+          <CommandGroup className={groupClassName} heading="Recent">
             {recentSearches.map(label => {
               const route = allRoutes.find(
                 r => r.label.toLowerCase() === label.toLowerCase()
@@ -475,6 +460,19 @@ export function CommandPalette() {
                 </CommandItem>
               )
             })}
+            {/* PSY-1071: Clear lives as a row, not in the group heading —
+                cmdk renders headings aria-hidden, so a button there is
+                invisible to AT (WCAG 4.1.2). As a CommandItem it rides the
+                existing arrow-key model and is announced as an option.
+                Muted styling marks it as an action, not a destination. */}
+            <CommandItem
+              value="clear-recent"
+              onSelect={handleClearRecent}
+              className="cursor-pointer gap-3 rounded-sm px-2 py-2.5 text-[13px] text-muted-foreground"
+            >
+              <X className="h-4 w-4" />
+              <span>Clear recent searches</span>
+            </CommandItem>
           </CommandGroup>
         )}
 


### PR DESCRIPTION
## Summary

The Cmd+K palette's "Clear" button for recent searches lived inside the Recent `CommandGroup`'s `heading` prop. cmdk renders heading containers with `aria-hidden="true"` (verified in `cmdk/dist/index.mjs` — `"cmdk-group-heading":"","aria-hidden":!0`), so the button was invisible to assistive tech (WCAG 2.1 SC 4.1.2).

Per the ticket's recommended option, the Clear affordance is now a `CommandItem` (`value="clear-recent"`) at the end of the Recent group:

- Rides the existing arrow-key selection model (no bespoke keyboard handling).
- Announced by AT as an option with the accessible name "Clear recent searches" (`aria-activedescendant` tracks it like every other row).
- Activating it fires `handleClearRecent`, the Recent group unmounts, the palette stays open, and cmdk re-selects the first remaining option.
- The heading goes back to a plain `"Recent"` string; the muted action-row styling keeps the PSY-1019 editorial register (X icon marks it as an action, not a result).

Edge cases: the row only renders when recents exist (`showRecent` requires length > 0), so it can never appear alone or leak into filtered results (`!search` gate); `value="clear-recent"` cannot collide with `recent-*` item values.

## Test plan

- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run lint` — 0 errors (145 pre-existing warnings in unrelated files)
- [x] `cd frontend && bun run test:run components/layout` — 16 files / 204 tests passed, including:
  - new `clear-recent is an AT-visible option and keyboard-operable (PSY-1071)` — asserts `getByRole('option', { name: /clear recent searches/i })` resolves (role queries exclude aria-hidden subtrees), `closest('[aria-hidden="true"]')` is null, ArrowDown+Enter clears recents, palette stays open, no navigation fires
  - updated `clearing recent searches removes the Recent group from the palette` — now clicks the option by role+name instead of bare text

## Manual repro (isolated dispatch stack + agent-browser)

1. Open app → ⌘K → select "Shows" to seed a recent entry.
2. Reopen ⌘K: a11y tree shows `option "Clear recent searches"` inside the listbox (previously absent — the heading subtree is aria-hidden).
3. ArrowDown to the Clear row → Enter: Recent group disappears, palette stays open, URL unchanged.

| Before (Recent + Clear row) | Clear row keyboard-selected | After Enter (recents gone, palette open) |
| --- | --- | --- |
| ![before](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1071-screenshots/01-before-recent-with-clear-row.png) | ![selected](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1071-screenshots/02-clear-row-keyboard-selected.png) | ![after](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1071-screenshots/03-after-clear-recents-gone-palette-open.png) |

## Code review

Run inline (dispatched agent — no Agent tool; per project convention). All candidates refuted: value collision impossible (`recent-` prefix), filter leakage impossible (`!search` gate), cmdk re-selects after item unmount (verified in dist source + live), accessible name unpolluted by the X svg (live a11y tree). No findings; no fix commit.

## Adversarial review

Run inline, 4 lenses — verdict CLEAN, no blocks. Saboteur: empty-recents / Clear-as-only-item impossible by the `showRecent` gate; double-Enter safe. Completeness vs WCAG 4.1.2: name/role/state/keyboard/announcement all verified by test + live tree. One pre-existing out-of-scope observation: recents seeded from entity selections are no-op rows in `handleRecentSelect` (only route labels resolve) — predates this change, untouched.

Closes PSY-1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)
