### PR TITLE
PSY-1093: reframe home hero sign-up nudge to value-forward CTA

### DIFF
--- a/frontend/features/home/components/HomeHero.test.tsx
+++ b/frontend/features/home/components/HomeHero.test.tsx
@@ -58,11 +58,14 @@ describe('HomeHero', () => {
     }
   })
 
-  it('renders a quiet Sign up nudge to /auth (not a contribution CTA)', () => {
+  it('renders a value-forward Sign up nudge linking to /auth', () => {
     render(<HomeHero />)
     expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute(
       'href',
       '/auth'
     )
+    expect(
+      screen.getByText(/to contribute, and never miss a show again\./)
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/features/home/components/HomeHero.tsx
+++ b/frontend/features/home/components/HomeHero.tsx
@@ -12,8 +12,9 @@ import { openCommandPalette } from '@/lib/hooks/common/useCommandPalette'
  * Pure mystique by design: an oblique What.cd call-back headline + evocative
  * two-line subtext, then a dominant search field and a "Find a show" primary
  * CTA. The concrete "what is this" work rests on the search placeholder, the
- * Discover quick-links row, and the sections below — never a contribution CTA
- * (value-before-contribution).
+ * Discover quick-links row, and the sections below — the dominant actions stay
+ * value-first (value-before-contribution). The only contribution prompt is the
+ * quiet, secondary sign-up nudge at the bottom of the section.
  *
  * The search field reuses the existing command-palette mechanism
  * (`openCommandPalette`, same as the nav `SearchTrigger`); it is presented
@@ -91,14 +92,14 @@ export function HomeHero() {
       </nav>
 
       {/* Quiet sign-up nudge */}
-      <p className="flex items-center gap-2 pt-1 text-sm">
-        <span className="text-muted-foreground">New here?</span>
+      <p className="pt-1 text-sm text-muted-foreground">
         <Link
           href="/auth"
           className="font-semibold text-primary transition-colors hover:underline underline-offset-4"
         >
           Sign up
-        </Link>
+        </Link>{' '}
+        to contribute, and never miss a show again.
       </p>
     </section>
   )


### PR DESCRIPTION
## What

Reframe the logged-out homepage hero's sign-up nudge from a neutral prompt to a value-forward CTA.

- **Before:** `New here?` **Sign up**
- **After:** **Sign up** ` to contribute, and never miss a show again.`

"Sign up" stays the clickable link to `/auth` (primary color, underline-on-hover); the benefit now leads the sentence.

## Why

The hero's docblock describes a "value-before-contribution" intent, but `New here?` is a generic prompt that says nothing about *why* to sign up. Leading with the benefit (contribute + never miss a show) makes the nudge earn its place. The dominant actions (search, Find a show, Discover) stay value-first; this is the one quiet, secondary contribution prompt.

## Changes

- `frontend/features/home/components/HomeHero.tsx` — copy + markup (`<p>` is now an inline sentence rather than a flex span+link); docblock updated so it no longer claims "never a contribution CTA."
- `HomeHero.test.tsx` — renamed the nudge test and added an assertion locking in the new copy.

## Verification

- `bun run typecheck` ✅
- `bun run test:run features/home/components/HomeHero.test.tsx` ✅ (5/5)
- `eslint` (changed files) ✅
- Live dev-server render confirmed: "New here" gone, new copy present, `Sign up` → `/auth`.

## Screenshot

![Home hero with new sign-up CTA](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-9ac359a0e276ad20f571/home-hero-signup-cta.png)

Closes PSY-1093
