### PR TITLE
PSY-1109: fix dead React-Query invalidation on artist music saves (id vs slug)

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -400,7 +400,6 @@ function ArtistSidebar({
 
 function AdminMusicControls({
   artist,
-  artistId,
 }: {
   artist: {
     id: number
@@ -411,9 +410,7 @@ function AdminMusicControls({
       bandcamp: string | null
     }
   }
-  artistId: string | number
 }) {
-  const queryClient = useQueryClient()
   const [showManualInput, setShowManualInput] = useState<
     'bandcamp' | 'spotify' | null
   >(null)
@@ -469,9 +466,7 @@ function AdminMusicControls({
     setFeedback(null)
     setSavingCandidateUrl(candidate.url)
     const onSuccess = () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.artists.detail(artistId),
-      })
+      // Cache invalidation is owned by the mutation hooks (PSY-1109).
       setFeedback({
         type: 'success',
         message: `${platform === 'bandcamp' ? 'Bandcamp' : 'Spotify'} URL saved`,
@@ -513,9 +508,6 @@ function AdminMusicControls({
       { artistId: artist.id, bandcampUrl: manualUrl.trim() },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.artists.detail(artistId),
-          })
           setFeedback({ type: 'success', message: 'Bandcamp URL saved' })
           setShowManualInput(null)
           setManualUrl('')
@@ -537,9 +529,6 @@ function AdminMusicControls({
       { artistId: artist.id, spotifyUrl: manualUrl.trim() },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.artists.detail(artistId),
-          })
           setFeedback({ type: 'success', message: 'Spotify URL saved' })
           setShowManualInput(null)
           setManualUrl('')
@@ -558,9 +547,6 @@ function AdminMusicControls({
     setFeedback(null)
     clearBandcamp.mutate(artist.id, {
       onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.artists.detail(artistId),
-        })
         setFeedback({ type: 'success', message: 'Bandcamp URL cleared' })
         setShowManualInput(null)
       },
@@ -577,9 +563,6 @@ function AdminMusicControls({
     setFeedback(null)
     clearSpotify.mutate(artist.id, {
       onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.artists.detail(artistId),
-        })
         setFeedback({ type: 'success', message: 'Spotify URL cleared' })
         setShowManualInput(null)
       },
@@ -1233,7 +1216,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
           />
 
           {isAdmin && (
-            <AdminMusicControls artist={artist} artistId={artistId} />
+            <AdminMusicControls artist={artist} />
           )}
 
           <RevisionHistory

--- a/frontend/lib/hooks/admin/useAdminArtists.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtists.test.tsx
@@ -228,8 +228,10 @@ describe('useAdminArtists', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
+      // Invalidates the artists prefix (matches the slug-keyed cache), not the
+      // numeric-id detail key. (PSY-1109)
       expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ['artists', 'detail', 456],
+        queryKey: ['artists'],
       })
     })
 
@@ -297,7 +299,7 @@ describe('useAdminArtists', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
       expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ['artists', 'detail', 789],
+        queryKey: ['artists'],
       })
     })
 
@@ -374,8 +376,10 @@ describe('useAdminArtists', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
+      // Invalidates the artists prefix (matches the slug-keyed cache), not the
+      // numeric-id detail key. (PSY-1109)
       expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ['artists', 'detail', 456],
+        queryKey: ['artists'],
       })
     })
 
@@ -443,7 +447,7 @@ describe('useAdminArtists', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
       expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ['artists', 'detail', 789],
+        queryKey: ['artists'],
       })
     })
 

--- a/frontend/lib/hooks/admin/useAdminArtists.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtists.test.tsx
@@ -228,8 +228,9 @@ describe('useAdminArtists', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-      // Invalidates the artists prefix (matches the slug-keyed cache), not the
-      // numeric-id detail key. (PSY-1109)
+      // Invalidates the artists prefix (matches the slug-keyed cache), not an
+      // id-keyed detail key (which holds a different value than the slug).
+      // (PSY-1109)
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: ['artists'],
       })
