### PR TITLE
PSY-1112: embed cleanup — shared bandcampEmbedSrc + typed contract + race fix + dedup

### DIFF
--- a/frontend/app/api/admin/artists/[id]/discover-music/route.ts
+++ b/frontend/app/api/admin/artists/[id]/discover-music/route.ts
@@ -110,6 +110,18 @@ function normalizeCandidate(raw: unknown): DiscoveryCandidate | null {
   }
 }
 
+// The LLM is told to "include EVERY plausible same-name candidate", so it
+// occasionally returns the same URL twice. Dedup by URL so the picker's React
+// keys (key={c.url}) stay unique.
+function dedupeByUrl(candidates: DiscoveryCandidate[]): DiscoveryCandidate[] {
+  const seen = new Set<string>()
+  return candidates.filter(c => {
+    if (seen.has(c.url)) return false
+    seen.add(c.url)
+    return true
+  })
+}
+
 function isCreditsError(error: unknown): boolean {
   if (error instanceof Anthropic.APIError) {
     const m = error.message.toLowerCase()
@@ -223,13 +235,18 @@ export async function POST(
       )
     }
 
-    // Normalize + filter to URL-shape-valid candidates per platform.
-    const bandcamp = parsed.bandcamp
-      .map(normalizeCandidate)
-      .filter((c): c is DiscoveryCandidate => !!c && BANDCAMP_ALBUM_RE.test(c.url))
-    const spotify = parsed.spotify
-      .map(normalizeCandidate)
-      .filter((c): c is DiscoveryCandidate => !!c && isValidSpotifyArtistUrl(c.url))
+    // Normalize + filter to URL-shape-valid candidates per platform, then dedup
+    // by URL (the LLM sometimes repeats a candidate).
+    const bandcamp = dedupeByUrl(
+      parsed.bandcamp
+        .map(normalizeCandidate)
+        .filter((c): c is DiscoveryCandidate => !!c && BANDCAMP_ALBUM_RE.test(c.url))
+    )
+    const spotify = dedupeByUrl(
+      parsed.spotify
+        .map(normalizeCandidate)
+        .filter((c): c is DiscoveryCandidate => !!c && isValidSpotifyArtistUrl(c.url))
+    )
 
     return NextResponse.json({ bandcamp, spotify })
   } catch (error) {

--- a/frontend/app/api/bandcamp/album-id/route.ts
+++ b/frontend/app/api/bandcamp/album-id/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
-import { resolveBandcampEmbed, isAllowedBandcampUrl } from '@/lib/bandcamp'
+import {
+  resolveBandcampEmbed,
+  isAllowedBandcampUrl,
+  type BandcampEmbedResponse,
+} from '@/lib/bandcamp'
 
 // Resolves a Bandcamp album OR track URL to an embeddable { kind, id }. The
 // route name predates standalone-track support; it now handles /track/ URLs and
@@ -38,12 +42,13 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: result.error }, { status })
   }
 
-  return NextResponse.json(
-    { kind: result.embed.kind, id: result.embed.id },
-    {
-      headers: {
-        'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
-      },
-    }
-  )
+  const body: BandcampEmbedResponse = {
+    kind: result.embed.kind,
+    id: result.embed.id,
+  }
+  return NextResponse.json(body, {
+    headers: {
+      'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+    },
+  })
 }

--- a/frontend/components/shared/MusicEmbed.tsx
+++ b/frontend/components/shared/MusicEmbed.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import * as Sentry from '@sentry/nextjs'
 import { ExternalLink, Loader2, Music } from 'lucide-react'
 import { parseSpotifyArtistId } from '@/lib/spotify'
