### PR TITLE
PSY-1103: guard number-typed && conditionals against stray 0 render

### DIFF
--- a/frontend/features/festivals/components/FestivalCard.tsx
+++ b/frontend/features/festivals/components/FestivalCard.tsx
@@ -32,7 +32,7 @@ export function FestivalCard({
   if (density === 'compact') {
     return (
       <article className="flex items-center gap-3 px-3 py-1.5 hover:bg-muted/50 rounded-md transition-colors">
-        {festival.edition_year && (
+        {festival.edition_year > 0 && (
           <span className="text-xs font-semibold text-muted-foreground shrink-0 tabular-nums">
             {festival.edition_year}
           </span>

--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -213,7 +213,9 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
                     {location}
                   </span>
                 )}
-                {label.founded_year && <span>Est. {label.founded_year}</span>}
+                {label.founded_year != null && (
+                  <span>Est. {label.founded_year}</span>
+                )}
               </>
             }
             actions={

--- a/frontend/features/releases/admin/ReleaseManagement.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.tsx
@@ -1224,7 +1224,7 @@ export function ReleaseManagement() {
                     </Badge>
                   </div>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
-                    {release.release_year && (
+                    {release.release_year != null && (
                       <span>{release.release_year}</span>
                     )}
                     {release.artist_count > 0 && (

--- a/frontend/features/releases/components/ReleaseCard.tsx
+++ b/frontend/features/releases/components/ReleaseCard.tsx
@@ -87,7 +87,7 @@ export function ReleaseCard({
         <Badge variant="secondary" className="text-[10px] shrink-0">
           {typeLabel}
         </Badge>
-        {release.release_year && (
+        {release.release_year != null && (
           <span className="text-xs text-muted-foreground shrink-0 tabular-nums">
             {release.release_year}
           </span>
@@ -131,7 +131,7 @@ export function ReleaseCard({
               <Badge variant="secondary" className="text-xs px-2 py-0.5">
                 {typeLabel}
               </Badge>
-              {release.release_year && (
+              {release.release_year != null && (
                 <span className="text-base font-medium text-muted-foreground tabular-nums">
                   {release.release_year}
                 </span>
@@ -193,7 +193,7 @@ export function ReleaseCard({
             <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
               {typeLabel}
             </Badge>
-            {release.release_year && (
+            {release.release_year != null && (
               <span className="text-sm text-muted-foreground">
                 {release.release_year}
               </span>

--- a/frontend/features/releases/components/ReleaseDetail.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.tsx
@@ -166,7 +166,7 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
             <span>Type: {getReleaseTypeLabel(release.release_type)}</span>
           </div>
 
-          {release.release_year && (
+          {release.release_year != null && (
             <div className="flex items-center gap-2 text-muted-foreground">
               <Calendar className="h-4 w-4 shrink-0" />
               <span>Year: {release.release_year}</span>
@@ -250,7 +250,9 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
                   <Badge variant="secondary">
                     {getReleaseTypeLabel(release.release_type)}
                   </Badge>
-                  {release.release_year && <span>{release.release_year}</span>}
+                  {release.release_year != null && (
+                    <span>{release.release_year}</span>
+                  )}
                 </>
               }
               actions={

--- a/frontend/features/tags/admin/TagManagement.test.tsx
+++ b/frontend/features/tags/admin/TagManagement.test.tsx
@@ -113,6 +113,49 @@ describe('TagManagement — official indicator', () => {
   })
 })
 
+describe('TagManagement — tag count line (PSY-1103)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not render a stray "0" when total is 0 but rows are present', () => {
+    // PSY-1103: `{tagsData?.total && ...}` rendered the literal 0 (a valid
+    // React child) whenever the server-reported total was 0 while the tag
+    // list still held rows — e.g. a stale/desynced cached page. The fix
+    // leads with the comparison so the guard is a boolean, not a number.
+    mockUseTags.mockReturnValue({
+      data: { tags: [makeTag({ id: 1, name: 'rock' })], total: 0 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagManagement />)
+
+    const countLine = screen.getByText(/1 tag/)
+    // Before the fix this rendered "1 tag0" — the literal 0 from the falsy
+    // left operand. Exact-text equality is the load-bearing assertion: a
+    // looser /\b0\b/ match misses it because there is no word boundary
+    // between "tag" and the appended "0".
+    expect(countLine.textContent).toBe('1 tag')
+    expect(countLine).not.toHaveTextContent(/of .* total/)
+  })
+
+  it('renders the "(of N total)" suffix when total exceeds visible rows', () => {
+    mockUseTags.mockReturnValue({
+      data: {
+        tags: [makeTag({ id: 1, name: 'rock' })],
+        total: 50,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagManagement />)
+
+    expect(screen.getByText(/\(of 50 total\)/)).toBeInTheDocument()
+  })
+})
+
 describe('TagManagement — category filter (PSY-924)', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -746,8 +746,8 @@ export function TagManagement() {
           <div className="text-sm text-muted-foreground">
             {tags.length} tag{tags.length !== 1 ? 's' : ''}
             {debouncedSearch && ` matching "${debouncedSearch}"`}
-            {tagsData?.total && tagsData.total > tags.length && (
-              <span> (of {tagsData.total} total)</span>
+            {tags.length < (tagsData?.total ?? 0) && (
+              <span> (of {tagsData?.total} total)</span>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
`{number && <JSX/>}` renders the literal number when the left operand is `0` (falsy but a valid React child). This PR converts number-typed `&&` render guards to boolean expressions.

**Real fix — `TagManagement`:** the tag-count "(of N total)" suffix used `{tagsData?.total && tagsData.total > tags.length && ...}`. When the server-reported `total` is `0` while the rendered tag list still holds rows (a stale/desynced cached page), the falsy `0` left operand renders a stray "0" next to the count (e.g. `1 tag0`). Now leads with the comparison: `{tags.length < (tagsData?.total ?? 0) && ...}`.

**Defensive sweep — year fields:** `release_year`/`founded_year` are `number | null`; `edition_year` is non-null `number`. A real year is never `0` and the true sentinel is `null`, so these are practically inert today, but the guards are now correct — `!= null` for the nullable fields, `> 0` for `edition_year`. Sites: `ReleaseDetail` (2), `ReleaseCard` (3), `ReleaseManagement` (1), `LabelDetail` (1), `FestivalCard` (1).

## Test plan
- `bun run typecheck` — pass (exit 0).
- `bun run lint` — pass (exit 0; 141 pre-existing warnings, none in touched lines).
- `bun run test:run features/tags` — 251 pass (incl. 2 new regression tests).
- `bun run test:run features/releases` — 138 pass.
- `bun run test:run features/labels features/festivals` — 253 pass.
- Added two regression tests on the `TagManagement` count line: the stray-0 case (`expect(textContent).toBe('1 tag')` — exact equality, since a `\b0\b` match misses `tag0`) and the positive "(of N total)" suffix. Verified the stray-0 test FAILS on the pre-fix code and PASSES on the fix.

## Manual repro
The zero-total state requires a server/cache desync (the count line only renders when `tags.length > 0`, and a healthy backend returns `total >= tags.length`), so it is impractical to force through the live UI. Covered instead by the verified unit-test assertion above (fails on buggy code, passes on fixed) — disclosed per the plan's fallback. The year-field guards are practically inert (no real year is `0`), so they produce no observable UI change.

## Code review
`/code-review` (xhigh) — no findings. Guards are correctly typed, no behavior lost, regression tests verified to catch the bug.

## Adversarial review
`/adversarial-review` — CLEAN, no fixes. Panel run inline (dispatched sub-agent, no Agent tool — expected fallback): Saboteur · Future-Maintainer · Security · Completeness, each against the branch diff with no prior session context. Probed: `tagsData?.total` undefined-in-span (guarded — never renders "of undefined total"), year `0`/negative/null boundaries, mixed `!= null` vs `> 0` convention (intentional, type-correct), and ticket completeness (all 8 year sites + the real TagManagement case covered). All lenses CLEAN.

Closes PSY-1103