@@ -376,8 +377,9 @@ describe('useAdminArtists', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-      // Invalidates the artists prefix (matches the slug-keyed cache), not the
-      // numeric-id detail key. (PSY-1109)
+      // Invalidates the artists prefix (matches the slug-keyed cache), not an
+      // id-keyed detail key (which holds a different value than the slug).
+      // (PSY-1109)
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: ['artists'],
       })
@@ -495,9 +497,10 @@ describe('useAdminArtists', () => {
       })
     })
 
-    it('invalidates artist detail, artists.all, AND shows.all on success', async () => {
+    it('invalidates the artists.all AND shows.all prefixes on success', async () => {
       // Updating an artist may rename them — show listings carry the artist
-      // name denormalised, so the shows scope also gets invalidated.
+      // name denormalised, so the shows scope also gets invalidated. (No
+      // detail(id) line — the artists prefix covers detail-by-slug. PSY-1109.)
       mockFetchResponse({ id: 456 })
 
       const queryClient = createTestQueryClient()
@@ -516,9 +519,6 @@ describe('useAdminArtists', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ['artists', 'detail', 456],
-      })
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: ['artists'],
       })

--- a/frontend/lib/hooks/admin/useAdminArtists.ts
+++ b/frontend/lib/hooks/admin/useAdminArtists.ts
@@ -140,9 +140,11 @@ export function useUpdateArtistBandcamp() {
       return data
     },
     onSuccess: () => {
-      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
-      // caches under detail(slug), so a numeric-id key never matches. Mirrors
-      // useArtistUpdate. (PSY-1109)
+      // Invalidate the artists prefix. These hooks know the numeric id, but the
+      // page caches the artist under detail(slug) — detail(id) and detail(slug)
+      // are different VALUES (detail() stringifies either, so it's not a
+      // key-shape difference), so an id-keyed invalidation never matches. The
+      // prefix does, regardless of id-vs-slug. (PSY-1109)
       queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
@@ -180,9 +182,11 @@ export function useClearArtistBandcamp() {
       return data
     },
     onSuccess: () => {
-      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
-      // caches under detail(slug), so a numeric-id key never matches. Mirrors
-      // useArtistUpdate. (PSY-1109)
+      // Invalidate the artists prefix. These hooks know the numeric id, but the
+      // page caches the artist under detail(slug) — detail(id) and detail(slug)
+      // are different VALUES (detail() stringifies either, so it's not a
+      // key-shape difference), so an id-keyed invalidation never matches. The
+      // prefix does, regardless of id-vs-slug. (PSY-1109)
       queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
@@ -231,9 +235,11 @@ export function useUpdateArtistSpotify() {
       return data
     },
     onSuccess: () => {
-      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
-      // caches under detail(slug), so a numeric-id key never matches. Mirrors
-      // useArtistUpdate. (PSY-1109)
+      // Invalidate the artists prefix. These hooks know the numeric id, but the
+      // page caches the artist under detail(slug) — detail(id) and detail(slug)
+      // are different VALUES (detail() stringifies either, so it's not a
+      // key-shape difference), so an id-keyed invalidation never matches. The
+      // prefix does, regardless of id-vs-slug. (PSY-1109)
       queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
@@ -271,9 +277,11 @@ export function useClearArtistSpotify() {
       return data
     },
     onSuccess: () => {
-      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
-      // caches under detail(slug), so a numeric-id key never matches. Mirrors
-      // useArtistUpdate. (PSY-1109)
+      // Invalidate the artists prefix. These hooks know the numeric id, but the
+      // page caches the artist under detail(slug) — detail(id) and detail(slug)
+      // are different VALUES (detail() stringifies either, so it's not a
+      // key-shape difference), so an id-keyed invalidation never matches. The
+      // prefix does, regardless of id-vs-slug. (PSY-1109)
       queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
@@ -314,16 +322,14 @@ export function useArtistUpdate() {
         }
       )
     },
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.artists.detail(variables.artistId),
-      })
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.artists.all,
-      })
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.shows.all,
-      })
+    onSuccess: () => {
+      // A rename changes the artist wherever it's denormalised, so invalidate
+      // the whole artists prefix (which covers detail-by-slug) and shows. No
+      // detail(id) line: these hooks know the numeric id, but the page caches
+      // under detail(slug) — different VALUES, so an id-keyed invalidation never
+      // matches; the prefix matches regardless. (PSY-1109)
+      queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.shows.all })
     },
   })
 }

