### PR TITLE
PSY-1116: toggle global shell between top-nav and side-nav via SSR cookie

### DIFF
--- a/frontend/components/layout/AppShell.test.tsx
+++ b/frontend/components/layout/AppShell.test.tsx
@@ -1,49 +1,75 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { AppShell } from './AppShell'
 
-vi.mock('./TopBar', () => ({
-  TopBar: () => <div data-testid="topbar" />,
+// AppShell is an async Server Component that resolves the nav-mode cookie.
+let cookieValue: string | undefined
+vi.mock('next/headers', () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) =>
+        name === 'nav_mode' && cookieValue ? { value: cookieValue } : undefined,
+    }),
 }))
 
+vi.mock('./TopBar', () => ({
+  TopBar: ({ variant = 'full' }: { variant?: string }) => (
+    <div data-testid="topbar" data-variant={variant} />
+  ),
+}))
 vi.mock('./CommandPalette', () => ({
   CommandPalette: () => <div data-testid="command-palette" />,
 }))
+vi.mock('./SideNavShell', () => ({
+  SideNavShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="side-nav-shell">{children}</div>
+  ),
+}))
+
+// Async Server Component: resolve the element, then render it.
+async function renderShell(children: React.ReactNode = <div>test content</div>) {
+  render(await AppShell({ children }))
+}
 
 describe('AppShell', () => {
-  it('renders children', () => {
-    render(
-      <AppShell>
-        <div>test content</div>
-      </AppShell>
-    )
+  beforeEach(() => {
+    cookieValue = undefined
+  })
+
+  it('renders children', async () => {
+    await renderShell(<div>test content</div>)
     expect(screen.getByText('test content')).toBeInTheDocument()
   })
 
-  it('renders the TopBar', () => {
-    render(
-      <AppShell>
-        <div>content</div>
-      </AppShell>
-    )
-    expect(screen.getByTestId('topbar')).toBeInTheDocument()
+  it('defaults to top-nav mode: full TopBar, no side-nav shell', async () => {
+    await renderShell()
+    expect(screen.getByTestId('topbar')).toHaveAttribute('data-variant', 'full')
+    expect(screen.queryByTestId('side-nav-shell')).not.toBeInTheDocument()
   })
 
-  it('mounts the CommandPalette once so global ⌘K works on every route', () => {
-    render(
-      <AppShell>
-        <div>content</div>
-      </AppShell>
-    )
+  it('renders side-nav mode when nav_mode=side: slim TopBar + SideNavShell wrapping content', async () => {
+    cookieValue = 'side'
+    await renderShell(<div>page</div>)
+    expect(screen.getByTestId('topbar')).toHaveAttribute('data-variant', 'slim')
+    const shell = screen.getByTestId('side-nav-shell')
+    expect(shell).toBeInTheDocument()
+    expect(shell).toHaveTextContent('page')
+  })
+
+  it('treats an unknown nav_mode cookie value as top mode', async () => {
+    cookieValue = 'bogus'
+    await renderShell()
+    expect(screen.getByTestId('topbar')).toHaveAttribute('data-variant', 'full')
+    expect(screen.queryByTestId('side-nav-shell')).not.toBeInTheDocument()
+  })
+
+  it('mounts the CommandPalette once so global ⌘K works on every route', async () => {
+    await renderShell()
     expect(screen.getByTestId('command-palette')).toBeInTheDocument()
   })
 
-  it('renders a skip link to #main-content as the first focusable element', () => {
-    render(
-      <AppShell>
-        <div>content</div>
-      </AppShell>
-    )
+  it('renders a skip link to #main-content as the first focusable element', async () => {
+    await renderShell()
     const skip = screen.getByRole('link', { name: 'Skip to content' })
     expect(skip).toHaveAttribute('href', '#main-content')
     // It must come before the top bar in the document so keyboard users hit it

--- a/frontend/components/layout/AppShell.tsx
+++ b/frontend/components/layout/AppShell.tsx
@@ -1,16 +1,26 @@
+import { cookies } from 'next/headers'
 import { TopBar } from './TopBar'
 import { CommandPalette } from './CommandPalette'
+import { SideNavShell } from './SideNavShell'
+import { NAV_MODE_COOKIE, parseNavMode } from '@/lib/nav-mode'
 
-// The global application shell (PSY-1013). Renamed from SidebarLayout now that
-// the left sidebar is retired as the primary navigation — the top bar owns
-// global nav, and a deep page that genuinely needs contextual sub-nav adds its
-// own page-level linkbox rather than a reinstated global sidebar.
+// The global application shell (PSY-1013 top-bar nav; PSY-1116 nav-mode toggle).
+// Resolves the user's nav-style preference from the `nav_mode` cookie at SSR and
+// renders one of two compositions:
+//   • 'top'  (default) — the top bar owns global nav; content renders full-width.
+//   • 'side' — a SLIM top bar (no PrimaryNav) above the revived left Sidebar.
+// Reading the cookie here makes only the per-request shell dynamic; pages keep
+// their own cache modes (same pattern as the auth-hydration + geo shell reads —
+// see lib/geo-default.ts). The shell already renders inside the root layout's
+// <Suspense> boundary alongside the cookie-reading AuthHydrator.
 //
 // Order matters: the skip-to-content link is the first focusable element (jumps
 // keyboard users past the banner/nav straight to <main id="main-content">, set
 // in app/layout.tsx). The CommandPalette is mounted once here so the global ⌘K
 // shortcut works on every route.
-export function AppShell({ children }: { children: React.ReactNode }) {
+export async function AppShell({ children }: { children: React.ReactNode }) {
+  const navMode = parseNavMode((await cookies()).get(NAV_MODE_COOKIE)?.value)
+
   return (
     <div className="flex min-h-screen flex-col">
       <a
@@ -19,8 +29,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       >
         Skip to content
       </a>
-      <TopBar />
-      {children}
+      <TopBar variant={navMode === 'side' ? 'slim' : 'full'} />
+      {navMode === 'side' ? <SideNavShell>{children}</SideNavShell> : children}
       <CommandPalette />
     </div>
   )

--- a/frontend/components/layout/SideNavShell.test.tsx
+++ b/frontend/components/layout/SideNavShell.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SideNavShell } from './SideNavShell'
+
+const mockPathname = vi.fn(() => '/shows')
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}))
+
+vi.mock('./Sidebar', () => ({
+  Sidebar: ({ collapsed }: { collapsed: boolean }) => (
+    <div data-testid="global-sidebar" data-collapsed={collapsed} />
+  ),
+}))
+
+describe('SideNavShell', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    mockPathname.mockReturnValue('/shows')
+  })
+
+  it('renders the global sidebar + children on a normal page', () => {
+    render(
+      <SideNavShell>
+        <div>page content</div>
+      </SideNavShell>
+    )
+    expect(screen.getByTestId('global-sidebar')).toBeInTheDocument()
+    expect(screen.getByText('page content')).toBeInTheDocument()
+  })
+
+  it('suppresses the global sidebar under /admin (admin owns its own rail) but still renders content', () => {
+    mockPathname.mockReturnValue('/admin')
+    render(
+      <SideNavShell>
+        <div>admin content</div>
+      </SideNavShell>
+    )
+    expect(screen.queryByTestId('global-sidebar')).not.toBeInTheDocument()
+    expect(screen.getByText('admin content')).toBeInTheDocument()
+  })
+
+  it('suppresses the global sidebar on /admin sub-routes too', () => {
+    mockPathname.mockReturnValue('/admin/users')
+    render(
+      <SideNavShell>
+        <div>x</div>
+      </SideNavShell>
+    )
+    expect(screen.queryByTestId('global-sidebar')).not.toBeInTheDocument()
+  })
+
+  it('passes the persisted collapsed preference through to the sidebar', () => {
+    localStorage.setItem('sidebar-collapsed', 'collapsed')
+    render(
+      <SideNavShell>
+        <div>x</div>
+      </SideNavShell>
+    )
+    expect(screen.getByTestId('global-sidebar')).toHaveAttribute('data-collapsed', 'true')
+  })
+})

--- a/frontend/components/layout/SideNavShell.tsx
+++ b/frontend/components/layout/SideNavShell.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useCallback } from 'react'
+import { usePathname } from 'next/navigation'
+import { Sidebar } from './Sidebar'
+import { useLocalStorageEnum } from '@/lib/hooks/common/useLocalStorageEnum'
+
+// Module-level `as const` tuple per useLocalStorageEnum's contract (stable
+// `allowed` reference). Distinct key from the admin rail's
+// `admin-sidebar-collapsed` so the two collapse states are independent.
+const COLLAPSE_STATES = ['expanded', 'collapsed'] as const
+
+// PSY-1116: the side-nav composition. Rendered by AppShell only when the
+// nav-mode cookie resolves to 'side' — it revives the pre-PSY-1013
+// SidebarLayout shape (the global left Sidebar to the left of the content
+// column). Client-side because the Sidebar's collapse state is local + browser
+// persisted; `children` is the server-rendered page subtree passed through as a
+// prop.
+export function SideNavShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const [collapseState, setCollapseState] = useLocalStorageEnum(
+    'sidebar-collapsed',
+    'expanded',
+    COLLAPSE_STATES
+  )
+  const collapsed = collapseState === 'collapsed'
+  const toggleCollapse = useCallback(
+    () => setCollapseState(collapsed ? 'expanded' : 'collapsed'),
+    [collapsed, setCollapseState]
+  )
+
+  // The admin area renders its OWN always-on rail (AdminSidebar, PSY-1114), so
+  // suppress the global public sidebar under /admin — otherwise side-nav mode
+  // would stack two left rails. usePathname() strips the ?tab= query, so this
+  // still matches the /admin tab-shell and its sub-routes.
+  const showGlobalSidebar = !pathname.startsWith('/admin')
+
+  return (
+    <div className="flex flex-1">
+      {showGlobalSidebar && (
+        <Sidebar collapsed={collapsed} onToggleCollapse={toggleCollapse} />
+      )}
+      <div className="flex min-w-0 flex-1 flex-col">{children}</div>
+    </div>
+  )
+}

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -8,17 +8,6 @@ vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
 }))
 
-// The admin rail is a dynamically-imported chunk (AdminSidebarNav, kept off the
-// public bundle). Stub next/dynamic so Sidebar renders a synchronous marker we
-// can assert on; the rail's own behavior (groups, badges, active state) is
-// covered by AdminSidebarNav.test.tsx.
-vi.mock('next/dynamic', () => ({
-  default: () =>
-    function AdminSidebarNavStub() {
-      return <div data-testid="admin-sidebar-nav" />
-    },
-}))
-
 // Return type widened so individual tests can override `user`/`isAuthenticated`
 // without TS narrowing from the default-null literal.
 type MockAuthContextValue = {
@@ -273,46 +262,19 @@ describe('Sidebar', () => {
     expect(onToggleCollapse).toHaveBeenCalledTimes(1)
   })
 
-  // Context-aware delegation (PSY-933): Sidebar mounts the lazily-loaded admin
-  // rail ONLY for an admin on the exact /admin shell; everywhere else (and for
-  // non-admins) it renders the public nav. The rail's contents are tested in
-  // AdminSidebarNav.test.tsx.
-  describe('admin nav delegation', () => {
-    const asAdmin = () =>
-      mockAuthContext.mockReturnValue({
-        user: { email: 'admin@test.com', is_admin: true },
-        isAuthenticated: true,
-        isLoading: false,
-        logout: vi.fn(),
-      })
-
-    it('mounts the admin rail (and hides public groups) for an admin on /admin', () => {
-      asAdmin()
-      mockPathname.mockReturnValue('/admin')
-      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      expect(screen.getByTestId('admin-sidebar-nav')).toBeInTheDocument()
-      expect(screen.queryByText('Discover')).not.toBeInTheDocument()
+  // Note: the global Sidebar is now purely the public Discover/Community nav.
+  // The PSY-933 admin context-swap was retired in PSY-1116 — the admin area's
+  // rail is owned by AdminSidebar (app/admin/layout.tsx), and SideNavShell
+  // suppresses this sidebar under /admin to avoid a double rail.
+  it('renders the public Discover nav even on /admin (no admin swap)', () => {
+    mockAuthContext.mockReturnValue({
+      user: { email: 'admin@test.com', is_admin: true },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
     })
-
-    it('keeps the public nav for a NON-admin at /admin (mid-redirect safety)', () => {
-      mockAuthContext.mockReturnValue({
-        user: { email: 'user@test.com', is_admin: false },
-        isAuthenticated: true,
-        isLoading: false,
-        logout: vi.fn(),
-      })
-      mockPathname.mockReturnValue('/admin')
-      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      expect(screen.getByText('Discover')).toBeInTheDocument()
-      expect(screen.queryByTestId('admin-sidebar-nav')).not.toBeInTheDocument()
-    })
-
-    it('keeps the public nav on standalone /admin/<section> sub-routes (scoped to the tab-shell, not startsWith)', () => {
-      asAdmin()
-      mockPathname.mockReturnValue('/admin/featured')
-      render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
-      expect(screen.getByText('Discover')).toBeInTheDocument()
-      expect(screen.queryByTestId('admin-sidebar-nav')).not.toBeInTheDocument()
-    })
+    mockPathname.mockReturnValue('/admin')
+    render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    expect(screen.getByText('Discover')).toBeInTheDocument()
   })
 })

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import dynamic from 'next/dynamic'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, UserCircle, Shield, PanelLeftClose, PanelLeft,
@@ -14,10 +13,6 @@ import {
   Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { SidebarNavLink } from './SidebarNavLink'
-
-// The admin rail (config + the 7 queue-count hooks) is a separate chunk loaded
-// only when an admin is on the /admin shell — public pages never download it.
-const AdminSidebarNav = dynamic(() => import('./AdminSidebarNav'), { ssr: false })
 
 export interface SidebarNavItem {
   href: string
@@ -73,17 +68,11 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const pathname = usePathname()
   const { user, isAuthenticated } = useAuthContext()
 
-  // In the admin area the rail becomes context-aware (PSY-933): it swaps the
-  // public Discover/Community groups for the grouped admin sections (rendered by
-  // the lazily-loaded AdminSidebarNav). Gated on isAdmin so a non-admin
-  // mid-redirect at /admin still sees the public nav, and scoped to the exact
-  // /admin tab-shell (usePathname() strips the ?tab= query, so this still matches
-  // /admin?tab=…). Standalone /admin/<section> sub-routes keep the public nav —
-  // their pre-PSY-933 behavior — rather than mis-rendering a ?tab=-only active
-  // state; a path-aware rail for those is a follow-up.
-  const isAdmin = !!user?.is_admin
-  const showAdminNav = isAdmin && pathname === '/admin'
-
+  // The global sidebar is purely the public Discover/Community nav. The admin
+  // area's own rail is owned by AdminSidebar (app/admin/layout.tsx, PSY-1114) —
+  // and in side-nav mode SideNavShell suppresses this sidebar under /admin — so
+  // the PSY-933 context-swap that used to render admin nav here is retired
+  // (PSY-1116) to avoid a double rail.
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/'
     return pathname === href || pathname.startsWith(href + '/')
@@ -117,31 +106,25 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
         )}
       >
         <nav className="flex-1 space-y-6 overflow-y-auto px-2 py-4">
-          {showAdminNav ? (
-            <AdminSidebarNav collapsed={collapsed} />
-          ) : (
-            <>
-              {sidebarGroups.map(group => (
-                <div key={group.label}>
-                  {renderGroupHeader(group.label)}
-                  <div className="space-y-0.5">
-                    {group.items.map(renderItem)}
-                  </div>
-                </div>
-              ))}
+          {sidebarGroups.map(group => (
+            <div key={group.label}>
+              {renderGroupHeader(group.label)}
+              <div className="space-y-0.5">
+                {group.items.map(renderItem)}
+              </div>
+            </div>
+          ))}
 
-              {isAuthenticated && (
-                <div>
-                  <div className={cn('mb-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
-                  <div className="space-y-0.5">
-                    {renderItem({ href: '/library', label: 'Library', icon: Library })}
-                    {renderItem({ href: '/settings/notification-filters', label: 'Notification Filters', icon: Bell })}
-                    {renderItem({ href: '/profile', label: 'Profile', icon: UserCircle })}
-                    {user?.is_admin && renderItem({ href: '/admin', label: 'Admin', icon: Shield })}
-                  </div>
-                </div>
-              )}
-            </>
+          {isAuthenticated && (
+            <div>
+              <div className={cn('mb-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
+              <div className="space-y-0.5">
+                {renderItem({ href: '/library', label: 'Library', icon: Library })}
+                {renderItem({ href: '/settings/notification-filters', label: 'Notification Filters', icon: Bell })}
+                {renderItem({ href: '/profile', label: 'Profile', icon: UserCircle })}
+                {user?.is_admin && renderItem({ href: '/admin', label: 'Admin', icon: Shield })}
+              </div>
+            </div>
           )}
         </nav>
 

--- a/frontend/components/layout/TopBar.test.tsx
+++ b/frontend/components/layout/TopBar.test.tsx
@@ -111,6 +111,15 @@ describe('TopBar', () => {
       expect(screen.getByRole('button', { name: 'Browse the catalog' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Contribute' })).toBeInTheDocument()
     })
+
+    it('omits the primary nav in the slim (side-nav) variant — nav lives in the sidebar', () => {
+      render(<TopBar variant="slim" />)
+      expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Explore' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Browse the catalog' })).not.toBeInTheDocument()
+      // Brand + search stay in the slim bar.
+      expect(screen.getByRole('link', { name: 'Psychic Homily — home' })).toBeInTheDocument()
+    })
   })
 
   describe('theme toggle', () => {

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -39,7 +39,11 @@ const glitchFilter = (
 // The Browse / Contribute menus, the authenticated bar, the palette re-skin,
 // and mobile are each elaborated by their own follow-up tickets (Radio became
 // a plain /radio link in PSY-1057); this file just assembles the seams.
-export function TopBar() {
+//
+// `variant` (PSY-1116): in side-nav mode the global nav lives in the left
+// Sidebar, so the top bar drops its PrimaryNav and becomes a slim brand +
+// search + theme + account bar. 'full' (default) is the top-nav-mode chrome.
+export function TopBar({ variant = 'full' }: { variant?: 'full' | 'slim' } = {}) {
   // resolvedTheme (not theme) so the first click always flips the *visible*
   // theme — with theme==='system' a `theme === 'dark'` check would set explicit
   // 'dark' and appear to do nothing. Matches the canonical ModeToggle.
@@ -71,7 +75,7 @@ export function TopBar() {
               </span>
             </Link>
           </div>
-          <PrimaryNav />
+          {variant === 'full' && <PrimaryNav />}
         </div>
 
         {/* Right: search + theme + account */}

--- a/frontend/lib/nav-mode.ts
+++ b/frontend/lib/nav-mode.ts
@@ -1,0 +1,24 @@
+// Global navigation-style preference (PSY-1116). The user chooses between the
+// default top-bar nav and a left side-nav; the choice is stored in a cookie so
+// the shell (AppShell, a Server Component) can resolve it at SSR with no layout
+// flash. The cookie name + parser are the single source of truth shared by the
+// server shell here and the settings toggle (PSY-1117).
+//
+// Server-and-client safe: no `next/headers` import, so both the server shell
+// (reads via cookies()) and client code (reads/writes document.cookie) use it.
+
+export const NAV_MODE_COOKIE = 'nav_mode'
+
+export type NavMode = 'top' | 'side'
+
+export const DEFAULT_NAV_MODE: NavMode = 'top'
+
+/**
+ * Coerce an arbitrary cookie value to a valid NavMode. Anything other than the
+ * explicit 'side' opt-in (missing, malformed, or a stale value) resolves to the
+ * top-bar default — the column-level contract mirrors the backend's
+ * users.nav_mode CHECK (PSY-1115).
+ */
+export function parseNavMode(value: string | undefined | null): NavMode {
+  return value === 'side' ? 'side' : DEFAULT_NAV_MODE
+}


### PR DESCRIPTION
## What & why

Implements the **side-nav / top-nav** user toggle's shell half. `AppShell` resolves the user's nav-style preference from a `nav_mode` cookie at SSR and renders one of two compositions:

- **`top`** (default) — today's shell: the top bar owns global nav, content full-width.
- **`side`** — a **slim** `TopBar` (PrimaryNav dropped — nav lives in the rail) above the revived left `Sidebar`, the pre-PSY-1013 `SidebarLayout` shape (new `SideNavShell`).

Reading the cookie only makes the per-request **shell** dynamic — pages keep their own cache modes (verified below). This follows the established shell-cookie precedent (`lib/auth-hydration.ts` already `await cookies()` in the same `<Suspense>` boundary; `lib/geo-default.ts` documents why shell reads don't un-ISR pages). `lib/nav-mode.ts` is the cookie-name + parser SSOT shared with the settings toggle (PSY-1117).

**Coordination:** `SideNavShell` suppresses the global `Sidebar` under `/admin` so the admin area's own rail (`AdminSidebar`, PSY-1114) is the single left rail there; the now-redundant PSY-933 admin context-swap inside `Sidebar.tsx` is retired.

## Screenshots (local dev, seeded admin)

**Top-nav mode (default) — `/shows`:**
![top mode](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-333a529c89d0b8e431ef/01-top-mode-shows.png)

**Side-nav mode — `/shows` (slim top bar, no PrimaryNav; global Sidebar owns nav):**
![side mode shows](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-333a529c89d0b8e431ef/02-side-mode-shows.png)

**Side-nav mode — `/admin` (single rail: the admin rail; global sidebar suppressed, no double rail):**
![side mode admin](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-333a529c89d0b8e431ef/03-side-mode-admin.png)

> The `/admin` shot was captured with PSY-1114 temporarily merged in (see merge-order note) — on this branch alone the admin rail isn't present yet.

## Scope (and what's deferred)

- **Cookie-driven only.** The settings UI that *writes* the cookie + the cross-device account reconciliation (account `nav_mode` → cookie via `router.refresh()`) are **PSY-1117**. Here the shell renders whatever the cookie says (the screenshots set `nav_mode=side` directly).
- **Merge after PSY-1114 (#1151).** The `/admin` suppression assumes PSY-1114's admin rail exists; if this merged first, `/admin` in side mode would briefly have no rail.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/layout` — **230 passed**, incl. rewritten `AppShell.test.tsx` (top vs side by cookie; async Server Component pattern), new `SideNavShell.test.tsx` (renders global sidebar; suppresses it on `/admin` + sub-routes; collapse persistence), `TopBar.test.tsx` slim-variant (no PrimaryNav), and updated `Sidebar.test.tsx` (admin-swap retired → public nav on `/admin`)
- [x] `bun run build` — succeeds; **no caching regression**: `/shows` stays `◐ Partial Prerender` (revalidate 1h), `/explore` PPR, `/admin/*` PPR — the shell cookie read does not un-ISR pages
- [x] Manual (screenshots): both modes render; side mode drops PrimaryNav + shows the Sidebar; `/admin` in side mode shows exactly one rail
- [x] `/simplify` (reuse / simplification / efficiency / altitude) — clean. A correctness lens raised a hydration-mismatch concern; **refuted** — RSC serializes the server-computed `variant`/composition into the Flight payload and the client hydrates with those exact values (it never re-reads the cookie), so SSR and hydration can't diverge. Its proposed fix (default-to-top + client sync) would reintroduce the first-paint flash this SSR approach avoids.

Closes PSY-1116
