### PR TITLE
PSY-1106: fix unauthenticated SSRF in Bandcamp fetch + add fetch/LLM timeouts

### DIFF
--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.test.ts
@@ -123,6 +123,24 @@ describe('POST /api/admin/artists/[id]/bandcamp', () => {
     expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
   })
 
+  it('rejects an SSRF substring-bypass URL with 400 and never fetches the page or backend', async () => {
+    fetchSpy = mockFetchRouting()
+
+    const res = await POST(
+      postRequest({ bandcamp_url: 'http://169.254.169.254/album/x?bandcamp.com' }),
+      params
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+    // Only the admin /auth/profile check should have fired — never the page
+    // fetch or the backend PATCH.
+    const nonAuthCalls = (fetchSpy.mock.calls as unknown[][]).filter(
+      (call) => !String(call[0]).endsWith('/auth/profile')
+    )
+    expect(nonAuthCalls).toHaveLength(0)
+  })
+
   it('auto-corrects an /album/ URL to /track/ on 404 and persists the corrected URL', async () => {
     // Mirrors the Soroche bug: the suggested /album/<slug> 404s, but the same
     // slug exists at /track/<slug>. The route must retry and save the /track/ URL.

--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import * as Sentry from '@sentry/nextjs'
 import { revalidateArtistDetail } from '@/lib/revalidate-entity'
-import { resolveBandcampEmbed } from '@/lib/bandcamp'
+import { resolveBandcampEmbed, isAllowedBandcampUrl } from '@/lib/bandcamp'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -52,8 +52,9 @@ async function getAuthenticatedUser(
 async function validateBandcampUrl(
   url: string
 ): Promise<{ valid: true; resolvedUrl: string } | { valid: false; error: string }> {
-  // Basic format validation
-  if (!url.includes('bandcamp.com')) {
+  // Host must be a real bandcamp.com (sub)domain — the URL is fetched
+  // server-side below, so a substring check would allow SSRF. See lib/bandcamp.
+  if (!isAllowedBandcampUrl(url)) {
     return { valid: false, error: 'URL must be a Bandcamp URL' }
   }
 

--- a/frontend/app/api/admin/artists/[id]/discover-music/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { cookies } from 'next/headers'
+import Anthropic from '@anthropic-ai/sdk'
+import { POST } from './route'
+
+vi.mock('next/headers', () => ({ cookies: vi.fn() }))
+
+// Mock the SDK constructor (so messages.create is controllable) but keep the
+// REAL error classes so the route's `instanceof Anthropic.APIError` /
+// `Anthropic.APIConnectionTimeoutError` checks resolve. Those statics are
+// inherited from BaseAnthropic (not own-enumerable on Anthropic), so copy them
+// by setting the prototype chain rather than Object.assign.
+const mockCreate = vi.fn()
+vi.mock('@anthropic-ai/sdk', async (importActual) => {
+  const actual = await importActual<typeof import('@anthropic-ai/sdk')>()
+  // Must be a real function (not an arrow) so `new Anthropic(...)` works.
+  const MockAnthropic = vi.fn(function (this: { messages: unknown }) {
+    this.messages = { create: mockCreate }
+  })
+  Object.setPrototypeOf(MockAnthropic, actual.default)
+  return { ...actual, default: MockAnthropic }
+})
+
+const mockCookies = vi.mocked(cookies)
+const BACKEND = 'http://localhost:8080'
+const ARTIST_ID = '42'
+
+function setAuthToken(token?: string) {
+  mockCookies.mockResolvedValue({
+    get: (name: string) =>
+      name === 'auth_token' && token ? { name, value: token } : undefined,
+  } as unknown as Awaited<ReturnType<typeof cookies>>)
+}
+
+function mockBackendFetch() {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === `${BACKEND}/auth/profile`) {
+        return new Response(
+          JSON.stringify({ success: true, user: { id: '1', is_admin: true } }),
+          { status: 200 }
+        )
+      }
+      if (url === `${BACKEND}/artists/${ARTIST_ID}`) {
+        return new Response(JSON.stringify({ id: 42, name: 'Soroche' }), {
+          status: 200,
+        })
+      }
+      throw new Error(`Unexpected fetch in test: ${url}`)
+    })
+}
+
+const postReq = () =>
+  new NextRequest(
+    `http://localhost:3000/api/admin/artists/${ARTIST_ID}/discover-music`,
+    { method: 'POST' }
+  )
+const params = { params: Promise.resolve({ id: ARTIST_ID }) }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('ANTHROPIC_API_KEY', 'test-key')
+  setAuthToken('admin-token')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('POST /api/admin/artists/[id]/discover-music', () => {
+  it('maps an Anthropic connection timeout to a clean 504 TIMEOUT', async () => {
+    mockBackendFetch()
+    mockCreate.mockRejectedValueOnce(new Anthropic.APIConnectionTimeoutError())
+
+    const res = await POST(postReq(), params)
+
+    expect(res.status).toBe(504)
+    expect((await res.json()).error).toBe('TIMEOUT')
+  })
+
+  it('calls the model as a single bounded attempt (timeout + maxRetries:0)', async () => {
+    // maxRetries:0 is load-bearing: with the SDK default (2) a timeout retries
+    // past maxDuration and the platform 504s before TIMEOUT can be returned.
+    mockBackendFetch()
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '{"bandcamp":[],"spotify":[]}' }],
+    })
+
+    const res = await POST(postReq(), params)
+
+    expect(res.status).toBe(200)
+    expect(mockCreate).toHaveBeenCalledWith(expect.anything(), {
+      timeout: 55_000,
+      maxRetries: 0,
+    })
+  })
+})

