### PR TITLE
PSY-1089: reduce Browse nav dropdown hover open/close delay

### DIFF
--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -542,7 +542,7 @@ function RequestCard({
       { id: request.id, decision: 'approved' },
       { onSuccess: () => onActionSuccess({ verb: 'created', entityLabel }) }
     )
-  }, [isShow, decideMutation, request.id, onActionSuccess, entityLabel])
+  }, [isShow, setShowFormOpen, decideMutation, request.id, onActionSuccess, entityLabel])
 
   const handleCreateShow = useCallback(
     (venue: ShowVenueInput, artists: ShowArtistInput[]) => {

--- a/frontend/components/layout/nav/BrowseMenu.tsx
+++ b/frontend/components/layout/nav/BrowseMenu.tsx
@@ -14,10 +14,16 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { browseGroups, browseHrefs, isNavActive, navItemClassName } from './navData'
 
-// Hover-intent timing. Kept short so the menu feels snappy on enter and leave
-// (PSY-1089). Open after a brief dwell so a pointer merely passing over the
-// trigger doesn't pop the panel; close is longer than open so the diagonal
-// travel from the trigger into the panel doesn't dismiss it mid-move.
+// Hover-intent timing, feel-tuned short for snappy enter/leave (PSY-1089). The
+// open dwell is deliberately near-instant; at 100ms a pointer merely passing over
+// the trigger may briefly pop the panel — an accepted trade-off for the snappy
+// feel, not a bug. The close delay (200ms) is feel-tuned, not derived: it just
+// has to comfortably outlast the time to drag a pointer across the trigger→panel
+// gap (`sideOffset` below) so diagonal travel hits the panel's `onPointerEnter` →
+// `clearTimer` and cancels the close instead of dismissing mid-move. The two are
+// tuned independently — shrinking `sideOffset` does not license shrinking this
+// delay. (NN/G's nominal 0.5s dwell is an upper bound; see
+// docs/open-questions/navigation-redesign.md.)
 const OPEN_DELAY_MS = 100
 const CLOSE_DELAY_MS = 200
 

--- a/frontend/components/layout/nav/BrowseMenu.tsx
+++ b/frontend/components/layout/nav/BrowseMenu.tsx
@@ -14,12 +14,12 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { browseGroups, browseHrefs, isNavActive, navItemClassName } from './navData'
 
-// NN/G hover-intent timing (cited in the redesign brief): open after a short
-// dwell so a pointer merely passing over the trigger doesn't pop the panel;
-// linger briefly before closing so the diagonal travel into the panel doesn't
-// dismiss it; full close-delay after leaving.
-const OPEN_DELAY_MS = 500
-const CLOSE_DELAY_MS = 500
+// Hover-intent timing. Kept short so the menu feels snappy on enter and leave
+// (PSY-1089). Open after a brief dwell so a pointer merely passing over the
+// trigger doesn't pop the panel; close is longer than open so the diagonal
+// travel from the trigger into the panel doesn't dismiss it mid-move.
+const OPEN_DELAY_MS = 100
+const CLOSE_DELAY_MS = 200
 
 // Browse ▾ — the wide three-column mega-menu (Catalog / Curation / Scenes) per
 // Figma `455:5`. Built on Radix DropdownMenu so it keeps the W3C APG menu


### PR DESCRIPTION
Closes PSY-1089.

## Summary
- Reduce the Browse nav mega-menu hover-intent delays so it feels snappy on enter and leave: `OPEN_DELAY_MS` 500→100, `CLOSE_DELAY_MS` 500→200 in `frontend/components/layout/nav/BrowseMenu.tsx`.
- Keep close > open so diagonal travel from the trigger into the panel still cancels the close (via the panel's `onPointerEnter` → `clearTimer`) instead of dismissing mid-move.
- Rewrite the explanatory comment: it no longer claims 100ms filters incidental pass-over (it doesn't — that's the accepted trade-off of the snappier feel), and it ties the close delay to the gap-crossing budget rather than the open/close ratio.
- Reconcile the redesign brief's timing prescription so the source-of-truth matches shipped code (see note below).

## Bundled fix — unblocks main (unrelated to the hover delay)
`main` has been red on **Frontend Lint** since #1119 (PSY-1037): `handleCreate` in `ModerationQueue.tsx:534` references `setShowFormOpen` but omitted it from the `useCallback` dependency array, so React Compiler reported "Compilation Skipped: Existing memoization could not be preserved" — the **sole** eslint error (alongside 143 pre-existing warnings, which don't fail CI), blocking every open PR. Bundled here per owner request rather than a separate PR. The fix adds the stable setState setter to the dep array (`commit 9f4ba819`); no behavior change, since setState setters are identity-stable. Verified: eslint clean on the file, typecheck clean, 30/30 ModerationQueue tests pass.

## Note on the redesign brief
`docs/open-questions/navigation-redesign.md:28` previously prescribed the NN/G nominal "0.5s open / 0.1s linger / 0.5s close" — the figures the old code comment cited. That doc is **gitignored (agent-only)**, so its reconciliation can't appear in this diff, but it was updated locally to mark NN/G's 0.5s as an upper bound that PSY-1089 deliberately superseded with 100/200ms, and to note "linger" collapses into `CLOSE_DELAY_MS`. This closes the AC's "redesign-brief citation reconciled" clause and prevents the next nav-redesign ticket (PSY-1018/1019/1020) from reading a stale spec.

## Deferred (per `/adversarial-review`)
- **Hover-intent path has no test coverage** — `BrowseMenu.test.tsx` exercises only click/keyboard; nothing guards the timing constants or the diagonal-travel cancel wiring. Pre-existing gap, not introduced here. Filed **PSY-1090** to add fake-timer tests (flagging the repo's known `fake-timers + userEvent + RQ` deadlock footgun).

## Adversarial review
`/adversarial-review` — round 1 BLOCK → round 2 CLEAN. Findings addressed in commit `9f6c4eea`.
- [HIGH/Completeness + MEDIUM/Future-Maintainer ⇒ corroborated] redesign brief still prescribed 0.5s/0.5s, contradicting the shipped 100/200ms → reconciled the brief (gitignored; see note above).
- [MEDIUM/Saboteur] in-code comment claimed 100ms filters incidental pass-over → rewritten to state the accepted trade-off.
- [LOW/Future-Maintainer] comment implied `CLOSE_DELAY_MS` is coupled to `sideOffset` → clarified the two are tuned independently.
- [LOW/Saboteur] no test pins the timing contract → deferred to PSY-1090.
Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff; round 2 re-verified the fixes and found nothing new.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/layout/nav` — 31/31 passing (BrowseMenu 6, PrimaryNav 9, userDisplay 16); no test asserts timing, so this gate does not itself guard the constants (see PSY-1090)
- [x] `/code-review` — reviewed inline (two integer constants + comment); no findings
- [x] `/adversarial-review` — round 2 CLEAN; fixes in separate commit `9f6c4eea`
- [x] `/psy-self-review` — clean (see below)
- [x] Bundled fix: `eslint` clean on `ModerationQueue.tsx` (the 1 error gone), `typecheck` clean, `bun run test:run app/admin/moderation` 30/30 passing
- [x] Manual repro on local dev stack: hovering Browse opens the mega-menu (`data-state=open`, full Catalog/Curation/Scenes), leaving dismisses it. Empirically measured **open ~138ms** (the 100ms timer + render overhead) and **close ~215ms** (the 200ms timer + overhead) via instrumented real-pointer events — confirms the new values are live, well below the old ~500ms.

## Screenshots
Browse mega-menu open via hover with the new timing (light mode; appearance is unchanged from before — this is a timing-only change):

![Browse mega-menu open](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-8b1f529422f99d1e975a/psy-1089-browse-open.png)

## Coverage gaps
- **Timing is not visually capturable** — a static screenshot can't show the delay change; the empirical millisecond measurements above are the load-bearing evidence for the actual change.
- **Authenticated state not exercised** — the Browse menu is identical for auth/unauth (public catalog nav); no auth-gated affordance is touched.
- **Mobile/narrow viewport not exercised** — at narrow widths the nav collapses to a hamburger and the hover-intent path doesn't apply; this change only affects the desktop dropdown.
- **Touch devices** — hover-intent is pointer-only; touch uses Radix's click path (unchanged).
