### PR TITLE
PSY-1114: restore admin nav as an always-on left rail on /admin

### DIFF
--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,14 +1,27 @@
 import { Metadata } from 'next'
 import AdminGuard from './admin-guard'
+import { AdminSidebar } from '@/components/layout/AdminSidebar'
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 }
 
+// The admin area renders its own always-on left rail (PSY-1114) alongside the
+// global TopBar, restoring the admin nav that was orphaned when PSY-1013
+// retired the global Sidebar. The rail lives inside AdminGuard so it only
+// mounts for authenticated admins; `min-w-0` lets the content column shrink
+// instead of forcing horizontal overflow on wide admin tables.
 export default function AdminLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  return <AdminGuard>{children}</AdminGuard>
+  return (
+    <AdminGuard>
+      <div className="flex flex-1">
+        <AdminSidebar />
+        <div className="min-w-0 flex-1">{children}</div>
+      </div>
+    </AdminGuard>
+  )
 }

--- a/frontend/components/layout/AdminSidebar.test.tsx
+++ b/frontend/components/layout/AdminSidebar.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AdminSidebar } from './AdminSidebar'
+
+// AdminSidebar lazy-loads AdminSidebarNav via next/dynamic(ssr:false). Stub
+// dynamic so the nav body renders synchronously as a marker that echoes the
+// `collapsed` prop — AdminSidebarNav's own behavior is covered by
+// AdminSidebarNav.test.tsx; here we exercise the rail chrome (collapse toggle +
+// localStorage persistence).
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function MockAdminSidebarNav({ collapsed }: { collapsed: boolean }) {
+      return <div data-testid="admin-nav">{collapsed ? 'collapsed' : 'expanded'}</div>
+    },
+}))
+
+describe('AdminSidebar', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('renders the admin nav body, expanded by default', () => {
+    render(<AdminSidebar />)
+    expect(screen.getByTestId('admin-nav')).toHaveTextContent('expanded')
+    expect(screen.getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
+  })
+
+  it('toggles collapsed state and persists it to localStorage', () => {
+    render(<AdminSidebar />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }))
+
+    expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
+    expect(screen.getByTestId('admin-nav')).toHaveTextContent('collapsed')
+    expect(localStorage.getItem('admin-sidebar-collapsed')).toBe('collapsed')
+  })
+
+  it('restores the collapsed preference from localStorage on mount', () => {
+    localStorage.setItem('admin-sidebar-collapsed', 'collapsed')
+    render(<AdminSidebar />)
+
+    expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
+    expect(screen.getByTestId('admin-nav')).toHaveTextContent('collapsed')
+  })
+})

--- a/frontend/components/layout/AdminSidebar.tsx
+++ b/frontend/components/layout/AdminSidebar.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useCallback } from 'react'
+import dynamic from 'next/dynamic'
+import { PanelLeftClose, PanelLeft } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useLocalStorageEnum } from '@/lib/hooks/common/useLocalStorageEnum'
+
+// The admin rail content (config + the queue-count hooks) loads client-side
+// only — it reads `useSearchParams()` for the active `?tab=`, and `ssr: false`
+// keeps that out of the prerendered shell (mirrors how the retired global
+// Sidebar mounted it; avoids a useSearchParams Suspense requirement under
+// cacheComponents). This component only ever mounts under /admin, so the chunk
+// is already admin-scoped.
+const AdminSidebarNav = dynamic(() => import('./AdminSidebarNav'), { ssr: false })
+
+// PSY-1114: the always-on admin left rail. Mounted by app/admin/layout.tsx so
+// the admin area keeps its dense 18-section nav on desktop regardless of the
+// global nav-style preference (the upcoming top-bar vs side-nav toggle,
+// PSY-1116). It is the sole owner of admin desktop nav — the prior admin nav
+// rode inside the global Sidebar's context-swap (PSY-933), which was orphaned
+// when PSY-1013 retired that Sidebar from the shell.
+//
+// The <aside> chrome + collapse toggle mirror the retired global Sidebar
+// (Sidebar.tsx) so the rail looks and behaves identically; the nav body is the
+// existing AdminSidebarNav. Hidden below `md` — mobile keeps the hamburger
+// drawer (MobileNav + AdminDrawerNav), unaffected by this rail.
+//
+// Module-level `as const` tuple per useLocalStorageEnum's contract: a stable
+// `allowed` reference keeps the snapshot getter from churning each render.
+const COLLAPSE_STATES = ['expanded', 'collapsed'] as const
+
+export function AdminSidebar() {
+  // SSR-safe persisted collapse state via the shared hook (useSyncExternalStore
+  // hydration + cross-tab sync) — the same primitive useDensity and the
+  // collections/contributions surfaces use, rather than a hand-rolled
+  // localStorage effect.
+  const [collapseState, setCollapseState] = useLocalStorageEnum(
+    'admin-sidebar-collapsed',
+    'expanded',
+    COLLAPSE_STATES
+  )
+  const collapsed = collapseState === 'collapsed'
+
+  const toggleCollapse = useCallback(
+    () => setCollapseState(collapsed ? 'expanded' : 'collapsed'),
+    [collapsed, setCollapseState]
+  )
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <aside
+        className={cn(
+          'sticky top-[var(--topbar-height)] z-40 hidden h-[calc(100vh-var(--topbar-height))] shrink-0 flex-col overflow-hidden border-r border-sidebar-border bg-sidebar transition-[width] duration-200 md:flex',
+          collapsed ? 'w-[var(--sidebar-width-collapsed)]' : 'w-[var(--sidebar-width)]'
+        )}
+        aria-label="Admin navigation"
+      >
+        <nav className="flex-1 space-y-6 overflow-y-auto px-2 py-4">
+          <AdminSidebarNav collapsed={collapsed} />
+        </nav>
+
+        <div className="border-t border-sidebar-border p-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={toggleCollapse}
+                className={cn(
+                  'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
+                  collapsed && 'justify-center px-2'
+                )}
+                aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              >
+                {collapsed ? (
+                  <PanelLeft className="h-4 w-4" />
+                ) : (
+                  <>
+                    <PanelLeftClose className="h-4 w-4" />
+                    <span>Collapse</span>
+                  </>
+                )}
+              </button>
+            </TooltipTrigger>
+            {collapsed && <TooltipContent side="right">Expand sidebar</TooltipContent>}
+          </Tooltip>
+        </div>
+      </aside>
+    </TooltipProvider>
+  )
+}