--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -5,6 +5,13 @@ import * as Sentry from '@sentry/nextjs'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
+// web_search on Haiku (up to 5 uses) can run long. Bound the platform function
+// and the Anthropic call so a stalled upstream returns a clean error instead of
+// an opaque platform 504 that skips the error taxonomy below. The SDK timeout
+// sits just under maxDuration so it fires first.
+export const maxDuration = 60
+const DISCOVERY_TIMEOUT_MS = 55_000
+
 // Discovery returns CANDIDATES only — the admin reviews and explicitly picks
 // before anything is saved. Same-name bands routinely collide; a name-only
 // auto-pick attached the wrong act's streaming links.
@@ -198,7 +205,10 @@ export async function POST(
           content: `Find candidates for the artist named "${artist.name}".`,
         },
       ],
-    })
+      // Single bounded attempt: the SDK retries timeouts twice by default, which
+      // would blow past maxDuration and 504 before APIConnectionTimeoutError is
+      // thrown. maxRetries: 0 keeps the clean timeout error path reachable.
+    }, { timeout: DISCOVERY_TIMEOUT_MS, maxRetries: 0 })
 
     let responseText = ''
     for (const block of response.content) {
@@ -268,6 +278,19 @@ export async function POST(
             'Anthropic API credits exhausted. Add credits to use AI discovery.',
         },
         { status: 503 }
+      )
+    }
+    if (error instanceof Anthropic.APIConnectionTimeoutError) {
+      Sentry.captureException(error, {
+        level: 'warning',
+        tags: { service: 'music-discovery', error_type: 'timeout' },
+      })
+      return NextResponse.json(
+        {
+          error: 'TIMEOUT',
+          message: 'Discovery timed out — try again, or use manual entry.',
+        },
+        { status: 504 }
       )
     }
     if (error instanceof Anthropic.APIError) {

--- a/frontend/app/api/bandcamp/album-id/route.test.ts
+++ b/frontend/app/api/bandcamp/album-id/route.test.ts
@@ -47,6 +47,15 @@ describe('GET /api/bandcamp/album-id', () => {
     expect(res.status).toBe(400)
   })
 
+  it('blocks an SSRF substring-bypass URL with 400 and no outbound fetch', async () => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const res = await GET(
+      getRequest('http://169.254.169.254/latest/meta-data/?x=bandcamp.com')
+    )
+    expect(res.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
   it('maps an unresolvable URL (both path types 404) to a 404', async () => {
     fetchSpy = vi
       .spyOn(globalThis, 'fetch')

--- a/frontend/app/api/bandcamp/album-id/route.ts
+++ b/frontend/app/api/bandcamp/album-id/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
-import { resolveBandcampEmbed } from '@/lib/bandcamp'
+import { resolveBandcampEmbed, isAllowedBandcampUrl } from '@/lib/bandcamp'
 
 // Resolves a Bandcamp album OR track URL to an embeddable { kind, id }. The
 // route name predates standalone-track support; it now handles /track/ URLs and
@@ -13,9 +13,14 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 })
   }
 
-  // Validate it's a Bandcamp URL
-  if (!url.includes('bandcamp.com')) {
-    return NextResponse.json({ error: 'Not a Bandcamp URL' }, { status: 400 })
+  // This route is PUBLIC and fetches the URL server-side, so the host must be
+  // verified — a substring check would allow SSRF (e.g. an internal IP with
+  // "bandcamp.com" in the query string). See isAllowedBandcampUrl.
+  if (!isAllowedBandcampUrl(url)) {
+    return NextResponse.json(
+      { error: 'Not a Bandcamp URL' },
+      { status: 400 }
+    )
   }
 
   const result = await resolveBandcampEmbed(url)

--- a/frontend/app/api/oembed/route.ts
+++ b/frontend/app/api/oembed/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
+import { isAllowedBandcampUrl } from '@/lib/bandcamp'
 
 interface OEmbedResponse {
   html?: string
@@ -17,22 +18,23 @@ interface OEmbedResponse {
 
 type Provider = 'bandcamp' | 'spotify' | null
 
+// Match on the PARSED host, not a substring — `hostname.includes('bandcamp.com')`
+// also matches `bandcamp.com.attacker.test`. This route's outbound fetch targets
+// are hardcoded provider endpoints (the user URL is only an encoded query param),
+// so a misclassification is not itself an SSRF, but the substring pattern is the
+// same drift-prone one lib/bandcamp's isAllowedBandcampUrl exists to replace.
 function detectProvider(url: string): Provider {
+  if (isAllowedBandcampUrl(url)) return 'bandcamp'
+  let parsed: URL
   try {
-    const parsed = new URL(url)
-    if (parsed.hostname.includes('bandcamp.com')) {
-      return 'bandcamp'
-    }
-    if (
-      parsed.hostname.includes('spotify.com') ||
-      parsed.hostname.includes('open.spotify.com')
-    ) {
-      return 'spotify'
-    }
-    return null
+    parsed = new URL(url)
   } catch {
     return null
   }
+  if (parsed.protocol !== 'https:') return null
+  const host = parsed.hostname.toLowerCase()
+  if (host === 'spotify.com' || host.endsWith('.spotify.com')) return 'spotify'
+  return null
 }
 
 function getOEmbedEndpoint(provider: Provider, url: string): string | null {

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -453,9 +453,9 @@ function AdminMusicControls({
         setShowManualInput(null)
       },
       onError: err => {
-        // The route already returns user-friendly messages for the known
-        // error classes (PARSE_FAILED, RATE_LIMIT, API_CREDITS_EXHAUSTED);
-        // pass them through.
+        // The route returns user-friendly messages for all its error classes
+        // (PARSE_FAILED, RATE_LIMIT, API_CREDITS_EXHAUSTED, TIMEOUT), as does
+        // the client timeout backstop; pass them through.
         const message = err instanceof Error ? err.message : 'Discovery failed'
         setFeedback({ type: 'error', message })
       },

--- a/frontend/lib/bandcamp.test.ts
+++ b/frontend/lib/bandcamp.test.ts
@@ -3,6 +3,7 @@ import {
   parseBandcampEmbedId,
   swapAlbumTrackPath,
   resolveBandcampEmbed,
+  isAllowedBandcampUrl,
 } from './bandcamp'
 
 // Every test that touches fetch installs a spy via mockFetchSequence; restore
@@ -34,6 +35,26 @@ function mockFetchSequence(
   }
   return spy
 }
+
+describe('isAllowedBandcampUrl (SSRF guard)', () => {
+  it('accepts https bandcamp.com and its subdomains', () => {
+    expect(isAllowedBandcampUrl('https://bandcamp.com/album/x')).toBe(true)
+    expect(isAllowedBandcampUrl('https://sorochemusic.bandcamp.com/track/leyenda')).toBe(true)
+  })
+  it('rejects the substring-bypass payloads a naive includes() would allow', () => {
+    // These all contain "bandcamp.com" but resolve to attacker/internal hosts.
+    expect(isAllowedBandcampUrl('http://169.254.169.254/latest/meta-data/?x=bandcamp.com')).toBe(false)
+    expect(isAllowedBandcampUrl('https://bandcamp.com.attacker.test/album/x')).toBe(false)
+    expect(isAllowedBandcampUrl('https://evil.test/?x=bandcamp.com')).toBe(false)
+    expect(isAllowedBandcampUrl('http://localhost:8080/admin?bandcamp.com')).toBe(false)
+  })
+  it('rejects non-https schemes and unparseable input', () => {
+    expect(isAllowedBandcampUrl('http://x.bandcamp.com/album/x')).toBe(false)
+    expect(isAllowedBandcampUrl('not a url')).toBe(false)
+    // A subdomain-suffix lookalike must not slip through endsWith.
+    expect(isAllowedBandcampUrl('https://notbandcamp.com/album/x')).toBe(false)
+  })
+})
 
 describe('swapAlbumTrackPath', () => {
   it('swaps /album/ -> /track/', () => {
@@ -90,6 +111,15 @@ describe('parseBandcampEmbedId', () => {
 })
 
 describe('resolveBandcampEmbed', () => {
+  it('rejects an off-allowlist URL without making any network request', async () => {
+    const spy = vi.spyOn(global, 'fetch')
+    const result = await resolveBandcampEmbed(
+      'http://169.254.169.254/latest/meta-data/?x=bandcamp.com'
+    )
+    expect(result.ok).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
   it('resolves a reachable track URL without changing the URL', async () => {
     mockFetchSequence({ ok: true, html: TRACK_HTML })
     const result = await resolveBandcampEmbed(

--- a/frontend/lib/bandcamp.ts
+++ b/frontend/lib/bandcamp.ts
@@ -12,6 +12,28 @@ const BANDCAMP_FETCH_HEADERS = {
   'User-Agent': 'Mozilla/5.0 (compatible; MusicEmbed/1.0)',
 }
 
+// Cap on how long a single Bandcamp page fetch may run. These run server-side
+// on a route handler; without a bound, a slow/hung Bandcamp connection ties up
+// the function until the platform timeout and turns a valid save into a failure.
+const BANDCAMP_FETCH_TIMEOUT_MS = 8000
+
+// SSRF guard. These URLs are fetched SERVER-SIDE, and one fetch site is a
+// PUBLIC route, so the host must be verified — not merely "contains the string
+// bandcamp.com". A substring check passes attacker-controlled targets like
+// `http://169.254.169.254/?x=bandcamp.com` or `https://bandcamp.com.evil.test/`.
+// Parse the URL and require https + an exact bandcamp.com (sub)domain.
+export function isAllowedBandcampUrl(url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:') return false
+  const host = parsed.hostname.toLowerCase()
+  return host === 'bandcamp.com' || host.endsWith('.bandcamp.com')
+}
+
 export type BandcampEmbedKind = 'album' | 'track'
 
 export interface BandcampEmbed {
@@ -66,8 +88,21 @@ export function parseBandcampEmbedId(
 async function fetchBandcampPage(
   url: string
 ): Promise<{ ok: true; html: string } | { ok: false; status: number | null }> {
+  // Defensive chokepoint: every fetch (input URL and the swapped sibling) goes
+  // through here, so the SSRF host check can't be bypassed by a caller.
+  if (!isAllowedBandcampUrl(url)) return { ok: false, status: null }
   try {
-    const response = await fetch(url, { headers: BANDCAMP_FETCH_HEADERS })
+    const response = await fetch(url, {
+      headers: BANDCAMP_FETCH_HEADERS,
+      // Any *.bandcamp.com subdomain is third-party-controlled (Bandcamp hands
+      // them out on signup), so an allowlisted page could still 30x to an
+      // internal host. `redirect: 'error'` refuses to follow it — undici never
+      // issues the second request — instead of catching it after the fact (by
+      // which point the internal request has already gone out). Legit
+      // album/track pages return 200 directly, so this doesn't cost us anything.
+      redirect: 'error',
+      signal: AbortSignal.timeout(BANDCAMP_FETCH_TIMEOUT_MS),
+    })
     if (!response.ok) return { ok: false, status: response.status }
     return { ok: true, html: await response.text() }
   } catch {

--- a/frontend/lib/hooks/admin/useAdminArtists.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtists.test.tsx
@@ -151,6 +151,28 @@ describe('useAdminArtists', () => {
         'Discovery is rate-limited right now — try again in about a minute.'
       )
     })
+
+    it('maps the client-side AbortSignal timeout to a friendly message', async () => {
+      // AbortSignal.timeout rejects fetch with a TimeoutError DOMException; the
+      // hook converts that to actionable copy instead of leaking the raw error.
+      mockFetch.mockRejectedValueOnce(
+        new DOMException('The operation timed out', 'TimeoutError')
+      )
+
+      const { result } = renderHook(() => useDiscoverMusic(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate(123)
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe(
+        'Discovery timed out — try again, or use manual entry.'
+      )
+    })
   })
 
   describe('useUpdateArtistBandcamp', () => {

--- a/frontend/lib/hooks/admin/useAdminArtists.ts
+++ b/frontend/lib/hooks/admin/useAdminArtists.ts
@@ -67,13 +67,24 @@ export interface UpdateSpotifyResponse {
 export function useDiscoverMusic() {
   return useMutation({
     mutationFn: async (artistId: number): Promise<DiscoverMusicResponse> => {
-      const response = await fetch(
-        `/api/admin/artists/${artistId}/discover-music`,
-        {
-          method: 'POST',
-          credentials: 'include',
+      let response: Response
+      try {
+        response = await fetch(
+          `/api/admin/artists/${artistId}/discover-music`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            // Backstop the route's own 60s bound so the spinner can't hang
+            // indefinitely if the server itself becomes unreachable.
+            signal: AbortSignal.timeout(70_000),
+          }
+        )
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'TimeoutError') {
+          throw new Error('Discovery timed out — try again, or use manual entry.')
         }
-      )
+        throw err
+      }
 
       const data = await response.json()
 


### PR DESCRIPTION
## Problem

An adversarial audit of the music-discovery / streaming-links / embed surface found a real **unauthenticated SSRF** plus missing fetch timeouts.

**SSRF (HIGH).** The public `/api/bandcamp/album-id` route (no auth — `proxy.ts` excludes `api`) and the admin save route gated a server-side `fetch` with `url.includes('bandcamp.com')` — a substring the caller controls. `GET /api/bandcamp/album-id?url=http://169.254.169.254/latest/meta-data/?x=bandcamp.com` passed and the server fetched it: an internal-reachability oracle / open proxy (status + timing leak).

**No timeouts (MEDIUM).** The discovery Anthropic `web_search` call, the Bandcamp page fetches, and the client fetch were unbounded; on Vercel the function 504s opaquely and the "Discovering…" spinner can hang.

## Fix

- `isAllowedBandcampUrl()` in `lib/bandcamp.ts`: `new URL()`-parse, require `https` + an exact `bandcamp.com` (sub)domain. Applied in the public `album-id` route, the admin `bandcamp` save route, and as a chokepoint in `fetchBandcampPage` (so the swapped sibling is checked too).
- `fetchBandcampPage` hardened with `redirect: 'error'` (any `*.bandcamp.com` page is third-party-controlled and could 30x to an internal host — refuse to follow it so the internal request never fires) and an `AbortSignal.timeout`.
- Discovery bounded: `export const maxDuration = 60`, a 55s Anthropic timeout with `maxRetries: 0` (the SDK default retries timeouts past the budget, which would 504 before the clean error fires), a `504 TIMEOUT` mapping, and a client-side `AbortSignal` backstop.

## Verification

- **Live SSRF block:** `isAllowedBandcampUrl` rejects `169.254.169.254/?x=bandcamp.com`, `bandcamp.com.attacker.test`, `localhost:8080?bandcamp.com`, `notbandcamp.com`, non-https — with **zero outbound fetch** (asserted in tests).
- **Live redirect proof:** against a local 302→internal server, `redirect: 'error'` throws *without* issuing the internal request (`internalHit === false`).
- **Real path unaffected:** `…/album/leyenda` still auto-corrects to `…/track/leyenda` (`track 2445352951`).
- `tsc --noEmit` clean; eslint clean; 76 affected tests pass (new SSRF-guard unit tests, SSRF-reject route tests on both routes, discover-music timeout→504 test, client TimeoutError test).

## Adversarial review

`/adversarial-review` — fresh-context panel (Saboteur · Security · Future-Maintainer), run against the branch diff with no building-session context. Findings addressed across commits `8c68761` (impl) and `0b728e6` (separable fixes):

- **[CRITICAL] Saboteur** — SDK retries timeouts (default `maxRetries: 2`), so the 55s timeout blows past `maxDuration` and 504s before `APIConnectionTimeoutError` fires → the clean error branch was dead code. → `maxRetries: 0` (single bounded attempt), verified against the SDK source + a route test. `8c68761`
- **[MEDIUM] Security** — the post-hoc `response.url` redirect check ran *after* undici had already issued the internal request (verified empirically). → replaced with `redirect: 'error'`; live-proven no internal request fires. `8c68761`
- **[MEDIUM] Future-Maintainer/Security** — a *second* public substring-check route (`app/api/oembed/route.ts`) was missed in the original audit. Not exploitable (hardcoded fetch target) but the same drift-prone pattern. → routed through `isAllowedBandcampUrl` + parsed spotify host. `0b728e6`
- **[HIGH] Saboteur** — the timeout path shipped untested. → `discover-music/route.test.ts` + a `useAdminArtists` client-timeout test. `0b728e6`
- **[MEDIUM] Future-Maintainer** — stale discovery error-class comment omitted `TIMEOUT`. → corrected. `0b728e6`

**Disclosed residuals (LOW, deferred):** any `*.bandcamp.com` host is third-party-registerable, so the `redirect: 'error'` guard is load-bearing (documented in code); DNS-rebinding is not addressed (would need resolved-IP pinning) — out of scope for this fix. Fixes were verified directly (live proofs + tests) rather than by re-running the full panel.

## Scope

Part of a broader audit of this feature. The remaining audit findings (backend substring validators, Spotify existence-validation + URL-definition unification, React-Query key-drift, admin-route auth dedup, discover-music + picker-UI test coverage, embed-builder dedup) are tracked as separate follow-up tickets.

Closes PSY-1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
