### PR TITLE
PSY-1115: add nav_mode user preference (model, profile, update endpoint)

### DIFF
--- a/backend/db/migrations/20260615190000_add_user_nav_mode.down.sql
+++ b/backend/db/migrations/20260615190000_add_user_nav_mode.down.sql
@@ -1,0 +1,3 @@
+-- Reverse PSY-1115: drop the nav_mode column (its CHECK constraint drops with
+-- it). Restores the pre-migration users shape for the up->down->up round-trip.
+ALTER TABLE users DROP COLUMN nav_mode;

--- a/backend/db/migrations/20260615190000_add_user_nav_mode.up.sql
+++ b/backend/db/migrations/20260615190000_add_user_nav_mode.up.sql
@@ -1,0 +1,9 @@
+-- PSY-1115: per-account global nav-style preference (top-bar vs left side nav).
+-- Additive, NOT NULL with a 'top' default so existing rows are backfilled to
+-- the current top-bar nav; the CHECK keeps the column to the two known modes
+-- (mirrors models/auth.NavModeTop / NavModeSide and the frontend encoding).
+-- Adding a column with a constant default is a metadata-only change in
+-- Postgres 11+, so no table rewrite / CONCURRENTLY concern.
+ALTER TABLE users
+  ADD COLUMN nav_mode VARCHAR(8) NOT NULL DEFAULT 'top'
+  CHECK (nav_mode IN ('top', 'side'));

--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -2096,6 +2096,7 @@ type UpdateProfileRequest struct {
 		FirstName   *string `json:"first_name,omitempty" required:"false" doc:"First name"`
 		LastName    *string `json:"last_name,omitempty" required:"false" doc:"Last name"`
 		Bio         *string `json:"bio,omitempty" required:"false" doc:"Short bio (max 500 chars)"`
+		NavMode     *string `json:"nav_mode,omitempty" required:"false" enum:"top,side" doc:"Global nav chrome preference: 'top' (top bar) or 'side' (left sidebar)"`
 	}
 }
 
@@ -2188,6 +2189,20 @@ func (h *AuthHandler) UpdateProfileHandler(ctx context.Context, req *UpdateProfi
 			return resp, nil
 		}
 		updates["bio"] = bio
+	}
+
+	if req.Body.NavMode != nil {
+		navMode := strings.TrimSpace(*req.Body.NavMode)
+		// Allowlist the two known modes — the column carries a matching CHECK
+		// constraint, but rejecting here returns a clean 400 instead of a 500
+		// from the DB constraint, and keeps the contract self-documenting.
+		if navMode != authm.NavModeTop && navMode != authm.NavModeSide {
+			resp.Body.Success = false
+			resp.Body.Message = "Nav mode must be 'top' or 'side'"
+			resp.Body.ErrorCode = autherrors.CodeValidationFailed
+			return resp, nil
+		}
+		updates["nav_mode"] = navMode
 	}
 
 	if len(updates) == 0 {

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -3619,6 +3619,47 @@ func TestUpdateProfileHandler_BioTooLong(t *testing.T) {
 	}
 }
 
+func TestUpdateProfileHandler_NavModeInvalid(t *testing.T) {
+	h := testAuthHandler()
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.NavMode = strPtr("sidebar") // not 'top' or 'side'
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeValidationFailed {
+		t.Errorf("expected validation failure, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+}
+
+func TestUpdateProfileHandler_NavModeSuccess(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		UpdateUserFn: func(_ uint, updates map[string]any) (*authm.User, error) {
+			if updates["nav_mode"] != authm.NavModeSide {
+				t.Errorf("expected nav_mode=%s, got %v", authm.NavModeSide, updates["nav_mode"])
+			}
+			return &authm.User{ID: 1, NavMode: authm.NavModeSide}, nil
+		},
+	}
+	h := NewAuthHandler(nil, nil, mock, nil, nil, nil, testConfig())
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.NavMode = strPtr(authm.NavModeSide)
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Fatalf("expected success=true, got message=%q code=%s", resp.Body.Message, resp.Body.ErrorCode)
+	}
+	if resp.Body.User == nil || resp.Body.User.NavMode != authm.NavModeSide {
+		t.Errorf("expected updated user with nav_mode=side, got %+v", resp.Body.User)
+	}
+}
+
 func TestUpdateProfileHandler_NoFields(t *testing.T) {
 	h := testAuthHandler()
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})

