### PR TITLE
PSY-1094: open Contribute nav dropdown on hover, like Browse

### DIFF
--- a/frontend/components/layout/nav/BrowseMenu.tsx
+++ b/frontend/components/layout/nav/BrowseMenu.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ChevronDown } from 'lucide-react'
@@ -13,19 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { browseGroups, browseHrefs, isNavActive, navItemClassName } from './navData'
-
-// Hover-intent timing, feel-tuned short for snappy enter/leave (PSY-1089). The
-// open dwell is deliberately near-instant; at 100ms a pointer merely passing over
-// the trigger may briefly pop the panel — an accepted trade-off for the snappy
-// feel, not a bug. The close delay (200ms) is feel-tuned, not derived: it just
-// has to comfortably outlast the time to drag a pointer across the trigger→panel
-// gap (`sideOffset` below) so diagonal travel hits the panel's `onPointerEnter` →
-// `clearTimer` and cancels the close instead of dismissing mid-move. The two are
-// tuned independently — shrinking `sideOffset` does not license shrinking this
-// delay. (NN/G's nominal 0.5s dwell is an upper bound; see
-// docs/open-questions/navigation-redesign.md.)
-const OPEN_DELAY_MS = 100
-const CLOSE_DELAY_MS = 200
+import { useHoverIntentMenu } from './useHoverIntentMenu'
 
 // Browse ▾ — the wide three-column mega-menu (Catalog / Curation / Scenes) per
 // Figma `455:5`. Built on Radix DropdownMenu so it keeps the W3C APG menu
@@ -34,61 +21,21 @@ const CLOSE_DELAY_MS = 200
 // the mock is intentionally DEFERRED for v1 — there is no recently-added /
 // trending data source yet.
 //
