### PR TITLE
PSY-1096: reword /shows tag-filter tooltip for multi-tag selection

### DIFF
--- a/frontend/features/tags/components/TagFacetPanel.test.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
 import {
@@ -105,6 +105,22 @@ describe('TagFacetPanel', () => {
     expect(screen.getByTestId('tag-facet-chip-post-punk')).toBeInTheDocument()
     expect(screen.getByTestId('tag-facet-chip-phoenix')).toBeInTheDocument()
     expect(screen.getByTestId('tag-facet-chip-diy')).toBeInTheDocument()
+  })
+
+  it('shows the multi-tag selection tooltip copy for the shows facet', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <TagFacetPanel
+        selectedSlugs={[]}
+        onToggle={() => {}}
+        onClear={() => {}}
+        entityType="show"
+      />
+    )
+    await user.hover(screen.getByTestId('tag-facet-transitive-info'))
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Select one or more tags to filter shows based on any tag combination.'
+    )
   })
 
   it('marks selected chips via aria-pressed', () => {

--- a/frontend/features/tags/components/TagFacetPanel.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.tsx
@@ -22,11 +22,12 @@ import {
 import type { TagCategory, TagEntityType, TagListItem } from '../types'
 
 // Copy for the info tooltip next to the facet heading, keyed by entity type.
-// `show` and `festival` surface transitive semantics (PSY-499): filtering by
-// genre matches the container entity whose lineup includes a tagged artist.
-// Other entity types use direct-tag semantics so they don't get a tooltip.
-const TRANSITIVE_TOOLTIP_COPY: Partial<Record<TagEntityType, string>> = {
-  show: 'Filtering by genre matches shows whose artists have that tag.',
+// `show` explains the multi-select behavior (combine tags to filter shows).
+// `festival` surfaces transitive semantics (PSY-499): filtering by genre matches
+// the container entity whose lineup includes a tagged artist. Other entity types
+// use direct-tag semantics so they don't get a tooltip.
+const FACET_TOOLTIP_COPY: Partial<Record<TagEntityType, string>> = {
+  show: 'Select one or more tags to filter shows based on any tag combination.',
   festival:
     'Filtering by genre matches festivals whose lineup artists have that tag.',
 }
@@ -177,9 +178,9 @@ export function TagFacetPanel({
           <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
             <TagIcon className="h-3.5 w-3.5" aria-hidden />
             {heading}
-            {entityType && TRANSITIVE_TOOLTIP_COPY[entityType] && (
+            {entityType && FACET_TOOLTIP_COPY[entityType] && (
               <TransitiveTagTooltip
-                text={TRANSITIVE_TOOLTIP_COPY[entityType] ?? ''}
+                text={FACET_TOOLTIP_COPY[entityType] ?? ''}
               />
             )}
           </h2>
@@ -219,9 +220,9 @@ export function TagFacetPanel({
           <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
             <TagIcon className="h-3.5 w-3.5" aria-hidden />
             {heading}
-            {entityType && TRANSITIVE_TOOLTIP_COPY[entityType] && (
+            {entityType && FACET_TOOLTIP_COPY[entityType] && (
               <TransitiveTagTooltip
-                text={TRANSITIVE_TOOLTIP_COPY[entityType] ?? ''}
+                text={FACET_TOOLTIP_COPY[entityType] ?? ''}
               />
             )}
           </h2>


### PR DESCRIPTION
## What

Update the info tooltip next to **"Filter shows by tag"** on `/shows`.

- **Before:** "Filtering by genre matches shows whose artists have that tag."
- **After:** "Select one or more tags to filter shows based on any tag combination."

Only the `show` variant changes. The `festival` variant (which still describes transitive lineup semantics, PSY-499) is unchanged.

## Changes

- `frontend/features/tags/components/TagFacetPanel.tsx` — new `show` copy + updated doc comment. Renamed the copy map `TRANSITIVE_TOOLTIP_COPY` → `FACET_TOOLTIP_COPY`, since `show` no longer describes transitive semantics (only `festival` does).
- `TagFacetPanel.test.tsx` — added a test that opens the tooltip and asserts the new copy renders; also dropped a pre-existing unused `render` import.

## Notes

- Added a trailing period to match the sibling `festival` string and tooltip convention.
- The copy now leads with the multi-select behavior rather than the artist→show tag mechanic.

## Verification

- `bun run typecheck` ✅
- `bun run test:run features/tags/components/TagFacetPanel.test.tsx` ✅ — 30/30 (incl. the new tooltip-copy test; ran 3× for stability)
- `eslint` ✅ (0 warnings after the unused-import cleanup)
- Live screenshot (Playwright hover on the real `/shows` page, frontend + Go backend up):

![/shows tag filter tooltip](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-881fc50079e4faaf0f23/shows-tag-filter-tooltip.png)

Closes PSY-1096
