### PR TITLE
PSY-1111: dedup admin artist music-route auth/forward boilerplate

### DIFF
--- a/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
+++ b/frontend/app/api/admin/artists/[id]/bandcamp/route.ts
@@ -1,48 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
-import * as Sentry from '@sentry/nextjs'
-import { revalidateArtistDetail } from '@/lib/revalidate-entity'
 import { resolveBandcampEmbed, isAllowedBandcampUrl } from '@/lib/bandcamp'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
-
-interface UserProfile {
-  success: boolean
-  user?: {
-    id: string
-    is_admin?: boolean
-  }
-}
-
-interface Artist {
-  id: number
-  slug: string
-  name: string
-  bandcamp_embed_url: string | null
-}
+import { requireAdmin, forwardArtistMusicUpdate } from '@/lib/admin-artist-route'
 
 interface UpdateBandcampRequest {
   bandcamp_url: string
-}
-
-async function getAuthenticatedUser(
-  authToken: string
-): Promise<UserProfile | null> {
-  try {
-    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
-      headers: {
-        Cookie: `auth_token=${authToken}`,
-      },
-    })
-
-    if (!response.ok) {
-      return null
-    }
-
-    return await response.json()
-  } catch {
-    return null
-  }
 }
 
 // Validates the URL is an embeddable Bandcamp album/track page and returns the
@@ -78,22 +39,8 @@ export async function POST(
 ) {
   const { id: artistId } = await params
 
-  // Get auth token from cookies
-  const cookieStore = await cookies()
-  const authToken = cookieStore.get('auth_token')
-
-  if (!authToken) {
-    return NextResponse.json(
-      { error: 'Authentication required' },
-      { status: 401 }
-    )
-  }
-
-  // Validate admin access
-  const profile = await getAuthenticatedUser(authToken.value)
-  if (!profile?.success || !profile.user?.is_admin) {
-    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-  }
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
 
   // Parse request body
   let body: UpdateBandcampRequest
@@ -104,7 +51,6 @@ export async function POST(
   }
 
   const { bandcamp_url } = body
-
   if (!bandcamp_url) {
     return NextResponse.json(
       { error: 'bandcamp_url is required' },
@@ -121,48 +67,16 @@ export async function POST(
     )
   }
 
-  // Forward to backend
-  try {
-    const response = await fetch(
-      `${BACKEND_URL}/admin/artists/${artistId}/bandcamp`,
-      {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Cookie: `auth_token=${authToken.value}`,
-        },
-        // Persist the resolved URL (path auto-corrected if it was wrong).
-        body: JSON.stringify({ bandcamp_embed_url: validation.resolvedUrl }),
-      }
-    )
-
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Unknown error' }))
-      return NextResponse.json(
-        { error: error.detail || 'Failed to update artist' },
-        { status: response.status }
-      )
-    }
-
-    const artist: Artist = await response.json()
-
-    revalidateArtistDetail(artist.slug)
-
-    return NextResponse.json({
-      success: true,
-      artist,
-    })
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
-      tags: { service: 'admin-bandcamp', operation: 'update' },
-      extra: { artistId },
-    })
-    return NextResponse.json(
-      { error: 'Failed to update artist' },
-      { status: 500 }
-    )
-  }
+  return forwardArtistMusicUpdate({
+    artistId,
+    authToken: auth.authToken,
+    field: 'bandcamp',
+    // Persist the resolved URL (path auto-corrected if it was wrong).
+    body: { bandcamp_embed_url: validation.resolvedUrl },
+    sentryService: 'admin-bandcamp',
+    sentryOperation: 'update',
+    failureMessage: 'Failed to update artist',
+  })
 }
 
 // Also support DELETE to clear the Bandcamp URL