--- a/frontend/lib/hooks/admin/useAdminArtists.ts
+++ b/frontend/lib/hooks/admin/useAdminArtists.ts
@@ -139,10 +139,11 @@ export function useUpdateArtistBandcamp() {
 
       return data
     },
-    onSuccess: (data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.artists.detail(variables.artistId),
-      })
+    onSuccess: () => {
+      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
+      // caches under detail(slug), so a numeric-id key never matches. Mirrors
+      // useArtistUpdate. (PSY-1109)
+      queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
 }
@@ -178,10 +179,11 @@ export function useClearArtistBandcamp() {
 
       return data
     },
-    onSuccess: (data, artistId) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.artists.detail(artistId),
-      })
+    onSuccess: () => {
+      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
+      // caches under detail(slug), so a numeric-id key never matches. Mirrors
+      // useArtistUpdate. (PSY-1109)
+      queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
 }
@@ -228,10 +230,11 @@ export function useUpdateArtistSpotify() {
 
       return data
     },
-    onSuccess: (data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.artists.detail(variables.artistId),
-      })
+    onSuccess: () => {
+      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
+      // caches under detail(slug), so a numeric-id key never matches. Mirrors
+      // useArtistUpdate. (PSY-1109)
+      queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
 }
@@ -267,10 +270,11 @@ export function useClearArtistSpotify() {
 
       return data
     },
-    onSuccess: (data, artistId) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.artists.detail(artistId),
-      })
+    onSuccess: () => {
+      // Invalidate the artists prefix, NOT detail(numeric id): the artist page
+      // caches under detail(slug), so a numeric-id key never matches. Mirrors
+      // useArtistUpdate. (PSY-1109)
+      queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
     },
   })
 }


### PR DESCRIPTION
## Problem

From the music-discovery feature audit. The artist page caches under `detail(slug)` (the page passes the slug as `artistId`), but the four music-save hooks (`useUpdateArtistBandcamp`/`useUpdateArtistSpotify`/`useClearArtistBandcamp`/`useClearArtistSpotify`) invalidated `detail(variables.artistId)` with the artist's **numeric id** — a different VALUE than the slug, so the key never matched the cached query.

It worked anyway, but only because `AdminMusicControls` *also* invalidated `detail(slug)` in every handler. The trap: a future cleanup removing that "redundant" component-level call would silently break post-save refresh.

## Fix

- The four music hooks now invalidate the `queryKeys.artists.all` (`['artists']`) prefix, which matches the slug-keyed detail query regardless of id-vs-slug — the same approach `useArtistUpdate` already uses. Cache invalidation now lives in the hooks (one source of truth), like every other admin artist hook, so no caller can forget it.
- Removed the five now-redundant component-level invalidations in `AdminMusicControls`, plus the now-unused `artistId` prop and `queryClient`.
- Updated the hook tests to assert the prefix invalidation.

## Verification

- `tsc` clean; eslint clean (removed the dead refs the change exposed); 64 affected tests pass (hook tests + ArtistDetail).

## Adversarial review

`/adversarial-review` — Saboteur **CLEAN** (verified the `['artists']` prefix matches `['artists','detail','<slug>']`, the only caller is `ArtistDetail`, no dropped side-effects, no race, over-invalidation is mild + consistent with `useArtistUpdate`). Future-Maintainer findings fixed in `7837b17c` (impl `2a9d7fd5`):

- **[MEDIUM]** the comments misdiagnosed the cause — `detail()` stringifies its arg, so the key *shape* was identical; the mismatch was the **value** (id vs slug), not "numeric vs string". Reworded.
- **[MEDIUM]** `useArtistUpdate` still carried the identical dead `detail(id)` line (a copy-paste trap, and the hook the comments pointed at). Removed it — its `.all` already covers detail-by-slug — and updated its test. The dead `detail(id)` pattern is now gone from every hook in the file.

Note: these are unit tests over a mocked queryClient, so they assert the invalidation *key* rather than true cache-matching; the real regression-resistance comes from the `.all` prefix being value-agnostic (it can't drift the way `detail(id)` did).

Closes PSY-1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
