### PR TITLE
PSY-1107: parse + host-anchor the backend Bandcamp/Spotify URL validators

### DIFF
--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -5,6 +5,8 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -549,17 +551,40 @@ func (h *ArtistHandler) UpdateArtistBandcampHandler(ctx context.Context, req *Up
 	return &UpdateArtistBandcampResponse{Body: artist}, nil
 }
 
-// isValidBandcampURL validates that the URL is a proper Bandcamp album/track URL
-func isValidBandcampURL(url string) bool {
-	// Must contain bandcamp.com
-	if !strings.Contains(url, "bandcamp.com") {
+// isValidBandcampURL validates that the URL is a proper Bandcamp album/track URL.
+// It parses the URL and anchors on the host (not a substring match), so a
+// hostile value like "http://169.254.169.254/album/x?bandcamp.com" — which the
+// old strings.Contains check accepted — is rejected. The frontend BFF already
+// fetches/canonicalizes these (PSY-1106); this is the backend's defense-in-depth
+// floor as the last writer.
+func isValidBandcampURL(rawURL string) bool {
+	u, ok := parseHTTPURL(rawURL)
+	if !ok {
 		return false
 	}
-	// Must be an album or track URL (not just profile)
-	if !strings.Contains(url, "/album/") && !strings.Contains(url, "/track/") {
+	host := strings.ToLower(u.Hostname())
+	if host != "bandcamp.com" && !strings.HasSuffix(host, ".bandcamp.com") {
 		return false
 	}
-	return true
+	// Album or track page, not a bare profile.
+	return strings.HasPrefix(u.Path, "/album/") || strings.HasPrefix(u.Path, "/track/")
+}
+
+// parseHTTPURL parses rawURL and confirms it has an http/https scheme and a
+// host, returning the parsed URL. Shared floor for the domain-specific
+// validators so the parse + scheme check lives in one place.
+func parseHTTPURL(rawURL string) (*url.URL, bool) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, false
+	}
+	if u.Hostname() == "" {
+		return nil, false
+	}
+	return u, true
 }
 
 // ============================================================================
@@ -670,13 +695,23 @@ func (h *ArtistHandler) UpdateArtistSpotifyHandler(ctx context.Context, req *Upd
 	return &UpdateArtistSpotifyResponse{Body: artist}, nil
 }
 
-// isValidSpotifyURL validates that the URL is a proper Spotify artist page URL
-func isValidSpotifyURL(url string) bool {
-	// Must contain open.spotify.com/artist/
-	if !strings.Contains(url, "open.spotify.com/artist/") {
+// spotifyArtistPath matches a canonical Spotify artist path: /artist/<22-char
+// base62 id>. The frontend canonicalizes to exactly this shape (PSY-1108).
+var spotifyArtistPath = regexp.MustCompile(`^/artist/[A-Za-z0-9]{22}/?$`)
+
+// isValidSpotifyURL validates that the URL is a proper Spotify artist page URL.
+// Parses and anchors on the host AND the 22-char base62 artist id, replacing the
+// old substring check that accepted any-length id and any URL merely containing
+// "open.spotify.com/artist/" (e.g. on an attacker-controlled host).
+func isValidSpotifyURL(rawURL string) bool {
+	u, ok := parseHTTPURL(rawURL)
+	if !ok {
 		return false
 	}
-	return true
+	if strings.ToLower(u.Hostname()) != "open.spotify.com" {
+		return false
+	}
+	return spotifyArtistPath.MatchString(u.Path)
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -554,16 +554,21 @@ func (h *ArtistHandler) UpdateArtistBandcampHandler(ctx context.Context, req *Up
 // isValidBandcampURL validates that the URL is a proper Bandcamp album/track URL.
 // It parses the URL and anchors on the host (not a substring match), so a
 // hostile value like "http://169.254.169.254/album/x?bandcamp.com" — which the
-// old strings.Contains check accepted — is rejected. The frontend BFF already
-// fetches/canonicalizes these (PSY-1106); this is the backend's defense-in-depth
-// floor as the last writer.
+// old strings.Contains check accepted — is rejected. This handler STORES the
+// value (later rendered in an iframe src); it does not fetch it, so the win here
+// is preventing a hostile/foreign host from being persisted, not SSRF.
+//
+// NOTE: the general social.bandcamp/social.spotify fields on the create/update
+// endpoints are still only scheme-checked (ValidateSocialURLs) — PSY-1113.
 func isValidBandcampURL(rawURL string) bool {
 	u, ok := parseHTTPURL(rawURL)
 	if !ok {
 		return false
 	}
-	host := strings.ToLower(u.Hostname())
-	if host != "bandcamp.com" && !strings.HasSuffix(host, ".bandcamp.com") {
+	// Real album/track pages always live on an artist subdomain
+	// (<artist>.bandcamp.com); the bare apex is not a release URL, and the
+	// social-link mirror (above) keys off the ".bandcamp.com" subdomain too.
+	if !strings.HasSuffix(strings.ToLower(u.Hostname()), ".bandcamp.com") {
 		return false
 	}
 	// Album or track page, not a bare profile.
@@ -571,8 +576,10 @@ func isValidBandcampURL(rawURL string) bool {
 }
 
 // parseHTTPURL parses rawURL and confirms it has an http/https scheme and a
-// host, returning the parsed URL. Shared floor for the domain-specific
-// validators so the parse + scheme check lives in one place.
+// host, returning the parsed URL. Shared by the two validators below so the
+// parse + scheme check lives in one place. http is accepted (not just https) to
+// match the codebase's URL convention (utils.ValidateHTTPURL); the host anchor,
+// not the scheme, is what rejects hostile values.
 func parseHTTPURL(rawURL string) (*url.URL, bool) {
 	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
@@ -695,14 +702,19 @@ func (h *ArtistHandler) UpdateArtistSpotifyHandler(ctx context.Context, req *Upd
 	return &UpdateArtistSpotifyResponse{Body: artist}, nil
 }
 
-// spotifyArtistPath matches a canonical Spotify artist path: /artist/<22-char
-// base62 id>. The frontend canonicalizes to exactly this shape (PSY-1108).
-var spotifyArtistPath = regexp.MustCompile(`^/artist/[A-Za-z0-9]{22}/?$`)
+// spotifyArtistPath matches an /artist/<id> segment ANYWHERE in the path, so a
+// locale prefix (/intl-de/artist/...) or a trailing sub-tab (/artist/<id>/about)
+// — both shapes Spotify's web player serves and admins paste verbatim — still
+// validate. Id length is intentionally not pinned to 22 here: the security win
+// is the open.spotify.com host anchor (below); the canonical 22-char form is a
+// frontend normalization concern, and rejecting other lengths server-side would
+// hard-422 real pasted URLs the BFF forwards unchanged.
+var spotifyArtistPath = regexp.MustCompile(`/artist/[A-Za-z0-9]+(?:/|$)`)
 
 // isValidSpotifyURL validates that the URL is a proper Spotify artist page URL.
-// Parses and anchors on the host AND the 22-char base62 artist id, replacing the
-// old substring check that accepted any-length id and any URL merely containing
-// "open.spotify.com/artist/" (e.g. on an attacker-controlled host).
+// Parses and anchors on the open.spotify.com host, replacing the old substring
+// check that accepted any URL merely containing "open.spotify.com/artist/" (e.g.
+// on an attacker-controlled host like "https://evil.test/artist/<id>").
 func isValidSpotifyURL(rawURL string) bool {
 	u, ok := parseHTTPURL(rawURL)
 	if !ok {

--- a/backend/internal/api/handlers/catalog/artist_integration_test.go
+++ b/backend/internal/api/handlers/catalog/artist_integration_test.go
@@ -515,7 +515,7 @@ func (s *ArtistHandlerIntegrationSuite) TestUpdateSpotify_AdminSuccess() {
 	artistID := s.createArtistViaService("Spotify Artist")
 
 	ctx := testhelpers.CtxWithUser(admin)
-	url := "https://open.spotify.com/artist/abc123"
+	url := "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP"
 	req := &UpdateArtistSpotifyRequest{ArtistID: fmt.Sprintf("%d", artistID)}
 	req.Body.SpotifyURL = &url
 
@@ -531,7 +531,7 @@ func (s *ArtistHandlerIntegrationSuite) TestUpdateSpotify_ClearURL() {
 	artistID := s.createArtistViaService("Spotify Clear Artist")
 
 	ctx := testhelpers.CtxWithUser(admin)
-	url := "https://open.spotify.com/artist/abc123"
+	url := "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP"
 	setReq := &UpdateArtistSpotifyRequest{ArtistID: fmt.Sprintf("%d", artistID)}
 	setReq.Body.SpotifyURL = &url
 	_, err := s.handler.UpdateArtistSpotifyHandler(ctx, setReq)
@@ -551,7 +551,7 @@ func (s *ArtistHandlerIntegrationSuite) TestUpdateSpotify_ClearURL() {
 func (s *ArtistHandlerIntegrationSuite) TestUpdateSpotify_NotFound() {
 	admin := testhelpers.CreateAdminUser(s.deps.DB)
 	ctx := testhelpers.CtxWithUser(admin)
-	url := "https://open.spotify.com/artist/abc123"
+	url := "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP"
 	req := &UpdateArtistSpotifyRequest{ArtistID: "99999"}
 	req.Body.SpotifyURL = &url
 

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -229,9 +229,17 @@ func TestIsValidBandcampURL(t *testing.T) {
 	}{
 		{"valid album URL", "https://artist.bandcamp.com/album/cool-album", true},
 		{"valid track URL", "https://artist.bandcamp.com/track/cool-track", true},
+		{"apex album URL", "https://bandcamp.com/album/cool-album", true},
 		{"profile only", "https://artist.bandcamp.com", false},
 		{"wrong domain", "https://example.com/album/test", false},
 		{"empty string", "", false},
+		// Host is anchored (parsed), not a substring — these all contain
+		// "bandcamp.com" but resolve to attacker/internal hosts (PSY-1107).
+		{"ssrf substring bypass via query", "http://169.254.169.254/album/x?bandcamp.com", false},
+		{"attacker subdomain suffix", "https://bandcamp.com.attacker.test/album/x", false},
+		{"lookalike domain", "https://notbandcamp.com/album/x", false},
+		{"scheme-less", "artist.bandcamp.com/album/x", false},
+		{"non-http scheme", "javascript:alert(1)//artist.bandcamp.com/album/x", false},
 	}
 
 	for _, tt := range tests {
@@ -250,10 +258,16 @@ func TestIsValidSpotifyURL(t *testing.T) {
 		url      string
 		expected bool
 	}{
-		{"valid URL", "https://open.spotify.com/artist/abc123", true},
-		{"wrong domain", "https://spotify.com/artist/abc123", false},
-		{"missing /artist/", "https://open.spotify.com/track/abc123", false},
+		{"valid 22-char id", "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP", true},
+		{"valid id with ?si= query", "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP?si=abc", true},
+		{"non-22-char id", "https://open.spotify.com/artist/abc123", false},
+		{"wrong domain", "https://spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP", false},
+		{"missing /artist/", "https://open.spotify.com/track/0WThQFCFaU1YR5s0bNLvtP", false},
 		{"empty string", "", false},
+		// Host anchored (parsed), not a substring (PSY-1107).
+		{"ssrf substring bypass via query", "http://169.254.169.254/?x=open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP", false},
+		{"attacker host with artist path", "https://evil.test/artist/0WThQFCFaU1YR5s0bNLvtP", false},
+		{"scheme-less", "open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP", false},
 	}
 
 	for _, tt := range tests {
@@ -742,7 +756,7 @@ func TestUpdateSpotify_Success(t *testing.T) {
 			}
 			if req.Spotify == nil {
 				t.Error("expected spotify to be set")
-			} else if *req.Spotify != "https://open.spotify.com/artist/abc123" {
+			} else if *req.Spotify != "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP" {
 				t.Errorf("expected spotify URL, got %q", *req.Spotify)
 			}
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
@@ -750,7 +764,7 @@ func TestUpdateSpotify_Success(t *testing.T) {
 	}
 	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
-	url := "https://open.spotify.com/artist/abc123"
+	url := "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP"
 	req := &UpdateArtistSpotifyRequest{ArtistID: "42"}
 	req.Body.SpotifyURL = &url
 

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -229,7 +229,7 @@ func TestIsValidBandcampURL(t *testing.T) {
 	}{
 		{"valid album URL", "https://artist.bandcamp.com/album/cool-album", true},
 		{"valid track URL", "https://artist.bandcamp.com/track/cool-track", true},
-		{"apex album URL", "https://bandcamp.com/album/cool-album", true},
+		{"apex rejected (releases live on a subdomain)", "https://bandcamp.com/album/cool-album", false},
 		{"profile only", "https://artist.bandcamp.com", false},
 		{"wrong domain", "https://example.com/album/test", false},
 		{"empty string", "", false},
@@ -260,7 +260,11 @@ func TestIsValidSpotifyURL(t *testing.T) {
 	}{
 		{"valid 22-char id", "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP", true},
 		{"valid id with ?si= query", "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP?si=abc", true},
-		{"non-22-char id", "https://open.spotify.com/artist/abc123", false},
+		// Length is not pinned to 22 server-side (host anchor is the win); these
+		// real shapes the BFF forwards unchanged must still validate.
+		{"short id (host-anchored, length not pinned)", "https://open.spotify.com/artist/abc123", true},
+		{"locale prefix", "https://open.spotify.com/intl-de/artist/0WThQFCFaU1YR5s0bNLvtP", true},
+		{"trailing sub-tab", "https://open.spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP/about", true},
 		{"wrong domain", "https://spotify.com/artist/0WThQFCFaU1YR5s0bNLvtP", false},
 		{"missing /artist/", "https://open.spotify.com/track/0WThQFCFaU1YR5s0bNLvtP", false},
 		{"empty string", "", false},


### PR DESCRIPTION
## Problem

From the music-discovery feature audit. The catalog handler's `isValidBandcampURL` / `isValidSpotifyURL` validated by **substring**, so a hostile value like `http://169.254.169.254/album/x?bandcamp.com` or `https://evil.test/artist/<id>` passed and was persisted as the artist's embed URL (rendered into an iframe `src` / a SocialLinks href). The frontend BFF was hardened in PSY-1106/PSY-1108; this closes the backend defense-in-depth gap — but the backend must not *assume* the frontend canonicalizes, since it's the last writer.

## Fix

- Parse with `net/url` and **anchor on the host**: Bandcamp requires a `*.bandcamp.com` subdomain (real release pages always live on a subdomain) + an `/album/` or `/track/` path; Spotify requires `open.spotify.com` + an `/artist/<id>` path segment. A shared `parseHTTPURL` enforces the http/https scheme + non-empty host.
- **Host-anchoring is the security win; shape stays lenient.** The Spotify check matches the `/artist/<id>` segment *anywhere* in the path (so `/intl-de/artist/…` locale prefixes and `/artist/<id>/about` sub-tabs validate) and does **not** pin id length — the canonical 22-char form is a frontend normalization concern, and pinning it server-side would hard-422 real pasted URLs the BFF forwards unchanged.

## Verification

- `go build ./...` + `go vet ./...` clean; `gofmt` clean; the catalog package + adjacent packages (admin, community) pass.
- Table tests assert the host-anchoring: SSRF substring-bypass (`169.254.169.254/album/x?bandcamp.com`), attacker host (`evil.test/artist/<id>`), lookalike (`notbandcamp.com`), subdomain-suffix (`bandcamp.com.attacker.test`), scheme-less, and non-http scheme all rejected; locale-prefix / sub-tab / `?si=` Spotify URLs accepted.

## Adversarial review

`/adversarial-review` — fresh panel (Saboteur · Security · Future-Maintainer). **Security CLEAN on the core**: it executed every bypass class (userinfo, backslash, `%2f@`, trailing-dot, IDN homoglyph, control chars, `////`, port, regex newline-injection) and confirmed all are rejected. Findings addressed in `3583f380` (impl `4f171ea7`):

- **[HIGH, Saboteur+FM]** the panel reviewed `main` (where PSY-1106/1108 aren't merged), exposing that my strict `^/artist/<22>$` regex assumed unmerged canonicalization and would hard-422 real Spotify URLs (`intl-xx`, `/about`, non-22 ids) the current BFF forwards verbatim. → match the segment anywhere + drop the server-side length pin (decoupled from merge order; host anchor preserved).
- **[HIGH, FM]** dropped the apex `bandcamp.com` allowance — it disagreed with the same-handler social mirror (which keys off `.bandcamp.com`) and the real Bandcamp URL grammar. Now subdomain-only.
- **[MEDIUM, Security]** the general `social.bandcamp`/`social.spotify` fields on create/update are still scheme-only (`ValidateSocialURLs`) — host-anchoring those is a distinct cross-entity change (a venue's `social.spotify` can be a playlist/user URL), filed as **PSY-1113** and noted in-code so the floor isn't implied-complete.
- **[LOW]** reworded comments to not assert PSY-1106/1108 are merged, and to say "stores a hostile host" rather than "SSRF" (this handler stores, it doesn't fetch).

Closes PSY-1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