-// DropdownMenu alone is click-only, so this layers NN/G hover-intent on top via
-// a controlled `open` state with open/close timers (Radix still owns click +
-// keyboard). Pointer parity: hovering EITHER the trigger or the panel keeps it
-// open; leaving both closes it after the delay.
+// NN/G hover-intent (open on hover) is layered on via `useHoverIntentMenu`,
+// shared with ContributeMenu so the two menus behave identically. The hook
+// requires `modal={false}` below — see its docblock for the rationale.
 export function BrowseMenu() {
   const pathname = usePathname()
   const active = browseHrefs.some(href => isNavActive(pathname, href))
 
-  const [open, setOpen] = useState(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const clearTimer = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current)
-      timerRef.current = null
-    }
-  }, [])
-
-  // Avoid leaking a pending open/close timer if the component unmounts mid-dwell.
-  useEffect(() => clearTimer, [clearTimer])
-
-  const scheduleOpen = useCallback(() => {
-    clearTimer()
-    timerRef.current = setTimeout(() => setOpen(true), OPEN_DELAY_MS)
-  }, [clearTimer])
-
-  const scheduleClose = useCallback(() => {
-    clearTimer()
-    timerRef.current = setTimeout(() => setOpen(false), CLOSE_DELAY_MS)
-  }, [clearTimer])
-
-  // Click / keyboard go through Radix's own open state; cancel any pending hover
-  // timer so a click doesn't get clobbered by a late open/close fire.
-  const handleOpenChange = useCallback(
-    (next: boolean) => {
-      clearTimer()
-      setOpen(next)
-    },
-    [clearTimer]
-  )
+  const { open, onOpenChange, triggerHoverProps, contentHoverProps } = useHoverIntentMenu()
 
   return (
-    // modal={false} is REQUIRED for the hover-intent model: Radix's default
-    // modal DropdownMenu sets `pointer-events: none` on <body> while open, which
-    // strips the trigger's pointer events the instant the menu opens → the
-    // browser fires pointerleave on the trigger → scheduleClose → close →
-    // pointer is over the trigger again → scheduleOpen → an endless open/close
-    // flicker. Non-modal keeps the page (and trigger) pointer-interactive;
-    // outside-click + Escape dismissal still work via Radix's dismissable layer.
-    <DropdownMenu open={open} onOpenChange={handleOpenChange} modal={false}>
+    <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
       <DropdownMenuTrigger
         className={navItemClassName(active)}
         aria-label="Browse the catalog"
-        onPointerEnter={scheduleOpen}
-        onPointerLeave={scheduleClose}
+        {...triggerHoverProps}
       >
         Browse
         <ChevronDown className="size-3.5 opacity-70" aria-hidden />
@@ -97,8 +44,7 @@ export function BrowseMenu() {
         align="start"
         sideOffset={10}
         className="flex w-auto gap-12 rounded-[10px] border-border p-0 px-7 py-6 shadow-[0px_2px_8px_0px_rgba(0,0,0,0.08)]"
-        onPointerEnter={clearTimer}
-        onPointerLeave={scheduleClose}
+        {...contentHoverProps}
       >
         {browseGroups.map(group => (
           <DropdownMenuGroup key={group.label} className="flex flex-col gap-3">

--- a/frontend/components/layout/nav/ContributeMenu.test.tsx
+++ b/frontend/components/layout/nav/ContributeMenu.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ContributeMenu } from './ContributeMenu'
+
+let mockPathname = '/'
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}))
+
+let mockIsAuthenticated = false
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ isAuthenticated: mockIsAuthenticated }),
+}))
+
+describe('ContributeMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPathname = '/'
+    mockIsAuthenticated = false
+  })
+
+  it('opens on click and renders both column headers', async () => {
+    const user = userEvent.setup()
+    render(<ContributeMenu />)
+    await user.click(screen.getByRole('button', { name: 'Contribute' }))
+    expect(await screen.findByText('Participate')).toBeInTheDocument()
+    expect(screen.getByText('Editorial')).toBeInTheDocument()
+  })
+
+  it('renders the Participate + Editorial items as real links to their routes', async () => {
+    const user = userEvent.setup()
+    render(<ContributeMenu />)
+    await user.click(screen.getByRole('button', { name: 'Contribute' }))
+
+    const cases: Array<[string, string]> = [
+      ['+ Submit a show', '/shows/submit'],
+      ['Requests', '/requests'],
+      ['Leaderboard', '/community/leaderboard'],
+      ['Contribute hub →', '/contribute'],
+      ['Blog', '/blog'],
+      ['DJ Sets', '/dj-sets'],
+      ['Substack ↗', 'https://psychichomily.substack.com/'],
+    ]
+    for (const [name, href] of cases) {
+      expect(await screen.findByRole('menuitem', { name })).toHaveAttribute('href', href)
+    }
+  })
+
+  it('hides the auth-only "My Submissions" item when logged out', async () => {
+    const user = userEvent.setup()
+    render(<ContributeMenu />)
+    await user.click(screen.getByRole('button', { name: 'Contribute' }))
+    expect(await screen.findByText('Participate')).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'My Submissions' })).not.toBeInTheDocument()
+  })
+
+  it('shows the auth-only "My Submissions" item when authenticated', async () => {
+    mockIsAuthenticated = true
+    const user = userEvent.setup()
+    render(<ContributeMenu />)
+    await user.click(screen.getByRole('button', { name: 'Contribute' }))
+    expect(await screen.findByRole('menuitem', { name: 'My Submissions' })).toHaveAttribute(
+      'href',
+      '/submissions'
+    )
+  })
+
+  it('opens via keyboard (Enter on the focused trigger) — APG menu pattern', async () => {
+    const user = userEvent.setup()
+    render(<ContributeMenu />)
+    const trigger = screen.getByRole('button', { name: 'Contribute' })
+    trigger.focus()
+    await user.keyboard('{Enter}')
+    expect(await screen.findByRole('menuitem', { name: 'Requests' })).toBeInTheDocument()
+  })
+
+  it('Escape closes the menu and returns focus to the trigger', async () => {
+    const user = userEvent.setup()
+    render(<ContributeMenu />)
+    const trigger = screen.getByRole('button', { name: 'Contribute' })
+    await user.click(trigger)
+    expect(await screen.findByRole('menuitem', { name: 'Requests' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('menuitem', { name: 'Requests' })).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('marks the trigger active when on a destination route', () => {
+    mockPathname = '/requests'
+    render(<ContributeMenu />)
+    expect(screen.getByRole('button', { name: 'Contribute' }).className).toContain('text-foreground')
+  })
+})

--- a/frontend/components/layout/nav/ContributeMenu.tsx
+++ b/frontend/components/layout/nav/ContributeMenu.tsx
@@ -21,6 +21,7 @@ import {
   navItemClassName,
   type NavLink as NavLinkData,
 } from './navData'
+import { useHoverIntentMenu } from './useHoverIntentMenu'
 
 // Contribute ▾ — the What.cd "request system as call-to-action". PSY-1015
 // refines the PSY-1013 functional menu into the two-column Participate /
@@ -86,15 +87,25 @@ export function ContributeMenu() {
   const { isAuthenticated } = useAuthContext()
   const active = contributeHrefs.some(href => isNavActive(pathname, href))
 
+  // NN/G hover-intent (open on hover), shared with BrowseMenu so the two menus
+  // behave identically. The hook requires `modal={false}` — see its docblock.
+  const { open, onOpenChange, triggerHoverProps, contentHoverProps } = useHoverIntentMenu()
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className={navItemClassName(active)} aria-label="Contribute">
+    <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
+      <DropdownMenuTrigger
+        className={navItemClassName(active)}
+        aria-label="Contribute"
+        {...triggerHoverProps}
+      >
         Contribute
         <ChevronDown className="size-3.5 opacity-70" aria-hidden />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
+        sideOffset={10}
         className="flex w-auto items-start gap-12 rounded-[10px] px-7 py-6"
+        {...contentHoverProps}
       >
         <DropdownMenuGroup className="flex flex-col gap-3">
           <DropdownMenuLabel className={groupLabelClassName}>Participate</DropdownMenuLabel>

--- a/frontend/components/layout/nav/useHoverIntentMenu.ts
+++ b/frontend/components/layout/nav/useHoverIntentMenu.ts
@@ -1,0 +1,87 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// Hover-intent timing, feel-tuned short for snappy enter/leave (PSY-1089). The
+// open dwell is deliberately near-instant; at 100ms a pointer merely passing over
+// the trigger may briefly pop the panel — an accepted trade-off for the snappy
+// feel, not a bug. The close delay (200ms) is feel-tuned, not derived: it just
+// has to comfortably outlast the time to drag a pointer across the trigger→panel
+// gap (`sideOffset` on the menu content) so diagonal travel hits the panel's
+// `onPointerEnter` → `clearTimer` and cancels the close instead of dismissing
+// mid-move. The two are tuned independently — shrinking `sideOffset` does not
+// license shrinking this delay. (NN/G's nominal 0.5s dwell is an upper bound;
+// see docs/open-questions/navigation-redesign.md.)
+const OPEN_DELAY_MS = 100
+const CLOSE_DELAY_MS = 200
+
+type HoverHandlers = {
+  onPointerEnter: () => void
+  onPointerLeave: () => void
+}
+
+export interface HoverIntentMenu {
+  /** Controlled open state — pass to `<DropdownMenu open={…}>`. */
+  open: boolean
+  /** Pass to `<DropdownMenu onOpenChange={…}>`; integrates click + keyboard. */
+  onOpenChange: (next: boolean) => void
+  /** Spread onto `<DropdownMenuTrigger>` (enter opens, leave closes). */
+  triggerHoverProps: HoverHandlers
+  /** Spread onto `<DropdownMenuContent>` (enter keeps open, leave closes). */
+  contentHoverProps: HoverHandlers
+}
+
+// NN/G hover-intent for a Radix DropdownMenu, shared by BrowseMenu and
+// ContributeMenu so the two behave identically (PSY-1094). Radix DropdownMenu is
+// click-only; this layers a controlled `open` state with open/close timers on top
+// (Radix still owns click + keyboard). Pointer parity: hovering EITHER the
+// trigger or the panel keeps it open; leaving both closes it after the delay.
+//
+// REQUIRES `modal={false}` on the consuming `<DropdownMenu>`: Radix's default
+// modal menu sets `pointer-events: none` on <body> while open, which strips the
+// trigger's pointer events the instant the menu opens → the browser fires
+// pointerleave on the trigger → scheduleClose → close → pointer is over the
+// trigger again → scheduleOpen → an endless open/close flicker. Non-modal keeps
+// the page (and trigger) pointer-interactive; outside-click + Escape dismissal
+// still work via Radix's dismissable layer.
+export function useHoverIntentMenu(): HoverIntentMenu {
+  const [open, setOpen] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  // Avoid leaking a pending open/close timer if the component unmounts mid-dwell.
+  useEffect(() => clearTimer, [clearTimer])
+
+  const scheduleOpen = useCallback(() => {
+    clearTimer()
+    timerRef.current = setTimeout(() => setOpen(true), OPEN_DELAY_MS)
+  }, [clearTimer])
+
+  const scheduleClose = useCallback(() => {
+    clearTimer()
+    timerRef.current = setTimeout(() => setOpen(false), CLOSE_DELAY_MS)
+  }, [clearTimer])
+
+  // Click / keyboard go through Radix's own open state; cancel any pending hover
+  // timer so a click doesn't get clobbered by a late open/close fire.
+  const onOpenChange = useCallback(
+    (next: boolean) => {
+      clearTimer()
+      setOpen(next)
+    },
+    [clearTimer]
+  )
+
+  return {
+    open,
+    onOpenChange,
+    triggerHoverProps: { onPointerEnter: scheduleOpen, onPointerLeave: scheduleClose },
+    contentHoverProps: { onPointerEnter: clearTimer, onPointerLeave: scheduleClose },
+  }
+}


### PR DESCRIPTION
## What

The **Contribute ▾** nav dropdown was click-only, while **Browse ▾** opens on hover (NN/G hover-intent, PSY-1089). This makes Contribute behave identically to Browse.

## How

Rather than copy-paste Browse's timer logic, I extracted the hover-intent into a shared **`useHoverIntentMenu`** hook (`frontend/components/layout/nav/useHoverIntentMenu.ts`) and consumed it from **both** `BrowseMenu` and `ContributeMenu`. One source of truth → the two menus stay in sync by construction.

The hook owns: controlled `open` state, the open (100ms) / close (200ms) dwell timers, trigger↔panel pointer parity, and the `onOpenChange` that lets click + full keyboard (APG) operation continue to work via Radix. `modal={false}` is required on the menu (Radix's modal mode strips trigger pointer events → open/close flicker); both menus now set it. Contribute also picks up Browse's `sideOffset={10}` so the trigger→panel gap (which the close delay is tuned against) matches.

## Changes

- **`useHoverIntentMenu.ts`** (new) — shared hover-intent hook; carries the timing + `modal={false}` rationale.
- **`BrowseMenu.tsx`** — refactored to use the hook (behavior unchanged).
- **`ContributeMenu.tsx`** — now hover-opens via the hook; `modal={false}`, `sideOffset={10}`.
- **`ContributeMenu.test.tsx`** (new) — click + keyboard open, links, auth-gated "My Submissions", Escape-returns-focus, active-route. (ContributeMenu had no test before.)

## Verification

- `bun run typecheck` ✅
- `bun run test:run components/layout/nav` ✅ — 38/38 (incl. 7 new ContributeMenu tests; `PrimaryNav` + `BrowseMenu` still green after the refactor)
- `eslint` (changed files) ✅
- Live hover check via Playwright (hover only, no click) — both menus open on hover:

**Contribute (now opens on hover):**

![Contribute dropdown open on hover](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-b93c8f4a04de22128f15/contribute-dropdown-hover.png)

**Browse (unchanged, for parity):**

![Browse dropdown open on hover](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-b93c8f4a04de22128f15/browse-dropdown-hover.png)

Closes PSY-1094
