### PR TITLE
PSY-1100: dedup remaining server fetch helpers with React.cache()

### DIFF
--- a/frontend/app/radio/[station-slug]/page.tsx
+++ b/frontend/app/radio/[station-slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
@@ -27,7 +28,11 @@ interface StationData {
   network?: StationNetwork | null
 }
 
-async function getStation(slug: string): Promise<StationData | null> {
+// Wrapped with `React.cache()` so `generateMetadata` and the page body
+// share ONE backend fetch per request instead of two. The body needs the
+// result for the sub-stream `redirect()` below. Matches the entity-page
+// pattern in `app/artists/[slug]/page.tsx`.
+const getStation = cache(async (slug: string): Promise<StationData | null> => {
   try {
     const res = await fetch(`${API_BASE_URL}/radio-stations/${slug}`, {
       next: { revalidate: 3600 },
@@ -50,7 +55,7 @@ async function getStation(slug: string): Promise<StationData | null> {
     })
   }
   return null
-}
+})
 
 export async function generateMetadata({ params }: StationPageProps): Promise<Metadata> {
   const { 'station-slug': stationSlug } = await params

--- a/frontend/features/blog/utils/blog.ts
+++ b/frontend/features/blog/utils/blog.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { cache } from 'react'
 import matter from 'gray-matter'
 import * as Sentry from '@sentry/nextjs'
 import { getTextExcerpt } from '@/lib/utils/markdownExcerpt'
@@ -55,9 +56,15 @@ function convertShortcodesToMDX(content: string): string {
 }
 
 /**
- * Get a single blog post by slug
+ * Get a single blog post by slug.
+ *
+ * Wrapped with `React.cache()` so the fs read + gray-matter parse runs once
+ * per slug per request — `app/blog/[slug]/page.tsx` calls it in both
+ * `generateMetadata` and the page body. `cache()` is request-scoped, so the
+ * non-request callers below (`getAllBlogPosts`, `getPostsByCategory`) are
+ * unaffected. Matches the entity-page pattern in `app/artists/[slug]/page.tsx`.
  */
-export function getBlogPost(slug: string): BlogPost | null {
+export const getBlogPost = cache((slug: string): BlogPost | null => {
   const filePath = path.join(BLOG_CONTENT_PATH, `${slug}.md`)
 
   try {
@@ -85,7 +92,7 @@ export function getBlogPost(slug: string): BlogPost | null {
     })
     return null
   }
-}
+})
 
 /**
  * Get all blog posts metadata for listing (sorted by date, newest first)

--- a/frontend/features/blog/utils/mixes.ts
+++ b/frontend/features/blog/utils/mixes.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { cache } from 'react'
 import matter from 'gray-matter'
 import * as Sentry from '@sentry/nextjs'
 import type { Mix, MixMeta, MixFrontmatter } from '../types'
@@ -43,9 +44,15 @@ function convertShortcodesToMDX(content: string): string {
 }
 
 /**
- * Get a single mix by slug
+ * Get a single mix by slug.
+ *
+ * Wrapped with `React.cache()` so the fs read + gray-matter parse runs once
+ * per slug per request — `app/dj-sets/[slug]/page.tsx` calls it in both
+ * `generateMetadata` and the page body. `cache()` is request-scoped, so the
+ * non-request caller below (`getAllMixes`) is unaffected. Matches the
+ * entity-page pattern in `app/artists/[slug]/page.tsx`.
  */
-export function getMix(slug: string): Mix | null {
+export const getMix = cache((slug: string): Mix | null => {
   const filePath = path.join(MIXES_CONTENT_PATH, `${slug}.md`)
 
   try {
@@ -72,7 +79,7 @@ export function getMix(slug: string): Mix | null {
     })
     return null
   }
-}
+})
 
 /**
  * Get all mixes metadata for listing (sorted by date, newest first)


### PR DESCRIPTION
## Summary
Three server fetch helpers were each called in BOTH `generateMetadata` and the page body in the same request, but were not wrapped in `React.cache()`, so each did duplicate work per render. This wraps them, matching the entity-page pattern already used by the 8 primary entity pages (`app/artists/[slug]/page.tsx`):

- `getStation` (`app/radio/[station-slug]/page.tsx`) — HIGH runtime dup: 2 backend round-trips per render (the body needs the result for the sub-stream `redirect()`).
- `getBlogPost` (`features/blog/utils/blog.ts`) — duplicate fs read + gray-matter parse + shortcode regex at build time.
- `getMix` (`features/blog/utils/mixes.ts`) — same, for dj-sets.

`cache()` is request-scoped, so the non-request callers (`getAllBlogPosts`, `getPostsByCategory`, `getAllMixes`) are unaffected. Sibling radio routes that call their fetch only in `generateMetadata` were left untouched per the ticket.

**Behavior-preserving**: same rendered output, fewer fetches/parses per render.

## Test plan
- [x] `bun run typecheck` — pass (`tsc --noEmit`, no errors)
- [x] `bun run lint` — pass (0 errors; only pre-existing warnings, none in changed files)
- [x] `bun run test:run features/blog app/blog` — 66 passed (6 files): blog/mixes util tests (which re-import the real `cache()`-wrapped fns under `vi.resetModules()` + changing fs mocks) + blog page tests, all green.

## Manual repro
Via dispatch stack (`--mode=shared`, seeded backend on :54123) + agent-browser, isolated session:
- `/radio/kexp` (flagship, no network) — title "KEXP — Radio" (from `generateMetadata`); body `StationDetail` rendered fully (Listen Live, shows, playlists); no redirect.
- `/radio/wfmu-drummer` (non-flagship in `wfmu` network) — body's `redirect()` fired correctly → `/radio/wfmu/channel/drummer`; title "Give the Drummer Radio — Radio". This is the path that consumes `getStation` in BOTH metadata and the body.
- `/blog/2025-02-16-psychic-homily-dot-com-is-now-live` — metadata title + body H1 both "PsychicHomily.com is now live!".
- `/dj-sets/2025-03-31-vinyl-mix-...` — metadata title + body H1 match.
- `/blog/this-slug-does-not-exist` — `getBlogPost` → null path through `cache()` → "Post Not Found".
All rendered correctly. Stack torn down after.

## Code review
`/code-review` (xhigh, ran inline as a dispatched sub-agent) — no findings (`[]`). Verified no TDZ from the function-declaration → `const` change (every definition precedes its call sites), call shapes unchanged, no wrapper re-entry.

## Adversarial review
`/adversarial-review` — CLEAN, no fixes needed (ran the 4 lenses inline as a dispatched sub-agent without the Agent tool, per the documented fallback).
- Saboteur: read-only helpers, per-slug distinct cache keys, error/null paths byte-identical → no finding.
- Future-Maintainer: matches existing `getArtist = cache(...)` convention; added "why" comments. One pre-existing LOW (no `getStation` page unit test) — already mitigated by manual repro, not introduced here.
- Security: no new trust boundary/injection/authz surface.
- Completeness: all 3 helpers wrapped, siblings correctly untouched, acceptance criteria met.

Panel: Saboteur · Future-Maintainer · Security · Completeness. Reviewers ran with no prior session context against the branch diff.

Closes PSY-1100