### PR TITLE
PSY-1099: embed standalone Bandcamp tracks + auto-correct /album/↔/track/ path

### DIFF
--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
@@ -123,6 +123,49 @@ describe('POST /api/admin/artists/[id]/bandcamp', () => {
     expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
   })
 
+  it('auto-corrects an /album/ URL to /track/ on 404 and persists the corrected URL', async () => {
+    // Mirrors the Soroche bug: the suggested /album/<slug> 404s, but the same
+    // slug exists at /track/<slug>. The route must retry and save the /track/ URL.
+    const trackPage =
+      '<div data-embed="{&quot;tralbum_param&quot;:{&quot;name&quot;:&quot;track&quot;,&quot;value&quot;:777}}"></div>'
+    let patchedBody: string | undefined
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url === `${BACKEND}/auth/profile`) {
+          return new Response(
+            JSON.stringify({ success: true, user: { id: '1', is_admin: true } }),
+            { status: 200 }
+          )
+        }
+        if (url === 'https://brighteyes.bandcamp.com/album/kids-table') {
+          return new Response('not found', { status: 404 })
+        }
+        if (url === 'https://brighteyes.bandcamp.com/track/kids-table') {
+          return new Response(trackPage, { status: 200 })
+        }
+        if (url === `${BACKEND}/admin/artists/${ARTIST_ID}/bandcamp`) {
+          patchedBody = init?.body as string
+          return new Response(
+            JSON.stringify({ id: 47, slug: 'bright-eyes', name: 'Bright Eyes' }),
+            { status: 200 }
+          )
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`)
+      })
+
+    const res = await POST(
+      postRequest({ bandcamp_url: 'https://brighteyes.bandcamp.com/album/kids-table' }),
+      params
+    )
+
+    expect(res.status).toBe(200)
+    expect(JSON.parse(patchedBody!)).toEqual({
+      bandcamp_embed_url: 'https://brighteyes.bandcamp.com/track/kids-table',
+    })
+  })
+
   it('does NOT revalidate when the backend save fails', async () => {
     fetchSpy = mockFetchRouting({
       backendResponse: new Response(JSON.stringify({ detail: 'boom' }), {

--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import * as Sentry from '@sentry/nextjs'
 import { revalidateArtistDetail } from '@/lib/revalidate-entity'
+import { resolveBandcampEmbed } from '@/lib/bandcamp'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -44,7 +45,13 @@ async function getAuthenticatedUser(
   }
 }
 
-async function validateBandcampUrl(url: string): Promise<{ valid: boolean; error?: string }> {
+// Validates the URL is an embeddable Bandcamp album/track page and returns the
+// URL that actually resolved — which may differ from the input when an
+// /album/ <-> /track/ path mismatch was auto-corrected (see lib/bandcamp). The
+// caller persists `resolvedUrl` so a corrected path is what gets stored.
+async function validateBandcampUrl(
+  url: string
+): Promise<{ valid: true; resolvedUrl: string } | { valid: false; error: string }> {
   // Basic format validation
   if (!url.includes('bandcamp.com')) {
     return { valid: false, error: 'URL must be a Bandcamp URL' }
@@ -57,28 +64,11 @@ async function validateBandcampUrl(url: string): Promise<{ valid: boolean; error
     }
   }
 
-  try {
-    // Fetch the Bandcamp page directly to validate it's embeddable
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; MusicEmbed/1.0)',
-      },
-    })
-
-    if (!response.ok) {
-      return { valid: false, error: `Failed to fetch Bandcamp page: ${response.status}` }
-    }
-
-    const html = await response.text()
-    const match = html.match(/album=(\d+)/)
-    if (!match) {
-      return { valid: false, error: 'Could not extract album ID from URL' }
-    }
-
-    return { valid: true }
-  } catch {
-    return { valid: false, error: 'Failed to validate URL' }
+  const result = await resolveBandcampEmbed(url)
+  if (!result.ok) {
+    return { valid: false, error: result.error }
   }
+  return { valid: true, resolvedUrl: result.embed.resolvedUrl }
 }
 
 export async function POST(
@@ -140,7 +130,8 @@ export async function POST(
           'Content-Type': 'application/json',
           Cookie: `auth_token=${authToken.value}`,
         },
-        body: JSON.stringify({ bandcamp_embed_url: bandcamp_url }),
+        // Persist the resolved URL (path auto-corrected if it was wrong).
+        body: JSON.stringify({ bandcamp_embed_url: validation.resolvedUrl }),
       }
     )
 

--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -18,6 +18,7 @@ Output STRICT JSON only — no prose, no markdown code fences. Shape:
 
 Rules:
 - Bandcamp URLs MUST be album or track URLs (e.g. https://artist.bandcamp.com/album/name), NOT profile URLs.
+- A standalone single lives at https://artist.bandcamp.com/track/<slug>; a multi-track release at https://artist.bandcamp.com/album/<slug>. Copy the EXACT URL from the search result — do NOT guess the /album/ vs /track/ segment or invent a slug.
 - Spotify URLs MUST be artist URLs in the form https://open.spotify.com/artist/{22-char-id}.
 - Include EVERY plausible same-name candidate you find, not just the most popular. The admin will disambiguate.
 - "popularity" is freeform text — for Spotify, include monthly listeners or follower count if known.

--- a/frontend/app/api/bandcamp/album-id/route.test.ts
+++ b/frontend/app/api/bandcamp/album-id/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Sentry is a no-op in tests; mock so the failure paths don't reach the SDK.
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+let fetchSpy: ReturnType<typeof vi.spyOn> | undefined
+
+afterEach(() => {
+  fetchSpy?.mockRestore()
+  fetchSpy = undefined
+  vi.clearAllMocks()
+})
+
+function getRequest(url?: string) {
+  const target = url
+    ? `http://localhost:3000/api/bandcamp/album-id?url=${encodeURIComponent(url)}`
+    : 'http://localhost:3000/api/bandcamp/album-id'
+  return new NextRequest(target)
+}
+
+describe('GET /api/bandcamp/album-id', () => {
+  it('returns { kind, id } for a resolvable track URL', async () => {
+    const trackPage =
+      '<div data-embed="{&quot;tralbum_param&quot;:{&quot;name&quot;:&quot;track&quot;,&quot;value&quot;:777}}"></div>'
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(trackPage, { status: 200 }))
+
+    const res = await GET(getRequest('https://x.bandcamp.com/track/song'))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ kind: 'track', id: '777' })
+  })
+
+  it('returns 400 when the url param is missing', async () => {
+    const res = await GET(getRequest())
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for a non-Bandcamp URL', async () => {
+    const res = await GET(getRequest('https://example.com/album/x'))
+    expect(res.status).toBe(400)
+  })
+
+  it('maps an unresolvable URL (both path types 404) to a 404', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('nope', { status: 404 }))
+
+    const res = await GET(getRequest('https://x.bandcamp.com/album/ghost'))
+
+    expect(res.status).toBe(404)
+  })
+
+  it('maps a page with no embed id to a 404', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('<html>nothing</html>', { status: 200 }))
+
+    const res = await GET(getRequest('https://x.bandcamp.com/album/empty'))
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/frontend/app/api/bandcamp/album-id/route.ts
+++ b/frontend/app/api/bandcamp/album-id/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
+import { resolveBandcampEmbed } from '@/lib/bandcamp'
 