### PR DESCRIPTION
## What & why

After **PSY-1013** retired the global left `Sidebar` as primary nav (*"SidebarLayout → AppShell — no longer renders a sidebar"*), the admin navigation built in **PSY-933** was orphaned: that admin nav lived inside the global Sidebar's context-swap (`Sidebar.tsx`), and the Sidebar is no longer mounted anywhere. Result: **desktop `/admin` had no admin navigation** — only the top bar (the reported regression). Mobile was unaffected — `MobileNav` mounts `AdminDrawerNav` directly.

This restores the admin nav as a **dedicated always-on left rail**, mounted in `app/admin/layout.tsx` and **decoupled from the global nav style** — so it survives the upcoming side-nav / top-nav user toggle (PSY-1116) untouched, per the product decision that the admin area always keeps its dense 18-section rail.

## Changes

- **New `components/layout/AdminSidebar.tsx`** — the `<aside>` chrome + collapse toggle (mirroring the retired `Sidebar`) wrapping the existing `AdminSidebarNav`. Collapse state persists via the shared `useLocalStorageEnum` hook (SSR-safe `useSyncExternalStore` + cross-tab sync) — the same primitive `useDensity` and the collections/contributions surfaces use, rather than a hand-rolled `localStorage` effect.
- **`app/admin/layout.tsx`** — renders `<AdminSidebar />` + content in a flex row inside `AdminGuard`, so the rail only mounts for authenticated admins; `min-w-0` lets dense admin tables shrink instead of forcing horizontal overflow.
- No backend, routing, or `TopBar` changes. The rail reuses the `adminNav.ts` SSOT, queue badge counts, and `--sidebar-*` CSS vars as-is.

## Screenshots (local dev, seeded admin)

**Expanded rail — `/admin` (Dashboard active, live badges):**
![admin rail expanded](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-505a7639ed6d39cb629a/01-admin-rail-expanded.png)

**Collapsed rail (icons + queue corner-dots):**
![admin rail collapsed](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-505a7639ed6d39cb629a/02-admin-rail-collapsed.png)

**Active sub-tab — `/admin?tab=moderation` (correct highlight + content):**
![admin moderation tab active](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-505a7639ed6d39cb629a/03-admin-tab-moderation-active.png)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/layout app/admin/layout.test.tsx app/admin/page.test.tsx` — **235 passed**, incl. new `AdminSidebar.test.tsx` (render, collapse + persist, restore-from-storage)
- [x] `/simplify` (4-agent reuse/simplification/efficiency/altitude pass) — adopted the `useLocalStorageEnum` reuse finding; other angles clean. The `useAdminNavCounts` query-load note is a pre-existing PSY-933 design choice (out of scope).
- [x] Manual (above screenshots): signed in as seeded admin, verified the rail renders on desktop `/admin` with all 6 groups + live badges (Moderation 3, Unverified Venues 2), collapse/expand persists across reloads, and active-tab highlight is correct on `?tab=` sections.

## Notes / scope

- Deliberately admin-only. The global side-nav/top-nav **toggle** is the follow-up chain (PSY-1115 backend pref → PSY-1116 shell → PSY-1117 settings page). The retired `Sidebar.tsx` is intentionally left intact for PSY-1116 to revive.
- PSY-933's now-redundant admin context-swap inside `Sidebar.tsx` is left untouched here (Sidebar is unmounted, so harmless); its retirement happens in PSY-1116 when side-nav mode goes live, to avoid a double rail on `/admin`.

Closes PSY-1114