@@ -172,62 +86,16 @@ export async function DELETE(
 ) {
   const { id: artistId } = await params
 
-  // Get auth token from cookies
-  const cookieStore = await cookies()
-  const authToken = cookieStore.get('auth_token')
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
 
-  if (!authToken) {
-    return NextResponse.json(
-      { error: 'Authentication required' },
-      { status: 401 }
-    )
-  }
-
-  // Validate admin access
-  const profile = await getAuthenticatedUser(authToken.value)
-  if (!profile?.success || !profile.user?.is_admin) {
-    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-  }
-
-  // Forward to backend with null to clear
-  try {
-    const response = await fetch(
-      `${BACKEND_URL}/admin/artists/${artistId}/bandcamp`,
-      {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Cookie: `auth_token=${authToken.value}`,
-        },
-        body: JSON.stringify({ bandcamp_embed_url: null }),
-      }
-    )
-
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Unknown error' }))
-      return NextResponse.json(
-        { error: error.detail || 'Failed to clear Bandcamp URL' },
-        { status: response.status }
-      )
-    }
-
-    const artist: Artist = await response.json()
-
-    revalidateArtistDetail(artist.slug)
-
-    return NextResponse.json({
-      success: true,
-      artist,
-    })
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
-      tags: { service: 'admin-bandcamp', operation: 'clear' },
-      extra: { artistId },
-    })
-    return NextResponse.json(
-      { error: 'Failed to clear Bandcamp URL' },
-      { status: 500 }
-    )
-  }
+  return forwardArtistMusicUpdate({
+    artistId,
+    authToken: auth.authToken,
+    field: 'bandcamp',
+    body: { bandcamp_embed_url: null },
+    sentryService: 'admin-bandcamp',
+    sentryOperation: 'clear',
+    failureMessage: 'Failed to clear Bandcamp URL',
+  })
 }

--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 import Anthropic from '@anthropic-ai/sdk'
 import * as Sentry from '@sentry/nextjs'
 import { isValidSpotifyArtistUrl } from '@/lib/spotify'