+// Resolves a Bandcamp album OR track URL to an embeddable { kind, id }. The
+// route name predates standalone-track support; it now handles /track/ URLs and
+// auto-corrects an /album/ <-> /track/ path mismatch (see lib/bandcamp).
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const url = searchParams.get('url')
@@ -14,55 +18,27 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Not a Bandcamp URL' }, { status: 400 })
   }
 
-  try {
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; MusicEmbed/1.0)',
-      },
-    })
+  const result = await resolveBandcampEmbed(url)
 
-    if (!response.ok) {
-      Sentry.captureMessage(`Bandcamp page fetch failed: ${response.status}`, {
-        level: 'warning',
-        tags: { service: 'bandcamp-scraper' },
-        extra: { url, status: response.status },
-      })
-      return NextResponse.json(
-        { error: `Failed to fetch Bandcamp page: ${response.status}` },
-        { status: response.status }
-      )
-    }
-
-    const html = await response.text()
-
-    // Extract album ID from the page - look for album=NUMBERS pattern
-    const match = html.match(/album=(\d+)/)
-    if (!match) {
-      return NextResponse.json(
-        { error: 'Could not find album ID on page' },
-        { status: 404 }
-      )
-    }
-
-    const albumId = match[1]
-
-    return NextResponse.json(
-      { albumId },
-      {
-        headers: {
-          'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
-        },
-      }
-    )
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
+  if (!result.ok) {
+    // Page loaded but no embed id (status 200) -> 404; network throw -> 500;
+    // otherwise surface the upstream status (e.g. a real 404).
+    const status =
+      result.status === null ? 500 : result.status === 200 ? 404 : result.status
+    Sentry.captureMessage(`Bandcamp embed resolve failed: ${result.error}`, {
+      level: status >= 500 ? 'error' : 'warning',
       tags: { service: 'bandcamp-scraper' },
-      extra: { url },
+      extra: { url, status: result.status },
     })
-    return NextResponse.json(
-      { error: 'Failed to extract album ID' },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: result.error }, { status })
   }
