### PR TITLE
PSY-1105: drop stale home E2E assertions for removed section

### DIFF
--- a/frontend/e2e/pages/home.spec.ts
+++ b/frontend/e2e/pages/home.spec.ts
@@ -79,14 +79,6 @@ test.describe('Homepage', () => {
       page.getByRole('link', { name: /KEXP.*Variety Mix/i })
     ).toHaveAttribute('href', '/radio')
 
-    // Across the scene — reserved activity-feed placeholder
-    await expect(
-      page.getByRole('heading', { name: /across the scene/i })
-    ).toBeVisible()
-    await expect(
-      page.getByText('Reserved for the Activity feed')
-    ).toBeVisible()
-
     // Editorial footer columns (PSY-389). Scope to the footer landmark — the
     // hero also renders a "Discover" quick-links nav, so an unscoped match is
     // a strict-mode violation (two `navigation[name="Discover"]` on the page).


### PR DESCRIPTION
## Summary

Restores main to green. PSY-1098 (#1135) removed the "Across the scene" / `ActivityFeedPlaceholder` home section but left two assertions in `e2e/pages/home.spec.ts` checking for its heading + "Reserved for the Activity feed" text. That spec is **non-`@smoke`**, so PR #1135's smoke-only CI passed while full-E2E-on-main failed on `E2E Tests (shard 3/4)`.

This removes the two now-stale assertions. The rest of the `displays discovery sections and footer (PSY-389)` test (radio shows, footer) is untouched.

## Test plan

- [x] `bun run typecheck` — passed
- [x] `eslint e2e/pages/home.spec.ts` — passed
- [x] grep confirms no remaining `across the scene` / `Reserved for the Activity feed` refs in `e2e/`

## Manual repro

The change is a pure deletion of the two assertions that match content removed in PSY-1098; it touches nothing else in the test, so it cannot affect the test's other (radio/footer) assertions. Full E2E was **not** run locally (requires the E2E stack: port 8080 backend + seeded DB); since the failing spec is non-`@smoke`, this PR's own CI won't exercise it either — confirmation comes from full-E2E-on-main post-merge (the same gate that caught the regression).

Closes PSY-1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