--- a/backend/internal/models/auth/user.go
+++ b/backend/internal/models/auth/user.go
@@ -11,6 +11,15 @@ type FavoriteCity struct {
 	State string `json:"state"`
 }
 
+// Nav-mode preference values (PSY-1115): the global navigation chrome a user
+// prefers. NavModeTop is the default top-bar nav; NavModeSide is the left
+// sidebar nav. Kept in sync with the users.nav_mode CHECK constraint and the
+// frontend's nav-mode cookie/encoding.
+const (
+	NavModeTop  = "top"
+	NavModeSide = "side"
+)
+
 // User represents a user account
 type User struct {
 	ID                  uint             `json:"id" gorm:"primaryKey"`
@@ -24,6 +33,7 @@ type User struct {
 	Bio                 *string          `json:"bio"`
 	ProfileVisibility   string           `json:"profile_visibility" gorm:"column:profile_visibility;not null;default:'public'"`
 	PrivacySettings     *json.RawMessage `json:"privacy_settings" gorm:"column:privacy_settings;type:jsonb;not null;default:'{\"contributions\":\"visible\",\"saved_shows\":\"hidden\",\"attendance\":\"visible\",\"following\":\"visible\",\"collections\":\"visible\",\"last_active\":\"visible\",\"profile_sections\":\"visible\"}'"`
+	NavMode             string           `json:"nav_mode" gorm:"column:nav_mode;not null;default:'top'"` // Global nav chrome preference: 'top' | 'side' (PSY-1115)
 	UserTier            string           `json:"user_tier" gorm:"column:user_tier;not null;default:'new_user'"`
 	IsActive            bool             `json:"is_active" gorm:"default:true"`
 	IsAdmin             bool             `json:"is_admin" gorm:"default:false"`


### PR DESCRIPTION
## What & why

Backend keystone for the global **side-nav / top-nav** user toggle (frontend follow-ups PSY-1116 → PSY-1117). Adds a per-account `nav_mode` preference (`'top' | 'side'`, default `'top'`) so the choice follows the user across devices. The cookie half (instant SSR, logged-out support) lands in PSY-1116; this PR is the account-persistence half.

## Changes

- **Migration** `20260615190000_add_user_nav_mode` — additive `nav_mode VARCHAR(8) NOT NULL DEFAULT 'top' CHECK (nav_mode IN ('top','side'))`. Existing rows backfill to the current top-bar nav. Reversible — verified `up → down → up` against the local DB (16 rows backfilled; CHECK rejects out-of-set values).
- **Model** `User.NavMode` (non-null string + DB default, mirroring `ProfileVisibility`) + `NavModeTop` / `NavModeSide` constants.
- **`GET /auth/profile`** returns `nav_mode` automatically — the full `User` is serialized and `GetUserProfile` loads the whole row (the same path `display_name` rides, PSY-1063). No resolver/email/projection plumbing: unlike `display_name`, `nav_mode` is a private preference, not attribution.
- **`PATCH /auth/profile`** accepts `nav_mode`, allowlisting `{top, side}` → a clean `400 VALIDATION_FAILED` rather than a 500 from the DB CHECK.

## Test plan

- [x] `go build ./...` — clean; `go vet` on changed packages — clean
- [x] `go test ./internal/api/handlers/auth/...` — pass, incl. new `NavModeInvalid` (rejects non-set value) + `NavModeSuccess` (persists `'side'`, returns updated user)
- [x] `go test ./internal/models/... ./internal/services/user/... ./internal/api/routes/... ./internal/api/handlers/catalog/...` — pass (OpenAPI snapshot unaffected; change is additive)
- [x] Migration round-trip verified locally (`migrate up/down/up`); CHECK constraint rejects `'bogus'`

## Scope

Backend only. The frontend that reads/writes `nav_mode` (SSR cookie + reconciliation, the settings toggle) is PSY-1116 + PSY-1117.

Closes PSY-1115
