### PR TITLE
PSY-1097: globally mock @sentry/nextjs to fix flaky Frontend Unit Tests

### DIFF
--- a/frontend/app/admin/error.test.tsx
+++ b/frontend/app/admin/error.test.tsx
@@ -4,9 +4,6 @@ import userEvent from '@testing-library/user-event'
 import * as Sentry from '@sentry/nextjs'
 import AdminError from './error'
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 describe('Admin route error boundary (app/admin/error.tsx)', () => {
   beforeEach(() => {

--- a/frontend/app/api/[...path]/route.test.ts
+++ b/frontend/app/api/[...path]/route.test.ts
@@ -5,11 +5,6 @@ import { cookies } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { GET, POST, PUT, DELETE, PATCH, OPTIONS } from './route'
 
-// Mock Sentry so capture calls are observable and never hit the network.
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 // Mock next/headers cookies(); each test sets the resolved cookie store.
 vi.mock('next/headers', () => ({

--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
@@ -4,11 +4,6 @@ import { cookies } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { POST, DELETE } from './route'
 
-// Mock Sentry so capture calls are observable and never hit the network.
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 // Mock next/headers cookies(); each test sets the resolved cookie store.
 vi.mock('next/headers', () => ({

--- a/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
@@ -4,11 +4,6 @@ import { cookies } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { POST, DELETE } from './route'
 
-// Mock Sentry so capture calls are observable and never hit the network.
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 // Mock next/headers cookies(); each test sets the resolved cookie store.
 vi.mock('next/headers', () => ({

--- a/frontend/app/artists/[slug]/page.test.tsx
+++ b/frontend/app/artists/[slug]/page.test.tsx
@@ -5,10 +5,6 @@ vi.mock('next/navigation', () => ({
   notFound: vi.fn(),
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 // Stub the heavy artists feature module so invoking generateMetadata doesn't
 // pull in the real ArtistDetail render path.

--- a/frontend/app/artists/error.test.tsx
+++ b/frontend/app/artists/error.test.tsx
@@ -4,9 +4,6 @@ import userEvent from '@testing-library/user-event'
 import * as Sentry from '@sentry/nextjs'
 import ArtistsError from './error'
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 describe('Artists route error boundary (app/artists/error.tsx)', () => {
   beforeEach(() => {

--- a/frontend/app/collections/[slug]/page.test.tsx
+++ b/frontend/app/collections/[slug]/page.test.tsx
@@ -14,10 +14,6 @@ vi.mock('next/headers', () => ({
   })),
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 // Stub the heavy collections feature module so invoking generateMetadata
 // doesn't pull in the real CollectionDetail render path.

--- a/frontend/app/global-error.test.tsx
+++ b/frontend/app/global-error.test.tsx
@@ -4,9 +4,6 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import * as Sentry from '@sentry/nextjs'
 import GlobalError from './global-error'
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 describe('Global error boundary (app/global-error.tsx)', () => {
   beforeEach(() => {

--- a/frontend/app/shows/[slug]/page.test.tsx
+++ b/frontend/app/shows/[slug]/page.test.tsx
@@ -14,10 +14,6 @@ vi.mock('next/navigation', () => ({
   notFound: () => notFoundMock(),
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 // Stub the heavy shows feature module so invoking the page body doesn't pull
 // in the real ShowDetail render path — this ticket exercises the page-level

--- a/frontend/app/shows/error.test.tsx
+++ b/frontend/app/shows/error.test.tsx
@@ -4,9 +4,6 @@ import userEvent from '@testing-library/user-event'
 import * as Sentry from '@sentry/nextjs'
 import ShowsError from './error'
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 describe('Shows route error boundary (app/shows/error.tsx)', () => {
   beforeEach(() => {

--- a/frontend/app/venues/[slug]/page.test.tsx
+++ b/frontend/app/venues/[slug]/page.test.tsx
@@ -5,10 +5,6 @@ vi.mock('next/navigation', () => ({
   notFound: vi.fn(),
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 // Stub the heavy venues feature module so invoking generateMetadata doesn't
 // pull in the real VenueDetail render path.

--- a/frontend/app/venues/error.test.tsx
+++ b/frontend/app/venues/error.test.tsx
@@ -4,9 +4,6 @@ import userEvent from '@testing-library/user-event'
 import * as Sentry from '@sentry/nextjs'
 import VenuesError from './error'
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 describe('Venues route error boundary (app/venues/error.tsx)', () => {
   beforeEach(() => {

--- a/frontend/components/filters/useGeoDefaultCity.test.tsx
+++ b/frontend/components/filters/useGeoDefaultCity.test.tsx
@@ -7,9 +7,6 @@ import {
 import type { CityState, CityWithCount } from './CityFilters'
 import type { GeoLocation } from '@/lib/geo-default'
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 // Centroids match the offline geocoder the backend uses (PSY-981).
 const PHOENIX: CityWithCount = {

--- a/frontend/components/settings/SettingsPanel.test.tsx
+++ b/frontend/components/settings/SettingsPanel.test.tsx
@@ -6,9 +6,6 @@ import { SettingsPanel } from './SettingsPanel'
 
 // --- Mocks ---
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 let mockUser: {
   email: string

--- a/frontend/components/settings/api-token-management.test.tsx
+++ b/frontend/components/settings/api-token-management.test.tsx
@@ -6,9 +6,6 @@ import { APITokenManagement } from './api-token-management'
 
 // --- Mocks ---
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 let mockTokensData: {
   tokens: {

--- a/frontend/components/settings/delete-account-dialog.test.tsx
+++ b/frontend/components/settings/delete-account-dialog.test.tsx
@@ -11,9 +11,6 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockRouterPush }),
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 const mockRefetch = vi.fn()
 let mockDeletionSummaryState = {

--- a/frontend/components/settings/passkey-management.test.tsx
+++ b/frontend/components/settings/passkey-management.test.tsx
@@ -12,9 +12,6 @@ vi.mock('@simplewebauthn/browser', () => ({
   browserSupportsWebAuthn: () => mockSupportsWebAuthn,
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 vi.mock('@/features/auth', () => ({
   PasskeyRegisterButton: ({ onSuccess, onError }: { onSuccess: () => void; onError: (err: string) => void }) => (

--- a/frontend/components/shared/MusicEmbed.test.tsx
+++ b/frontend/components/shared/MusicEmbed.test.tsx
@@ -2,10 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { MusicEmbed } from './MusicEmbed'
 
-// Mock Sentry
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 describe('MusicEmbed', () => {
   beforeEach(() => {

--- a/frontend/features/shows/components/ExportShowButton.test.tsx
+++ b/frontend/features/shows/components/ExportShowButton.test.tsx
@@ -2,11 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ExportShowButton } from './ExportShowButton'
 
-// Mock Sentry
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 describe('ExportShowButton', () => {
   const originalEnv = process.env.NODE_ENV

--- a/frontend/features/shows/components/HomeShowList.test.tsx
+++ b/frontend/features/shows/components/HomeShowList.test.tsx
@@ -3,10 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { HomeShowList } from './HomeShowList'
 import type { ShowResponse } from '../types'
 
-// Mock Sentry so a geo-fetch rejection in tests is observable & offline.
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 // Mock AuthContext.
 // Return type widened so individual tests can override `user`/`isAuthenticated`

--- a/frontend/features/shows/components/ShowList.test.tsx
+++ b/frontend/features/shows/components/ShowList.test.tsx
@@ -4,10 +4,6 @@ import userEvent from '@testing-library/user-event'
 import { ShowList } from './ShowList'
 import type { ShowResponse, ArtistResponse } from '../types'
 
-// Mock Sentry so a geo-fetch rejection in tests is observable & offline.
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-}))
 
 // Mock AuthContext
 const mockAuthContext = vi.fn(() => ({

--- a/frontend/instrumentation-client.test.ts
+++ b/frontend/instrumentation-client.test.ts
@@ -4,10 +4,6 @@ import * as Sentry from '@sentry/nextjs'
 // Replay is attached LAZILY (PSY-1091): Sentry.init runs at module-load, but the
 // replay integration lives in ./instrumentation-replay, dynamic-import()ed after
 // interactivity (production only). Mock that module so the lazy path is testable.
-vi.mock('@sentry/nextjs', () => ({
-  init: vi.fn(),
-  captureRouterTransitionStart: vi.fn(),
-}))
 // Hoisted stable spy so it survives vi.resetModules() — the dynamic import in
 // instrumentation-client and the assertions below share one instance.
 const { attachReplay } = vi.hoisted(() => ({ attachReplay: vi.fn() }))

--- a/frontend/instrumentation.test.ts
+++ b/frontend/instrumentation.test.ts
@@ -1,11 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import * as Sentry from '@sentry/nextjs'
 
-// instrumentation.ts binds onRequestError = Sentry.captureRequestError at
-// module-load time, so the mock must be in place before the import below.
-vi.mock('@sentry/nextjs', () => ({
-  captureRequestError: vi.fn(),
-}))
+// @sentry/nextjs is mocked globally in test/setup.ts (PSY-1097), so
+// Sentry.captureRequestError below is the shared mock fn — instrumentation.ts
+// binds onRequestError to that same reference at module-load time.
 
 describe('instrumentation.ts', () => {
   it('exports a callable register function', async () => {

--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -2,10 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as Sentry from '@sentry/nextjs'
 import { AuthError, AuthErrorCode } from './errors'
 
-vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
-  captureMessage: vi.fn(),
-}))
 
 // We need to test the module functions, but getApiBaseUrl runs at module load time
 // So we'll test the exported functions and mock fetch for apiRequest tests

--- a/frontend/lib/proxy-revalidation.test.ts
+++ b/frontend/lib/proxy-revalidation.test.ts
@@ -11,10 +11,6 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 const mockRevalidatePath = vi.mocked(revalidatePath)
 const mockCaptureMessage = vi.mocked(Sentry.captureMessage)

--- a/frontend/lib/revalidate-entity.test.ts
+++ b/frontend/lib/revalidate-entity.test.ts
@@ -7,10 +7,6 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-vi.mock('@sentry/nextjs', () => ({
-  captureMessage: vi.fn(),
-  captureException: vi.fn(),
-}))
 
 const mockRevalidatePath = vi.mocked(revalidatePath)
 const mockCaptureMessage = vi.mocked(Sentry.captureMessage)

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -3,6 +3,42 @@ import { afterAll, afterEach, beforeAll, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import { server } from './mocks/server'
 
+// Globally mock @sentry/nextjs (PSY-1097). The real package is large and slow to
+// transform; when a test pulls it in transitively (e.g. via lib/api.ts) the vite
+// module-runner can still be fetching it when the worker pool tears down,
+// surfacing as the intermittent "[vitest-worker]: Closing rpc while \"fetch\" was
+// pending" CI failure — the module-runner variant of the PSY-945 teardown race
+// (that one was an app HTTP fetch; this one is module resolution). Mocking it
+// here means the real module is never loaded in any unit test, so that race can't
+// fire, and per-file Sentry mocks become unnecessary. App code only calls
+// captureException / captureMessage / init / captureRequestError /
+// captureRouterTransitionStart / addIntegration; the rest are defensive stubs so
+// nothing throws if a consumer reaches for a common Sentry API.
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  captureEvent: vi.fn(),
+  init: vi.fn(),
+  captureRequestError: vi.fn(),
+  captureRouterTransitionStart: vi.fn(),
+  addIntegration: vi.fn(),
+  replayIntegration: vi.fn(() => ({ name: 'Replay' })),
+  reactErrorHandler: vi.fn(),
+  withScope: vi.fn((cb: (scope: unknown) => unknown) =>
+    cb({
+      setTag: vi.fn(),
+      setExtra: vi.fn(),
+      setContext: vi.fn(),
+      setLevel: vi.fn(),
+    })
+  ),
+  setUser: vi.fn(),
+  setTag: vi.fn(),
+  setContext: vi.fn(),
+  addBreadcrumb: vi.fn(),
+  flush: vi.fn(() => Promise.resolve(true)),
+}))
+
 // Start MSW server before all tests, reset handlers after each test,
 // and shut down the server when all tests complete.
 //


### PR DESCRIPTION
## Problem

The **Frontend Unit Tests** job intermittently fails with:

```
Error: [vitest-worker]: Closing rpc while "fetch" was pending
❯ VitestModuleRunner.getModuleInformation .../vite/dist/node/module-runner.js
❯ lib/api.ts:16:1          → import * as Sentry from '@sentry/nextjs'
❯ lib/hooks/admin/useAdminShows.ts:4:1
This error originated in "app/admin/page.test.tsx"
```

All tests pass (e.g. 5969/5969 on #1132), but vitest counts the stray rejection as a run error, so the job goes red and needs `gh run rerun --failed`.

## Root cause

This is the **module-runner** variant of the teardown race — distinct from the HTTP-fetch variant already handled by PSY-945 (`onUnhandledRequest: 'error'`). The vite module-runner is still fetching/transforming a *module's code* — the large, slow-to-transform `@sentry/nextjs` package, pulled in transitively via `lib/api.ts` — when the worker pool closes the RPC. `app/admin/page.test.tsx` doesn't mock Sentry, so the real module loads and can still be in flight at teardown.

## Fix

Mock `@sentry/nextjs` globally in `test/setup.ts` so the real module is never loaded in any unit test → the module-runner never fetches it → this race can't fire.

- App source only calls 6 Sentry APIs (`captureException`, `captureMessage`, `init`, `captureRequestError`, `captureRouterTransitionStart`, `addIntegration`); the global mock covers those plus a few defensive stubs.
- Removes **26 now-redundant per-file `vi.mock('@sentry/nextjs')`** calls (DRY).
- **Keeps 3** that wire local spies / custom behavior: `instrumentation-replay.test.ts`, `app/api/ai/extract-show/route.test.ts`, `components/settings/oauth-accounts.test.tsx`.
- Side benefit: faster suite (the biggest dep is never transformed).

## Verification

- Confirmed the global mock applies across files — a throwaway test with no per-file mock saw `vi.isMockFunction(Sentry.captureException) === true`.
- Full suite green locally: **488 files / 5968 tests, 0 errors**.
- `typecheck` ✅; `eslint` ✅ (0 errors; only pre-existing unused-var warnings remain — the one `vi`-unused warning my change introduced is fixed).
- **Honest caveat:** the flake isn't locally reproducible (it needs CI's no-backend timing), so the real proof is CI staying green across runs after merge. This is a strong mitigation of the observed (Sentry) instance, not a guaranteed cure for any future heavy-module teardown race.

Closes PSY-1097
EOF