+import { getAuthenticatedUser } from '@/lib/admin-artist-route'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -34,11 +35,6 @@ Rules:
 - If a field is unknown, use null. If no candidates for a platform, return an empty array.
 - Output ONLY the JSON object.`
 
-interface UserProfile {
-  success: boolean
-  user?: { id: string; is_admin?: boolean }
-}
-
 interface Artist {
   id: number
   name: string
@@ -53,20 +49,6 @@ export interface DiscoveryCandidate {
   popularity: string | null
   confidence: 'high' | 'medium' | 'low'
   why_might_match: string | null
-}
-
-async function getAuthenticatedUser(
-  authToken: string
-): Promise<UserProfile | null> {
-  try {
-    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
-      headers: { Cookie: `auth_token=${authToken}` },
-    })
-    if (!response.ok) return null
-    return await response.json()
-  } catch {
-    return null
-  }
 }
 
 async function getArtist(artistId: string): Promise<Artist | null> {

--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import Anthropic from '@anthropic-ai/sdk'
 import * as Sentry from '@sentry/nextjs'
 import { isValidSpotifyArtistUrl } from '@/lib/spotify'
-import { getAuthenticatedUser } from '@/lib/admin-artist-route'
+import { getAuthenticatedUser } from '@/lib/auth-profile'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 

--- a/frontend/app/api/admin/artists/[id]/spotify/route.ts
+++ b/frontend/app/api/admin/artists/[id]/spotify/route.ts
@@ -1,50 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
-import * as Sentry from '@sentry/nextjs'
-import { revalidateArtistDetail } from '@/lib/revalidate-entity'
 import { resolveSpotifyArtist } from '@/lib/spotify'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
-
-interface UserProfile {
-  success: boolean
-  user?: {
-    id: string
-    is_admin?: boolean
-  }
-}
-
-interface Artist {
-  id: number
-  slug: string
-  name: string
-  social?: {
-    spotify?: string | null
-  }
-}
+import { requireAdmin, forwardArtistMusicUpdate } from '@/lib/admin-artist-route'
 
 interface UpdateSpotifyRequest {
   spotify_url: string
-}
-
-async function getAuthenticatedUser(
-  authToken: string
-): Promise<UserProfile | null> {
-  try {
-    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
-      headers: {
-        Cookie: `auth_token=${authToken}`,
-      },
-    })
-
-    if (!response.ok) {
-      return null
-    }
-
-    return await response.json()
-  } catch {
-    return null
-  }
 }
 
 // Validates shape AND existence (via Spotify oEmbed — mirrors the Bandcamp save
@@ -66,22 +25,8 @@ export async function POST(
 ) {
   const { id: artistId } = await params
 
-  // Get auth token from cookies
-  const cookieStore = await cookies()
-  const authToken = cookieStore.get('auth_token')
-
-  if (!authToken) {
-    return NextResponse.json(
-      { error: 'Authentication required' },
-      { status: 401 }
-    )
-  }
-
-  // Validate admin access
-  const profile = await getAuthenticatedUser(authToken.value)
-  if (!profile?.success || !profile.user?.is_admin) {
-    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-  }
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
 
   // Parse request body
   let body: UpdateSpotifyRequest
@@ -92,7 +37,6 @@ export async function POST(
   }
 
   const { spotify_url } = body
-
   if (!spotify_url) {
     return NextResponse.json(
       { error: 'spotify_url is required' },
@@ -103,53 +47,18 @@ export async function POST(
   // Validate the URL (shape + existence); persist the canonical artist URL.
   const validation = await validateSpotifyUrl(spotify_url)
   if (!validation.valid) {
-    return NextResponse.json(
-      { error: validation.error },
-      { status: 400 }
-    )
+    return NextResponse.json({ error: validation.error }, { status: 400 })
   }
 
-  // Forward to backend
-  try {
-    const response = await fetch(
-      `${BACKEND_URL}/admin/artists/${artistId}/spotify`,
-      {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Cookie: `auth_token=${authToken.value}`,
-        },
-        body: JSON.stringify({ spotify_url: validation.canonicalUrl }),
-      }
-    )
-
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Unknown error' }))
-      return NextResponse.json(
-        { error: error.detail || 'Failed to update artist' },
-        { status: response.status }
-      )
-    }
-
-    const artist: Artist = await response.json()
-
-    revalidateArtistDetail(artist.slug)
-
-    return NextResponse.json({
-      success: true,
-      artist,
-    })
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
-      tags: { service: 'admin-spotify', operation: 'update' },
-      extra: { artistId },
-    })
-    return NextResponse.json(
-      { error: 'Failed to update artist' },
-      { status: 500 }
-    )
-  }
+  return forwardArtistMusicUpdate({
+    artistId,
+    authToken: auth.authToken,
+    field: 'spotify',
+    body: { spotify_url: validation.canonicalUrl },
+    sentryService: 'admin-spotify',
+    sentryOperation: 'update',
+    failureMessage: 'Failed to update artist',
+  })
 }
 
 // Also support DELETE to clear the Spotify URL
@@ -159,62 +68,16 @@ export async function DELETE(
 ) {
   const { id: artistId } = await params
 
-  // Get auth token from cookies
-  const cookieStore = await cookies()
-  const authToken = cookieStore.get('auth_token')
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
 
-  if (!authToken) {
-    return NextResponse.json(
-      { error: 'Authentication required' },
-      { status: 401 }
-    )
-  }
-
-  // Validate admin access
-  const profile = await getAuthenticatedUser(authToken.value)
-  if (!profile?.success || !profile.user?.is_admin) {
-    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-  }
-
-  // Forward to backend with null to clear
-  try {
-    const response = await fetch(
-      `${BACKEND_URL}/admin/artists/${artistId}/spotify`,
-      {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Cookie: `auth_token=${authToken.value}`,
-        },
-        body: JSON.stringify({ spotify_url: null }),
-      }
-    )
-
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Unknown error' }))
-      return NextResponse.json(
-        { error: error.detail || 'Failed to clear Spotify URL' },
-        { status: response.status }
-      )
-    }
-
-    const artist: Artist = await response.json()
-
-    revalidateArtistDetail(artist.slug)
-
-    return NextResponse.json({
-      success: true,
-      artist,
-    })
-  } catch (error) {
-    Sentry.captureException(error, {
-      level: 'error',
-      tags: { service: 'admin-spotify', operation: 'clear' },
-      extra: { artistId },
-    })
-    return NextResponse.json(
-      { error: 'Failed to clear Spotify URL' },
-      { status: 500 }
-    )
-  }
+  return forwardArtistMusicUpdate({
+    artistId,
+    authToken: auth.authToken,
+    field: 'spotify',
+    body: { spotify_url: null },
+    sentryService: 'admin-spotify',
+    sentryOperation: 'clear',
+    failureMessage: 'Failed to clear Spotify URL',
+  })
 }

--- a/frontend/app/api/ai/extract-collection/route.ts
+++ b/frontend/app/api/ai/extract-collection/route.ts
@@ -27,6 +27,7 @@ import type {
   ExtractedCollectionItem,
   MatchSuggestion,
 } from '@/lib/types/extraction'
+import { getAuthenticatedUser } from '@/lib/auth-profile'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -64,14 +65,6 @@ Rules:
 - Return ONLY the JSON object, no explanation or markdown code blocks.`
 }
 
