### PR TITLE
PSY-1029: slim cookie-consent bar — keep first-paint content visible

### DIFF
--- a/frontend/components/layout/CookieConsentBanner.test.tsx
+++ b/frontend/components/layout/CookieConsentBanner.test.tsx
@@ -152,8 +152,9 @@ describe('CookieConsentBanner', () => {
     // the space once consent is given and the bar unmounts.
     it('reserves body bottom padding while visible and clears it on unmount', () => {
       const { unmount } = render(<CookieConsentBanner />)
-      // jsdom reports offsetHeight 0; the contract is that SOME padding is set.
-      expect(document.body.style.paddingBottom).toBe('0px')
+      // jsdom reports offsetHeight 0, so the value is '0px' here; the contract
+      // under test is that SOME padding is set while the bar is mounted.
+      expect(document.body.style.paddingBottom).not.toBe('')
 
       unmount()
       expect(document.body.style.paddingBottom).toBe('')
@@ -161,7 +162,7 @@ describe('CookieConsentBanner', () => {
 
     it('clears reserved body padding when consent is given (banner hides)', () => {
       const { rerender } = render(<CookieConsentBanner />)
-      expect(document.body.style.paddingBottom).toBe('0px')
+      expect(document.body.style.paddingBottom).not.toBe('')
 
       mockUseCookieConsent.mockReturnValue({
         showBanner: false,

--- a/frontend/components/layout/CookieConsentBanner.test.tsx
+++ b/frontend/components/layout/CookieConsentBanner.test.tsx
@@ -68,11 +68,6 @@ describe('CookieConsentBanner', () => {
   })
 
   describe('when banner should be shown', () => {
-    it('renders the banner with "Cookie Preferences" heading', () => {
-      render(<CookieConsentBanner />)
-      expect(screen.getByText('Cookie Preferences')).toBeInTheDocument()
-    })
-
     it('renders description text', () => {
       render(<CookieConsentBanner />)
       expect(screen.getByText(/We use cookies to improve your experience/)).toBeInTheDocument()
@@ -150,6 +145,44 @@ describe('CookieConsentBanner', () => {
     it('does not show GPC signal notice when not detected', () => {
       render(<CookieConsentBanner />)
       expect(screen.queryByText(/Global Privacy Control signal/)).not.toBeInTheDocument()
+    })
+
+    // PSY-1029: the fixed bar reserves matching scroll space on <body> so it
+    // never makes document-end content (the footer) unreachable, and releases
+    // the space once consent is given and the bar unmounts.
+    it('reserves body bottom padding while visible and clears it on unmount', () => {
+      const { unmount } = render(<CookieConsentBanner />)
+      // jsdom reports offsetHeight 0; the contract is that SOME padding is set.
+      expect(document.body.style.paddingBottom).toBe('0px')
+
+      unmount()
+      expect(document.body.style.paddingBottom).toBe('')
+    })
+
+    it('clears reserved body padding when consent is given (banner hides)', () => {
+      const { rerender } = render(<CookieConsentBanner />)
+      expect(document.body.style.paddingBottom).toBe('0px')
+
+      mockUseCookieConsent.mockReturnValue({
+        showBanner: false,
+        gpcSignalDetected: false,
+        acceptAll: mockAcceptAll,
+        rejectAll: mockRejectAll,
+        openPreferences: mockOpenPreferences,
+        closePreferences: mockClosePreferences,
+        savePreferences: mockSavePreferences,
+        preferencesOpen: false,
+        consent: {
+          version: 1,
+          timestamp: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 86400000).toISOString(),
+          gpcDetected: false,
+          categories: { essential: true, analytics: true },
+          consentMethod: 'banner_accept_all' as const,
+        },
+      })
+      rerender(<CookieConsentBanner />)
+      expect(document.body.style.paddingBottom).toBe('')
     })
   })
 

--- a/frontend/components/layout/CookieConsentBanner.tsx
+++ b/frontend/components/layout/CookieConsentBanner.tsx
@@ -13,19 +13,9 @@ import { CookiePreferencesDialog } from './CookiePreferencesDialog'
  * so content at the document end (the footer) stays reachable by scrolling
  * rather than being permanently covered until the visitor consents. */
 
-interface ConsentBarProps {
-  gpcSignalDetected: boolean
-  acceptAll: () => void
-  rejectAll: () => void
-  openPreferences: () => void
-}
-
-function ConsentBar({
-  gpcSignalDetected,
-  acceptAll,
-  rejectAll,
-  openPreferences,
-}: ConsentBarProps) {
+function ConsentBar() {
+  const { gpcSignalDetected, acceptAll, rejectAll, openPreferences } =
+    useCookieConsent()
   const barRef = useRef<HTMLDivElement>(null)
 
   // Reserve scroll space matching the bar's rendered height (it varies with
@@ -95,9 +85,6 @@ export function CookieConsentBanner() {
   const {
     showBanner,
     gpcSignalDetected,
-    acceptAll,
-    rejectAll,
-    openPreferences,
     preferencesOpen,
     closePreferences,
     savePreferences,
@@ -106,14 +93,7 @@ export function CookieConsentBanner() {
 
   return (
     <>
-      {showBanner && (
-        <ConsentBar
-          gpcSignalDetected={gpcSignalDetected}
-          acceptAll={acceptAll}
-          rejectAll={rejectAll}
-          openPreferences={openPreferences}
-        />
-      )}
+      {showBanner && <ConsentBar />}
 
       <CookiePreferencesDialog
         open={preferencesOpen}

--- a/frontend/components/layout/CookieConsentBanner.tsx
+++ b/frontend/components/layout/CookieConsentBanner.tsx
@@ -1,9 +1,95 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { useCookieConsent } from '@/lib/context/CookieConsentContext'
 import { CookiePreferencesDialog } from './CookiePreferencesDialog'
+
+/* PSY-1029: the consent banner is a slim fixed bottom bar (one compact row of
+ * copy + small buttons) instead of the old two-deck layout, so the first
+ * content row of the logged-out homepage stays fully visible on first paint.
+ * While the bar is visible it mirrors its height into `body` bottom padding,
+ * so content at the document end (the footer) stays reachable by scrolling
+ * rather than being permanently covered until the visitor consents. */
+
+interface ConsentBarProps {
+  gpcSignalDetected: boolean
+  acceptAll: () => void
+  rejectAll: () => void
+  openPreferences: () => void
+}
+
+function ConsentBar({
+  gpcSignalDetected,
+  acceptAll,
+  rejectAll,
+  openPreferences,
+}: ConsentBarProps) {
+  const barRef = useRef<HTMLDivElement>(null)
+
+  // Reserve scroll space matching the bar's rendered height (it varies with
+  // viewport width / text wrapping), and release it when the bar unmounts.
+  useEffect(() => {
+    const bar = barRef.current
+    if (!bar) return
+
+    const reserveSpace = () => {
+      document.body.style.paddingBottom = `${bar.offsetHeight}px`
+    }
+    reserveSpace()
+    const observer = new ResizeObserver(reserveSpace)
+    observer.observe(bar)
+
+    return () => {
+      observer.disconnect()
+      document.body.style.paddingBottom = ''
+    }
+  }, [])
+
+  return (
+    <div
+      ref={barRef}
+      className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background px-4 py-2.5 motion-safe:animate-in motion-safe:slide-in-from-bottom motion-safe:duration-300"
+      role="dialog"
+      aria-label="Cookie consent"
+      aria-describedby="cookie-consent-description"
+    >
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-x-6 gap-y-2">
+        <div className="min-w-0">
+          <p
+            id="cookie-consent-description"
+            className="text-sm text-muted-foreground"
+          >
+            We use cookies to improve your experience.{' '}
+            <Link
+              href="/privacy"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              Learn more
+            </Link>
+          </p>
+          {gpcSignalDetected && (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              We detected a Global Privacy Control signal from your browser.
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={rejectAll}>
+            Reject All
+          </Button>
+          <Button size="sm" variant="outline" onClick={openPreferences}>
+            Customize
+          </Button>
+          <Button size="sm" onClick={acceptAll}>
+            Accept All
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 export function CookieConsentBanner() {
   const {
@@ -18,76 +104,22 @@ export function CookieConsentBanner() {
     consent,
   } = useCookieConsent()
 
-  if (!showBanner) {
-    return (
+  return (
+    <>
+      {showBanner && (
+        <ConsentBar
+          gpcSignalDetected={gpcSignalDetected}
+          acceptAll={acceptAll}
+          rejectAll={rejectAll}
+          openPreferences={openPreferences}
+        />
+      )}
+
       <CookiePreferencesDialog
         open={preferencesOpen}
         onOpenChange={(open) => !open && closePreferences()}
         gpcSignalDetected={gpcSignalDetected}
         currentAnalytics={consent?.categories.analytics ?? false}
-        onSave={savePreferences}
-      />
-    )
-  }
-
-  return (
-    <>
-      <div
-        className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background p-3 motion-safe:animate-in motion-safe:slide-in-from-bottom motion-safe:duration-300"
-        role="dialog"
-        aria-label="Cookie consent"
-        aria-describedby="cookie-consent-description"
-      >
-        <div className="mx-auto max-w-4xl">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex-1">
-              <p className="text-sm font-medium">Cookie Preferences</p>
-              <p
-                id="cookie-consent-description"
-                className="mt-1 text-sm text-muted-foreground"
-              >
-                We use cookies to improve your experience.{' '}
-                <Link
-                  href="/privacy"
-                  className="underline underline-offset-4 hover:text-foreground"
-                >
-                  Learn more
-                </Link>
-              </p>
-              {gpcSignalDetected && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  We detected a Global Privacy Control signal from your browser.
-                </p>
-              )}
-            </div>
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <Button
-                variant="outline"
-                onClick={rejectAll}
-                className="w-full sm:w-auto"
-              >
-                Reject All
-              </Button>
-              <Button
-                variant="outline"
-                onClick={openPreferences}
-                className="w-full sm:w-auto"
-              >
-                Customize
-              </Button>
-              <Button onClick={acceptAll} className="w-full sm:w-auto">
-                Accept All
-              </Button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <CookiePreferencesDialog
-        open={preferencesOpen}
-        onOpenChange={(open) => !open && closePreferences()}
-        gpcSignalDetected={gpcSignalDetected}
-        currentAnalytics={false}
         onSave={savePreferences}
       />
     </>


### PR DESCRIPTION
## Summary

The cookie-consent banner overlapped the logged-out homepage's first "Upcoming shows" row on first paint (PSY-389's brief explicitly set "no content-blocking cookie dialog on first paint" as a goal). This PR makes the banner a **slim non-overlapping bottom bar** (ticket option 2):

- Drops the two-deck layout ("Cookie Preferences" heading + stacked full-width buttons) for a single compact row: description + Learn more link, and three `size="sm"` inline buttons. Bar height: desktop ~80px → **53px**, mobile ~215px → **~101px**.
- While visible, the bar mirrors its measured height (ResizeObserver) into `body` bottom padding so document-end content (the footer) stays reachable by scrolling instead of being permanently covered until the visitor consents; the padding is released when consent is given.
- Compliance behavior unchanged: same Accept All / Reject All / Customize handlers, always-rendered preferences dialog, GPC notice, `role="dialog"` ARIA semantics, and persisted consent shape.

**Rejected options:**
- *Reserve layout space (in-flow / sticky banner):* the banner only mounts post-hydration (`showBanner` requires the client `isLoaded` effect), so space can't be reserved at SSR; a sticky-in-flow variant is fragile to ancestor DOM/overflow changes. The body-padding mirror keeps the reachability benefit without those costs.
- *Defer until after FCP:* the banner already renders post-hydration (effectively after FCP); deferring further is a pop-in regression and doesn't reduce coverage at all once it appears.

**Disclosure (from adversarial review):** at exactly 1280x720 the first show card's bottom ~21px (empty padding/border region — all text, time, and icons visible) sits behind the 53px bar, because the card's bottom edge is at ~688px and no usable bar can clear it at that viewport height. The card fully clears the bar at viewport heights ≥ ~741px (verified at 1440x900). Before this PR the 80px banner covered the card's content (venue line) at the same viewport.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run test:run components/layout` — 16 files, 204 tests passed; removed the dropped-heading test, added 2 tests for body-padding reservation/release

## Manual repro (isolated dispatch stack + agent-browser, fresh state each run)

- Logged-out homepage, no consent in localStorage, desktop 1440x900: first show card fully clear of the bar (`firstCardBottom: 688.5 < bannerTop: 847`, measured via `getBoundingClientRect`), `body` padding-bottom mirrors bar height (53px).
- Mobile 390x844: bar is ~101px (was ~215px); "Upcoming shows" heading, city filter, and popular-cities row fully visible.
- **Accept All**: banner dismissed, `cookie-consent` localStorage written (`banner_accept_all`, analytics: true), body padding released.
- **Reject All**: banner dismissed, consent persisted (`banner_reject_all`, analytics: false), padding released.
- **Customize**: preferences dialog opens; toggling analytics + Save persists `customized` consent; banner dismissed.
- Reload after consent: banner stays hidden; footer "Cookie Preferences" trigger still opens the dialog with the saved analytics state reflected.

## Screenshots

| Before (1280x720) | Before (mobile 390x844) |
| --- | --- |
| ![before desktop](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1029-screenshots/before-first-paint.png) | ![before mobile](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1029-screenshots/before-mobile.png) |

| After (1440x900 first paint) | After (mobile 390x844) |
| --- | --- |
| ![after desktop](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1029-screenshots/after-first-paint.png) | ![after mobile](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1029-screenshots/after-mobile.png) |

| After Accept All | Preferences dialog (via Customize) |
| --- | --- |
| ![after accept](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1029-screenshots/after-accept.png) | ![preferences](https://github.com/mtrifilo/psychic-homily-web/releases/download/psy-1029-screenshots/preferences-dialog.png) |

(The red "1 Issue" badge in screenshots is the Next.js dev-tools overlay, not app UI.)

## Code review

`/code-review` (inline lenses — sub-agent worktree): no correctness findings; one simplification applied in `3d00ddcb` (ConsentBar reads `useCookieConsent()` directly instead of threading 4 props). Verified: nothing else writes `body` padding-bottom; no other fixed/sticky bottom elements; `currentAnalytics` unification is equivalent (`showBanner` implies `consent === null`).

## Adversarial review

`/adversarial-review` — 2 MEDIUM findings; 1 fixed in `d5369e2d`, 1 disclosed above.
- [MEDIUM] body-padding tests asserted the jsdom artifact `'0px'` while claiming the contract was "some padding set" → fixed in `d5369e2d` (`not.toBe('')`).
- [MEDIUM] 1280x720 partial-clearance nuance → disclosed in Summary (no code fix possible; content fully visible).
Panel: Saboteur · Future-Maintainer · Security · Completeness, run inline (dispatched sub-agent — no Agent tool) against the branch diff. Held up: no body-padding conflicts, no bottom-nav stacking conflict, no ResizeObserver feedback loop (fixed bar's size independent of body padding), no SSR/hydration risk, 320px-wide viewports fit the button row, enumeration of all three consent paths + GPC notice verified live.

Closes PSY-1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)