+
+  return NextResponse.json(
+    { kind: result.embed.kind, id: result.embed.id },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+      },
+    }
+  )
 }

--- a/frontend/components/shared/MusicEmbed.test.tsx
+++ b/frontend/components/shared/MusicEmbed.test.tsx
@@ -54,7 +54,7 @@ describe('MusicEmbed', () => {
   it('renders bandcamp iframe when album ID is fetched successfully', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ albumId: '12345' }),
+      json: async () => ({ kind: 'album', id: '12345' }),
     } as Response)
 
     render(
@@ -70,6 +70,28 @@ describe('MusicEmbed', () => {
       expect(iframe).toHaveAttribute(
         'src',
         expect.stringContaining('album=12345')
+      )
+    })
+  })
+
+  it('renders a track embed when the resolver returns a track', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ kind: 'track', id: '2445352951' }),
+    } as Response)
+
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/track/test"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      const iframe = screen.getByTitle('Test Artist on Bandcamp')
+      expect(iframe).toHaveAttribute(
+        'src',
+        expect.stringContaining('track=2445352951')
       )
     })
   })
@@ -157,7 +179,7 @@ describe('MusicEmbed', () => {
   it('prioritizes bandcamp over spotify', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ albumId: '99999' }),
+      json: async () => ({ kind: 'album', id: '99999' }),
     } as Response)
 
     render(

--- a/frontend/components/shared/MusicEmbed.tsx
+++ b/frontend/components/shared/MusicEmbed.tsx
@@ -24,7 +24,7 @@ function parseSpotifyArtistId(url: string): string | null {
 
 type EmbedState =
   | { type: 'loading' }
-  | { type: 'bandcamp'; albumId: string }
+  | { type: 'bandcamp'; embedKind: 'album' | 'track'; embedId: string }
   | { type: 'spotify'; artistId: string }
   | { type: 'fallback'; url: string; label: string }
   | { type: 'none' }
@@ -40,7 +40,7 @@ export function MusicEmbed({
 
   useEffect(() => {
     async function resolveEmbed() {
-      // Priority 1: Bandcamp album URL - fetch album ID
+      // Priority 1: Bandcamp album/track URL - resolve the embed kind + id
       if (bandcampAlbumUrl) {
         try {
           const response = await fetch(
@@ -48,8 +48,8 @@ export function MusicEmbed({
           )
           if (response.ok) {
             const data = await response.json()
-            if (data.albumId) {
-              setEmbed({ type: 'bandcamp', albumId: data.albumId })
+            if (data.id && (data.kind === 'album' || data.kind === 'track')) {
+              setEmbed({ type: 'bandcamp', embedKind: data.kind, embedId: data.id })
               return
             }
           }
@@ -140,7 +140,7 @@ export function MusicEmbed({
           <iframe
             title={`${artistName} on Bandcamp`}
             style={{ border: 0, width: '100%', maxWidth: '700px', height: '120px' }}
-            src={`https://bandcamp.com/EmbeddedPlayer/album=${embed.albumId}/size=large/bgcol=1a1a1a/linkcol=f59e0b/tracklist=false/artwork=small/`}
+            src={`https://bandcamp.com/EmbeddedPlayer/${embed.embedKind}=${embed.embedId}/size=large/bgcol=1a1a1a/linkcol=f59e0b/tracklist=false/artwork=small/`}
             seamless
           />
         </div>

--- a/frontend/lib/bandcamp.test.ts
+++ b/frontend/lib/bandcamp.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  parseBandcampEmbedId,
+  swapAlbumTrackPath,
+  resolveBandcampEmbed,
+} from './bandcamp'
+
+// Every test that touches fetch installs a spy via mockFetchSequence; restore
+// after each so no spy leaks into the next test.
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// Real-shape `data-embed` attributes (HTML-entity-encoded, as Bandcamp serves).
+const TRACK_HTML =
+  '<div data-embed="{&quot;tralbum_param&quot;:{&quot;name&quot;:&quot;track&quot;,&quot;value&quot;:2445352951},&quot;art_id&quot;:2137030374}"></div>'
+const ALBUM_HTML =
+  '<div data-embed="{&quot;tralbum_param&quot;:{&quot;name&quot;:&quot;album&quot;,&quot;value&quot;:123456789}}"></div>'
+
+function mockFetchSequence(
+  ...responses: Array<{ ok: boolean; status?: number; html?: string } | Error>
+) {
+  const spy = vi.spyOn(global, 'fetch')
+  for (const r of responses) {
+    if (r instanceof Error) {
+      spy.mockRejectedValueOnce(r)
+    } else {
+      spy.mockResolvedValueOnce({
+        ok: r.ok,
+        status: r.status ?? (r.ok ? 200 : 404),
+        text: async () => r.html ?? '',
+      } as Response)
+    }
+  }
+  return spy
+}
+
+describe('swapAlbumTrackPath', () => {
+  it('swaps /album/ -> /track/', () => {
+    expect(swapAlbumTrackPath('https://x.bandcamp.com/album/leyenda')).toBe(
+      'https://x.bandcamp.com/track/leyenda'
+    )
+  })
+  it('swaps /track/ -> /album/', () => {
+    expect(swapAlbumTrackPath('https://x.bandcamp.com/track/leyenda')).toBe(
+      'https://x.bandcamp.com/album/leyenda'
+    )
+  })
+  it('returns null when neither segment is present', () => {
+    expect(swapAlbumTrackPath('https://x.bandcamp.com')).toBeNull()
+  })
+  it('swaps only the path segment, preserving a slug that contains album/track', () => {
+    // The literal "/album/" (slash-delimited) only appears as the path type;
+    // a single-segment slug can't contain it, so the slug is left intact.
+    expect(
+      swapAlbumTrackPath('https://x.bandcamp.com/album/my-album-remix')
+    ).toBe('https://x.bandcamp.com/track/my-album-remix')
+    expect(
+      swapAlbumTrackPath('https://x.bandcamp.com/track/album-version?x=1')
+    ).toBe('https://x.bandcamp.com/album/album-version?x=1')
+  })
+})
+
+describe('parseBandcampEmbedId', () => {
+  it('reads kind+id from a track data-embed', () => {
+    expect(parseBandcampEmbedId(TRACK_HTML)).toEqual({
+      kind: 'track',
+      id: '2445352951',
+    })
+  })
+  it('reads kind+id from an album data-embed', () => {
+    expect(parseBandcampEmbedId(ALBUM_HTML)).toEqual({
+      kind: 'album',
+      id: '123456789',
+    })
+  })
+  it('falls back to a bare track= identifier', () => {
+    expect(
+      parseBandcampEmbedId('<iframe src="EmbeddedPlayer/track=999/size=large">')
+    ).toEqual({ kind: 'track', id: '999' })
+  })
+  it('falls back to a bare album= identifier, preferring album', () => {
+    expect(
+      parseBandcampEmbedId('...album=42... track=7...')
+    ).toEqual({ kind: 'album', id: '42' })
+  })
+  it('returns null when no identifier is present', () => {
+    expect(parseBandcampEmbedId('<html>nothing here</html>')).toBeNull()
+  })
+})
+
+describe('resolveBandcampEmbed', () => {
+  it('resolves a reachable track URL without changing the URL', async () => {
+    mockFetchSequence({ ok: true, html: TRACK_HTML })
+    const result = await resolveBandcampEmbed(
+      'https://sorochemusic.bandcamp.com/track/leyenda'
+    )
+    expect(result).toEqual({
+      ok: true,
+      embed: {
+        kind: 'track',
+        id: '2445352951',
+        resolvedUrl: 'https://sorochemusic.bandcamp.com/track/leyenda',
+      },
+    })
+  })
+
+  it('auto-corrects /album/ -> /track/ on a 404 and persists the corrected URL', async () => {
+    // First fetch (the LLM's /album/ guess) 404s; the /track/ sibling resolves.
+    const spy = mockFetchSequence(
+      { ok: false, status: 404 },
+      { ok: true, html: TRACK_HTML }
+    )
+    const result = await resolveBandcampEmbed(
+      'https://sorochemusic.bandcamp.com/album/leyenda'
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.embed.kind).toBe('track')
+      expect(result.embed.id).toBe('2445352951')
+      expect(result.embed.resolvedUrl).toBe(
+        'https://sorochemusic.bandcamp.com/track/leyenda'
+      )
+    }
+    // Confirms it retried the sibling path.
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      'https://sorochemusic.bandcamp.com/track/leyenda',
+      expect.anything()
+    )
+  })
+
+  it('fails with the 404 status when neither path type resolves', async () => {
+    mockFetchSequence({ ok: false, status: 404 }, { ok: false, status: 404 })
+    const result = await resolveBandcampEmbed(
+      'https://x.bandcamp.com/album/ghost'
+    )
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: 'Failed to fetch Bandcamp page: 404',
+    })
+  })
+
+  it('does not retry the sibling on a non-404 error', async () => {
+    const spy = mockFetchSequence({ ok: false, status: 503 })
+    const result = await resolveBandcampEmbed(
+      'https://x.bandcamp.com/album/down'
+    )
+    expect(result).toEqual({
+      ok: false,
+      status: 503,
+      error: 'Failed to fetch Bandcamp page: 503',
+    })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a null status when the fetch throws', async () => {
+    mockFetchSequence(new Error('network down'))
+    const result = await resolveBandcampEmbed(
+      'https://x.bandcamp.com/track/x'
+    )
+    expect(result).toEqual({
+      ok: false,
+      status: null,
+      error: 'Failed to fetch Bandcamp page',
+    })
+  })
+
+  it('fails when the page loads but has no embed id', async () => {
+    mockFetchSequence({ ok: true, html: '<html>no embed</html>' })
+    const result = await resolveBandcampEmbed(
+      'https://x.bandcamp.com/album/empty'
+    )
+    expect(result).toEqual({
+      ok: false,
+      status: 200,
+      error: 'Could not extract embed ID from Bandcamp page',
+    })
+  })
+})

--- a/frontend/lib/bandcamp.ts
+++ b/frontend/lib/bandcamp.ts
@@ -1,0 +1,119 @@
+// Shared resolver for Bandcamp album/track pages.
+//
+// Bandcamp serves the same slug under EITHER /album/<slug> OR /track/<slug>,
+// depending on whether the release is a full album or a standalone single.
+// The two namespaces don't overlap, so a caller (the LLM "Discover Music"
+// suggester especially) routinely produces an /album/ URL for what is actually
+// a /track/ single — which 404s. This module fetches the page, auto-corrects
+// the path type on a 404, and reads the canonical embed descriptor so both
+// albums and standalone tracks can be embedded.
+
+const BANDCAMP_FETCH_HEADERS = {
+  'User-Agent': 'Mozilla/5.0 (compatible; MusicEmbed/1.0)',
+}
+
+export type BandcampEmbedKind = 'album' | 'track'
+
+export interface BandcampEmbed {
+  kind: BandcampEmbedKind
+  id: string
+  // The URL that actually resolved. Differs from the input when the
+  // album/track path segment was auto-corrected — callers persist this so the
+  // stored URL points at the page that really exists.
+  resolvedUrl: string
+}
+
+export type ResolveBandcampResult =
+  | { ok: true; embed: BandcampEmbed }
+  | { ok: false; status: number | null; error: string }
+
+// Swap /album/<slug> <-> /track/<slug>. Returns null when the URL has neither
+// segment (e.g. a bare profile URL), so callers don't retry meaninglessly.
+export function swapAlbumTrackPath(url: string): string | null {
+  if (url.includes('/album/')) return url.replace('/album/', '/track/')
+  if (url.includes('/track/')) return url.replace('/track/', '/album/')
+  return null
+}
+
+// The page embeds its canonical player descriptor in a `data-embed` attribute,
+// HTML-entity-encoded, e.g.
+//   data-embed="{&quot;tralbum_param&quot;:{&quot;name&quot;:&quot;track&quot;,&quot;value&quot;:2445352951},...}"
+// This is the authoritative source for BOTH the kind and the numeric id, and
+// is present for albums and standalone tracks alike. Quotes may be encoded
+// (&quot;) in the attribute or bare (") in inline JSON, so accept either.
+const Q = '(?:&quot;|")'
+const TRALBUM_PARAM_RE = new RegExp(
+  `tralbum_param${Q}\\s*:\\s*\\{\\s*${Q}name${Q}\\s*:\\s*${Q}(album|track)${Q}\\s*,\\s*${Q}value${Q}\\s*:\\s*(\\d+)`
+)
+
+export function parseBandcampEmbedId(
+  html: string
+): { kind: BandcampEmbedKind; id: string } | null {
+  const tralbum = html.match(TRALBUM_PARAM_RE)
+  if (tralbum) return { kind: tralbum[1] as BandcampEmbedKind, id: tralbum[2] }
+
+  // Fallback for pages where the descriptor isn't found: a bare album=/track=
+  // identifier from an EmbeddedPlayer reference. Prefer album (a full release)
+  // to preserve prior behavior; standalone-track pages carry only track=.
+  const album = html.match(/album=(\d+)/)
+  if (album) return { kind: 'album', id: album[1] }
+  const track = html.match(/track=(\d+)/)
+  if (track) return { kind: 'track', id: track[1] }
+
+  return null
+}
+
+async function fetchBandcampPage(
+  url: string
+): Promise<{ ok: true; html: string } | { ok: false; status: number | null }> {
+  try {
+    const response = await fetch(url, { headers: BANDCAMP_FETCH_HEADERS })
+    if (!response.ok) return { ok: false, status: response.status }
+    return { ok: true, html: await response.text() }
+  } catch {
+    return { ok: false, status: null }
+  }
+}
+
+// Fetch a Bandcamp album/track URL and resolve it to an embeddable descriptor.
+// On a 404 for an /album/ or /track/ URL, retries the sibling path type once
+// before giving up.
+export async function resolveBandcampEmbed(
+  inputUrl: string
+): Promise<ResolveBandcampResult> {
+  let resolvedUrl = inputUrl
+  let page = await fetchBandcampPage(inputUrl)
+
+  if (!page.ok && page.status === 404) {
+    const sibling = swapAlbumTrackPath(inputUrl)
+    if (sibling) {
+      const siblingPage = await fetchBandcampPage(sibling)
+      if (siblingPage.ok) {
+        resolvedUrl = sibling
+        page = siblingPage
+      }
+    }
+  }
+
+  if (!page.ok) {
+    return {
+      ok: false,
+      status: page.status,
+      error:
+        page.status === null
+          ? 'Failed to fetch Bandcamp page'
+          : `Failed to fetch Bandcamp page: ${page.status}`,
+    }
+  }
+
+  const parsed = parseBandcampEmbedId(page.html)
+  if (!parsed) {
+    return {
+      ok: false,
+      status: 200,
+      error: 'Could not extract embed ID from Bandcamp page',
+    }
+  }
+
+  return { ok: true, embed: { kind: parsed.kind, id: parsed.id, resolvedUrl } }
+}


### PR DESCRIPTION
## Problem

The admin **Discover Music** feature returned Bandcamp links that 404 on save. Found during stage dogfooding on the **Soroche** artist page: the top "high confidence" candidate was `https://sorochemusic.bandcamp.com/album/leyenda`, which 404s. Clicking **Use this** failed with "Failed to fetch Bandcamp page: 404".

Two independent defects:

**A. Wrong Bandcamp path type, never validated until save.** "Leyenda" is a standalone **single** at `/track/leyenda`, but the LLM guessed `/album/leyenda`. `discover-music/route.ts` only regex-checks URL *shape* — it never fetches the candidate, so a well-formed-but-nonexistent URL shows as "high confidence" and the 404 only surfaces at save time.

**B. The embed pipeline couldn't handle standalone tracks at all (latent limitation).** Verified against the live page:

```
/album/leyenda  -> 404   (LLM guess)
/track/leyenda  -> 200   (real page)   no album=<digits>, only track=2445352951
data-embed = {"tralbum_param":{"name":"track","value":2445352951}, ...}
```

Both the album-id route and the save validator extracted `album=(\d+)`, and `MusicEmbed` hardcoded `EmbeddedPlayer/album=${id}`. **Result: no standalone Bandcamp single could be saved or embedded — only albums.**

## Fix

New shared resolver `frontend/lib/bandcamp.ts` (`resolveBandcampEmbed`) consolidates the three duplicated fetch/extract sites. It:

1. Fetches the URL; on a **404 for an `/album/` or `/track/` URL, retries the sibling path type** (fixes A).
2. Parses the page's `data-embed` `tralbum_param` for **both `kind` (`album`/`track`) and `id`** (fixes B), with the old `album=`/`track=` regex as fallback.
3. Returns `{ kind, id, resolvedUrl }` so the save path persists the **corrected** URL.

Wired into:
- `app/api/bandcamp/album-id/route.ts` — returns `{ kind, id }`.
- `app/api/admin/artists/[id]/bandcamp/route.ts` — persists `resolvedUrl`.
- `components/shared/MusicEmbed.tsx` — builds `EmbeddedPlayer/${kind}=${id}`.

Plus one line in the discovery system prompt: copy the exact URL, don't guess `/album/` vs `/track/`.

## Verification

- **Live integration check** against the real Bandcamp page: `/album/leyenda` (404) auto-corrects to `/track/leyenda`, returning `kind: track, id: 2445352951`.
- `tsc --noEmit` clean; eslint clean.
- New `lib/bandcamp.test.ts` (15) + new `album-id/route.test.ts` (5) + a 404-retry/`resolvedUrl`-persistence case in the existing save-route test + updated `MusicEmbed.test.tsx` (track embed). 114 MusicEmbed-consumer tests unaffected.
- Two-agent code review (correctness clean; cleanup findings addressed).

## Out of scope (follow-up)

Discovery-time candidate validation — fetch-validate each candidate inside the Discover Music route so dead/wrong-path candidates never reach the admin. Deferred to keep this PR focused and discovery cheap.

Closes PSY-1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)