-interface UserProfile {
-  success: boolean
-  user?: {
-    id: string
-    email?: string
-  }
-}
-
 interface ArtistSearchResult {
   artists: Array<{
     id: number
@@ -79,22 +72,6 @@ interface ArtistSearchResult {
     slug: string
   }>
   count: number
-}
-
-async function getAuthenticatedUser(
-  authToken: string
-): Promise<UserProfile | null> {
-  try {
-    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
-      headers: {
-        Cookie: `auth_token=${authToken}`,
-      },
-    })
-    if (!response.ok) return null
-    return await response.json()
-  } catch {
-    return null
-  }
 }
 
 async function searchArtist(name: string): Promise<ArtistSearchResult | null> {

--- a/frontend/app/api/ai/extract-show/route.ts
+++ b/frontend/app/api/ai/extract-show/route.ts
@@ -11,6 +11,7 @@ import type {
   MatchSuggestion,
   VenueMatchSuggestion,
 } from '@/lib/types/extraction'
+import { getAuthenticatedUser } from '@/lib/auth-profile'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
@@ -44,14 +45,6 @@ Rules:
 - Return ONLY the JSON object, no explanation or markdown code blocks`
 }
 
-interface UserProfile {
-  success: boolean
-  user?: {
-    id: string
-    email?: string
-  }
-}
-
 interface ArtistSearchResult {
   artists: Array<{
     id: number
@@ -70,29 +63,6 @@ interface VenueSearchResult {
     state: string
   }>
   count: number
-}
-
-/**
- * Verify the user is authenticated (any user, not admin-only)
- */
-async function getAuthenticatedUser(
-  authToken: string
-): Promise<UserProfile | null> {
-  try {
-    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
-      headers: {
-        Cookie: `auth_token=${authToken}`,
-      },
-    })
-
-    if (!response.ok) {
-      return null
-    }
-
-    return await response.json()
-  } catch {
-    return null
-  }
 }
 
 /**

--- a/frontend/lib/admin-artist-route.test.ts
+++ b/frontend/lib/admin-artist-route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cookies } from 'next/headers'
+import { revalidateArtistDetail } from '@/lib/revalidate-entity'
+import { requireAdmin, forwardArtistMusicUpdate } from './admin-artist-route'
+
+vi.mock('next/headers', () => ({ cookies: vi.fn() }))
+vi.mock('@/lib/revalidate-entity', () => ({ revalidateArtistDetail: vi.fn() }))
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }))
+
+const mockCookies = vi.mocked(cookies)
+const mockRevalidate = vi.mocked(revalidateArtistDetail)
+const BACKEND = 'http://localhost:8080'
+
+function setCookie(token?: string) {
+  mockCookies.mockResolvedValue({
+    get: (name: string) =>
+      name === 'auth_token' && token ? { name, value: token } : undefined,
+  } as unknown as Awaited<ReturnType<typeof cookies>>)
+}
+
+function profileResponse(isAdmin: boolean) {
+  return new Response(
+    JSON.stringify({ success: true, user: { id: '1', is_admin: isAdmin } }),
+    { status: 200 }
+  )
+}
+
+let fetchSpy: ReturnType<typeof vi.spyOn> | undefined
+
+beforeEach(() => vi.clearAllMocks())
+afterEach(() => {
+  fetchSpy?.mockRestore()
+  fetchSpy = undefined
+})
+
+describe('requireAdmin', () => {
+  it('401 Authentication required when no auth_token cookie', async () => {
+    setCookie(undefined)
+    const result = await requireAdmin()
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.response.status).toBe(401)
+      expect(await result.response.json()).toEqual({
+        error: 'Authentication required',
+      })
+    }
+  })
+
+  it('403 Admin access required when the profile is not admin', async () => {
+    setCookie('token')
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(profileResponse(false))
+    const result = await requireAdmin()
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.response.status).toBe(403)
+      expect(await result.response.json()).toEqual({
+        error: 'Admin access required',
+      })
+    }
+  })
+
+  it('403 when the profile fetch fails (treated as unauthenticated)', async () => {
+    setCookie('token')
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('nope', { status: 500 }))
+    const result = await requireAdmin()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.response.status).toBe(403)
+  })
+
+  it('returns the validated session token for an admin', async () => {
+    setCookie('admin-token')
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(profileResponse(true))
+    const result = await requireAdmin()
+    expect(result).toEqual({ ok: true, authToken: 'admin-token' })
+  })
+})
+
+describe('forwardArtistMusicUpdate', () => {
+  const base = {
+    artistId: '47',
+    authToken: 'tok',
+    field: 'bandcamp' as const,
+    body: { bandcamp_embed_url: 'https://x.bandcamp.com/album/y' },
+    sentryService: 'admin-bandcamp',
+    sentryOperation: 'update',
+    failureMessage: 'Failed to update artist',
+  }
+
+  it('PATCHes the field path with the auth cookie, revalidates, returns success', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: 47, slug: 'bright-eyes' }), {
+          status: 200,
+        })
+      )
+
+    const res = await forwardArtistMusicUpdate(base)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      success: true,
+      artist: { id: 47, slug: 'bright-eyes' },
+    })
+    expect(mockRevalidate).toHaveBeenCalledWith('bright-eyes')
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(String(url)).toBe(`${BACKEND}/admin/artists/47/bandcamp`)
+    expect(init).toMatchObject({
+      method: 'PATCH',
+      headers: { Cookie: 'auth_token=tok' },
+    })
+  })
+
+  it('passes through the backend detail + status on a non-2xx and does not revalidate', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ detail: 'boom' }), { status: 422 })
+      )
+
+    const res = await forwardArtistMusicUpdate(base)
+
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({ error: 'boom' })
+    expect(mockRevalidate).not.toHaveBeenCalled()
+  })
+
+  it('maps a thrown fetch to a 500 with the failure message', async () => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'))
+
+    const res = await forwardArtistMusicUpdate(base)
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Failed to update artist' })
+  })
+})

--- a/frontend/lib/admin-artist-route.ts
+++ b/frontend/lib/admin-artist-route.ts
@@ -1,0 +1,116 @@
+// Shared helpers for the admin artist BFF routes (bandcamp / spotify /
+// discover-music). These routes had the auth gate and the backend-forward
+// copy-pasted across every handler (PSY-1111); this module is the single source
+// of truth for both so the next change is made once, not six times.
+
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import * as Sentry from '@sentry/nextjs'
+import { revalidateArtistDetail } from '@/lib/revalidate-entity'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
+
+export interface UserProfile {
+  success: boolean
+  user?: {
+    id: string
+    is_admin?: boolean
+  }
+}
+
+// Fetches the backend auth profile for a session token. Returns null on any
+// failure (network error or non-2xx) so callers treat it as unauthenticated.
+export async function getAuthenticatedUser(
+  authToken: string
+): Promise<UserProfile | null> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
+      headers: { Cookie: `auth_token=${authToken}` },
+    })
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+// Gate an admin-only route: requires the auth_token cookie and an is_admin
+// profile, returning the session token on success. On failure returns the exact
+// 401/403 envelopes the routes returned inline, so the caller does:
+//   const auth = await requireAdmin()
+//   if (!auth.ok) return auth.response
+export async function requireAdmin(): Promise<
+  { ok: true; authToken: string } | { ok: false; response: NextResponse }
+> {
+  const cookieStore = await cookies()
+  const authToken = cookieStore.get('auth_token')
+  if (!authToken) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      ),
+    }
+  }
+  const profile = await getAuthenticatedUser(authToken.value)
+  if (!profile?.success || !profile.user?.is_admin) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Admin access required' },
+        { status: 403 }
+      ),
+    }
+  }
+  return { ok: true, authToken: authToken.value }
+}
+
+// Forward an artist Bandcamp/Spotify mutation to the backend, revalidate the
+// artist ISR page on success, and map failures to the same responses the routes
+// returned inline. `failureMessage` is the human fallback for both the upstream
+// non-2xx (after the backend's `detail`) and the 500 catch.
+export async function forwardArtistMusicUpdate(opts: {
+  artistId: string
+  authToken: string
+  field: 'bandcamp' | 'spotify'
+  body: Record<string, unknown>
+  sentryService: string
+  sentryOperation: string
+  failureMessage: string
+}): Promise<NextResponse> {
+  try {
+    const response = await fetch(
+      `${BACKEND_URL}/admin/artists/${opts.artistId}/${opts.field}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `auth_token=${opts.authToken}`,
+        },
+        body: JSON.stringify(opts.body),
+      }
+    )
+
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ detail: 'Unknown error' }))
+      return NextResponse.json(
+        { error: error.detail || opts.failureMessage },
+        { status: response.status }
+      )
+    }
+
+    const artist = (await response.json()) as { slug: string }
+    revalidateArtistDetail(artist.slug)
+    return NextResponse.json({ success: true, artist })
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: opts.sentryService, operation: opts.sentryOperation },
+      extra: { artistId: opts.artistId },
+    })
+    return NextResponse.json({ error: opts.failureMessage }, { status: 500 })
+  }
+}