+import { bandcampEmbedSrc, type BandcampEmbedResponse } from '@/lib/bandcamp'
 
 interface MusicEmbedProps {
   bandcampAlbumUrl?: string | null
@@ -30,7 +31,9 @@ export function MusicEmbed({
   const [embed, setEmbed] = useState<EmbedState>({ type: 'loading' })
 
   useEffect(() => {
-    async function resolveEmbed() {
+    let cancelled = false
+
+    async function resolveEmbed(): Promise<EmbedState> {
       // Priority 1: Bandcamp album/track URL - resolve the embed kind + id
       if (bandcampAlbumUrl) {
         try {
@@ -38,10 +41,9 @@ export function MusicEmbed({
             `/api/bandcamp/album-id?url=${encodeURIComponent(bandcampAlbumUrl)}`
           )
           if (response.ok) {
-            const data = await response.json()
+            const data = (await response.json()) as BandcampEmbedResponse
             if (data.id && (data.kind === 'album' || data.kind === 'track')) {
-              setEmbed({ type: 'bandcamp', embedKind: data.kind, embedId: data.id })
-              return
+              return { type: 'bandcamp', embedKind: data.kind, embedId: data.id }
             }
           }
         } catch (error) {
@@ -58,34 +60,39 @@ export function MusicEmbed({
       if (spotifyUrl) {
         const artistId = parseSpotifyArtistId(spotifyUrl)
         if (artistId) {
-          setEmbed({ type: 'spotify', artistId })
-          return
+          return { type: 'spotify', artistId }
         }
       }
 
       // Priority 3: Bandcamp fallback links
       if (bandcampAlbumUrl) {
-        setEmbed({
+        return {
           type: 'fallback',
           url: bandcampAlbumUrl,
           label: `Listen to ${artistName} on Bandcamp`,
-        })
-        return
+        }
       }
 
       if (bandcampProfileUrl) {
-        setEmbed({
+        return {
           type: 'fallback',
           url: bandcampProfileUrl,
           label: `Listen to ${artistName} on Bandcamp`,
-        })
-        return
+        }
       }
 
-      setEmbed({ type: 'none' })
+      return { type: 'none' }
     }
 
-    resolveEmbed()
+    // Ignore a resolution that finishes after the deps changed/unmounted, so a
+    // slow earlier request can't overwrite a newer embed.
+    resolveEmbed().then(state => {
+      if (!cancelled) setEmbed(state)
+    })
+
+    return () => {
+      cancelled = true
+    }
   }, [bandcampAlbumUrl, bandcampProfileUrl, spotifyUrl, artistName])
 
   if (embed.type === 'none') {
@@ -131,7 +138,7 @@ export function MusicEmbed({
           <iframe
             title={`${artistName} on Bandcamp`}
             style={{ border: 0, width: '100%', maxWidth: '700px', height: '120px' }}
-            src={`https://bandcamp.com/EmbeddedPlayer/${embed.embedKind}=${embed.embedId}/size=large/bgcol=1a1a1a/linkcol=f59e0b/tracklist=false/artwork=small/`}
+            src={bandcampEmbedSrc({ kind: embed.embedKind, id: embed.embedId })}
             seamless
           />
         </div>

--- a/frontend/features/blog/components/bandcamp-embed.tsx
+++ b/frontend/features/blog/components/bandcamp-embed.tsx
@@ -25,6 +25,7 @@ export function Bandcamp({
   tracklist = 'false',
   height = '120',
 }: BandcampProps) {
+  // A Bandcamp embed is an album OR a track; authors pass exactly one prop.
   const embedUrl = bandcampEmbedSrc({
     kind: album ? 'album' : 'track',
     id: album ?? track ?? '',

--- a/frontend/features/blog/components/bandcamp-embed.tsx
+++ b/frontend/features/blog/components/bandcamp-embed.tsx
@@ -1,3 +1,5 @@
+import { bandcampEmbedSrc } from '@/lib/bandcamp'
+
 interface BandcampProps {
   album?: string
   track?: string
@@ -23,18 +25,16 @@ export function Bandcamp({
   tracklist = 'false',
   height = '120',
 }: BandcampProps) {
-  // Build the embed URL
-  const embedParts: string[] = []
-  if (album) embedParts.push(`album=${album}`)
-  if (track) embedParts.push(`track=${track}`)
-  embedParts.push(`size=${size}`)
-  embedParts.push(`bgcol=${bgcol}`)
-  embedParts.push(`linkcol=${linkcol}`)
-  embedParts.push(`tracklist=${tracklist}`)
-  embedParts.push(`artwork=${artwork}`)
-  embedParts.push('transparent=true')
-
-  const embedUrl = `https://bandcamp.com/EmbeddedPlayer/${embedParts.join('/')}/`
+  const embedUrl = bandcampEmbedSrc({
+    kind: album ? 'album' : 'track',
+    id: album ?? track ?? '',
+    size,
+    bgcol,
+    linkcol,
+    artwork,
+    tracklist: tracklist === 'true',
+    transparent: true,
+  })
 
   // Build the link URL. `artist` is an author-authored Bandcamp subdomain slug
   // (encodeURIComponent is invalid in a hostname), so only the title path

--- a/frontend/lib/bandcamp.test.ts
+++ b/frontend/lib/bandcamp.test.ts
@@ -4,7 +4,48 @@ import {
   swapAlbumTrackPath,
   resolveBandcampEmbed,
   isAllowedBandcampUrl,
+  bandcampEmbedSrc,
 } from './bandcamp'
+
+describe('bandcampEmbedSrc', () => {
+  it('builds the dark-default player src for an album (MusicEmbed usage)', () => {
+    const src = bandcampEmbedSrc({ kind: 'album', id: '12345' })
+    expect(src).toBe(
+      'https://bandcamp.com/EmbeddedPlayer/album=12345/size=large/bgcol=1a1a1a/linkcol=f59e0b/tracklist=false/artwork=small/'
+    )
+  })
+  it('uses the track segment for a track', () => {
+    const src = bandcampEmbedSrc({ kind: 'track', id: '777' })
+    expect(src).toContain('track=777')
+    expect(src).not.toContain('album=')
+  })
+  it('honors overrides + transparent (blog <Bandcamp> usage)', () => {
+    const src = bandcampEmbedSrc({
+      kind: 'album',
+      id: '1',
+      size: 'small',
+      bgcol: 'ffffff',
+      linkcol: '0687f5',
+      artwork: 'big',
+      tracklist: true,
+      transparent: true,
+    })
+    for (const part of [
+      'album=1',
+      'size=small',
+      'bgcol=ffffff',
+      'linkcol=0687f5',
+      'tracklist=true',
+      'artwork=big',
+      'transparent=true',
+    ]) {
+      expect(src).toContain(part)
+    }
+  })
+  it('omits transparent unless requested', () => {
+    expect(bandcampEmbedSrc({ kind: 'album', id: '1' })).not.toContain('transparent')
+  })
+})
 
 // Every test that touches fetch installs a spy via mockFetchSequence; restore
 // after each so no spy leaks into the next test.

--- a/frontend/lib/bandcamp.ts
+++ b/frontend/lib/bandcamp.ts
@@ -53,6 +53,10 @@ export type BandcampEmbedResponse = Pick<BandcampEmbed, 'kind' | 'id'>
 // source of truth for that URL shape, used by both MusicEmbed (dark defaults)
 // and the blog <Bandcamp> component (its own colors + a fallback link). The
 // player parses the `key=value` path segments order-independently.
+//
+// The default bgcol/linkcol are MusicEmbed's hardcoded dark theme, baked into
+// the iframe src — they are NOT theme-aware. Making the embed follow the
+// light/dark theme (a re-render on toggle) is a deferred follow-up.
 export function bandcampEmbedSrc(opts: {
   kind: BandcampEmbedKind
   id: string

--- a/frontend/lib/bandcamp.ts
+++ b/frontend/lib/bandcamp.ts
@@ -45,6 +45,36 @@ export interface BandcampEmbed {
   resolvedUrl: string
 }
 
+// The shape the /api/bandcamp/album-id route returns and MusicEmbed consumes.
+// Shared so a field rename is a compile error at both ends.
+export type BandcampEmbedResponse = Pick<BandcampEmbed, 'kind' | 'id'>
+
+// Builds a Bandcamp EmbeddedPlayer iframe `src` from a kind + id. The single
+// source of truth for that URL shape, used by both MusicEmbed (dark defaults)
+// and the blog <Bandcamp> component (its own colors + a fallback link). The
+// player parses the `key=value` path segments order-independently.
+export function bandcampEmbedSrc(opts: {
+  kind: BandcampEmbedKind
+  id: string
+  size?: 'large' | 'small'
+  bgcol?: string
+  linkcol?: string
+  artwork?: 'small' | 'big'
+  tracklist?: boolean
+  transparent?: boolean
+}): string {
+  const parts = [
+    `${opts.kind}=${opts.id}`,
+    `size=${opts.size ?? 'large'}`,
+    `bgcol=${opts.bgcol ?? '1a1a1a'}`,
+    `linkcol=${opts.linkcol ?? 'f59e0b'}`,
+    `tracklist=${opts.tracklist ?? false}`,
+    `artwork=${opts.artwork ?? 'small'}`,
+  ]
+  if (opts.transparent) parts.push('transparent=true')
+  return `https://bandcamp.com/EmbeddedPlayer/${parts.join('/')}/`
+}
+
 export type ResolveBandcampResult =
   | { ok: true; embed: BandcampEmbed }
   | { ok: false; status: number | null; error: string }


### PR DESCRIPTION
## Problem

From the music-discovery feature audit (the low-severity cleanups).

## Fix

- **Shared `bandcampEmbedSrc()`** in `lib/bandcamp.ts` — the single source of truth for the Bandcamp `EmbeddedPlayer` iframe URL, used by both `MusicEmbed` (dark defaults) and the blog `<Bandcamp>` component (its own colors + `transparent` + a fallback link), replacing two independent inline builders.
- **Typed `album-id` contract** — exported `BandcampEmbedResponse` and typed both the route response and `MusicEmbed`'s parse, so a field rename is a compile error at both ends (was consumed as `any`).
- **Race fix** — `MusicEmbed`'s resolve effect now returns the `EmbedState` and `setEmbed` runs once behind a `cancelled` guard, so a slow earlier request can't overwrite a newer embed.
- **Candidate dedup** — `discover-music` dedups candidates by URL (the prompt asks for every same-name candidate, so the LLM repeats some), keeping the picker's `key={c.url}` unique.

**Deferred** (cosmetic, ripples across 5+ files/tests for no functional gain): the `bandcampAlbumUrl` prop + `/api/bandcamp/album-id` route renames. The route already carries a clarifying comment that it handles tracks.

## Verification

- `tsc` clean; eslint clean; **169 affected tests pass** — including the blog `bandcamp-embed` suite (9, protects the builder dedup) and `MusicEmbed` (15, protects the refactor), plus a new `bandcampEmbedSrc` unit suite.

## Adversarial review

`/adversarial-review` — **Saboteur** verified the `MusicEmbed` src is byte-for-byte identical, the race fix maps every branch correctly, and the typed contract keeps its runtime guard; **Future-Maintainer** verified the blog output is byte-equivalent and the race fix is idiomatic. Both surviving findings were LOW + doc-only, addressed in `fe86ecef` (impl `8cba104d`):

- the hardcoded `bgcol`/`linkcol` now live as builder defaults → added a note that they're baked-in / not theme-aware (a deferred follow-up the ticket flagged).
- the blog builder collapses to a single `kind` (album XOR track) → verified no content passes both/neither (dead case; the new output is arguably more correct), added a clarifying note.

Closes PSY-1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
