### PR TITLE
PSY-1095: faster nav dropdown open (reaction 100→50ms, anim 150→100ms)

### DIFF
--- a/frontend/components/layout/nav/BrowseMenu.tsx
+++ b/frontend/components/layout/nav/BrowseMenu.tsx
@@ -43,7 +43,7 @@ export function BrowseMenu() {
       <DropdownMenuContent
         align="start"
         sideOffset={10}
-        className="flex w-auto gap-12 rounded-[10px] border-border p-0 px-7 py-6 shadow-[0px_2px_8px_0px_rgba(0,0,0,0.08)]"
+        className="flex w-auto gap-12 rounded-[10px] border-border p-0 px-7 py-6 shadow-[0px_2px_8px_0px_rgba(0,0,0,0.08)] duration-100"
         {...contentHoverProps}
       >
         {browseGroups.map(group => (

--- a/frontend/components/layout/nav/ContributeMenu.tsx
+++ b/frontend/components/layout/nav/ContributeMenu.tsx
@@ -104,7 +104,7 @@ export function ContributeMenu() {
       <DropdownMenuContent
         align="start"
         sideOffset={10}
-        className="flex w-auto items-start gap-12 rounded-[10px] px-7 py-6"
+        className="flex w-auto items-start gap-12 rounded-[10px] px-7 py-6 duration-100"
         {...contentHoverProps}
       >
         <DropdownMenuGroup className="flex flex-col gap-3">

--- a/frontend/components/layout/nav/useHoverIntentMenu.ts
+++ b/frontend/components/layout/nav/useHoverIntentMenu.ts
@@ -2,17 +2,19 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-// Hover-intent timing, feel-tuned short for snappy enter/leave (PSY-1089). The
-// open dwell is deliberately near-instant; at 100ms a pointer merely passing over
-// the trigger may briefly pop the panel — an accepted trade-off for the snappy
-// feel, not a bug. The close delay (200ms) is feel-tuned, not derived: it just
-// has to comfortably outlast the time to drag a pointer across the trigger→panel
-// gap (`sideOffset` on the menu content) so diagonal travel hits the panel's
-// `onPointerEnter` → `clearTimer` and cancels the close instead of dismissing
-// mid-move. The two are tuned independently — shrinking `sideOffset` does not
-// license shrinking this delay. (NN/G's nominal 0.5s dwell is an upper bound;
-// see docs/open-questions/navigation-redesign.md.)
-const OPEN_DELAY_MS = 100
+// Hover-intent timing, feel-tuned short for a snappy enter/leave (PSY-1089,
+// shortened further in the PSY-1094 follow-up for an even faster open). The open
+// dwell is deliberately near-instant; at 50ms a pointer merely passing over the
+// trigger can briefly pop the panel — an accepted (and now slightly larger)
+// trade-off for the snappier feel, not a bug. The close delay (200ms) is
+// feel-tuned, not derived: it just has to comfortably outlast the time to drag a
+// pointer across the trigger→panel gap (`sideOffset` on the menu content) so
+// diagonal travel hits the panel's `onPointerEnter` → `clearTimer` and cancels
+// the close instead of dismissing mid-move. The two are tuned independently —
+// shrinking the open dwell (or `sideOffset`) does not license shrinking this
+// delay. (NN/G's nominal 0.5s dwell is an upper bound; see
+// docs/open-questions/navigation-redesign.md.)
+const OPEN_DELAY_MS = 50
 const CLOSE_DELAY_MS = 200
 
 type HoverHandlers = {


### PR DESCRIPTION
## What

Follow-up feel tuning on the nav dropdowns from PSY-1094 (#1130): make the **open** feel even faster.

- **Reaction time** — hover-intent open dwell `OPEN_DELAY_MS` **100 → 50ms** (`frontend/components/layout/nav/useHoverIntentMenu.ts`). The menu pops the moment you settle on the trigger.
- **Animation time** — open/close animation **150 → 100ms** via `duration-100` on the Browse + Contribute menu content. (`tw-animate-css`'s `animate-in` resolves to `var(--tw-duration, .15s)`; `duration-100` sets `--tw-duration`, so this is a real override.)

## Intentionally left as-is

- **`CLOSE_DELAY_MS` (200ms)** — the leave-grace dwell, tuned to outlast the time to drag the pointer across the trigger→panel gap (`sideOffset`). Shrinking it makes the menu twitchy / dismiss mid-move, so it stays.
- **Global `components/ui/dropdown-menu.tsx`** — untouched. The animation change is scoped to the two nav menus, so `UserMenu` and other dropdowns keep their current timing.

## Verification

- `bun run typecheck` ✅
- `bun run test:run components/layout/nav` ✅ — 38/38
- `eslint` (changed files) ✅
- **Animation override is real, not a no-op** — measured computed `animation-duration` on both open menus = `0.1s` (via Playwright `getComputedStyle`).

Closes PSY-1095