--- a/frontend/lib/admin-artist-route.ts
+++ b/frontend/lib/admin-artist-route.ts
@@ -1,44 +1,23 @@
 // Shared helpers for the admin artist BFF routes (bandcamp / spotify /
-// discover-music). These routes had the auth gate and the backend-forward
-// copy-pasted across every handler (PSY-1111); this module is the single source
-// of truth for both so the next change is made once, not six times.
+// discover-music), which had the admin auth gate and the backend-forward
+// copy-pasted across every handler (PSY-1111). The lower-level /auth/profile
+// fetch lives in lib/auth-profile (also used by the AI extract routes).
 
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
 import { revalidateArtistDetail } from '@/lib/revalidate-entity'
+import { getAuthenticatedUser } from '@/lib/auth-profile'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
-
-export interface UserProfile {
-  success: boolean
-  user?: {
-    id: string
-    is_admin?: boolean
-  }
-}
-
-// Fetches the backend auth profile for a session token. Returns null on any
-// failure (network error or non-2xx) so callers treat it as unauthenticated.
-export async function getAuthenticatedUser(
-  authToken: string
-): Promise<UserProfile | null> {
-  try {
-    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
-      headers: { Cookie: `auth_token=${authToken}` },
-    })
-    if (!response.ok) return null
-    return await response.json()
-  } catch {
-    return null
-  }
-}
 
 // Gate an admin-only route: requires the auth_token cookie and an is_admin
 // profile, returning the session token on success. On failure returns the exact
 // 401/403 envelopes the routes returned inline, so the caller does:
 //   const auth = await requireAdmin()
 //   if (!auth.ok) return auth.response
