### PR TITLE
PSY-1104: parallelize independent awaits in admin/AI routes

### DIFF
--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -147,7 +147,14 @@ export async function POST(
       { status: 401 }
     )
   }
-  const profile = await getAuthenticatedUser(authCookie.value)
+  // Auth and artist lookup are independent (getArtist uses only the path id),
+  // so kick both off concurrently. We still AWAIT auth first and return 403
+  // before awaiting the artist — the gate runs before any artist result is
+  // consumed, and the unauthorized path just discards an in-flight fetch.
+  const profilePromise = getAuthenticatedUser(authCookie.value)
+  const artistPromise = getArtist(artistId)
+
+  const profile = await profilePromise
   if (!profile?.success || !profile.user?.is_admin) {
     return NextResponse.json(
       { error: 'Admin access required' },
@@ -155,7 +162,7 @@ export async function POST(
     )
   }
 
-  const artist = await getArtist(artistId)
+  const artist = await artistPromise
   if (!artist) {
     return NextResponse.json({ error: 'Artist not found' }, { status: 404 })
   }

--- a/frontend/app/api/ai/extract-show/route.ts
+++ b/frontend/app/api/ai/extract-show/route.ts
@@ -440,12 +440,22 @@ export async function POST(request: NextRequest) {
 
     const warnings: string[] = []
 
-    // Extract and match artists
+    // Extract artist + venue inputs, then match them concurrently. The two
+    // matches are independent (matchVenue does not consume matchedArtists), so
+    // run them in parallel and compute the warning strings afterward.
+    // matchArtists' inner per-artist loop stays sequential by design — see the
+    // sibling extract-collection route, which keeps its loop bounded to avoid
+    // firing N concurrent backend search requests.
     const rawArtists = Array.isArray(parsed.artists) ? parsed.artists : []
     if (rawArtists.length === 0) {
       warnings.push('No artists were found in the input')
     }
-    const matchedArtists = await matchArtists(rawArtists)
+    const rawVenue = parsed.venue as { name: string; city?: string; state?: string } | undefined
+
+    const [matchedArtists, matchedVenue] = await Promise.all([
+      matchArtists(rawArtists),
+      matchVenue(rawVenue),
+    ])
 
     // Track match statistics for warnings
     const matchedArtistCount = matchedArtists.filter(a => a.matched_id).length
@@ -458,10 +468,6 @@ export async function POST(request: NextRequest) {
       if (newArtistCount > 0) parts.push(`${newArtistCount} new`)
       warnings.push(`Artists: ${parts.join(', ')}`)
     }
-
-    // Extract and match venue
-    const rawVenue = parsed.venue as { name: string; city?: string; state?: string } | undefined
-    const matchedVenue = await matchVenue(rawVenue)
 
     if (matchedVenue && !matchedVenue.matched_id) {
       if (matchedVenue.suggestions?.length) {


### PR DESCRIPTION
## Summary

Two Next.js route handlers serialized independent awaits (a waterfall). Both
are admin/AI paths, so the savings are small — low priority, filed for
completeness.

- **discover-music** (`app/api/admin/artists/[id]/discover-music/route.ts`):
  `getAuthenticatedUser(...)` then `getArtist(artistId)` ran back-to-back, but
  `getArtist` consumes only the path id, not the auth result. Now both promises
  start together; auth is **still awaited first** and a 403 returns **before**
  the artist is awaited or consumed — preserving the auth-gates-before-work
  ordering. The unauthorized path trades a discarded in-flight fetch for
  happy-path latency (acceptable for an admin tool). ~50-100ms recoverable.

- **extract-show** (`app/api/ai/extract-show/route.ts`): `matchArtists(...)`
  then `matchVenue(...)` were serialized, though the venue match does not
  consume the artist results. Now run via `Promise.all`; warning strings are
  computed afterward and pushed in the **same order** as before. The inner
  per-artist loop in `matchArtists` stays sequential by design (see the sibling
  `extract-collection` route, which bounds its loop to avoid N concurrent
  backend requests). ~10-50ms (dwarfed by the upstream Claude AI call).

Behavior-preserving: identical outputs and warning ordering in both routes.

## Test plan

- [x] `bun run typecheck` — clean (`tsc --noEmit`, no output).
- [x] `bun run lint` — 0 errors (pre-existing warnings only; none in the two
  changed files — the one `extract-show/route.test.ts` warning is a pre-existing
  `_opts` unused-var in the untouched test file).
- [x] `bun run test:run app/api/ai/extract-show/route.test.ts` — **20/20 pass**,
  covering the exact matching paths parallelized (happy-path artists+venue,
  exact artist match, near/suggestion match, exact venue match + DB city/state,
  warning cases).

## Manual repro

Behavior-preserving change (`Promise.all` + reordered awaits, identical output
and warning order). Primary evidence is the **extract-show route unit suite**:
all 20 tests pass, including "returns parsed artists, venue, date, time, cost,
and ages", "attaches matched_id when an artist exactly matches the database",
"returns suggestions when an artist is a near (non-exact) match", and "attaches
matched_id and DB city/state when a venue exactly matches" — these directly
exercise the parallelized artist+venue match paths and their warning output.

`discover-music` has **no route test** (the ticket's note that #1137 added one
is inaccurate — verified via git history; #1137's only change to that file was a
1-line system-prompt edit). Exercising it live needs a running backend + admin
auth + a valid `ANTHROPIC_API_KEY` to reach the LLM call, which is heavy setup
for a latency-only refactor whose observable output is unchanged. The
behavior-preserving carveout applies: the await-ordering is structurally
preserved (auth awaited and 403-returned before the artist result is consumed),
and `getArtist` catches internally so the un-awaited promise on the 403 path
cannot become an unhandled rejection.

## Code review

`/code-review` (xhigh effort, 9 angles + sweep) — **no findings (`[]`)**. Probed
the un-awaited-promise / unhandled-rejection vector and confirmed `getArtist`,
`matchArtists`, and `matchVenue` all catch internally and never reject; auth
gate runs before artist consumption; warning push order preserved.

## Adversarial review

`/adversarial-review` — **CLEAN**, no findings, no fixes commit. Ran inline (4
lenses, dispatched-sub-agent fallback) against the branch diff with no session
context:
- **Saboteur** — CLEAN. Un-awaited promise on the 403 path cannot crash:
  `getArtist` is fully try/catch-wrapped and always resolves. The two `Promise.all`
  matches hit different endpoints with no shared mutable state.
- **Future-Maintainer** — CLEAN. Comments document the non-obvious ordering and
  cite the sibling route for the bounded-loop rationale.
- **Security** — CLEAN. Auth is awaited and 403-returned before any artist data
  is consumed/returned/logged; no privilege escalation or info disclosure.
- **Completeness** — CLEAN. All acceptance criteria met; inner loop left
  sequential per the pointer.

Panel: Saboteur · Future-Maintainer · Security · Completeness.

Closes PSY-1104
