### PR TITLE
PSY-1108: existence-validate Spotify on save + unify the 4 URL definitions

### DIFF
--- a/backend/cmd/seed/exemplars.go
+++ b/backend/cmd/seed/exemplars.go
@@ -260,6 +260,13 @@ func seedExemplarArtist(db *gorm.DB, userID, labelID uint) uint {
 		return existing.ID
 	}
 
+	social := fullSocial("marissanadler")
+	// A Spotify embed needs a canonical 22-char base62 artist id; the slug-shaped
+	// handle renders no embed. Use a real, valid artist id (placeholder — not
+	// literally Marissa Nadler's) so the exemplar artist page demonstrates a live
+	// Spotify player for screenshots/dogfood.
+	social.Spotify = strptr("https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb")
+
 	artist := &catalogm.Artist{
 		Name:        "Marissa Nadler (Exemplar)",
 		Slug:        strptr(exemplarArtistSlug),
@@ -268,7 +275,7 @@ func seedExemplarArtist(db *gorm.DB, userID, labelID uint) uint {
 		Country:     strptr("USA"),
 		Description: strptr("A singer-songwriter and guitarist whose gothic, dream-folk songwriting pairs fingerpicked guitar with reverb-soaked vocals. Across a long discography she has moved between hushed solo records and fuller, collaborative productions.\n\nSeeded as the PSY-665 rich artist exemplar: bio, image, all social links, multiple aliases, tags across categories, releases, label links, tracked shows, similar artists, and a festival appearance are all populated."),
 		ImageURL:    strptr("/seed-placeholders/artist.svg"),
-		Social:      fullSocial("marissanadler"),
+		Social:      social,
 	}
 	if err := db.Create(artist).Error; err != nil {
 		log.Printf("Warning: failed to create exemplar artist: %v", err)

--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -95,9 +95,9 @@ function extractCandidateJson(
 
 const BANDCAMP_ALBUM_RE =
   /^https?:\/\/[a-zA-Z0-9-]+\.bandcamp\.com\/(album|track)\/[a-zA-Z0-9-]+/
-// Spotify candidate URLs are validated via the shared parser (isValidSpotify
-// ArtistUrl), which — unlike the old anchored regex here — tolerates the
-// `?si=...` share suffix Spotify's own "Copy link" appends.
+// Spotify candidates are kept when the shared parser accepts them (it tolerates
+// the `?si=...` suffix the old anchored regex here dropped). The raw candidate
+// URL is forwarded to the admin as-is; the save route canonicalizes it.
 
 function normalizeCandidate(raw: unknown): DiscoveryCandidate | null {
   if (!raw || typeof raw !== 'object') return null

--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import Anthropic from '@anthropic-ai/sdk'
 import * as Sentry from '@sentry/nextjs'
+import { isValidSpotifyArtistUrl } from '@/lib/spotify'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -94,8 +95,9 @@ function extractCandidateJson(
 
 const BANDCAMP_ALBUM_RE =
   /^https?:\/\/[a-zA-Z0-9-]+\.bandcamp\.com\/(album|track)\/[a-zA-Z0-9-]+/
-const SPOTIFY_ARTIST_RE =
-  /^https?:\/\/open\.spotify\.com\/artist\/[a-zA-Z0-9]+$/
+// Spotify candidate URLs are validated via the shared parser (isValidSpotify
+// ArtistUrl), which — unlike the old anchored regex here — tolerates the
+// `?si=...` share suffix Spotify's own "Copy link" appends.
 
 function normalizeCandidate(raw: unknown): DiscoveryCandidate | null {
   if (!raw || typeof raw !== 'object') return null
@@ -235,7 +237,7 @@ export async function POST(
       .filter((c): c is DiscoveryCandidate => !!c && BANDCAMP_ALBUM_RE.test(c.url))
     const spotify = parsed.spotify
       .map(normalizeCandidate)
-      .filter((c): c is DiscoveryCandidate => !!c && SPOTIFY_ARTIST_RE.test(c.url))
+      .filter((c): c is DiscoveryCandidate => !!c && isValidSpotifyArtistUrl(c.url))
 
     return NextResponse.json({ bandcamp, spotify })
   } catch (error) {

--- a/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
@@ -71,9 +71,8 @@ function mockFetchRouting({
         )
       }
       if (url.startsWith('https://open.spotify.com/oembed')) {
-        return new Response(oembedStatus === 200 ? '{"html":"<iframe>"}' : 'x', {
-          status: oembedStatus,
-        })
+        // resolveSpotifyArtist branches on status only; the body is ignored.
+        return new Response('', { status: oembedStatus })
       }
       if (url === `${BACKEND}/admin/artists/${ARTIST_ID}/spotify`) {
         return backendResponse

--- a/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
+++ b/frontend/app/api/admin/artists/[id]/spotify/route.test.ts
@@ -45,17 +45,19 @@ function setAuthToken(token?: string) {
 }
 
 /**
- * Route fetch traffic by URL: auth profile check and the backend PATCH.
- * (Spotify URL validation is regex-only — no network call.)
+ * Route fetch traffic by URL: auth profile check, the Spotify oEmbed existence
+ * check (validation now hits the network), and the backend PATCH.
  */
 function mockFetchRouting({
   isAdmin = true,
+  oembedStatus = 200,
   backendResponse = new Response(
     JSON.stringify({ id: 47, slug: 'bright-eyes', name: 'Bright Eyes' }),
     { status: 200 }
   ),
 }: {
   isAdmin?: boolean
+  oembedStatus?: number
   backendResponse?: Response
 } = {}) {
   return vi
@@ -67,6 +69,11 @@ function mockFetchRouting({
           JSON.stringify({ success: true, user: { id: '1', is_admin: isAdmin } }),
           { status: 200 }
         )
+      }
+      if (url.startsWith('https://open.spotify.com/oembed')) {
+        return new Response(oembedStatus === 200 ? '{"html":"<iframe>"}' : 'x', {
+          status: oembedStatus,
+        })
       }
       if (url === `${BACKEND}/admin/artists/${ARTIST_ID}/spotify`) {
         return backendResponse
@@ -114,6 +121,53 @@ describe('POST /api/admin/artists/[id]/spotify', () => {
     expect(body.success).toBe(true)
     expect(mockRevalidatePath).toHaveBeenCalledTimes(1)
     expect(mockRevalidatePath).toHaveBeenCalledWith('/artists/bright-eyes')
+  })
+
+  it('persists the canonical artist URL, stripping a `?si=` share suffix', async () => {
+    let patchedBody: string | undefined
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url === `${BACKEND}/auth/profile`) {
+          return new Response(
+            JSON.stringify({ success: true, user: { id: '1', is_admin: true } }),
+            { status: 200 }
+          )
+        }
+        if (url.startsWith('https://open.spotify.com/oembed')) {
+          return new Response('{"html":"<iframe>"}', { status: 200 })
+        }
+        if (url === `${BACKEND}/admin/artists/${ARTIST_ID}/spotify`) {
+          patchedBody = init?.body as string
+          return new Response(
+            JSON.stringify({ id: 47, slug: 'bright-eyes', name: 'Bright Eyes' }),
+            { status: 200 }
+          )
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`)
+      })
+
+    const res = await POST(
+      postRequest({ spotify_url: `${VALID_SPOTIFY_URL}?si=trackingtoken` }),
+      params
+    )
+
+    expect(res.status).toBe(200)
+    expect(JSON.parse(patchedBody!)).toEqual({ spotify_url: VALID_SPOTIFY_URL })
+  })
+
+  it('rejects a non-existent artist (oEmbed 404) with 400 and no backend write', async () => {
+    fetchSpy = mockFetchRouting({ oembedStatus: 404 })
+
+    const res = await POST(postRequest({ spotify_url: VALID_SPOTIFY_URL }), params)
+
+    expect(res.status).toBe(400)
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
+    const patchCalls = (fetchSpy.mock.calls as unknown[][]).filter((call) =>
+      String(call[0]).startsWith(`${BACKEND}/admin/`)
+    )
+    expect(patchCalls).toHaveLength(0)
   })
 
   it('does NOT revalidate when the backend save fails', async () => {

--- a/frontend/app/api/admin/artists/[id]/spotify/route.ts
+++ b/frontend/app/api/admin/artists/[id]/spotify/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import * as Sentry from '@sentry/nextjs'
 import { revalidateArtistDetail } from '@/lib/revalidate-entity'
+import { resolveSpotifyArtist } from '@/lib/spotify'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -46,27 +47,17 @@ async function getAuthenticatedUser(
   }
 }
 
-function validateSpotifyUrl(url: string): { valid: boolean; error?: string } {
-  // Must be a Spotify URL
-  if (!url.includes('open.spotify.com')) {
-    return { valid: false, error: 'URL must be a Spotify URL' }
+// Validates shape AND existence (via Spotify oEmbed — mirrors the Bandcamp save
+// path), returning the canonical artist URL so a `?si=` share suffix is stripped
+// before persisting. See lib/spotify.
+async function validateSpotifyUrl(
+  url: string
+): Promise<{ valid: true; canonicalUrl: string } | { valid: false; error: string }> {
+  const result = await resolveSpotifyArtist(url)
+  if (!result.ok) {
+    return { valid: false, error: result.error }
   }
-
-  // Must be an artist page URL
-  if (!url.includes('/artist/')) {
-    return {
-      valid: false,
-      error: 'URL must be a Spotify artist page URL (open.spotify.com/artist/...)',
-    }
-  }
-
-  // Validate URL format: open.spotify.com/artist/{id}
-  const artistMatch = url.match(/open\.spotify\.com\/artist\/([a-zA-Z0-9]+)/)
-  if (!artistMatch) {
-    return { valid: false, error: 'Invalid Spotify artist URL format' }
-  }
-
-  return { valid: true }
+  return { valid: true, canonicalUrl: result.canonicalUrl }
 }
 
 export async function POST(
@@ -109,11 +100,11 @@ export async function POST(
     )
   }
 
-  // Validate the URL
-  const validation = validateSpotifyUrl(spotify_url)
+  // Validate the URL (shape + existence); persist the canonical artist URL.
+  const validation = await validateSpotifyUrl(spotify_url)
   if (!validation.valid) {
     return NextResponse.json(
-      { error: validation.error || 'Invalid Spotify URL' },
+      { error: validation.error },
       { status: 400 }
     )
   }
@@ -128,7 +119,7 @@ export async function POST(
           'Content-Type': 'application/json',
           Cookie: `auth_token=${authToken.value}`,
         },
-        body: JSON.stringify({ spotify_url }),
+        body: JSON.stringify({ spotify_url: validation.canonicalUrl }),
       }
     )
 

--- a/frontend/components/shared/MusicEmbed.test.tsx
+++ b/frontend/components/shared/MusicEmbed.test.tsx
@@ -99,7 +99,7 @@ describe('MusicEmbed', () => {
   it('renders spotify iframe when spotify URL is provided', async () => {
     render(
       <MusicEmbed
-        spotifyUrl="https://open.spotify.com/artist/abc123"
+        spotifyUrl="https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb"
         artistName="Test Artist"
       />
     )
@@ -109,7 +109,7 @@ describe('MusicEmbed', () => {
       expect(iframe).toBeInTheDocument()
       expect(iframe).toHaveAttribute(
         'src',
-        expect.stringContaining('embed/artist/abc123')
+        expect.stringContaining('embed/artist/4Z8W4fKeB5YxbusRsdQVPb')
       )
     })
   })
@@ -117,7 +117,7 @@ describe('MusicEmbed', () => {
   it('parses spotify URI format', async () => {
     render(
       <MusicEmbed
-        spotifyUrl="spotify:artist:xyz789"
+        spotifyUrl="spotify:artist:0TnOYISbd1XYRBk9myaseg"
         artistName="Test Artist"
       />
     )
@@ -126,7 +126,7 @@ describe('MusicEmbed', () => {
       const iframe = screen.getByTitle('Test Artist on Spotify')
       expect(iframe).toHaveAttribute(
         'src',
-        expect.stringContaining('embed/artist/xyz789')
+        expect.stringContaining('embed/artist/0TnOYISbd1XYRBk9myaseg')
       )
     })
   })
@@ -185,7 +185,7 @@ describe('MusicEmbed', () => {
     render(
       <MusicEmbed
         bandcampAlbumUrl="https://band.bandcamp.com/album/test"
-        spotifyUrl="https://open.spotify.com/artist/abc123"
+        spotifyUrl="https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb"
         artistName="Test Artist"
       />
     )
@@ -202,7 +202,7 @@ describe('MusicEmbed', () => {
     render(
       <MusicEmbed
         bandcampAlbumUrl="https://band.bandcamp.com/album/test"
-        spotifyUrl="https://open.spotify.com/artist/abc123"
+        spotifyUrl="https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb"
         artistName="Test Artist"
       />
     )
@@ -232,7 +232,7 @@ describe('MusicEmbed', () => {
   it('uses compact height for spotify iframe', async () => {
     render(
       <MusicEmbed
-        spotifyUrl="https://open.spotify.com/artist/abc123"
+        spotifyUrl="https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb"
         artistName="Test Artist"
         compact={true}
       />
@@ -247,7 +247,7 @@ describe('MusicEmbed', () => {
   it('uses full height for spotify iframe when not compact', async () => {
     render(
       <MusicEmbed
-        spotifyUrl="https://open.spotify.com/artist/abc123"
+        spotifyUrl="https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb"
         artistName="Test Artist"
         compact={false}
       />

--- a/frontend/components/shared/MusicEmbed.tsx
+++ b/frontend/components/shared/MusicEmbed.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import * as Sentry from '@sentry/nextjs'
 import { ExternalLink, Loader2, Music } from 'lucide-react'
+import { parseSpotifyArtistId } from '@/lib/spotify'
 
 interface MusicEmbedProps {
   bandcampAlbumUrl?: string | null
@@ -10,16 +11,6 @@ interface MusicEmbedProps {
   spotifyUrl?: string | null
   artistName: string
   compact?: boolean
-}
-
-function parseSpotifyArtistId(url: string): string | null {
-  const webMatch = url.match(/spotify\.com\/artist\/([a-zA-Z0-9]+)/)
-  if (webMatch) return webMatch[1]
-
-  const uriMatch = url.match(/spotify:artist:([a-zA-Z0-9]+)/)
-  if (uriMatch) return uriMatch[1]
-
-  return null
 }
 
 type EmbedState =

--- a/frontend/lib/spotify.test.ts
+++ b/frontend/lib/spotify.test.ts
@@ -25,6 +25,16 @@ describe('parseSpotifyArtistId', () => {
   it('extracts the id from a spotify:artist: URI', () => {
     expect(parseSpotifyArtistId(`spotify:artist:${ID}`)).toBe(ID)
   })
+  it('tolerates a locale prefix and a trailing path segment', () => {
+    expect(parseSpotifyArtistId(`https://open.spotify.com/intl-de/artist/${ID}`)).toBe(ID)
+    expect(parseSpotifyArtistId(`https://open.spotify.com/artist/${ID}/about`)).toBe(ID)
+  })
+  it('tolerates a scheme-less stored URL (legacy data) but still checks the host', () => {
+    expect(parseSpotifyArtistId(`open.spotify.com/artist/${ID}`)).toBe(ID)
+    expect(parseSpotifyArtistId(`open.spotify.com/artist/${ID}?si=x`)).toBe(ID)
+    // scheme-less must NOT bypass the host allowlist
+    expect(parseSpotifyArtistId(`evil.test/artist/${ID}`)).toBeNull()
+  })
   it('rejects a non-22-char id (hallucinated short/long)', () => {
     expect(parseSpotifyArtistId('https://open.spotify.com/artist/abc123')).toBeNull()
     expect(

--- a/frontend/lib/spotify.test.ts
+++ b/frontend/lib/spotify.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  parseSpotifyArtistId,
+  isValidSpotifyArtistUrl,
+  resolveSpotifyArtist,
+} from './spotify'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// A real-shape 22-char base62 artist id.
+const ID = '4Z8W4fKeB5YxbusRsdQVPb'
+
+describe('parseSpotifyArtistId', () => {
+  it('extracts the id from a canonical web URL', () => {
+    expect(parseSpotifyArtistId(`https://open.spotify.com/artist/${ID}`)).toBe(ID)
+  })
+  it('tolerates a `?si=` share suffix (the bug this fixes) and a trailing slash', () => {
+    expect(
+      parseSpotifyArtistId(`https://open.spotify.com/artist/${ID}?si=abc123XYZ`)
+    ).toBe(ID)
+    expect(parseSpotifyArtistId(`https://open.spotify.com/artist/${ID}/`)).toBe(ID)
+  })
+  it('extracts the id from a spotify:artist: URI', () => {
+    expect(parseSpotifyArtistId(`spotify:artist:${ID}`)).toBe(ID)
+  })
+  it('rejects a non-22-char id (hallucinated short/long)', () => {
+    expect(parseSpotifyArtistId('https://open.spotify.com/artist/abc123')).toBeNull()
+    expect(
+      parseSpotifyArtistId(`https://open.spotify.com/artist/${ID}EXTRA`)
+    ).toBeNull()
+  })
+  it('rejects a non-artist path, the wrong host, and garbage', () => {
+    expect(parseSpotifyArtistId(`https://open.spotify.com/track/${ID}`)).toBeNull()
+    expect(parseSpotifyArtistId(`https://evil.test/artist/${ID}`)).toBeNull()
+    expect(
+      parseSpotifyArtistId(`https://open.spotify.com.evil.test/artist/${ID}`)
+    ).toBeNull()
+    expect(parseSpotifyArtistId('not a url')).toBeNull()
+  })
+})
+
+describe('isValidSpotifyArtistUrl', () => {
+  it('mirrors parseSpotifyArtistId', () => {
+    expect(isValidSpotifyArtistUrl(`https://open.spotify.com/artist/${ID}?si=x`)).toBe(true)
+    expect(isValidSpotifyArtistUrl('https://open.spotify.com/artist/abc123')).toBe(false)
+  })
+})
+
+describe('resolveSpotifyArtist', () => {
+  it('rejects an invalid URL without any network request', async () => {
+    const spy = vi.spyOn(global, 'fetch')
+    const result = await resolveSpotifyArtist('https://open.spotify.com/track/x')
+    expect(result.ok).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('returns the canonical URL (stripping `?si=`) when oEmbed confirms the artist', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+    } as Response)
+
+    const result = await resolveSpotifyArtist(
+      `https://open.spotify.com/artist/${ID}?si=tracking`
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      id: ID,
+      canonicalUrl: `https://open.spotify.com/artist/${ID}`,
+    })
+  })
+
+  it('fetches oEmbed with the canonical (sanitized) URL, not the raw input', async () => {
+    const spy = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await resolveSpotifyArtist(`https://open.spotify.com/artist/${ID}?si=tracking`)
+
+    const calledUrl = String(spy.mock.calls[0][0])
+    expect(calledUrl).toContain('open.spotify.com/oembed')
+    // The canonical id-only URL is what gets passed to oEmbed — no `?si=`.
+    expect(calledUrl).toContain(encodeURIComponent(`https://open.spotify.com/artist/${ID}`))
+    expect(calledUrl).not.toContain('tracking')
+  })
+
+  it('maps a 404 oEmbed to "not found"', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response)
+
+    const result = await resolveSpotifyArtist(`https://open.spotify.com/artist/${ID}`)
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: 'No Spotify artist found at that URL',
+    })
+  })
+
+  it('surfaces a non-404 oEmbed failure', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    } as Response)
+
+    const result = await resolveSpotifyArtist(`https://open.spotify.com/artist/${ID}`)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(503)
+  })
+
+  it('handles a thrown fetch (network/timeout)', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('network'))
+
+    const result = await resolveSpotifyArtist(`https://open.spotify.com/artist/${ID}`)
+    expect(result).toEqual({
+      ok: false,
+      status: null,
+      error: 'Failed to verify Spotify artist',
+    })
+  })
+})

--- a/frontend/lib/spotify.ts
+++ b/frontend/lib/spotify.ts
@@ -7,28 +7,40 @@
 // module is the single source of truth: parse the URL, require the canonical
 // host, and enforce the 22-char base62 artist id.
 
-// Spotify artist IDs are base62, exactly 22 characters.
-const SPOTIFY_ARTIST_ID_RE = /^[A-Za-z0-9]{22}$/
+// Spotify artist IDs are base62, exactly 22 characters. Keep the id pattern in
+// one place so the URI and path matchers stay in agreement.
+const SPOTIFY_ARTIST_ID = '[A-Za-z0-9]{22}'
+const SPOTIFY_URI_RE = new RegExp(`^spotify:artist:(${SPOTIFY_ARTIST_ID})$`)
+const SPOTIFY_PATH_RE = new RegExp(`/artist/(${SPOTIFY_ARTIST_ID})(?:/|$)`)
 const SPOTIFY_OEMBED_TIMEOUT_MS = 8000
 
-// Extract the artist id from a web URL (https://open.spotify.com/artist/<id>,
-// with or without a trailing slash or query string like `?si=...`) or a
-// `spotify:artist:<id>` URI. Returns null if it isn't a valid artist reference.
+// Extract the artist id from a web URL or a `spotify:artist:<id>` URI. Tolerant
+// of the shapes that legitimately occur so existing/pasted links all resolve to
+// the same id: a `?si=...` share suffix, a missing scheme (legacy stored
+// values), a locale prefix (`/intl-de/artist/...`), and a trailing segment
+// (`/artist/<id>/about`). But it REQUIRES the canonical open.spotify.com host
+// and the 22-char base62 id — a slug or hallucinated id returns null rather than
+// resolving to a broken embed.
 export function parseSpotifyArtistId(input: string): string | null {
-  const uri = input.match(/^spotify:artist:([A-Za-z0-9]+)$/)
-  if (uri) return SPOTIFY_ARTIST_ID_RE.test(uri[1]) ? uri[1] : null
+  const uri = input.match(SPOTIFY_URI_RE)
+  if (uri) return uri[1]
 
   let parsed: URL
   try {
     parsed = new URL(input)
   } catch {
-    return null
+    // Retry as a scheme-less value (e.g. a stored "open.spotify.com/artist/...").
+    try {
+      parsed = new URL(`https://${input}`)
+    } catch {
+      return null
+    }
   }
   if (parsed.hostname.toLowerCase() !== 'open.spotify.com') return null
-  // pathname excludes the query string, so `?si=...` share params are tolerated.
-  const path = parsed.pathname.match(/^\/artist\/([A-Za-z0-9]+)\/?$/)
-  if (!path) return null
-  return SPOTIFY_ARTIST_ID_RE.test(path[1]) ? path[1] : null
+  // pathname excludes the query string, so `?si=...` is tolerated; matching the
+  // segment anywhere in the path tolerates locale prefixes and trailing parts.
+  const path = parsed.pathname.match(SPOTIFY_PATH_RE)
+  return path ? path[1] : null
 }
 
 export function isValidSpotifyArtistUrl(input: string): boolean {
@@ -39,11 +51,12 @@ export type ResolveSpotifyResult =
   | { ok: true; id: string; canonicalUrl: string }
   | { ok: false; status: number | null; error: string }
 
-// Verify a Spotify artist actually exists (mirrors the Bandcamp save-time
-// check). Spotify's public oEmbed endpoint 404s for non-existent artists and
-// needs no auth. The outbound request targets the HARDCODED oEmbed host and
-// passes the CANONICAL url we rebuild from the validated id — never the raw
-// caller input — so this is not an SSRF/injection vector.
+// Verify a Spotify artist actually exists — the Spotify analogue of the
+// Bandcamp save-time existence check (same intent; the fetch details differ).
+// Spotify's public oEmbed endpoint 404s for non-existent artists and needs no
+// auth. The outbound request targets the HARDCODED oEmbed host and passes the
+// CANONICAL url we rebuild from the validated id — never the raw caller input —
+// so this is not an SSRF/injection vector.
 export async function resolveSpotifyArtist(
   input: string
 ): Promise<ResolveSpotifyResult> {

--- a/frontend/lib/spotify.ts
+++ b/frontend/lib/spotify.ts
@@ -1,0 +1,82 @@
+// Shared Spotify artist-URL parsing + validation.
+//
+// "Valid Spotify artist URL" was previously defined four different ways across
+// the codebase (an anchored discovery regex that dropped `?si=` share links, a
+// loose save-route check, a backend substring check, and the embed extractor),
+// which let a URL that one layer accepted be silently rejected by another. This
+// module is the single source of truth: parse the URL, require the canonical
+// host, and enforce the 22-char base62 artist id.
+
+// Spotify artist IDs are base62, exactly 22 characters.
+const SPOTIFY_ARTIST_ID_RE = /^[A-Za-z0-9]{22}$/
+const SPOTIFY_OEMBED_TIMEOUT_MS = 8000
+
+// Extract the artist id from a web URL (https://open.spotify.com/artist/<id>,
+// with or without a trailing slash or query string like `?si=...`) or a
+// `spotify:artist:<id>` URI. Returns null if it isn't a valid artist reference.
+export function parseSpotifyArtistId(input: string): string | null {
+  const uri = input.match(/^spotify:artist:([A-Za-z0-9]+)$/)
+  if (uri) return SPOTIFY_ARTIST_ID_RE.test(uri[1]) ? uri[1] : null
+
+  let parsed: URL
+  try {
+    parsed = new URL(input)
+  } catch {
+    return null
+  }
+  if (parsed.hostname.toLowerCase() !== 'open.spotify.com') return null
+  // pathname excludes the query string, so `?si=...` share params are tolerated.
+  const path = parsed.pathname.match(/^\/artist\/([A-Za-z0-9]+)\/?$/)
+  if (!path) return null
+  return SPOTIFY_ARTIST_ID_RE.test(path[1]) ? path[1] : null
+}
+
+export function isValidSpotifyArtistUrl(input: string): boolean {
+  return parseSpotifyArtistId(input) !== null
+}
+
+export type ResolveSpotifyResult =
+  | { ok: true; id: string; canonicalUrl: string }
+  | { ok: false; status: number | null; error: string }
+
+// Verify a Spotify artist actually exists (mirrors the Bandcamp save-time
+// check). Spotify's public oEmbed endpoint 404s for non-existent artists and
+// needs no auth. The outbound request targets the HARDCODED oEmbed host and
+// passes the CANONICAL url we rebuild from the validated id — never the raw
+// caller input — so this is not an SSRF/injection vector.
+export async function resolveSpotifyArtist(
+  input: string
+): Promise<ResolveSpotifyResult> {
+  const id = parseSpotifyArtistId(input)
+  if (!id) {
+    return {
+      ok: false,
+      status: null,
+      error:
+        'URL must be a Spotify artist URL (https://open.spotify.com/artist/...)',
+    }
+  }
+
+  const canonicalUrl = `https://open.spotify.com/artist/${id}`
+  const oembedUrl = `https://open.spotify.com/oembed?url=${encodeURIComponent(canonicalUrl)}`
+  try {
+    const response = await fetch(oembedUrl, {
+      headers: { Accept: 'application/json' },
+      redirect: 'error',
+      signal: AbortSignal.timeout(SPOTIFY_OEMBED_TIMEOUT_MS),
+    })
+    if (response.status === 404) {
+      return { ok: false, status: 404, error: 'No Spotify artist found at that URL' }
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        error: `Failed to verify Spotify artist: ${response.status}`,
+      }
+    }
+    return { ok: true, id, canonicalUrl }
+  } catch {
+    return { ok: false, status: null, error: 'Failed to verify Spotify artist' }
+  }
+}


### PR DESCRIPTION
## Problem

From the music-discovery feature audit. Two related Spotify gaps:

1. **"Valid Spotify artist URL" was defined four inconsistent ways** — an anchored discovery regex that silently **dropped `…/artist/<id>?si=…` share links** (Spotify's own Copy-link format), a loose save-route check, a backend substring check, and the embed extractor. A URL one layer accepted, another rejected.
2. **The Spotify save path never checked existence** (unlike Bandcamp), so a hallucinated-but-well-formed artist id saved clean and rendered a broken public embed with no feedback.

## Fix

- **New `frontend/lib/spotify.ts`** — single source of truth: `parseSpotifyArtistId` (web URL or `spotify:` URI; tolerates `?si=`, a missing scheme, a `/intl-xx/` locale prefix, and a trailing `/about` segment; requires the canonical `open.spotify.com` host + 22-char base62 id), `isValidSpotifyArtistUrl`, and `resolveSpotifyArtist` (oEmbed existence check — 404s for non-existent artists, no auth; fetches the **hardcoded** oEmbed host with the **canonical** rebuilt URL, so no SSRF).
- The **discovery filter** uses `isValidSpotifyArtistUrl` → `?si=` candidates are no longer dropped.
- The **Spotify save route** existence-checks via oEmbed (mirrors Bandcamp) and persists the **canonical** artist URL (stripping `?si=`).
- **MusicEmbed** uses the shared parser instead of its own loose regex.

Backend `isValidSpotifyURL` host-anchoring stays in PSY-1107 (the backend now receives the already-canonical URL).

## Verification

- **Live oEmbed:** valid artist → 200 → ok + canonical (strips `?si=`); bogus 22-char → 404 → rejected; non-22 → rejected with no fetch.
- **Live parser tolerance:** `/intl-de/artist/<id>`, `/artist/<id>/about`, scheme-less, and `?si=` all resolve to the id; a non-`open.spotify.com` host (even scheme-less) → null; a slug → null.
- `tsc` clean; eslint clean; `go build ./cmd/seed/...` OK; affected vitest suites pass (new `lib/spotify.test.ts`, updated spotify-route + MusicEmbed tests, ArtistDetail/ShowCard/ShowDetail unaffected).

## Adversarial review

`/adversarial-review` — fresh-context panel (Saboteur · Security · Future-Maintainer). **Security: CLEAN** (ran the parser against 22 bypass payloads + the live endpoint; the SSRF surface is genuinely closed — only the validated 22-char id survives into a hardcoded-host URL). Findings addressed in commit `c59bf62` (impl in `5ed2272d`):

- **[HIGH, corroborated ×3]** the parser was strict on path AND scheme, regressing URLs the old extractor handled (`/intl-xx/` locale prefix, `/artist/<id>/about`, scheme-less) — the seed exemplar's slug Spotify URL was the concrete repro. → match the id anywhere in the path + retry scheme-less as https, keeping the host + 22-char requirement. Seed exemplar given a real 22-char id so the screenshot surface renders a live embed.
- **[MEDIUM/LOW]** comment fixes (soften "mirrors Bandcamp"; clarify candidates are canonicalized at save; drop a decorative test-mock body).
- **[LOW, disclosed/deferred]** a transient Spotify oEmbed blip (5xx/timeout) rejects a valid save with a 400 — left as-is: consistent with the Bandcamp save path, and the error copy already signals a retryable verification failure.

Closes PSY-1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