+// (discover-music intentionally does NOT use this — it inlines the same gate so
+// it can run the profile fetch concurrently with its artist lookup.)
 export async function requireAdmin(): Promise<
   { ok: true; authToken: string } | { ok: false; response: NextResponse }
 > {

--- a/frontend/lib/auth-profile.ts
+++ b/frontend/lib/auth-profile.ts
@@ -1,0 +1,31 @@
+// The backend session-profile fetch, shared by every BFF route that needs to
+// identify the caller (admin artist routes via requireAdmin; the AI extract
+// routes for an auth-only check). Single source of truth for the
+// /auth/profile contract so a change to it is made once (PSY-1111).
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
+
+export interface UserProfile {
+  success: boolean
+  user?: {
+    id: string
+    is_admin?: boolean
+    email?: string
+  }
+}
+
+// Fetches the backend auth profile for a session token. Returns null on any
+// failure (network error or non-2xx) so callers treat it as unauthenticated.
+export async function getAuthenticatedUser(
+  authToken: string
+): Promise<UserProfile | null> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/auth/profile`, {
+      headers: { Cookie: `auth_token=${authToken}` },
+    })
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Problem

From the music-discovery feature audit. The bandcamp / spotify / discover-music admin BFF routes had `getAuthenticatedUser` copy-pasted and the cookie→401→profile→403 admin gate + the backend-PATCH-forward pasted across every handler.

## Fix

- **`lib/auth-profile.ts`** — the `/auth/profile` fetch (`getAuthenticatedUser` + `UserProfile`), the single source of truth used by all five callers (the 3 admin routes + the 2 AI extract routes, which previously each had their own copy).
- **`lib/admin-artist-route.ts`** — `requireAdmin()` (returns the 401/403 envelopes or the validated session token) and `forwardArtistMusicUpdate()` (backend PATCH + revalidate + error mapping).
- bandcamp/spotify routes use both helpers (233→101 and 220→83 lines). discover-music keeps its deliberately-parallelized auth gate inline but uses the shared `getAuthenticatedUser`.

Behavior-preserving — error envelopes, status codes, Sentry tags, and revalidation are all 1:1. Fully unifying the *validation* envelope into the discover-music `{error: CODE, message}` shape was left out of scope (it ripples to the consuming hooks/UI).

## Verification

- `tsc` clean; eslint clean; `getAuthenticatedUser` now defined in exactly one place.
- **47 tests pass**: the 20 existing admin-route tests (the behavior-preservation safety net), a new `lib/admin-artist-route.test.ts` (requireAdmin's 4 outcomes + forwardArtistMusicUpdate's success/non-2xx/500 branches), and the extract-show suite (20 tests, confirming the auth-profile consolidation didn't regress that feature).

## Adversarial review

`/adversarial-review` — **Security CLEAN** (verified `requireAdmin` is byte-equivalent to the old inline gate, ordering preserved, the validated token flows to the backend, no bypass/leak) and **Saboteur CLEAN** (behavior preserved field-by-field: envelopes, status codes, Sentry tags, revalidation, discover-music's parallelization). Future-Maintainer findings fixed in `bcb957d6` (impl `d81ac6af`):

- **[HIGH]** the "single source of truth" comment overclaimed — two more `getAuthenticatedUser` copies lived in the AI extract routes, and the shared one was buried in an artist-named module. Moved it to a generic `lib/auth-profile.ts` and pointed all five call sites at it; softened the comment; noted discover-music's intentional divergence.
- **[MEDIUM]** no direct test for the new module → added `lib/admin-artist-route.test.ts`.

Closes PSY-1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
